### PR TITLE
Zone-aware training analysis with dynamic zone theories

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -1024,7 +1024,7 @@ def diagnose_training(
                 for i in range(n_zones)
             ]
             result["zone_ranges"] = compute_zones(base, current_cp, bounds, names if zone_names else None)
-            result["theory_name"] = theory_name
+            result["theory_name"] = theory_name or ("Coggan 5-Zone" if len(bounds) == 4 else f"{n_zones}-Zone")
             _add_diagnosis_items(result, current_cp, base)
             return result
 
@@ -1143,7 +1143,7 @@ def diagnose_training(
         ]
 
     result["zone_ranges"] = compute_zones(base, current_cp, bounds, names if zone_names else None)
-    result["theory_name"] = theory_name
+    result["theory_name"] = theory_name or ("Coggan 5-Zone" if len(bounds) == 4 else f"{n_zones}-Zone")
 
     _add_diagnosis_items(result, current_cp, base)
     return result

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from analysis.config import TrainingBase
     from analysis.providers.models import ThresholdEstimate
 
+from analysis.zones import compute_zones, _DEFAULT_NAMES as _ZONE_DEFAULT_NAMES
+from analysis.config import DEFAULT_ZONES
+
 # Distance configs: km, sustainable power fraction of CP, display label.
 # Power fractions for 5K–marathon from Stryd Race Power Calculator
 # (https://help.stryd.com/en/articles/6879547-race-power-calculator).
@@ -893,6 +896,10 @@ def diagnose_training(
     current_date: date | None = None,
     base: TrainingBase = "power",
     threshold_value: float | None = None,
+    zone_boundaries: list[float] | None = None,
+    zone_names: list[str] | None = None,
+    target_distribution: list[float] | None = None,
+    theory_name: str | None = None,
 ) -> dict:
     """Analyze recent training and diagnose issues holding back threshold progression.
 
@@ -906,6 +913,10 @@ def diagnose_training(
         current_date: override for testing (defaults to today)
         base: training base ("power", "hr", or "pace")
         threshold_value: threshold for the active base (CP watts, LTHR bpm, or threshold pace sec/km)
+        zone_boundaries: zone boundary fractions (N boundaries -> N+1 zones); defaults to Coggan 5-zone
+        zone_names: names for each zone (must be len(boundaries)+1); defaults per base
+        target_distribution: target fraction for each zone (must sum to ~1.0); optional
+        theory_name: name of the zone theory (e.g. "Seiler Polarized 3-Zone"); optional
     """
     today = current_date or date.today()
     cutoff = today - timedelta(weeks=lookback_weeks)
@@ -1004,8 +1015,17 @@ def diagnose_training(
         else:
             result["diagnosis"].append({"type": "warning", "message": "No split data available — interval analysis skipped."})
             result["interval_power"] = {"max": None, "avg_work": None, "supra_cp_sessions": 0, "total_quality_sessions": 0}
-            result["distribution"] = {"supra_cp": 0, "threshold": 0, "tempo": 0, "easy": 100}
-            _add_diagnosis_items(result, current_cp)
+            bounds = zone_boundaries or DEFAULT_ZONES.get(base, DEFAULT_ZONES["power"])
+            n_zones = len(bounds) + 1
+            names = zone_names if (zone_names and len(zone_names) == n_zones) else _ZONE_DEFAULT_NAMES.get(base, [f"Zone {i+1}" for i in range(n_zones)])
+            targets = [round(t * 100) for t in target_distribution] if target_distribution and len(target_distribution) == n_zones else [None] * n_zones
+            result["distribution"] = [
+                {"name": names[i], "actual_pct": 100 if i == 0 else 0, "target_pct": targets[i]}
+                for i in range(n_zones)
+            ]
+            result["zone_ranges"] = compute_zones(base, current_cp, bounds, names if zone_names else None)
+            result["theory_name"] = theory_name
+            _add_diagnosis_items(result, current_cp, base)
             return result
 
     # Join splits with activity dates
@@ -1070,7 +1090,12 @@ def diagnose_training(
         "total_quality_sessions": total_quality_sessions,
     }
 
-    # --- Training distribution ---
+    # --- Training distribution (dynamic zones) ---
+    bounds = zone_boundaries or DEFAULT_ZONES.get(base, DEFAULT_ZONES["power"])
+    n_zones = len(bounds) + 1
+    names = zone_names if (zone_names and len(zone_names) == n_zones) else _ZONE_DEFAULT_NAMES.get(base, [f"Zone {i+1}" for i in range(n_zones)])
+    targets = [round(t * 100) for t in target_distribution] if target_distribution and len(target_distribution) == n_zones else [None] * n_zones
+
     if "activity_id" in recent_splits.columns:
         if base == "pace":
             activity_best = recent_splits.groupby(recent_splits["activity_id"].astype(str))[metric_col].min()
@@ -1081,24 +1106,44 @@ def diagnose_training(
 
     total_activities = len(recent)
     if total_activities > 0 and not activity_best.empty and current_cp > 0:
-        if base == "pace":
-            # For pace: faster (lower) = harder intensity
-            supra = int((activity_best <= current_cp * 1.00).sum())
-            threshold_count = int(((activity_best > current_cp * 1.00) & (activity_best <= current_cp * 1.06)).sum())
-            tempo = int(((activity_best > current_cp * 1.06) & (activity_best <= current_cp * 1.14)).sum())
-        else:
-            supra = int((activity_best >= current_cp * 0.98).sum())
-            threshold_count = int(((activity_best >= current_cp * 0.92) & (activity_best < current_cp * 0.98)).sum())
-            tempo = int(((activity_best >= current_cp * 0.85) & (activity_best < current_cp * 0.92)).sum())
-        easy = total_activities - supra - threshold_count - tempo
-        result["distribution"] = {
-            "supra_cp": round(supra / total_activities * 100),
-            "threshold": round(threshold_count / total_activities * 100),
-            "tempo": round(tempo / total_activities * 100),
-            "easy": round(easy / total_activities * 100),
-        }
+        # Classify each activity into a zone based on its best split value
+        zone_counts = [0] * n_zones
+        for val in activity_best:
+            if base == "pace":
+                # For pace: lower value = faster = harder. Compute ratio as threshold/value.
+                ratio = current_cp / val if val > 0 else 0
+                inv_bounds = [1.0 / b if b > 0 else 0 for b in bounds]
+                assigned = 0
+                for i in range(len(inv_bounds) - 1, -1, -1):
+                    if ratio >= inv_bounds[i]:
+                        assigned = i + 1
+                        break
+            else:
+                # For power/HR: higher = harder
+                ratio = val / current_cp if current_cp > 0 else 0
+                assigned = 0
+                for i in range(len(bounds) - 1, -1, -1):
+                    if ratio >= bounds[i]:
+                        assigned = i + 1
+                        break
+            zone_counts[assigned] += 1
+
+        result["distribution"] = [
+            {
+                "name": names[i],
+                "actual_pct": round(zone_counts[i] / total_activities * 100),
+                "target_pct": targets[i],
+            }
+            for i in range(n_zones)
+        ]
     else:
-        result["distribution"] = {"supra_cp": 0, "threshold": 0, "tempo": 0, "easy": 100}
+        result["distribution"] = [
+            {"name": names[i], "actual_pct": 100 if i == 0 else 0, "target_pct": targets[i]}
+            for i in range(n_zones)
+        ]
+
+    result["zone_ranges"] = compute_zones(base, current_cp, bounds, names if zone_names else None)
+    result["theory_name"] = theory_name
 
     _add_diagnosis_items(result, current_cp, base)
     return result
@@ -1188,16 +1233,32 @@ def _add_diagnosis_items(result: dict, current_threshold: float, base: TrainingB
             "message": f"Peak interval {labels['metric']}: {max_val:.0f}{t_unit} ({pct:.0f}% of {t_name}) across {quality} quality sessions.",
         })
 
-    # Distribution check
-    easy_pct = dist.get("easy", 0)
-    hard_pct = dist.get("supra_cp", 0) + dist.get("threshold", 0)
-    if easy_pct > 85 and hard_pct < 10:
-        diag.append({
-            "type": "warning",
-            "message": f"Training is {easy_pct}% easy — insufficient hard sessions for {t_name} adaptation.",
-        })
-    elif 70 <= easy_pct <= 85:
-        diag.append({
-            "type": "positive",
-            "message": f"Good polarization: {easy_pct}% easy, {hard_pct}% hard.",
-        })
+    # Distribution check (dist is a list of zone dicts)
+    if isinstance(dist, list) and len(dist) > 0:
+        easy_pct = dist[0].get("actual_pct", 0)
+        hard_pct = sum(d.get("actual_pct", 0) for d in dist[2:])  # zones above the 2nd
+        has_targets = any(d.get("target_pct") is not None for d in dist)
+
+        if has_targets:
+            # Compare actual vs target, flag deviations > 5 percentage points
+            for d in dist:
+                target = d.get("target_pct")
+                actual = d.get("actual_pct", 0)
+                if target is not None and abs(actual - target) > 5:
+                    direction = "over" if actual > target else "under"
+                    diag.append({
+                        "type": "warning",
+                        "message": f"{d['name']} zone is {direction}-represented: {actual}% actual vs {target}% target.",
+                    })
+        else:
+            # Generic polarization check (no targets available)
+            if easy_pct > 85 and hard_pct < 10:
+                diag.append({
+                    "type": "warning",
+                    "message": f"Training is {easy_pct}% easy — insufficient hard sessions for {t_name} adaptation.",
+                })
+            elif 70 <= easy_pct <= 85:
+                diag.append({
+                    "type": "positive",
+                    "message": f"Good polarization: {easy_pct}% easy, {hard_pct}% hard.",
+                })

--- a/analysis/zones.py
+++ b/analysis/zones.py
@@ -1,62 +1,63 @@
 """Zone calculation for all training bases."""
 from analysis.config import TrainingBase, DEFAULT_ZONES
 
+# Default zone names per base for Coggan 5-zone (used when no names provided)
+_DEFAULT_NAMES: dict[str, list[str]] = {
+    "power": ["Easy", "Tempo", "Threshold", "Supra-CP", "VO2max"],
+    "hr": ["Recovery", "Aerobic", "Tempo", "Threshold", "VO2max"],
+    "pace": ["Recovery", "Easy", "Tempo", "Threshold", "Interval"],
+}
+
+_UNITS: dict[str, str] = {"power": "W", "hr": "bpm", "pace": "sec/km"}
+
 
 def compute_zones(
     base: TrainingBase,
     threshold_value: float,
     custom_boundaries: list[float] | None = None,
+    zone_names: list[str] | None = None,
 ) -> list[dict]:
-    """Compute 5 training zones based on training base and threshold.
+    """Compute training zones based on training base and threshold.
+
+    Supports variable zone counts: N boundaries produce N+1 zones.
 
     Args:
         base: "power", "hr", or "pace"
         threshold_value: CP (W), LTHR (bpm), or threshold pace (sec/km)
-        custom_boundaries: 4 fractions defining zone boundaries; defaults used if None
+        custom_boundaries: fractions defining zone boundaries; defaults used if None
+        zone_names: optional names for each zone; generic "Zone N" used if None
 
     Returns:
-        List of 5 zone dicts with: name, lower, upper, unit
+        List of zone dicts with: name, lower, upper, unit
     """
     boundaries = custom_boundaries or DEFAULT_ZONES[base]
-    if len(boundaries) != 4:
-        boundaries = DEFAULT_ZONES[base]
+    n_zones = len(boundaries) + 1
+    unit = _UNITS.get(base, "")
 
-    if base == "power":
-        unit = "W"
-        names = ["Easy", "Tempo", "Threshold", "Supra-CP", "VO2max"]
-        # Boundaries are fractions of CP; zones go low → high
-        vals = [round(b * threshold_value) for b in boundaries]
-        return [
-            {"name": names[0], "lower": 0, "upper": vals[0], "unit": unit},
-            {"name": names[1], "lower": vals[0], "upper": vals[1], "unit": unit},
-            {"name": names[2], "lower": vals[1], "upper": vals[2], "unit": unit},
-            {"name": names[3], "lower": vals[2], "upper": vals[3], "unit": unit},
-            {"name": names[4], "lower": vals[3], "upper": None, "unit": unit},
-        ]
-    elif base == "hr":
-        unit = "bpm"
-        names = ["Recovery", "Aerobic", "Tempo", "Threshold", "VO2max"]
-        vals = [round(b * threshold_value) for b in boundaries]
-        return [
-            {"name": names[0], "lower": 0, "upper": vals[0], "unit": unit},
-            {"name": names[1], "lower": vals[0], "upper": vals[1], "unit": unit},
-            {"name": names[2], "lower": vals[1], "upper": vals[2], "unit": unit},
-            {"name": names[3], "lower": vals[2], "upper": vals[3], "unit": unit},
-            {"name": names[4], "lower": vals[3], "upper": None, "unit": unit},
-        ]
-    else:  # pace
-        unit = "sec/km"
-        names = ["Recovery", "Easy", "Tempo", "Threshold", "Interval"]
-        # Pace boundaries are inverted: higher fraction = slower pace
-        vals = [round(b * threshold_value) for b in boundaries]
-        # Zone 1 is slowest (highest sec/km), Zone 5 is fastest (lowest)
-        return [
-            {"name": names[0], "lower": vals[0], "upper": None, "unit": unit},
-            {"name": names[1], "lower": vals[1], "upper": vals[0], "unit": unit},
-            {"name": names[2], "lower": vals[2], "upper": vals[1], "unit": unit},
-            {"name": names[3], "lower": vals[3], "upper": vals[2], "unit": unit},
-            {"name": names[4], "lower": 0, "upper": vals[3], "unit": unit},
-        ]
+    # Resolve zone names
+    if zone_names and len(zone_names) == n_zones:
+        names = zone_names
+    elif not custom_boundaries and base in _DEFAULT_NAMES:
+        names = _DEFAULT_NAMES[base]
+    else:
+        names = [f"Zone {i + 1}" for i in range(n_zones)]
+
+    vals = [round(b * threshold_value) for b in boundaries]
+
+    if base in ("power", "hr"):
+        # Zones go low → high
+        zones = [{"name": names[0], "lower": 0, "upper": vals[0], "unit": unit}]
+        for i in range(1, len(vals)):
+            zones.append({"name": names[i], "lower": vals[i - 1], "upper": vals[i], "unit": unit})
+        zones.append({"name": names[-1], "lower": vals[-1], "upper": None, "unit": unit})
+        return zones
+    else:  # pace — higher value = slower
+        # Zone 1 is slowest (highest sec/km), last zone is fastest (lowest)
+        zones = [{"name": names[0], "lower": vals[0], "upper": None, "unit": unit}]
+        for i in range(1, len(vals)):
+            zones.append({"name": names[i], "lower": vals[i], "upper": vals[i - 1], "unit": unit})
+        zones.append({"name": names[-1], "lower": 0, "upper": vals[-1], "unit": unit})
+        return zones
 
 
 def classify_intensity(
@@ -67,34 +68,41 @@ def classify_intensity(
 ) -> str:
     """Classify a value into an intensity zone name.
 
+    Supports variable boundary counts. Returns "zone_N" for the matched zone
+    (0-indexed), or legacy names for 4-boundary (5-zone) configs.
+
     Args:
         base: "power", "hr", or "pace"
         value: power (W), HR (bpm), or pace (sec/km)
         threshold: CP, LTHR, or threshold pace
-        boundaries: custom zone boundaries (4 fractions); defaults used if None
+        boundaries: custom zone boundaries (fractions); defaults used if None
 
     Returns:
-        Zone key: "easy", "tempo", "threshold", "supra_threshold"
+        Zone key: e.g. "easy", "tempo", "threshold", "supra_threshold" for 5-zone,
+        or "zone_0", "zone_1", etc. for other configs
     """
     bounds = boundaries or DEFAULT_ZONES[base]
 
+    # Legacy 4-boundary (5-zone) names for backward compatibility
+    _LEGACY_KEYS = ["easy", "tempo", "threshold", "supra_threshold"]
+
     if base in ("power", "hr"):
         ratio = value / threshold if threshold > 0 else 0
-        if ratio >= bounds[3]:
-            return "supra_threshold"
-        if ratio >= bounds[2]:
-            return "threshold"
-        if ratio >= bounds[1]:
-            return "tempo"
-        return "easy"
+        # Walk boundaries top-down
+        for i in range(len(bounds) - 1, -1, -1):
+            if ratio >= bounds[i]:
+                zone_idx = i + 1  # zone above this boundary
+                if len(bounds) == 4 and zone_idx <= len(_LEGACY_KEYS):
+                    return _LEGACY_KEYS[min(zone_idx, len(_LEGACY_KEYS) - 1)]
+                return f"zone_{zone_idx}"
+        return _LEGACY_KEYS[0] if len(bounds) == 4 else "zone_0"
     else:  # pace — lower value = faster
         ratio = threshold / value if value > 0 else 0
-        # bounds for pace are inverted: [1.29, 1.14, 1.06, 1.00]
-        # ratio > 1.0 means running faster than threshold
-        if ratio >= 1.0 / bounds[3]:  # faster than threshold boundary
-            return "supra_threshold"
-        if ratio >= 1.0 / bounds[2]:
-            return "threshold"
-        if ratio >= 1.0 / bounds[1]:
-            return "tempo"
-        return "easy"
+        inv_bounds = [1.0 / b if b > 0 else 0 for b in bounds]
+        for i in range(len(inv_bounds) - 1, -1, -1):
+            if ratio >= inv_bounds[i]:
+                zone_idx = i + 1
+                if len(bounds) == 4 and zone_idx <= len(_LEGACY_KEYS):
+                    return _LEGACY_KEYS[min(zone_idx, len(_LEGACY_KEYS) - 1)]
+                return f"zone_{zone_idx}"
+        return _LEGACY_KEYS[0] if len(bounds) == 4 else "zone_0"

--- a/api/deps.py
+++ b/api/deps.py
@@ -1013,10 +1013,29 @@ def get_dashboard_data() -> dict:
     else:
         active_threshold = thresholds.threshold_pace_sec_km
 
+    # Get zone theory data for diagnosis
+    zones_theory = science.get("zones")
+    zone_boundaries = config.zones.get(config.training_base)
+    zone_names_list: list[str] | None = None
+    target_dist: list[float] | None = None
+    zone_theory_name: str | None = None
+    if zones_theory:
+        zone_theory_name = zones_theory.name
+        zn = zones_theory.zone_names
+        if isinstance(zn, dict):
+            zone_names_list = zn.get(config.training_base)
+        elif isinstance(zn, list):
+            zone_names_list = zn
+        target_dist = zones_theory.target_distribution or None
+
     diagnosis = diagnose_training(
         merged, splits, cp_trend_data,
         base=config.training_base,
         threshold_value=active_threshold,
+        zone_boundaries=zone_boundaries,
+        zone_names=zone_names_list,
+        target_distribution=target_dist,
+        theory_name=zone_theory_name,
     )
 
     # Activities for history

--- a/api/routes/science.py
+++ b/api/routes/science.py
@@ -8,6 +8,7 @@ from analysis.science import (
     list_theories,
     list_label_sets,
     load_active_science,
+    load_theory,
     recommend_science,
 )
 
@@ -103,6 +104,15 @@ def update_science(body: dict) -> dict:
         for pillar, theory_id in body["science"].items():
             if pillar in PILLARS and isinstance(theory_id, str):
                 config.science[pillar] = theory_id
+
+                # When changing zone theory, apply its boundaries to config.zones
+                if pillar == "zones":
+                    try:
+                        theory = load_theory("zones", theory_id)
+                        if theory.zone_boundaries:
+                            config.zones = theory.zone_boundaries
+                    except FileNotFoundError:
+                        pass  # Keep existing zones if theory file missing
 
     if "zone_labels" in body:
         config.zone_labels = str(body["zone_labels"])

--- a/api/routes/science.py
+++ b/api/routes/science.py
@@ -103,16 +103,18 @@ def update_science(body: dict) -> dict:
     if "science" in body:
         for pillar, theory_id in body["science"].items():
             if pillar in PILLARS and isinstance(theory_id, str):
-                config.science[pillar] = theory_id
-
-                # When changing zone theory, apply its boundaries to config.zones
+                # When changing zone theory, validate first and apply boundaries
                 if pillar == "zones":
                     try:
                         theory = load_theory("zones", theory_id)
+                        config.science[pillar] = theory_id
                         if theory.zone_boundaries:
-                            config.zones = theory.zone_boundaries
+                            for base_key, bounds in theory.zone_boundaries.items():
+                                config.zones[base_key] = bounds
                     except FileNotFoundError:
-                        pass  # Keep existing zones if theory file missing
+                        continue  # Don't save invalid theory_id
+                else:
+                    config.science[pillar] = theory_id
 
     if "zone_labels" in body:
         config.zone_labels = str(body["zone_labels"])

--- a/data/config.json
+++ b/data/config.json
@@ -45,6 +45,13 @@
     "distance": "marathon",
     "target_time_sec": 10800
   },
+  "science": {
+    "load": "banister_pmc",
+    "recovery": "hrv_weighted",
+    "prediction": "critical_power",
+    "zones": "coggan_5zone"
+  },
+  "zone_labels": "standard",
   "source_options": {
     "garmin_region": "international"
   }

--- a/docs/superpowers/specs/2026-04-09-zone-aware-training-analysis-design.md
+++ b/docs/superpowers/specs/2026-04-09-zone-aware-training-analysis-design.md
@@ -1,0 +1,140 @@
+# Zone-Aware Training Analysis
+
+## Problem
+
+When a user selects a different zone theory on the Science page (e.g., Coggan 5-Zone → Polarized 3-Zone), nothing meaningful changes in the app:
+
+1. **`config.zones` now updates correctly** (fixed in prior commit), but no analysis code reads it
+2. **`diagnose_training()` hardcodes intensity boundaries** — lines 1084-1092 of `analysis/metrics.py` use fixed percentages (98%, 92%, 85%) regardless of the selected theory
+3. **`DistributionBar` hardcodes 4 zones** — `supra_cp`, `threshold`, `tempo`, `easy` are baked into the component
+4. **No zone ranges are shown anywhere** — the user can't see what power/HR/pace ranges correspond to each zone
+5. **No target comparison** — theories define target distributions (e.g., Polarized 80/5/15) but these are never shown
+
+## Design
+
+### Backend Changes
+
+#### 1. `diagnose_training()` accepts zone boundaries (`analysis/metrics.py`)
+
+Add parameters:
+- `zone_boundaries: list[float] | None` — boundary fractions from `config.zones[base]`
+- `zone_names: list[str] | None` — names from the active zone theory
+- `target_distribution: list[float] | None` — from the zone theory YAML
+
+**Distribution classification (lines 1073-1101):** Replace the hardcoded 4-bucket classification with a dynamic loop. For N boundaries, produce N+1 buckets. Each activity's best split metric is compared against `threshold * boundary[i]` to assign it to a zone.
+
+The distribution dict keys change from `{"supra_cp": 8, "threshold": 15, ...}` to a list format:
+```python
+"distribution": [
+    {"name": "VO2max", "actual_pct": 8, "target_pct": 5},
+    {"name": "Supra-CP", "actual_pct": 18, "target_pct": 10},
+    ...
+]
+```
+
+**Zone ranges:** Add a `zone_ranges` list to the result:
+```python
+"zone_ranges": [
+    {"name": "VO2max", "lower": 263, "upper": None, "unit": "W"},
+    {"name": "Supra-CP", "lower": 225, "upper": 263, "unit": "W"},
+    ...
+]
+```
+
+Reuse `compute_zones()` from `analysis/zones.py` to generate `zone_ranges`.
+
+**Diagnostic text (`_add_diagnosis_items`):** The distribution-check section (lines 1191-1202) adapts to use the theory's target distribution for comparison rather than hardcoded 70-85% easy thresholds.
+
+#### 2. `api/deps.py` passes zone config to `diagnose_training()`
+
+Currently calls `diagnose_training(merged, splits, cp_trend_data, base=config.training_base, threshold_value=active_threshold)`.
+
+Add: `zone_boundaries=config.zones.get(config.training_base)`, `zone_names` and `target_distribution` from the active science zones theory (already loaded as `science["zones"]` in deps.py).
+
+#### 3. API response includes zone metadata
+
+The training route already returns `diagnosis` dict. The new `distribution` (list format) and `zone_ranges` fields are included automatically. Also add `theory_name` (e.g., "Coggan 5-Zone") to the response.
+
+### Frontend Changes
+
+#### 4. New `ZoneAnalysisCard` component
+
+Location: `web/src/components/ZoneAnalysisCard.tsx`
+
+A shadcn `Card` with:
+- **Header:** "Zone Analysis · {theory_name}" on the left, "{threshold_abbrev}: {value}{unit}" on the right
+- **Table body:** One row per zone (top = highest intensity, bottom = lowest). Columns:
+  - Zone name (colored with zone accent color)
+  - Power/HR/pace range (muted text)
+  - Actual % (bold white)
+  - Target % (muted)
+- **Footer alerts:** When actual diverges from target by >5pp for any zone, show an `Alert` with amber styling explaining the gap
+
+Adapts to 3 or 5 zones — just renders N rows.
+
+#### 5. Update `DistributionBar` to be dynamic
+
+Change from hardcoded 4 `DIST_KEYS` to accepting a dynamic list from the API. The stacked bar renders N segments with N colors. Colors assigned from a palette array indexed by zone position.
+
+#### 6. Update TypeScript types (`web/src/types/api.ts`)
+
+Add to the diagnosis response type:
+```typescript
+interface ZoneDistribution {
+  name: string;
+  actual_pct: number;
+  target_pct: number | null;
+}
+
+interface ZoneRange {
+  name: string;
+  lower: number;
+  upper: number | null;
+  unit: string;
+}
+
+// In DiagnosisResponse:
+distribution: ZoneDistribution[];  // replaces old Record<string, number>
+zone_ranges: ZoneRange[];
+theory_name: string;
+```
+
+#### 7. Training page layout
+
+Add `<ZoneAnalysisCard>` below the existing `<DiagnosisCard>` on the Training page. Both cards are in the same grid column.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `analysis/metrics.py` | `diagnose_training()` + `_add_diagnosis_items()` — dynamic zone classification |
+| `analysis/zones.py` | Already updated — `compute_zones()` handles variable counts |
+| `api/deps.py` | Pass zone config + theory data to `diagnose_training()` |
+| `api/routes/training.py` | Include `theory_name` in response (if not already in diagnosis dict) |
+| `web/src/types/api.ts` | New `ZoneDistribution`, `ZoneRange` interfaces; update diagnosis type |
+| `web/src/components/ZoneAnalysisCard.tsx` | **New file** — zone table + target comparison + alerts |
+| `web/src/components/DistributionBar.tsx` | Make dynamic (N zones, N colors) |
+| `web/src/pages/Training.tsx` | Add `<ZoneAnalysisCard>` |
+
+### Backward Compatibility
+
+The `distribution` field changes from `{supra_cp: N, ...}` (dict with fixed keys) to a list of objects. The `DistributionBar` component must be updated in the same change. No other consumers of the old format exist (checked: only `DistributionBar` reads it).
+
+### Zone Colors
+
+Zone colors are assigned by position (highest intensity → lowest):
+- For 5-zone: `destructive`, `accent-amber`, `accent-blue`, `accent-blue/50`, `muted-foreground`
+- For 3-zone: `destructive`, `accent-amber`, `muted-foreground`
+
+These come from the existing `ZONE_COLORS` array in `DistributionBar.tsx`, extended to handle variable counts.
+
+## Verification
+
+1. `python -m pytest tests/ -v` — existing tests pass
+2. Start API + frontend: `python -m uvicorn api.main:app --reload` and `cd web && npm run dev`
+3. On Training page: verify the existing DiagnosisCard distribution bar shows dynamic zones
+4. Verify new ZoneAnalysisCard shows zone names, ranges, actual vs target
+5. Switch zone theory on Science page (Coggan → Polarized)
+6. Return to Training page — verify card now shows 3 zones with 80/5/15 targets
+7. Verify diagnostic alerts fire when actual diverges from target
+8. Test with different training bases (power, HR, pace) — zone ranges should use correct units

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -342,3 +342,78 @@ def test_diagnose_empty_splits():
     # Should handle gracefully
     assert "interval_power" in result
     assert any("split" in d["message"].lower() or "interval" in d["message"].lower() for d in result["diagnosis"])
+
+
+def test_diagnose_distribution_uses_zone_boundaries():
+    """Distribution should use provided zone boundaries, not hardcoded values."""
+    today = date(2026, 3, 23)
+    dates = [date(2026, 3, d) for d in [2, 4, 7, 9, 11, 14, 16, 18, 20, 21]]
+    activities = _make_activities(dates, [8, 10, 25, 8, 10, 8, 10, 25, 8, 10])
+    splits = _make_splits(
+        ["2", "2", "7", "7"],
+        [260, 220, 255, 210],
+        [600, 600, 600, 600],
+    )
+    trend = {"current": 250.0, "direction": "flat", "slope_per_month": 0.5}
+
+    result = diagnose_training(
+        activities, splits, trend,
+        lookback_weeks=4, current_date=today,
+        zone_boundaries=[0.82, 1.00],
+        zone_names=["Easy", "Moderate", "Hard"],
+        target_distribution=[0.80, 0.05, 0.15],
+    )
+
+    dist = result["distribution"]
+    assert isinstance(dist, list)
+    assert len(dist) == 3
+    assert dist[0]["name"] == "Easy"
+    assert dist[1]["name"] == "Moderate"
+    assert dist[2]["name"] == "Hard"
+    assert all("actual_pct" in d and "target_pct" in d for d in dist)
+    assert dist[0]["target_pct"] == 80
+    assert dist[1]["target_pct"] == 5
+    assert dist[2]["target_pct"] == 15
+
+
+def test_diagnose_distribution_default_5zone():
+    """Without zone_boundaries, should still produce 5-zone distribution as list."""
+    today = date(2026, 3, 23)
+    dates = [date(2026, 3, d) for d in [2, 4, 7, 9, 11]]
+    activities = _make_activities(dates, [8, 10, 15, 8, 10])
+    splits = _make_splits(["2"], [260], [600])
+    trend = {"current": 250.0, "direction": "flat", "slope_per_month": 0.5}
+
+    result = diagnose_training(
+        activities, splits, trend,
+        lookback_weeks=4, current_date=today,
+    )
+
+    dist = result["distribution"]
+    assert isinstance(dist, list)
+    assert len(dist) == 5
+    names = [d["name"] for d in dist]
+    assert names == ["Easy", "Tempo", "Threshold", "Supra-CP", "VO2max"]
+
+
+def test_diagnose_zone_ranges_included():
+    """Result should include zone_ranges and theory_name."""
+    today = date(2026, 3, 23)
+    dates = [date(2026, 3, d) for d in [2, 4, 7]]
+    activities = _make_activities(dates, [8, 10, 15])
+    splits = _make_splits(["0"], [200], [600])
+    trend = {"current": 250.0, "direction": "flat", "slope_per_month": 0.5}
+
+    result = diagnose_training(
+        activities, splits, trend,
+        lookback_weeks=4, current_date=today,
+        zone_boundaries=[0.82, 1.00],
+        zone_names=["Easy", "Moderate", "Hard"],
+        theory_name="Seiler Polarized 3-Zone",
+    )
+
+    assert "zone_ranges" in result
+    assert len(result["zone_ranges"]) == 3
+    assert result["zone_ranges"][0]["name"] == "Easy"
+    assert result["zone_ranges"][0]["unit"] == "W"
+    assert result["theory_name"] == "Seiler Polarized 3-Zone"

--- a/web/src/components/DiagnosisCard.tsx
+++ b/web/src/components/DiagnosisCard.tsx
@@ -22,7 +22,7 @@ export default function DiagnosisCard({ diagnosis, display }: Props) {
 
   const intensityLabel = display?.intensity_metric ?? 'Power';
   const unit = display?.threshold_unit ?? 'W';
-  const topZoneName = display?.zone_names?.[3] ?? 'Supra-CP';
+  const topZoneName = distribution.length > 0 ? distribution[distribution.length - 1].name : 'Supra-CP';
 
   return (
     <Card>
@@ -63,7 +63,7 @@ export default function DiagnosisCard({ diagnosis, display }: Props) {
 
       {/* Distribution bar */}
       <div className="mb-6">
-        <DistributionBar distribution={distribution} display={display} />
+        <DistributionBar distribution={distribution} />
       </div>
 
       {/* Findings */}

--- a/web/src/components/DistributionBar.tsx
+++ b/web/src/components/DistributionBar.tsx
@@ -1,61 +1,54 @@
-import type { DisplayConfig } from '@/types/api';
+import type { ZoneDistribution } from '@/types/api';
 
 interface Props {
-  distribution: { supra_cp: number; threshold: number; tempo: number; easy: number };
-  display?: DisplayConfig;
+  distribution: ZoneDistribution[];
 }
 
 const ZONE_COLORS = [
   { color: 'bg-destructive', textColor: 'text-destructive' },
   { color: 'bg-accent-amber', textColor: 'text-accent-amber' },
   { color: 'bg-accent-blue', textColor: 'text-accent-blue' },
+  { color: 'bg-accent-blue/50', textColor: 'text-accent-blue' },
   { color: 'bg-muted-foreground', textColor: 'text-muted-foreground' },
 ];
 
-// Map distribution keys to ordered zone indices (highest intensity first)
-const DIST_KEYS = ['supra_cp', 'threshold', 'tempo', 'easy'] as const;
+function getZoneColor(index: number, total: number) {
+  const colorIdx = total - 1 - index;
+  return ZONE_COLORS[Math.min(colorIdx, ZONE_COLORS.length - 1)] ?? ZONE_COLORS[ZONE_COLORS.length - 1];
+}
 
-export default function DistributionBar({ distribution, display }: Props) {
-  const total = distribution.supra_cp + distribution.threshold + distribution.tempo + distribution.easy;
+export default function DistributionBar({ distribution }: Props) {
+  const total = distribution.reduce((sum, d) => sum + d.actual_pct, 0);
 
-  // Use display config zone names if available (reversed: Z5→Z2 = highest→lowest)
-  const zoneLabels = display?.zone_names
-    ? [display.zone_names[4] || display.zone_names[3], display.zone_names[3] || 'Threshold', display.zone_names[2] || 'Tempo', display.zone_names[1] || 'Easy']
-    : ['Supra-CP', 'Threshold', 'Tempo', 'Easy'];
-
-  const zones = DIST_KEYS.map((key, i) => ({
-    key,
-    label: zoneLabels[i],
-    ...ZONE_COLORS[i],
-    pct: total > 0 ? (distribution[key] / total) * 100 : 0,
+  const zones = [...distribution].reverse().map((d, i) => ({
+    name: d.name,
+    pct: total > 0 ? d.actual_pct : 0,
+    ...getZoneColor(distribution.length - 1 - i, distribution.length),
   }));
 
   return (
     <div>
-      {/* Stacked bar */}
       <div className="flex h-6 w-full overflow-hidden rounded-full">
         {zones.map((zone) => {
           if (zone.pct === 0) return null;
           return (
             <div
-              key={zone.key}
+              key={zone.name}
               className={`${zone.color} flex items-center justify-center text-[10px] font-semibold text-base`}
               style={{ width: `${zone.pct}%` }}
-              title={`${zone.label}: ${zone.pct.toFixed(0)}%`}
+              title={`${zone.name}: ${zone.pct}%`}
             >
-              {zone.pct >= 8 ? `${zone.pct.toFixed(0)}%` : ''}
+              {zone.pct >= 8 ? `${zone.pct}%` : ''}
             </div>
           );
         })}
       </div>
-
-      {/* Legend */}
       <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-xs">
         {zones.map((zone) => (
-          <span key={zone.key} className="flex items-center gap-1.5">
+          <span key={zone.name} className="flex items-center gap-1.5">
             <span className={`inline-block h-2.5 w-2.5 rounded-full ${zone.color}`} />
-            <span className="text-muted-foreground">{zone.label}</span>
-            <span className={`font-data font-semibold ${zone.textColor}`}>{zone.pct.toFixed(0)}%</span>
+            <span className="text-muted-foreground">{zone.name}</span>
+            <span className={`font-data font-semibold ${zone.textColor}`}>{zone.pct}%</span>
           </span>
         ))}
       </div>

--- a/web/src/components/ZoneAnalysisCard.tsx
+++ b/web/src/components/ZoneAnalysisCard.tsx
@@ -1,0 +1,96 @@
+import type { ZoneDistribution, ZoneRange, DisplayConfig } from '@/types/api';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface Props {
+  distribution: ZoneDistribution[];
+  zoneRanges: ZoneRange[];
+  theoryName: string;
+  display?: DisplayConfig;
+}
+
+const ZONE_TEXT_COLORS = [
+  'text-muted-foreground',
+  'text-accent-blue/70',
+  'text-accent-blue',
+  'text-accent-amber',
+  'text-destructive',
+];
+
+function getZoneTextColor(index: number, total: number) {
+  const scaled = Math.round((index / Math.max(total - 1, 1)) * (ZONE_TEXT_COLORS.length - 1));
+  return ZONE_TEXT_COLORS[scaled] ?? ZONE_TEXT_COLORS[0];
+}
+
+function formatRange(range: ZoneRange): string {
+  if (range.upper == null) return `> ${range.lower}${range.unit}`;
+  if (range.lower === 0) return `< ${range.upper}${range.unit}`;
+  return `${range.lower}–${range.upper}${range.unit}`;
+}
+
+export default function ZoneAnalysisCard({ distribution, zoneRanges, theoryName, display }: Props) {
+  const thresholdLabel = display ? `${display.threshold_abbrev}` : '';
+
+  const rows = [...distribution].reverse();
+  const ranges = [...zoneRanges].reverse();
+
+  const alerts = distribution
+    .filter((d) => d.target_pct != null && Math.abs(d.actual_pct - d.target_pct!) > 5)
+    .map((d) => {
+      const diff = d.actual_pct - d.target_pct!;
+      const direction = diff > 0 ? 'above' : 'below';
+      return `${d.name}: ${d.actual_pct}% (${Math.abs(diff)}pp ${direction} ${d.target_pct}% target)`;
+    });
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Zone Analysis · {theoryName}
+          </CardTitle>
+          {thresholdLabel && (
+            <span className="text-xs text-muted-foreground font-data">{thresholdLabel}</span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center pb-2 mb-2 border-b border-border">
+          <span className="w-20 text-[10px] uppercase tracking-wider text-muted-foreground">Zone</span>
+          <span className="flex-1 text-[10px] uppercase tracking-wider text-muted-foreground">Range</span>
+          <span className="w-14 text-right text-[10px] uppercase tracking-wider text-muted-foreground">Actual</span>
+          <span className="w-14 text-right text-[10px] uppercase tracking-wider text-muted-foreground">Target</span>
+        </div>
+
+        <div className="space-y-1.5">
+          {rows.map((d, i) => {
+            const range = ranges[i];
+            const colorClass = getZoneTextColor(distribution.length - 1 - i, distribution.length);
+            return (
+              <div key={d.name} className="flex items-center">
+                <span className={`w-20 text-sm font-medium ${colorClass}`}>{d.name}</span>
+                <span className="flex-1 text-sm text-muted-foreground font-data">
+                  {range ? formatRange(range) : ''}
+                </span>
+                <span className="w-14 text-right text-sm font-semibold font-data text-foreground">
+                  {d.actual_pct}%
+                </span>
+                <span className="w-14 text-right text-sm font-data text-muted-foreground">
+                  {d.target_pct != null ? `${d.target_pct}%` : '—'}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {alerts.length > 0 && (
+          <Alert className="mt-4 border-accent-amber/30 bg-accent-amber/5">
+            <AlertDescription className="text-sm text-accent-amber">
+              Distribution deviates from target: {alerts.join('; ')}
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -5,6 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import DiagnosisCard from '@/components/DiagnosisCard';
+import ZoneAnalysisCard from '@/components/ZoneAnalysisCard';
 import UpcomingPlanCard from '@/components/UpcomingPlanCard';
 import FitnessFatigueChart from '@/components/charts/FitnessFatigueChart';
 import CpTrendChart from '@/components/charts/CpTrendChart';
@@ -61,6 +62,18 @@ export default function Training() {
       <div className="mb-6">
         <DiagnosisCard diagnosis={data.diagnosis} display={activeDisplay ?? undefined} />
       </div>
+
+      {/* Zone analysis card */}
+      {data.diagnosis.zone_ranges.length > 0 && (
+        <div className="mb-6">
+          <ZoneAnalysisCard
+            distribution={data.diagnosis.distribution}
+            zoneRanges={data.diagnosis.zone_ranges}
+            theoryName={data.diagnosis.theory_name}
+            display={activeDisplay ?? undefined}
+          />
+        </div>
+      )}
 
       {/* Upcoming plan schedule */}
       <div className="mb-6">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -211,6 +211,19 @@ export interface TodayResponse {
   upcoming?: UpcomingWorkout[];
 }
 
+export interface ZoneDistribution {
+  name: string;
+  actual_pct: number;
+  target_pct: number | null;
+}
+
+export interface ZoneRange {
+  name: string;
+  lower: number;
+  upper: number | null;
+  unit: string;
+}
+
 export interface DiagnosisFinding {
   type: 'positive' | 'warning' | 'neutral';
   message: string;
@@ -228,12 +241,9 @@ export interface DiagnosisData {
     weekly_avg_km: number;
     trend: string;
   };
-  distribution: {
-    supra_cp: number;
-    threshold: number;
-    tempo: number;
-    easy: number;
-  };
+  distribution: ZoneDistribution[];
+  zone_ranges: ZoneRange[];
+  theory_name: string;
   consistency: {
     weeks_with_gaps: number;
     longest_gap_days: number;


### PR DESCRIPTION
## Summary

- **Zone theory switching now works end-to-end**: Selecting a zone theory on the Science page (Coggan 5-Zone, Polarized 3-Zone) updates `config.zones` with the theory's boundaries and propagates them through the entire analysis pipeline
- **Dynamic zone classification**: `diagnose_training()` uses configurable zone boundaries instead of hardcoded percentages, producing N zones with actual vs target distribution comparison
- **New ZoneAnalysisCard on Training page**: Table showing zone name, power/HR/pace range, actual %, and target % with deviation alerts when distribution diverges >5pp from theory targets
- **DistributionBar adapts to zone count**: Stacked bar now renders 3 or 5 segments dynamically based on the selected theory

## Test plan

- [x] All 116 backend tests pass (`python -m pytest tests/ -v`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Start API + frontend, open Training page — verify DiagnosisCard distribution bar and new ZoneAnalysisCard render
- [ ] Switch zone theory on Science page (Coggan → Polarized), return to Training — verify 3-zone layout with 80/5/15 targets
- [ ] Switch back to Coggan — verify 5-zone layout restores
- [ ] Test with different training bases (power, HR, pace) — zone ranges use correct units

🤖 Generated with [Claude Code](https://claude.com/claude-code)