### PR TITLE
Remove stale cache references from docs and skills

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -156,8 +156,7 @@ Use `analysis/config.py` functions:
 
 Or edit `data/config.json` directly (simpler for targeted changes).
 
-After any config change, remind the user to restart the API server if it's running
-(the cache refreshes every 5 minutes, but a restart is instant).
+After any config change, remind the user that changes take effect on the next API request.
 
 ## First-Time Setup Checklist
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ sync/*.py → data/**/*.csv → analysis/metrics.py → api/deps.py → api/rout
 - **sync/**: API sync scripts (Garmin, Stryd, Oura) → CSV files
 - **analysis/metrics.py**: Pure computation functions (no I/O, no side effects)
 - **analysis/data_loader.py**: All CSV I/O lives here
-- **api/deps.py**: Cached data layer — `get_dashboard_data()` is the central function
+- **api/deps.py**: Data layer — `get_dashboard_data()` is the central function
 - **api/routes/**: Thin wrappers calling deps, all under `/api/` prefix
 - **web/src/**: React + TypeScript + Tailwind v4 + Recharts
 
@@ -38,7 +38,7 @@ sync/*.py → data/**/*.csv → analysis/metrics.py → api/deps.py → api/rout
 
 - User config (goals, thresholds) in `data/config.json`, managed via Goal page UI
 - API credentials in `sync/.env` (see `sync/.env.example`)
-- Data cache: 5 minutes in `api/deps.py`
+- Data recomputed fresh per request in `api/deps.py`
 
 ## For Full Details
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@
 
 ### API Agent
 - **Focus:** `api/main.py`, `api/deps.py`, `api/routes/`
-- **Tasks:** Add endpoints, modify data layer, optimize caching
-- **Context needed:** `api/deps.py` `get_dashboard_data()` is the central data function — all routes read from its cached result
+- **Tasks:** Add endpoints, modify data layer
+- **Context needed:** `api/deps.py` `get_dashboard_data()` is the central data function — all routes call it fresh per request
 - **Key rule:** Routes are thin — computation belongs in `analysis/metrics.py`, not in route handlers
 
 ### AI Features Agent (Future)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Garmin/Stryd/Oura APIs → sync/*.py → data/**/*.csv
                                           ↓
                                    analysis/metrics.py (pure computation)
                                           ↓
-                                   api/deps.py (cached data layer)
+                                   api/deps.py (data layer)
                                           ↓
                                    api/routes/*.py (JSON endpoints)
                                           ↓
@@ -25,7 +25,7 @@ Garmin/Stryd/Oura APIs → sync/*.py → data/**/*.csv
 | `sync/` | API sync scripts | `garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`, `csv_utils.py`, `sync_all.py` (orchestrator), `bootstrap_garmin_tokens.py` |
 | `analysis/` | Metric computation | `metrics.py` (pure functions), `data_loader.py` (CSV I/O + merge), `science.py` (theory YAML loader), `config.py` (UserConfig dataclass), `zones.py`, `thresholds.py`, `training_base.py` |
 | `analysis/providers/` | Pluggable data sources | `base.py` (abstract provider ABCs), `garmin.py`, `stryd.py`, `oura.py`, `ai.py` (AI plan CSV loader), `models.py` |
-| `api/` | FastAPI backend | `main.py` (app), `deps.py` (cached data layer), `views.py` (shared view helpers), `routes/` (endpoints) |
+| `api/` | FastAPI backend | `main.py` (app), `deps.py` (data layer), `views.py` (shared view helpers), `routes/` (endpoints) |
 | `web/src/` | React frontend | `pages/` (6 pages: Today, Training, Goal, History, Science, Settings), `components/` (UI + `charts/` sub-dir), `hooks/` (`useApi`, `useChartColors`, `useTheme`, `use-mobile`), `contexts/` (`ScienceContext`, `SettingsContext`), `types/` (API contracts), `lib/` (`chart-theme`, `format`, `utils`, `workout-parser`) |
 | `tests/` | pytest suite | `test_metrics.py`, `test_integration.py`, etc. |
 | `data/` | User CSV data | `garmin/`, `stryd/`, `oura/`, `ai/` (gitignored), `sample/` (tracked), `science/` (theory YAMLs: load, recovery, prediction, zones, labels) |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Then open `http://localhost:5173`.
 ```
 sync/*.py            -> pulls source data into CSVs
 analysis/metrics.py  -> pure computation
-api/deps.py          -> cached data layer used by API + skills
+api/deps.py          -> data layer used by API + skills
 api/routes/*.py      -> JSON endpoints
 web/                 -> optional local visualization UI
 .claude/skills/      -> AI skill definitions (auto-discovered)

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -236,7 +236,7 @@ Current configuration, platform capabilities, and detected thresholds.
 
 ### PUT /api/settings
 
-Update settings (partial update). Invalidates dashboard cache.
+Update settings (partial update).
 
 **Request body:** Any subset of config fields:
 ```json


### PR DESCRIPTION
## Summary
- Removes all remaining references to the 5-minute API response cache that was removed in #21
- Updates 6 files: CLAUDE.md, README.md, AGENTS.md, copilot-instructions.md, setup skill, and API reference
- Found by the comment-analyzer review agent after the cache removal commit

## Test plan
- [ ] Verify no remaining references to "cached data layer" or "5 minutes" cache in docs
- [ ] Confirm all doc descriptions match current behavior (fresh recompute per request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)