### PR TITLE
Add Stryd workout upload API and push-to-Stryd UI

### DIFF
--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -1,12 +1,19 @@
-"""Upcoming training plan endpoint."""
-from datetime import date
+"""Upcoming training plan endpoint with Stryd push integration."""
+import json
+import os
+from datetime import date, datetime, timezone
 
 import pandas as pd
-from fastapi import APIRouter
+from dotenv import load_dotenv
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from api.deps import get_dashboard_data
 
 router = APIRouter()
+
+_DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data")
+_STRYD_PUSH_STATUS_PATH = os.path.join(_DATA_DIR, "ai", "stryd_push_status.json")
 
 
 @router.get("/plan")
@@ -49,3 +56,163 @@ def get_plan() -> dict:
             cp_current = plan.get("power_max")
 
     return {"workouts": workouts, "cp_current": cp_current}
+
+
+def _load_push_status() -> dict:
+    """Load the Stryd push status JSON."""
+    if os.path.exists(_STRYD_PUSH_STATUS_PATH):
+        with open(_STRYD_PUSH_STATUS_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def _save_push_status(status: dict) -> None:
+    """Save the Stryd push status JSON."""
+    os.makedirs(os.path.dirname(_STRYD_PUSH_STATUS_PATH), exist_ok=True)
+    with open(_STRYD_PUSH_STATUS_PATH, "w") as f:
+        json.dump(status, f, indent=2)
+
+
+@router.get("/plan/stryd-status")
+def get_stryd_push_status() -> dict:
+    """Return push status for all workouts synced to Stryd."""
+    return _load_push_status()
+
+
+class PushStrydRequest(BaseModel):
+    workout_dates: list[str]
+
+
+@router.post("/plan/push-stryd")
+def push_plan_to_stryd(request: PushStrydRequest) -> dict:
+    """Push selected AI plan workouts to Stryd calendar.
+
+    Converts AI plan workouts to Stryd structured format and uploads them.
+    """
+    from sync.stryd_sync import (
+        _login_api,
+        _STRYD_WORKOUT_TYPES,
+        build_workout_blocks,
+        create_workout_api,
+    )
+
+    # Load Stryd credentials
+    load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "sync", ".env"))
+    email = os.environ.get("STRYD_EMAIL")
+    password = os.environ.get("STRYD_PASSWORD")
+    if not email or not password:
+        raise HTTPException(status_code=400, detail="STRYD_EMAIL / STRYD_PASSWORD not configured")
+
+    # Login to Stryd
+    try:
+        user_id, token = _login_api(email, password)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Stryd login failed: {e}")
+
+    # Load AI plan data
+    data = get_dashboard_data()
+    plan_df: pd.DataFrame = data.get("plan", pd.DataFrame())
+    if plan_df.empty:
+        raise HTTPException(status_code=404, detail="No training plan found")
+
+    # Get current CP for block building
+    cp_watts = None
+    signal = data.get("signal", {})
+    if isinstance(signal, dict):
+        cp_data = signal.get("plan", {})
+        if isinstance(cp_data, dict) and cp_data.get("power_max"):
+            cp_watts = float(cp_data["power_max"])
+    # Fallback: try from latest activities
+    if not cp_watts:
+        activities = data.get("activities", pd.DataFrame())
+        if not isinstance(activities, pd.DataFrame) or activities.empty:
+            pass
+        else:
+            cp_col = "cp_estimate" if "cp_estimate" in activities.columns else None
+            if cp_col:
+                valid_cp = activities[cp_col].dropna()
+                if not valid_cp.empty:
+                    cp_watts = float(valid_cp.iloc[-1])
+    if not cp_watts:
+        cp_watts = 248.0  # reasonable fallback
+
+    push_status = _load_push_status()
+    results = []
+
+    for workout_date in request.workout_dates:
+        # Skip rest days
+        matching = plan_df[plan_df["date"].astype(str) == workout_date]
+        if matching.empty:
+            results.append({"date": workout_date, "status": "error", "error": "No workout found for this date"})
+            continue
+
+        row = matching.iloc[0]
+        workout_type = str(row.get("workout_type", ""))
+
+        # Skip rest days
+        if workout_type.lower() in ("rest", "off"):
+            results.append({"date": workout_date, "status": "error", "error": "Rest day — nothing to push"})
+            continue
+
+        workout = row.to_dict()
+        # Convert date objects to strings for the dict
+        for k, v in workout.items():
+            if hasattr(v, "isoformat"):
+                workout[k] = v.isoformat()
+
+        try:
+            blocks = build_workout_blocks(workout, cp_watts)
+            stryd_type = _STRYD_WORKOUT_TYPES.get(workout_type.lower(), "")
+            title = f"{workout_type.replace('_', ' ').title()}"
+            description = str(row.get("workout_description", ""))
+
+            result = create_workout_api(
+                user_id=user_id,
+                token=token,
+                workout_date=workout_date,
+                title=title,
+                blocks=blocks,
+                workout_type=stryd_type,
+                description=description,
+            )
+
+            workout_id = str(result.get("id", ""))
+            push_status[workout_date] = {
+                "workout_id": workout_id,
+                "pushed_at": datetime.now(timezone.utc).isoformat(),
+                "status": "pushed",
+            }
+            results.append({"date": workout_date, "status": "success", "workout_id": workout_id})
+
+        except Exception as e:
+            results.append({"date": workout_date, "status": "error", "error": str(e)})
+
+    _save_push_status(push_status)
+    return {"results": results}
+
+
+@router.delete("/plan/stryd-workout/{workout_id}")
+def delete_stryd_workout(workout_id: str) -> dict:
+    """Delete a previously pushed workout from Stryd."""
+    from sync.stryd_sync import _login_api, delete_workout_api
+
+    load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "sync", ".env"))
+    email = os.environ.get("STRYD_EMAIL")
+    password = os.environ.get("STRYD_PASSWORD")
+    if not email or not password:
+        raise HTTPException(status_code=400, detail="STRYD_EMAIL / STRYD_PASSWORD not configured")
+
+    try:
+        user_id, token = _login_api(email, password)
+        delete_workout_api(user_id, token, workout_id)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed to delete from Stryd: {e}")
+
+    # Remove from push status
+    push_status = _load_push_status()
+    to_remove = [d for d, info in push_status.items() if info.get("workout_id") == workout_id]
+    for d in to_remove:
+        del push_status[d]
+    _save_push_status(push_status)
+
+    return {"deleted": True, "workout_id": workout_id}

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -4,6 +4,7 @@ import os
 from datetime import date, datetime, timezone
 
 import pandas as pd
+import requests
 from dotenv import load_dotenv
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -59,18 +60,27 @@ def get_plan() -> dict:
 
 
 def _load_push_status() -> dict:
-    """Load the Stryd push status JSON."""
-    if os.path.exists(_STRYD_PUSH_STATUS_PATH):
+    """Load the Stryd push status JSON. Returns {} on missing or corrupt file."""
+    if not os.path.exists(_STRYD_PUSH_STATUS_PATH):
+        return {}
+    try:
         with open(_STRYD_PUSH_STATUS_PATH) as f:
-            return json.load(f)
-    return {}
+            data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError(f"Expected dict, got {type(data).__name__}")
+            return data
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        print(f"WARNING: Corrupt push status file {_STRYD_PUSH_STATUS_PATH}: {e}")
+        return {}
 
 
 def _save_push_status(status: dict) -> None:
-    """Save the Stryd push status JSON."""
+    """Save the Stryd push status JSON atomically via temp file + rename."""
     os.makedirs(os.path.dirname(_STRYD_PUSH_STATUS_PATH), exist_ok=True)
-    with open(_STRYD_PUSH_STATUS_PATH, "w") as f:
+    tmp_path = _STRYD_PUSH_STATUS_PATH + ".tmp"
+    with open(tmp_path, "w") as f:
         json.dump(status, f, indent=2)
+    os.replace(tmp_path, _STRYD_PUSH_STATUS_PATH)
 
 
 @router.get("/plan/stryd-status")
@@ -107,7 +117,8 @@ def push_plan_to_stryd(request: PushStrydRequest) -> dict:
     try:
         user_id, token = _login_api(email, password)
     except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Stryd login failed: {e}")
+        print(f"ERROR: Stryd login failed: {e}")
+        raise HTTPException(status_code=502, detail="Stryd login failed. Check your credentials in sync/.env")
 
     # Load AI plan data
     data = get_dashboard_data()
@@ -134,7 +145,10 @@ def push_plan_to_stryd(request: PushStrydRequest) -> dict:
                 if not valid_cp.empty:
                     cp_watts = float(valid_cp.iloc[-1])
     if not cp_watts:
-        cp_watts = 248.0  # reasonable fallback
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot determine Critical Power from your data. Ensure recent activities with power data are synced before pushing to Stryd.",
+        )
 
     push_status = _load_push_status()
     results = []
@@ -184,10 +198,23 @@ def push_plan_to_stryd(request: PushStrydRequest) -> dict:
             }
             results.append({"date": workout_date, "status": "success", "workout_id": workout_id})
 
+        except requests.HTTPError as e:
+            detail = str(e)
+            if e.response is not None:
+                try:
+                    detail = e.response.json().get("message", detail)
+                except (ValueError, AttributeError):
+                    pass
+            results.append({"date": workout_date, "status": "error", "error": f"Stryd API error: {detail}"})
         except Exception as e:
+            print(f"ERROR: Failed to push workout for {workout_date}: {type(e).__name__}: {e}")
             results.append({"date": workout_date, "status": "error", "error": str(e)})
 
-    _save_push_status(push_status)
+    try:
+        _save_push_status(push_status)
+    except OSError as e:
+        print(f"WARNING: Failed to save push status: {e}")
+
     return {"results": results}
 
 
@@ -204,9 +231,20 @@ def delete_stryd_workout(workout_id: str) -> dict:
 
     try:
         user_id, token = _login_api(email, password)
-        delete_workout_api(user_id, token, workout_id)
     except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Failed to delete from Stryd: {e}")
+        print(f"ERROR: Stryd login failed: {e}")
+        raise HTTPException(status_code=502, detail="Stryd login failed. Check your credentials in sync/.env")
+
+    try:
+        delete_workout_api(user_id, token, workout_id)
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 404:
+            pass  # Already deleted on Stryd — proceed to clean local status
+        else:
+            raise HTTPException(status_code=502, detail=f"Stryd delete failed: {e}")
+    except Exception as e:
+        print(f"ERROR: Stryd delete failed: {e}")
+        raise HTTPException(status_code=502, detail="Failed to delete from Stryd")
 
     # Remove from push status
     push_status = _load_push_status()

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -9,6 +9,7 @@ The user ID is automatically derived from the Stryd login API response.
 import argparse
 import os
 import re
+import uuid
 from datetime import date, datetime, timedelta, timezone
 
 import requests
@@ -28,6 +29,8 @@ def _workout_type_from_name(name: str) -> str:
 STRYD_LOGIN_URL = "https://www.stryd.com/b/email/signin"
 STRYD_CALENDAR_API = "https://api.stryd.com/b/api/v1/users/{user_id}/calendar"
 STRYD_ACTIVITY_API = "https://api.stryd.com/b/api/v1/activities/{activity_id}"
+STRYD_WORKOUT_API = "https://api.stryd.com/b/api/v1/users/{user_id}/workouts"
+STRYD_ESTIMATE_API = "https://api.stryd.com/b/api/v1/users/workouts/estimate"
 
 
 def _login_api(email: str, password: str) -> tuple[str, str]:
@@ -500,6 +503,288 @@ def _round_or_empty(val: float | int | None, decimals: int = 1) -> str:
     if val is None:
         return ""
     return str(round(float(val), decimals))
+
+
+# --- Workout upload ---
+
+# Map AI plan workout_type to Stryd workout type strings
+_STRYD_WORKOUT_TYPES: dict[str, str] = {
+    "easy": "easy run",
+    "recovery": "recovery",
+    "long_run": "long run",
+    "long run": "long run",
+    "steady_aerobic": "steady state",
+    "tempo": "tempo",
+    "threshold": "threshold",
+    "interval": "intervals",
+    "repetition": "repetition",
+    "hill_repeat": "hill repeat",
+}
+
+
+def _make_segment(
+    intensity_class: str,
+    minutes: float,
+    cp_min_pct: int,
+    cp_max_pct: int,
+) -> dict:
+    """Build a single Stryd workout segment."""
+    h = int(minutes // 60)
+    m = int(minutes % 60)
+    s = int((minutes * 60) % 60)
+    return {
+        "desc": "",
+        "desc_no_cp": "",
+        "duration_type": "time",
+        "duration_time": {"hour": h, "minute": m, "second": s},
+        "intensity_class": intensity_class,
+        "intensity_type": "percentage",
+        "intensity_percent": {
+            "min": cp_min_pct,
+            "max": cp_max_pct,
+            "value": (cp_min_pct + cp_max_pct) // 2,
+        },
+        "flexible": False,
+        "incline": 0,
+        "grade": 0,
+        "distance_unit_selected": "km",
+        "duration_distance": 0,
+        "pdc_target": 0,
+        "rpe_selected": 1,
+        "zone_selected": 0,
+        "uuid": str(uuid.uuid4()),
+    }
+
+
+def _parse_structured_description(
+    description: str, cp_watts: float
+) -> list[dict] | None:
+    """Parse AI plan descriptions like 'WU 15min, 3x3min @275-290W w/ 3min jog recovery, CD 10min'.
+
+    Returns list of Stryd blocks if parseable, None if description is unstructured.
+    """
+    if not description:
+        return None
+
+    # Strip trailing markers like [DONE]
+    desc = re.sub(r"\s*\[DONE\]\s*$", "", description).strip()
+
+    blocks: list[dict] = []
+
+    # Try to extract structured segments from comma-separated parts
+    # Pattern: "WU 15min, 3x3min @275-290W w/ 3min jog recovery, CD 10min"
+    parts = [p.strip() for p in desc.split(",")]
+
+    for part in parts:
+        part_lower = part.lower()
+
+        # Warmup: "WU 15min" or "WU 10min easy"
+        wu_match = re.match(r"wu\s+(\d+)\s*min", part_lower)
+        if wu_match:
+            mins = int(wu_match.group(1))
+            blocks.append({
+                "uuid": str(uuid.uuid4()),
+                "repeat": 1,
+                "segments": [_make_segment("warmup", mins, 65, 75)],
+            })
+            continue
+
+        # Cooldown: "CD 10min"
+        cd_match = re.match(r"cd\s+(\d+)\s*min", part_lower)
+        if cd_match:
+            mins = int(cd_match.group(1))
+            blocks.append({
+                "uuid": str(uuid.uuid4()),
+                "repeat": 1,
+                "segments": [_make_segment("cooldown", mins, 65, 75)],
+            })
+            continue
+
+        # Intervals: "3x3min @275-290W w/ 3min jog recovery"
+        # or "4x4min @265-280W w/ 3min jog recovery"
+        interval_match = re.match(
+            r"(\d+)x(\d+)\s*min\s+@(\d+)-(\d+)w\s+w/\s+(\d+)\s*min",
+            part_lower,
+        )
+        if interval_match:
+            reps = int(interval_match.group(1))
+            work_min = int(interval_match.group(2))
+            power_min = int(interval_match.group(3))
+            power_max = int(interval_match.group(4))
+            rest_min = int(interval_match.group(5))
+            work_cp_min = round(power_min / cp_watts * 100)
+            work_cp_max = round(power_max / cp_watts * 100)
+            blocks.append({
+                "uuid": str(uuid.uuid4()),
+                "repeat": reps,
+                "segments": [
+                    _make_segment("work", work_min, work_cp_min, work_cp_max),
+                    _make_segment("rest", rest_min, 55, 65),
+                ],
+            })
+            continue
+
+        # Threshold reps: "2x20min @235-255W w/ 5min easy"
+        threshold_match = re.match(
+            r"(\d+)x(\d+)\s*min\s+@(\d+)-(\d+)w\s+w/\s+(\d+)\s*min",
+            part_lower,
+        )
+        if threshold_match:
+            # Already handled by interval_match above
+            continue
+
+        # Tempo block: "15min @220-240W"
+        tempo_match = re.match(r"(\d+)\s*min\s+@(\d+)-(\d+)w", part_lower)
+        if tempo_match:
+            mins = int(tempo_match.group(1))
+            power_min = int(tempo_match.group(2))
+            power_max = int(tempo_match.group(3))
+            cp_min = round(power_min / cp_watts * 100)
+            cp_max = round(power_max / cp_watts * 100)
+            blocks.append({
+                "uuid": str(uuid.uuid4()),
+                "repeat": 1,
+                "segments": [_make_segment("work", mins, cp_min, cp_max)],
+            })
+            continue
+
+    # Only return if we parsed at least a warmup or work block
+    has_content = any(
+        seg.get("intensity_class") in ("warmup", "work")
+        for b in blocks
+        for seg in b.get("segments", [])
+    )
+    return blocks if has_content else None
+
+
+def build_workout_blocks(workout: dict, cp_watts: float) -> list[dict]:
+    """Convert an AI plan workout dict to Stryd API block format.
+
+    Args:
+        workout: Dict with keys from the AI plan CSV (workout_type, planned_duration_min,
+                 target_power_min, target_power_max, workout_description).
+        cp_watts: Current Critical Power in watts for percentage conversion.
+
+    Returns:
+        List of Stryd block dicts ready for the create workout API.
+    """
+    description = workout.get("workout_description", "")
+
+    # Try parsing structured descriptions first (interval/threshold/tempo workouts)
+    parsed = _parse_structured_description(description, cp_watts)
+    if parsed:
+        return parsed
+
+    # Fallback: build a simple single-block workout from power targets and duration
+    duration_min = float(workout.get("planned_duration_min") or 0)
+    power_min = workout.get("target_power_min")
+    power_max = workout.get("target_power_max")
+    workout_type = (workout.get("workout_type") or "easy").lower()
+
+    if power_min and power_max and cp_watts:
+        cp_min_pct = round(float(power_min) / cp_watts * 100)
+        cp_max_pct = round(float(power_max) / cp_watts * 100)
+    else:
+        # Default zones by workout type
+        defaults = {
+            "easy": (65, 75),
+            "recovery": (55, 65),
+            "long_run": (68, 78),
+            "long run": (68, 78),
+            "steady_aerobic": (72, 82),
+            "tempo": (82, 92),
+            "threshold": (88, 100),
+            "interval": (100, 110),
+        }
+        cp_min_pct, cp_max_pct = defaults.get(workout_type, (65, 75))
+
+    # Determine intensity class
+    if workout_type in ("easy", "recovery"):
+        intensity = "warmup"  # Stryd uses warmup for easy/recovery single-block
+    elif workout_type in ("tempo", "threshold", "interval", "steady_aerobic"):
+        intensity = "work"
+    else:
+        intensity = "warmup"
+
+    if duration_min <= 0:
+        duration_min = 30  # default
+
+    return [{
+        "uuid": str(uuid.uuid4()),
+        "repeat": 1,
+        "segments": [_make_segment(intensity, duration_min, cp_min_pct, cp_max_pct)],
+    }]
+
+
+def create_workout_api(
+    user_id: str,
+    token: str,
+    workout_date: str,
+    title: str,
+    blocks: list[dict],
+    workout_type: str = "",
+    description: str = "",
+    surface: str = "road",
+) -> dict:
+    """Create a structured workout on the Stryd calendar.
+
+    Args:
+        workout_date: ISO date string like '2026-04-10'.
+        title: Workout name shown in the calendar.
+        blocks: List of Stryd block dicts (from build_workout_blocks).
+        workout_type: Stryd workout type string (e.g., 'easy run', 'intervals').
+        description: Free-text description.
+        surface: 'road', 'track', 'trail', or 'treadmill'.
+
+    Returns:
+        The created workout response dict (includes server-assigned id, stress, etc).
+    """
+    # Convert date to Unix timestamp at midnight UTC
+    dt = datetime.strptime(workout_date, "%Y-%m-%d")
+    timestamp = int(dt.replace(tzinfo=timezone.utc).timestamp())
+
+    url = STRYD_WORKOUT_API.format(user_id=user_id)
+    payload = {
+        "type": workout_type,
+        "desc": description,
+        "title": title,
+        "blocks": blocks,
+        "id": -1,
+        "objective": "",
+        "source": "USER",
+        "duration": 0,
+        "stress": 0,
+        "surface": surface,
+        "tags": None,
+    }
+
+    resp = requests.post(
+        url,
+        params={"timestamp": timestamp},
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def delete_workout_api(user_id: str, token: str, workout_id: str) -> bool:
+    """Delete a workout from the Stryd calendar.
+
+    Returns True if successfully deleted.
+    """
+    url = f"{STRYD_WORKOUT_API.format(user_id=user_id)}/{workout_id}"
+    resp = requests.delete(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return True
 
 
 # --- Sync entry point ---

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -624,15 +624,6 @@ def _parse_structured_description(
             })
             continue
 
-        # Threshold reps: "2x20min @235-255W w/ 5min easy"
-        threshold_match = re.match(
-            r"(\d+)x(\d+)\s*min\s+@(\d+)-(\d+)w\s+w/\s+(\d+)\s*min",
-            part_lower,
-        )
-        if threshold_match:
-            # Already handled by interval_match above
-            continue
-
         # Tempo block: "15min @220-240W"
         tempo_match = re.match(r"(\d+)\s*min\s+@(\d+)-(\d+)w", part_lower)
         if tempo_match:

--- a/tests/test_stryd_upload.py
+++ b/tests/test_stryd_upload.py
@@ -1,0 +1,262 @@
+"""Tests for Stryd workout upload functions."""
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from sync.stryd_sync import (
+    build_workout_blocks,
+    create_workout_api,
+    delete_workout_api,
+    _parse_structured_description,
+    _make_segment,
+)
+
+
+# --- build_workout_blocks ---
+
+
+class TestBuildWorkoutBlocks:
+    """Tests for converting AI plan workouts to Stryd block format."""
+
+    def test_easy_run_single_block(self):
+        """Easy run produces a single warmup-class block."""
+        workout = {
+            "workout_type": "easy",
+            "planned_duration_min": "50",
+            "target_power_min": "140",
+            "target_power_max": "191",
+            "workout_description": "Easy aerobic run.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        assert len(blocks) == 1
+        seg = blocks[0]["segments"][0]
+        assert seg["intensity_class"] == "warmup"
+        assert seg["duration_time"]["minute"] == 50
+        # CP percentages: 140/248 ≈ 56%, 191/248 ≈ 77%
+        assert seg["intensity_percent"]["min"] == 56
+        assert seg["intensity_percent"]["max"] == 77
+
+    def test_recovery_run(self):
+        """Recovery run uses warmup class with lower power."""
+        workout = {
+            "workout_type": "recovery",
+            "planned_duration_min": "35",
+            "target_power_min": "130",
+            "target_power_max": "155",
+            "workout_description": "Recovery shake-out.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        assert len(blocks) == 1
+        seg = blocks[0]["segments"][0]
+        assert seg["intensity_class"] == "warmup"
+        assert seg["intensity_percent"]["min"] == 52  # 130/248
+        assert seg["intensity_percent"]["max"] == 62  # round(155/248*100) = 62
+
+    def test_structured_interval_description(self):
+        """Interval workout with structured description parses into warmup + intervals + cooldown."""
+        workout = {
+            "workout_type": "interval",
+            "planned_duration_min": "65",
+            "target_power_min": "265",
+            "target_power_max": "280",
+            "workout_description": "WU 15min, 4x4min @265-280W w/ 3min jog recovery, CD 10min.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        assert len(blocks) == 3  # warmup, intervals, cooldown
+
+        # Warmup
+        assert blocks[0]["repeat"] == 1
+        assert blocks[0]["segments"][0]["intensity_class"] == "warmup"
+        assert blocks[0]["segments"][0]["duration_time"]["minute"] == 15
+
+        # Intervals: 4x(work + rest)
+        assert blocks[1]["repeat"] == 4
+        assert len(blocks[1]["segments"]) == 2
+        assert blocks[1]["segments"][0]["intensity_class"] == "work"
+        assert blocks[1]["segments"][0]["duration_time"]["minute"] == 4
+        assert blocks[1]["segments"][1]["intensity_class"] == "rest"
+        assert blocks[1]["segments"][1]["duration_time"]["minute"] == 3
+
+        # Work intensity: 265/248 ≈ 107%, 280/248 ≈ 113%
+        work_pct = blocks[1]["segments"][0]["intensity_percent"]
+        assert work_pct["min"] == 107
+        assert work_pct["max"] == 113
+
+        # Cooldown
+        assert blocks[2]["segments"][0]["intensity_class"] == "cooldown"
+        assert blocks[2]["segments"][0]["duration_time"]["minute"] == 10
+
+    def test_threshold_description(self):
+        """Threshold workout with 2x20min reps."""
+        workout = {
+            "workout_type": "threshold",
+            "planned_duration_min": "65",
+            "target_power_min": "235",
+            "target_power_max": "255",
+            "workout_description": "WU 10min, 2x20min @235-255W w/ 5min easy, CD 10min.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        assert len(blocks) == 3
+        assert blocks[1]["repeat"] == 2
+        assert blocks[1]["segments"][0]["duration_time"]["minute"] == 20
+
+    def test_rest_day_fallback(self):
+        """Rest day still produces blocks (caller should filter)."""
+        workout = {
+            "workout_type": "rest",
+            "planned_duration_min": "",
+            "target_power_min": "",
+            "target_power_max": "",
+            "workout_description": "Rest day.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        # Falls back to default single block
+        assert len(blocks) == 1
+
+    def test_no_power_targets_uses_defaults(self):
+        """When power targets are missing, uses type-based defaults."""
+        workout = {
+            "workout_type": "long_run",
+            "planned_duration_min": "140",
+            "target_power_min": "",
+            "target_power_max": "",
+            "workout_description": "Long trail run.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        seg = blocks[0]["segments"][0]
+        assert seg["intensity_percent"]["min"] == 68
+        assert seg["intensity_percent"]["max"] == 78
+
+    def test_blocks_have_uuids(self):
+        """All blocks and segments have unique UUIDs."""
+        workout = {
+            "workout_type": "interval",
+            "planned_duration_min": "65",
+            "target_power_min": "265",
+            "target_power_max": "280",
+            "workout_description": "WU 15min, 4x4min @265-280W w/ 3min jog recovery, CD 10min.",
+        }
+        blocks = build_workout_blocks(workout, cp_watts=248.0)
+        uuids = set()
+        for b in blocks:
+            uuids.add(b["uuid"])
+            for seg in b["segments"]:
+                uuids.add(seg["uuid"])
+        # All unique
+        total = sum(1 + len(b["segments"]) for b in blocks)
+        assert len(uuids) == total
+
+
+# --- _parse_structured_description ---
+
+
+class TestParseStructuredDescription:
+    """Tests for description string parsing."""
+
+    def test_full_interval_description(self):
+        blocks = _parse_structured_description(
+            "WU 15min, 3x3min @275-290W w/ 3min jog recovery, CD 10min",
+            cp_watts=248.0,
+        )
+        assert blocks is not None
+        assert len(blocks) == 3
+
+    def test_unstructured_returns_none(self):
+        result = _parse_structured_description("Easy aerobic run.", cp_watts=248.0)
+        assert result is None
+
+    def test_done_marker_stripped(self):
+        blocks = _parse_structured_description(
+            "WU 10min, 2x20min @235-255W w/ 5min easy, CD 10min. [DONE]",
+            cp_watts=248.0,
+        )
+        assert blocks is not None
+        assert len(blocks) == 3
+
+    def test_empty_description(self):
+        assert _parse_structured_description("", cp_watts=248.0) is None
+        assert _parse_structured_description(None, cp_watts=248.0) is None
+
+
+# --- _make_segment ---
+
+
+class TestMakeSegment:
+    def test_segment_structure(self):
+        seg = _make_segment("work", 5, 90, 100)
+        assert seg["intensity_class"] == "work"
+        assert seg["duration_type"] == "time"
+        assert seg["duration_time"] == {"hour": 0, "minute": 5, "second": 0}
+        assert seg["intensity_type"] == "percentage"
+        assert seg["intensity_percent"] == {"min": 90, "max": 100, "value": 95}
+        assert "uuid" in seg
+
+    def test_long_duration(self):
+        seg = _make_segment("warmup", 90, 65, 75)
+        assert seg["duration_time"] == {"hour": 1, "minute": 30, "second": 0}
+
+
+# --- create_workout_api ---
+
+
+class TestCreateWorkoutApi:
+    @patch("sync.stryd_sync.requests.post")
+    def test_payload_shape(self, mock_post: MagicMock):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"id": 12345, "stress": 13.0}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+
+        blocks = [{"uuid": "test", "repeat": 1, "segments": []}]
+        create_workout_api(
+            user_id="abc-123",
+            token="tok",
+            workout_date="2026-04-10",
+            title="Test Workout",
+            blocks=blocks,
+            workout_type="easy run",
+            description="A test",
+            surface="road",
+        )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["title"] == "Test Workout"
+        assert payload["id"] == -1
+        assert payload["source"] == "USER"
+        assert payload["blocks"] == blocks
+
+    @patch("sync.stryd_sync.requests.post")
+    def test_timestamp_calculation(self, mock_post: MagicMock):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"id": 1}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+
+        create_workout_api("uid", "tok", "2026-04-10", "Test", [])
+
+        call_kwargs = mock_post.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        # 2026-04-10 00:00:00 UTC
+        expected_ts = int(datetime(2026, 4, 10, tzinfo=timezone.utc).timestamp())
+        assert params["timestamp"] == expected_ts
+
+
+# --- delete_workout_api ---
+
+
+class TestDeleteWorkoutApi:
+    @patch("sync.stryd_sync.requests.delete")
+    def test_delete_url(self, mock_delete: MagicMock):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_delete.return_value = mock_resp
+
+        result = delete_workout_api("abc-123", "tok", "5401718379937792")
+        assert result is True
+
+        url = mock_delete.call_args[0][0]
+        assert "abc-123" in url
+        assert "5401718379937792" in url

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -99,12 +99,14 @@ function StrydStatusBadge({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger className="inline-flex">
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={onPush}
-              className="w-6 h-6 flex items-center justify-center shrink-0 text-destructive hover:text-destructive/80 cursor-pointer rounded transition-colors"
+              className="w-6 h-6 shrink-0 text-destructive hover:text-destructive/80"
             >
               <ErrorIcon className="h-3.5 w-3.5" />
-            </button>
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="left">
             <p className="text-xs">{error || 'Push failed'} — click to retry</p>
@@ -136,12 +138,14 @@ function StrydStatusBadge({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger className="inline-flex">
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={onPush}
-            className="w-6 h-6 flex items-center justify-center shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary cursor-pointer rounded transition-colors"
+            className="w-6 h-6 shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary"
           >
             <UploadIcon className="h-3.5 w-3.5" />
-          </button>
+          </Button>
         </TooltipTrigger>
         <TooltipContent side="left">
           <p className="text-xs">Push to Stryd</p>
@@ -255,19 +259,25 @@ export default function UpcomingPlanCard() {
   // Check if Stryd is connected
   useEffect(() => {
     fetch('/api/settings')
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((config) => {
         if (config?.config?.connections?.includes('stryd')) setHasStryd(true);
       })
-      .catch(() => {});
+      .catch((err) => console.error('Failed to load settings:', err));
   }, []);
 
   // Load push status
   useEffect(() => {
     fetch('/api/plan/stryd-status')
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
       .then((status) => setPushStatus(status))
-      .catch(() => {});
+      .catch((err) => console.error('Failed to load Stryd push status:', err));
   }, []);
 
   const getPushState = useCallback(
@@ -289,15 +299,15 @@ export default function UpcomingPlanCard() {
       for (const d of dates) delete newErrors[d];
 
       for (const r of results) {
-        if (r.status === 'success' && r.workout_id) {
+        if (r.status === 'success') {
           newStatus[r.date] = {
             workout_id: r.workout_id,
             pushed_at: new Date().toISOString(),
             status: 'pushed',
           };
           delete newErrors[r.date];
-        } else if (r.status === 'error') {
-          newErrors[r.date] = r.error || 'Unknown error';
+        } else {
+          newErrors[r.date] = r.error;
         }
       }
 

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -1,7 +1,10 @@
+import { useState, useEffect, useCallback } from 'react';
 import { useApi } from '@/hooks/useApi';
-import type { PlanResponse, PlannedWorkout } from '@/types/api';
+import type { PlanResponse, PlannedWorkout, StrydPushStatus, StrydPushResult } from '@/types/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
   easy:       { bg: 'bg-primary/15', text: 'text-primary' },
@@ -17,7 +20,6 @@ const DEFAULT_COLOR = { bg: 'bg-accent-purple/15', text: 'text-accent-purple' };
 
 function getTypeColor(type: string) {
   const key = type.toLowerCase().replace(/\s+/g, ' ');
-  // Check exact match first, then partial
   if (TYPE_COLORS[key]) return TYPE_COLORS[key];
   for (const [k, v] of Object.entries(TYPE_COLORS)) {
     if (key.includes(k)) return v;
@@ -44,9 +46,127 @@ function formatDate(dateStr: string): { day: string; weekday: string; isToday: b
   };
 }
 
-function WorkoutRow({ workout }: { workout: PlannedWorkout }) {
+type PushState = 'none' | 'pushed' | 'pushing' | 'error';
+
+const UploadIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M8 2v8M5 7l3-3 3 3M3 12h10" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const SpinnerIcon = ({ className }: { className?: string }) => (
+  <svg className={`animate-spin ${className}`} viewBox="0 0 24 24" fill="none">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+  </svg>
+);
+
+const CheckIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 8.5l3 3 7-7" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const ErrorIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 16 16" fill="currentColor">
+    <path d="M8 1a7 7 0 100 14A7 7 0 008 1zM7 5h2v4H7V5zm0 5h2v2H7v-2z" />
+  </svg>
+);
+
+function StrydStatusBadge({
+  state,
+  error,
+  onPush,
+  showStryd,
+}: {
+  state: PushState;
+  error?: string;
+  onPush?: () => void;
+  showStryd: boolean;
+}) {
+  if (!showStryd) return null;
+
+  if (state === 'pushing') {
+    return (
+      <div className="w-6 h-6 flex items-center justify-center shrink-0">
+        <SpinnerIcon className="h-3.5 w-3.5 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger className="inline-flex">
+            <button
+              onClick={onPush}
+              className="w-6 h-6 flex items-center justify-center shrink-0 text-destructive hover:text-destructive/80 cursor-pointer rounded transition-colors"
+            >
+              <ErrorIcon className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            <p className="text-xs">{error || 'Push failed'} — click to retry</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  if (state === 'pushed') {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger className="inline-flex">
+            <div className="w-6 h-6 flex items-center justify-center shrink-0 text-primary">
+              <CheckIcon className="h-3.5 w-3.5" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            <p className="text-xs">Synced to Stryd</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  // state === 'none' — show push button on hover
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className="inline-flex">
+          <button
+            onClick={onPush}
+            className="w-6 h-6 flex items-center justify-center shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary cursor-pointer rounded transition-colors"
+          >
+            <UploadIcon className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p className="text-xs">Push to Stryd</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function WorkoutRow({
+  workout,
+  pushState,
+  pushError,
+  showStryd,
+  onPushSingle,
+}: {
+  workout: PlannedWorkout;
+  pushState: PushState;
+  pushError?: string;
+  showStryd: boolean;
+  onPushSingle: (date: string) => void;
+}) {
   const { day, weekday, isToday } = formatDate(workout.date);
   const color = getTypeColor(workout.workout_type);
+  const isRest = workout.workout_type.toLowerCase() === 'rest';
 
   const details: string[] = [];
   if (workout.duration_min != null) details.push(`${Math.round(workout.duration_min)}m`);
@@ -56,7 +176,7 @@ function WorkoutRow({ workout }: { workout: PlannedWorkout }) {
 
   return (
     <div
-      className={`flex items-center gap-3 py-2.5 px-3 rounded-lg transition-colors ${
+      className={`group flex items-center gap-3 py-2.5 px-3 rounded-lg transition-colors ${
         isToday
           ? 'bg-primary/5 ring-1 ring-accent-green/20'
           : 'hover:bg-muted/50'
@@ -95,12 +215,152 @@ function WorkoutRow({ workout }: { workout: PlannedWorkout }) {
           <p className="text-xs text-muted-foreground mt-0.5 truncate">{workout.description}</p>
         )}
       </div>
+
+      {/* Stryd sync status / push button */}
+      {!isRest && (
+        <StrydStatusBadge
+          state={pushState}
+          error={pushError}
+          showStryd={showStryd}
+          onPush={() => onPushSingle(workout.date)}
+        />
+      )}
     </div>
   );
 }
 
+async function pushDatesToStryd(dates: string[]): Promise<{
+  results: StrydPushResult[];
+}> {
+  const resp = await fetch('/api/plan/push-stryd', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ workout_dates: dates }),
+  });
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }));
+    throw new Error(err.detail || `HTTP ${resp.status}`);
+  }
+  return resp.json();
+}
+
 export default function UpcomingPlanCard() {
   const { data, loading, error } = useApi<PlanResponse>('/api/plan');
+  const [pushStatus, setPushStatus] = useState<StrydPushStatus>({});
+  const [pushErrors, setPushErrors] = useState<Record<string, string>>({});
+  const [pushing, setPushing] = useState(false);
+  const [pushingDates, setPushingDates] = useState<Set<string>>(new Set());
+  const [hasStryd, setHasStryd] = useState(false);
+
+  // Check if Stryd is connected
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((config) => {
+        if (config?.config?.connections?.includes('stryd')) setHasStryd(true);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Load push status
+  useEffect(() => {
+    fetch('/api/plan/stryd-status')
+      .then((r) => r.json())
+      .then((status) => setPushStatus(status))
+      .catch(() => {});
+  }, []);
+
+  const getPushState = useCallback(
+    (date: string): PushState => {
+      if (pushingDates.has(date)) return 'pushing';
+      if (pushErrors[date]) return 'error';
+      if (pushStatus[date]) return 'pushed';
+      return 'none';
+    },
+    [pushingDates, pushErrors, pushStatus],
+  );
+
+  const handlePushResults = useCallback(
+    (results: StrydPushResult[], dates: string[]) => {
+      const newStatus = { ...pushStatus };
+      const newErrors = { ...pushErrors };
+
+      // Clear errors for dates we just retried
+      for (const d of dates) delete newErrors[d];
+
+      for (const r of results) {
+        if (r.status === 'success' && r.workout_id) {
+          newStatus[r.date] = {
+            workout_id: r.workout_id,
+            pushed_at: new Date().toISOString(),
+            status: 'pushed',
+          };
+          delete newErrors[r.date];
+        } else if (r.status === 'error') {
+          newErrors[r.date] = r.error || 'Unknown error';
+        }
+      }
+
+      setPushStatus(newStatus);
+      setPushErrors(newErrors);
+    },
+    [pushStatus, pushErrors],
+  );
+
+  // Push a single workout
+  const pushSingle = useCallback(
+    async (date: string) => {
+      if (pushingDates.has(date) || pushStatus[date]) return;
+
+      setPushingDates((prev) => new Set(prev).add(date));
+
+      try {
+        const { results } = await pushDatesToStryd([date]);
+        handlePushResults(results, [date]);
+      } catch (e) {
+        setPushErrors((prev) => ({
+          ...prev,
+          [date]: e instanceof Error ? e.message : 'Push failed',
+        }));
+      } finally {
+        setPushingDates((prev) => {
+          const next = new Set(prev);
+          next.delete(date);
+          return next;
+        });
+      }
+    },
+    [pushingDates, pushStatus, handlePushResults],
+  );
+
+  // Push all unpushed workouts
+  const pushAll = useCallback(async () => {
+    if (!data) return;
+
+    const datesToPush = data.workouts
+      .filter((w) => !pushStatus[w.date] && w.workout_type.toLowerCase() !== 'rest')
+      .map((w) => w.date);
+
+    if (datesToPush.length === 0) return;
+
+    setPushing(true);
+    setPushingDates(new Set(datesToPush));
+    setPushErrors({});
+
+    try {
+      const { results } = await pushDatesToStryd(datesToPush);
+      handlePushResults(results, datesToPush);
+    } catch (e) {
+      const newErrors: Record<string, string> = {};
+      for (const d of datesToPush) {
+        newErrors[d] = e instanceof Error ? e.message : 'Push failed';
+      }
+      setPushErrors(newErrors);
+    } finally {
+      setPushing(false);
+      setPushingDates(new Set());
+    }
+  }, [data, pushStatus, handlePushResults]);
 
   if (loading) {
     return (
@@ -130,20 +390,63 @@ export default function UpcomingPlanCard() {
 
   if (!data || data.workouts.length === 0) return null;
 
+  const unpushedCount = data.workouts.filter(
+    (w) => !pushStatus[w.date] && w.workout_type.toLowerCase() !== 'rest',
+  ).length;
+  const allPushed = unpushedCount === 0;
+
   return (
     <Card>
       <CardHeader className="flex-row items-baseline justify-between space-y-0">
         <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Upcoming Plan
         </CardTitle>
-        <span className="text-xs text-muted-foreground font-data">
-          {data.workouts.length} workouts
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground font-data">
+            {data.workouts.length} workouts
+          </span>
+          {hasStryd && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-[10px] font-semibold uppercase tracking-wider gap-1"
+              disabled={pushing || allPushed}
+              onClick={pushAll}
+            >
+              {pushing ? (
+                <>
+                  <SpinnerIcon className="h-3 w-3" />
+                  Pushing...
+                </>
+              ) : allPushed ? (
+                <>
+                  <CheckIcon className="h-3 w-3" />
+                  Synced
+                </>
+              ) : (
+                <>
+                  <UploadIcon className="h-3 w-3" />
+                  Push All
+                  {unpushedCount > 0 && (
+                    <span className="font-data ml-0.5">({unpushedCount})</span>
+                  )}
+                </>
+              )}
+            </Button>
+          )}
+        </div>
       </CardHeader>
       <CardContent>
         <div className="space-y-0.5">
           {data.workouts.map((w) => (
-            <WorkoutRow key={w.date} workout={w} />
+            <WorkoutRow
+              key={w.date}
+              workout={w}
+              pushState={getPushState(w.date)}
+              pushError={pushErrors[w.date]}
+              showStryd={hasStryd}
+              onPushSingle={pushSingle}
+            />
           ))}
         </div>
       </CardContent>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -121,6 +121,21 @@ export interface PlanResponse {
   cp_current?: number;
 }
 
+export interface StrydPushResult {
+  date: string;
+  status: 'success' | 'error';
+  workout_id?: string;
+  error?: string;
+}
+
+export interface StrydPushStatusEntry {
+  workout_id: string;
+  pushed_at: string;
+  status: 'pushed';
+}
+
+export type StrydPushStatus = Record<string, StrydPushStatusEntry>;
+
 export interface TrainingSignal {
   recommendation: 'follow_plan' | 'easy' | 'modify' | 'reduce_intensity' | 'rest';
   reason: string;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -121,12 +121,9 @@ export interface PlanResponse {
   cp_current?: number;
 }
 
-export interface StrydPushResult {
-  date: string;
-  status: 'success' | 'error';
-  workout_id?: string;
-  error?: string;
-}
+export type StrydPushResult =
+  | { date: string; status: 'success'; workout_id: string }
+  | { date: string; status: 'error'; error: string };
 
 export interface StrydPushStatusEntry {
   workout_id: string;


### PR DESCRIPTION
## Summary
- Discovered Stryd's undocumented workout CRUD API via Chrome DevTools interception and integrated it end-to-end
- AI training plan workouts can now be pushed directly to Stryd's calendar (syncs to watch) via "Push All" or per-workout buttons
- Backend: `build_workout_blocks()` parses structured AI plan descriptions into Stryd block format, new API endpoints for push/status/delete
- Frontend: UpcomingPlanCard shows push button in header + per-row upload icons on hover with sync status indicators

## Test plan
- [x] 16 new unit tests pass (`tests/test_stryd_upload.py`)
- [x] All 113 existing tests pass
- [x] Frontend builds with no TypeScript errors
- [ ] Manual E2E: push a workout, verify it appears on Stryd PowerCenter calendar
- [ ] Manual E2E: verify per-workout push and Push All both work
- [ ] Manual E2E: delete a pushed workout, verify removal from Stryd

🤖 Generated with [Claude Code](https://claude.com/claude-code)