### PR TITLE
Fix Stryd push using wrong CP and add re-push support

### DIFF
--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -131,11 +131,9 @@ def push_plan_to_stryd(request: PushStrydRequest) -> dict:
 
     # Get current CP for block building
     cp_watts = None
-    signal = data.get("signal", {})
-    if isinstance(signal, dict):
-        cp_data = signal.get("plan", {})
-        if isinstance(cp_data, dict) and cp_data.get("power_max"):
-            cp_watts = float(cp_data["power_max"])
+    latest_cp = data.get("latest_cp")
+    if latest_cp and float(latest_cp) > 0:
+        cp_watts = float(latest_cp)
     # Fallback: try from latest activities
     if not cp_watts:
         activities = data.get("activities", pd.DataFrame())

--- a/data/config.json
+++ b/data/config.json
@@ -20,21 +20,15 @@
   },
   "zones": {
     "power": [
-      0.55,
-      0.75,
-      0.9,
-      1.05
+      0.82,
+      1.0
     ],
     "hr": [
-      0.72,
       0.82,
-      0.89,
-      0.96
+      0.89
     ],
     "pace": [
-      1.29,
       1.14,
-      1.06,
       1.0
     ]
   },
@@ -49,7 +43,7 @@
     "load": "banister_pmc",
     "recovery": "hrv_weighted",
     "prediction": "critical_power",
-    "zones": "coggan_5zone"
+    "zones": "polarized_3zone"
   },
   "zone_labels": "standard",
   "source_options": {

--- a/skills/training-plan/SKILL.md
+++ b/skills/training-plan/SKILL.md
@@ -54,7 +54,69 @@ Then decide:
 Ask the user which approach they want if it's ambiguous. If the user said
 "update my plan" → update. If "generate a new plan" → regenerate.
 
-**If there is NO existing plan**, proceed to generate a fresh 4-week plan.
+**Regardless of which approach you choose** — update, extend, or regenerate —
+the new plan must connect logically to the athlete's recent training. Even a
+"regenerate" is not a blank slate. The athlete has training history, momentum,
+and a position in their training cycle. Step 2's "Continuity First" section
+explains how to determine where they are and what comes next.
+
+**If there is NO existing plan**, proceed to generate a plan — but still treat
+the athlete's recent training history as the "previous plan." They've been
+training; the new plan picks up from where their self-directed training left off.
+
+## Step 1.75: Validate Threshold Estimate
+
+Auto-calculated thresholds (Stryd auto-CP, Garmin threshold estimates) can be
+unreliable. A bad threshold cascades into wrong zone boundaries, misleading
+zone distribution diagnoses, and incorrectly targeted workouts. Before building
+the plan, cross-reference the reported threshold against actual performance.
+
+### Check for recalibration artifacts
+
+Look at `cp_estimate` (or equivalent threshold) across recent sessions. If the
+value drops >10W within a few days without a corresponding performance decline
+in the quality sessions, it's likely a device recalibration artifact — not a
+real fitness change. Signs of an artifact:
+- Sudden step-change in CP (e.g., 271→255→248 over a week)
+- Quality session power outputs remain consistent before and after the drop
+- Athlete reports no change in perceived effort on easy or hard runs
+
+### Estimate working threshold from performance data
+
+Scan recent sessions for sustained hard efforts (splits >230W held for 5+
+minutes). The best recent 20-minute sustained power is the gold standard:
+- **Working CP ≈ best 20-minute power × 0.95–1.00**
+- If no 20-minute effort exists, use the best 15-minute power × 0.97 or
+  10-minute power × 0.92
+
+Also consider: if the athlete holds X watts for a 30-minute block inside a
+long run, their CP is likely ≥ X.
+
+### Cross-check with subjective effort
+
+If the athlete provides feedback on how efforts feel:
+- Runs at 75-80% of reported CP "feel easy" → CP is probably understated
+- Threshold sessions at 95% CP feel moderate → CP is probably understated
+- Easy runs feel hard at 70% CP → CP might be overstated (or non-CP fatigue)
+
+### Decide which threshold to use
+
+Compare the reported threshold (`athlete_profile.threshold`) against your
+estimated working threshold:
+- **Within 5%**: Use the reported value. It's close enough.
+- **Working threshold is 5-15% higher**: Use the working threshold for all zone
+  calculations and power targets. Tell the athlete: "Your device CP (XXX W)
+  appears understated based on recent efforts. Using a working CP of YYY W for
+  this plan."
+- **Working threshold is >15% higher**: Something unusual is going on (device
+  issue, very stale CP, or the hard efforts were short enough to be above true
+  CP). Flag this to the athlete and ask for confirmation before proceeding.
+- **Working threshold is lower**: The reported value may be stale from a fitter
+  period. Use the working threshold.
+
+**Carry the validated working threshold forward into all subsequent steps.**
+Zone boundaries, power targets, and zone distribution analysis must use this
+value, not the raw device number.
 
 ## Step 2: Analyze and Generate Plan
 
@@ -62,8 +124,66 @@ Using the training context, generate or update the training plan. The context
 includes a `science` section with the user's active training theories — use these
 instead of assuming a specific framework.
 
+### Continuity First — This Is Not a Fresh Start
+
+The athlete is always mid-training. A new plan is a continuation of their
+existing training arc, not a reset. Before deciding structure:
+
+1. **Read the training arc.** Look at `recent_training.weekly_summary` (6-8
+   weeks back) and identify the pattern:
+   - Has volume been building, stable, or declining?
+   - Was the most recent full week a build week, a peak, or a recovery?
+   - Are there signs of an existing periodization rhythm (e.g., 3 hard weeks
+     then a lighter week)?
+
+2. **Determine where they are in the cycle.** Examples:
+   - Just finished a peak week (highest volume/load in the window) → next week
+     should be recovery or a slight step-back, then resume building
+   - In the middle of a build phase with stable volume → continue the build,
+     adding 5-10% per week
+   - Just had a recovery/light week → ready to build again
+   - Coming off illness/travel gap → re-entry week at ~80% of pre-gap volume
+
+3. **Continue the progression, don't restart it.** If the athlete has been
+   building from 55→60→65→70km, the plan should pick up from where that
+   leaves off (e.g., recovery week at 48km, then next build starting at 60km).
+   Don't drop them to 45km "Week 1" just because the plan is new.
+
+4. **Respect what's working.** If the athlete's current workout pattern is
+   producing good results (consistent sessions, hitting power targets, good
+   recovery), preserve it. Change what needs changing, not everything.
+
+### Volume Anchoring — Anchor to Recent History
+
+Extract the athlete's recent baselines from `recent_training.weekly_summary`
+and individual sessions:
+- **Recent weekly average** (last 4-6 full weeks of consistent training)
+- **Recent peak week** (highest volume in that window)
+- **Recent long run distances** (longest run each week from session data)
+- **Current week status** (partial week — how much has already been done?)
+
+These baselines anchor the plan. Never prescribe volumes dramatically different
+from what the athlete has been doing unless there's a specific reason (injury
+return, taper, overreaching recovery). Rules of thumb:
+- **First full week** should relate logically to the last full week — if the
+  last full week was a peak, this week is recovery; if it was moderate, this
+  week continues the build
+- **Peak build week** can exceed the recent peak by up to ~10%
+- **Recovery week** should be ~60-70% of the peak build week
+- **Long runs** should progress from the athlete's recent long run distance, not
+  start from scratch. If they've been doing 25-28km long runs, don't prescribe
+  18km. Continue from where they are.
+
+Show your reasoning: when presenting the plan, include a note like "You've been
+averaging 62km/week with a 70km peak in W14. Plan continues: 63→70→48→60km."
+This helps the athlete verify the plan connects to their training reality.
+
 ### Periodization
-- Use rolling 4-week mesocycles: 3 progressive build weeks + 1 recovery week
+- Use rolling 4-week mesocycles — but adapt the structure to where the athlete
+  is in their current cycle. Don't force "3 build + 1 recovery" if they just
+  finished 3 build weeks and need recovery first. The pattern might be
+  "1 recovery + 3 build" or "2 build + 1 recovery + 1 build" depending on
+  context.
 - Build weeks increase weekly load by 5-10% over the previous week
 - Recovery week reduces volume to ~60-70% of peak build week
 
@@ -96,6 +216,10 @@ using the zone names from `athlete_profile.zone_names`.
 Do NOT hardcode zone boundaries — always derive from the context.
 
 ### Key Considerations
+- **Use the validated working threshold from Step 1.75** for all zone boundaries
+  and power targets — never blindly trust auto-CP or device-reported thresholds.
+  A deflated CP leads to deflated targets, false zone distribution warnings, and
+  a plan that's too easy. An inflated CP leads to unachievable targets.
 - **Use split-level data** from recent sessions to assess if the athlete is
   actually hitting prescribed intensities (activity avg_power is diluted by
   warmup/cooldown)
@@ -141,11 +265,18 @@ This ensures the user knows which scientific framework is shaping their plan.
 ## Step 3: Generate Coaching Narrative
 
 Write a coaching narrative explaining:
-1. **Current Assessment** — where the athlete is right now (fitness, fatigue, CP trend)
-2. **4-Week Phase** — what this mesocycle focuses on and why
-3. **Key Sessions** — explain the 2-3 most important workouts and their purpose
-4. **Watch-For Signals** — when the athlete should modify the plan (signs of overreaching, illness, etc.)
-5. **Expected Outcomes** — what improvement to expect if the plan is followed
+1. **Current Assessment** — where the athlete is right now (fitness, fatigue, CP trend).
+   If the working threshold differs from the device-reported value, explain why and
+   what evidence supports the working estimate.
+2. **Volume & Structure Rationale** — explain _why_ each week has the volume it
+   does, anchored to recent history. Cover: why week 1 is build/transition/recovery,
+   how weekly km progresses and why, how long run distances progress, and what the
+   recovery week ratio is. The athlete should be able to see the logic connecting
+   their recent training to the prescribed volumes.
+3. **4-Week Phase** — what this mesocycle focuses on and why
+4. **Key Sessions** — explain the 2-3 most important workouts and their purpose
+5. **Watch-For Signals** — when the athlete should modify the plan (signs of overreaching, illness, etc.)
+6. **Expected Outcomes** — what improvement to expect if the plan is followed
 
 ## Step 4: Validate the Plan
 

--- a/tests/test_science.py
+++ b/tests/test_science.py
@@ -33,7 +33,7 @@ class TestLoadTheory:
         assert theory.zone_count == 5
         assert "power" in theory.zone_boundaries
         assert len(theory.zone_boundaries["power"]) == 4
-        assert theory.zone_names["power"] == ["Easy", "Tempo", "Threshold", "Supra-CP", "VO2max"]
+        assert theory.zone_names["power"] == ["Recovery", "Endurance", "Tempo", "Threshold", "VO2max"]
 
     def test_load_critical_power(self):
         theory = load_theory("prediction", "critical_power")

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -8,7 +8,7 @@ class TestComputeZones:
     def test_power_5zone_default(self):
         zones = compute_zones("power", 250)
         assert len(zones) == 5
-        assert zones[0]["name"] == "Easy"
+        assert zones[0]["name"] == "Recovery"
         assert zones[0]["lower"] == 0
         assert zones[0]["upper"] == 138  # round(0.55 * 250)
         assert zones[-1]["name"] == "VO2max"

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -112,7 +112,6 @@ function StrydStatusBadge({
                 size="icon"
                 onClick={onPush}
                 aria-label="Retry push to Stryd"
-                title="Retry push to Stryd"
                 className="w-6 h-6 shrink-0 text-destructive hover:text-destructive/80"
               >
                 <ErrorIcon className="h-3.5 w-3.5" />
@@ -138,7 +137,6 @@ function StrydStatusBadge({
                 size="icon"
                 onClick={onPush}
                 aria-label="Re-push to Stryd"
-                title="Re-push to Stryd"
                 className="w-6 h-6 shrink-0 text-primary [&>svg.check]:block [&>svg.refresh]:hidden hover:[&>svg.check]:hidden hover:[&>svg.refresh]:block hover:text-accent-amber"
               >
                 <CheckIcon className="check h-3.5 w-3.5" />
@@ -165,7 +163,6 @@ function StrydStatusBadge({
               size="icon"
               onClick={onPush}
               aria-label="Push to Stryd"
-              title="Push to Stryd"
               className="w-6 h-6 shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary"
             >
               <UploadIcon className="h-3.5 w-3.5" />

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -105,16 +105,20 @@ function StrydStatusBadge({
     return (
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger className="inline-flex">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onPush}
-              className="w-6 h-6 shrink-0 text-destructive hover:text-destructive/80"
-            >
-              <ErrorIcon className="h-3.5 w-3.5" />
-            </Button>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={(
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onPush}
+                aria-label="Retry push to Stryd"
+                title="Retry push to Stryd"
+                className="w-6 h-6 shrink-0 text-destructive hover:text-destructive/80"
+              >
+                <ErrorIcon className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          />
           <TooltipContent side="left">
             <p className="text-xs">{error || 'Push failed'} — click to retry</p>
           </TooltipContent>
@@ -127,17 +131,21 @@ function StrydStatusBadge({
     return (
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger className="inline-flex">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onPush}
-              className="w-6 h-6 shrink-0 text-primary [&>svg.check]:block [&>svg.refresh]:hidden hover:[&>svg.check]:hidden hover:[&>svg.refresh]:block hover:text-accent-amber"
-            >
-              <CheckIcon className="check h-3.5 w-3.5" />
-              <RefreshIcon className="refresh h-3.5 w-3.5" />
-            </Button>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={(
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onPush}
+                aria-label="Re-push to Stryd"
+                title="Re-push to Stryd"
+                className="w-6 h-6 shrink-0 text-primary [&>svg.check]:block [&>svg.refresh]:hidden hover:[&>svg.check]:hidden hover:[&>svg.refresh]:block hover:text-accent-amber"
+              >
+                <CheckIcon className="check h-3.5 w-3.5" />
+                <RefreshIcon className="refresh h-3.5 w-3.5" />
+              </Button>
+            )}
+          />
           <TooltipContent side="left">
             <p className="text-xs">Re-push to Stryd</p>
           </TooltipContent>
@@ -150,16 +158,20 @@ function StrydStatusBadge({
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger className="inline-flex">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onPush}
-            className="w-6 h-6 shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary"
-          >
-            <UploadIcon className="h-3.5 w-3.5" />
-          </Button>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={(
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onPush}
+              aria-label="Push to Stryd"
+              title="Push to Stryd"
+              className="w-6 h-6 shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary"
+            >
+              <UploadIcon className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        />
         <TooltipContent side="left">
           <p className="text-xs">Push to Stryd</p>
         </TooltipContent>
@@ -305,29 +317,38 @@ export default function UpcomingPlanCard() {
 
   const handlePushResults = useCallback(
     (results: StrydPushResult[], dates: string[]) => {
-      const newStatus = { ...pushStatus };
-      const newErrors = { ...pushErrors };
-
-      // Clear errors for dates we just retried
-      for (const d of dates) delete newErrors[d];
-
-      for (const r of results) {
-        if (r.status === 'success') {
-          newStatus[r.date] = {
-            workout_id: r.workout_id,
-            pushed_at: new Date().toISOString(),
-            status: 'pushed',
-          };
-          delete newErrors[r.date];
-        } else {
-          newErrors[r.date] = r.error;
+      setPushStatus((prev) => {
+        const next = { ...prev };
+        for (const r of results) {
+          if (r.status === 'success') {
+            next[r.date] = {
+              workout_id: r.workout_id,
+              pushed_at: new Date().toISOString(),
+              status: 'pushed',
+            };
+          }
         }
-      }
+        return next;
+      });
 
-      setPushStatus(newStatus);
-      setPushErrors(newErrors);
+      setPushErrors((prev) => {
+        const next = { ...prev };
+
+        // Clear errors for dates we just retried
+        for (const d of dates) delete next[d];
+
+        for (const r of results) {
+          if (r.status === 'success') {
+            delete next[r.date];
+          } else {
+            next[r.date] = r.error;
+          }
+        }
+
+        return next;
+      });
     },
-    [pushStatus, pushErrors],
+    [],
   );
 
   // Push a single workout (or re-push by deleting old one first)
@@ -341,7 +362,11 @@ export default function UpcomingPlanCard() {
         // If already pushed, delete the old workout from Stryd first
         const existing = pushStatus[date];
         if (existing?.workout_id) {
-          await fetch(`/api/plan/stryd-workout/${existing.workout_id}`, { method: 'DELETE' });
+          const resp = await fetch(`/api/plan/stryd-workout/${existing.workout_id}`, { method: 'DELETE' });
+          if (!resp.ok) {
+            const err = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }));
+            throw new Error(err.detail || `HTTP ${resp.status}`);
+          }
           setPushStatus((prev) => {
             const next = { ...prev };
             delete next[date];

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -73,6 +73,13 @@ const ErrorIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+const RefreshIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path d="M2.5 8a5.5 5.5 0 019.3-4M13.5 8a5.5 5.5 0 01-9.3 4" strokeLinecap="round" />
+    <path d="M12 1.5v3h-3M4 11.5v3h3" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
 function StrydStatusBadge({
   state,
   error,
@@ -121,12 +128,18 @@ function StrydStatusBadge({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger className="inline-flex">
-            <div className="w-6 h-6 flex items-center justify-center shrink-0 text-primary">
-              <CheckIcon className="h-3.5 w-3.5" />
-            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onPush}
+              className="w-6 h-6 shrink-0 text-primary [&>svg.check]:block [&>svg.refresh]:hidden hover:[&>svg.check]:hidden hover:[&>svg.refresh]:block hover:text-accent-amber"
+            >
+              <CheckIcon className="check h-3.5 w-3.5" />
+              <RefreshIcon className="refresh h-3.5 w-3.5" />
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="left">
-            <p className="text-xs">Synced to Stryd</p>
+            <p className="text-xs">Re-push to Stryd</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -317,14 +330,25 @@ export default function UpcomingPlanCard() {
     [pushStatus, pushErrors],
   );
 
-  // Push a single workout
+  // Push a single workout (or re-push by deleting old one first)
   const pushSingle = useCallback(
     async (date: string) => {
-      if (pushingDates.has(date) || pushStatus[date]) return;
+      if (pushingDates.has(date)) return;
 
       setPushingDates((prev) => new Set(prev).add(date));
 
       try {
+        // If already pushed, delete the old workout from Stryd first
+        const existing = pushStatus[date];
+        if (existing?.workout_id) {
+          await fetch(`/api/plan/stryd-workout/${existing.workout_id}`, { method: 'DELETE' });
+          setPushStatus((prev) => {
+            const next = { ...prev };
+            delete next[date];
+            return next;
+          });
+        }
+
         const { results } = await pushDatesToStryd([date]);
         handlePushResults(results, [date]);
       } catch (e) {


### PR DESCRIPTION
## Summary
- **Bug fix**: Stryd workout push was using `signal.plan.power_max` (today's workout target power) as Critical Power, causing a recovery run at 140-165W to be pushed as 211-248W (85-100% CP). Now uses `latest_cp` from dashboard data.
- **Re-push UI**: Pushed workouts now show a refresh icon on hover — clicking deletes the old Stryd workout and pushes the corrected version.
- **Training plan skill**: Added threshold validation step (cross-reference auto-CP against actual performance) and continuity guidance (anchor new plans to recent training history).
- **Zone name fixes**: Updated test assertions for Coggan zone rename (Recovery/Endurance/Tempo/Threshold/VO2max).
- **Config update**: Switched active zone theory to polarized_3zone.

## Test plan
- [x] All 174 tests pass
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Push a workout to Stryd — verify power targets match plan (e.g., 140-165W → ~56-67% CP, not 85-100%)
- [ ] Re-push an already-pushed workout — verify old workout deleted and new one created
- [ ] Verify re-push shows spinner during operation and checkmark on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)