### PR TITLE
Fix deadlock in /api/sync/status causing empty Today page

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -448,9 +448,11 @@ def get_sync_status(
     """Return current sync status for this user's connected platforms."""
     from db.models import UserConnection
 
-    # Snapshot runtime status under lock to avoid reading partial updates
+    # Snapshot runtime status under lock to avoid reading partial updates.
+    # _get_user_status acquires _sync_lock internally, so call it outside
+    # our own `with _sync_lock` — threading.Lock is not reentrant.
+    status = _get_user_status(user_id)
     with _sync_lock:
-        status = _get_user_status(user_id)
         runtime_snapshot = {src: dict(info) for src, info in status.items()}
 
     # Merge with DB connection info (last_sync from DB is more reliable)


### PR DESCRIPTION
## Summary

`get_sync_status` in `api/routes/sync.py` acquired `_sync_lock` then called `_get_user_status()`, which acquires `_sync_lock` itself. `threading.Lock` is not reentrant, so the request hung forever.

The hung `/api/sync/status` request left `useSetupStatus`'s `Promise.all` unresolved, `connectionsLoading` stayed `true`, and `<TodayOrSetup>` rendered `null` — blank Today page after login.

## Root cause

Every other callsite in `sync.py` calls `_get_user_status()` *before* acquiring `_sync_lock`. This one did it inside the lock, a copy-paste regression introduced in #27.

## Fix

Call `_get_user_status()` outside the `with _sync_lock:` block, matching the pattern used elsewhere in the file.

## Test plan

- [x] Reproduced: `/api/sync/status` hung in browser DevTools network tab
- [ ] After deploy: `/api/sync/status` returns 200 quickly
- [ ] Today page renders content after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)