### PR TITLE
Add Claude Code automations (hooks, agents, seed skill)

### DIFF
--- a/.claude/agents/api-contract-reviewer.md
+++ b/.claude/agents/api-contract-reviewer.md
@@ -1,0 +1,87 @@
+---
+name: api-contract-reviewer
+description: >-
+  Use proactively after edits to api/routes/*.py, api/deps.py, api/views.py,
+  or web/src/types/api.ts to check that the Python response shape matches
+  the TypeScript interface the frontend expects. Catches renamed fields,
+  newly-nullable values, nesting changes, and missing TS additions before
+  they become runtime `undefined` on the client.
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# API Contract Reviewer
+
+Trainsight has no codegen between FastAPI and the React client. The Python
+side builds a dict in `api/deps.py` → `get_dashboard_data()` (plus helpers
+in `api/views.py`), serves it through a route in `api/routes/`, and the
+frontend consumes it via `useApi<T>()` with `T` defined in
+`web/src/types/api.ts`. A silent drift between the two produces
+`undefined`, `NaN`, or blank UI regions that look like bugs elsewhere.
+
+Your job is to verify the contract in both directions.
+
+## How to Scope
+
+1. Identify which endpoint(s) changed. Read the route file and trace the
+   response shape back to its source (deps.py helpers, views.py, or a
+   dict literal in the route).
+2. Find the matching TypeScript type. Types are usually named by endpoint
+   or page — grep `web/src/types/api.ts` for field names that appear in
+   the Python response.
+3. If you cannot find a matching TS type for a changed Python response,
+   that is itself a finding.
+
+## What to Check
+
+### Field-level match
+- [ ] Every key the Python dict produces is present in the TS interface
+- [ ] Every TS field corresponds to a key the Python side actually returns
+- [ ] Snake_case on the Python side is preserved as snake_case on the TS
+      side (Trainsight does not camelCase-transform)
+
+### Types and nullability
+- [ ] `Optional[X]` / `X | None` on the Python side is typed as
+      `X | null` in TS (or made optional with `?`)
+- [ ] Numeric fields that can be 0, -0, or NaN have TS types that reflect
+      that (`number` is fine; guarded callers should handle the edge)
+- [ ] Dates/times: Python often returns ISO strings — TS should type
+      them as `string`, not `Date`
+
+### Nesting
+- [ ] Nested objects preserve shape. If a helper in `api/views.py` was
+      refactored to move a field up/down a level, the TS interface must
+      move too.
+- [ ] List element types are correct (`T[]` vs `T | null[]`)
+
+### Consumer sites
+- [ ] Components that destructure the response still work. If a field
+      was renamed, grep `web/src/` for the old name — every usage must
+      update.
+
+## Output Format
+
+```
+## API Contract Review: <endpoint or type>
+
+Python side: <route file:line, helper files>
+TS side:     <web/src/types/api.ts:line>
+
+### ✅ Matches
+- <field>: <python type> ↔ <ts type>
+
+### ❌ Drift
+- <field>: <python shape> vs <ts shape> — <consequence>
+- <field>: present in Python, missing from TS
+
+### ⚠️ Stale consumers
+- <web/src/components/Foo.tsx:NN> — references `old_name`, renamed to `new_name`
+
+### Summary
+<N fields checked, M drifts, K stale consumers>
+```
+
+Be specific with file:line references so the primary agent can jump
+directly to the fix. Do not propose fixes — your role is verification.

--- a/.claude/agents/metric-addition-reviewer.md
+++ b/.claude/agents/metric-addition-reviewer.md
@@ -1,0 +1,96 @@
+---
+name: metric-addition-reviewer
+description: >-
+  Use proactively after any change that adds or modifies a training metric
+  (edits to analysis/metrics.py, api/deps.py, api/routes/*, web/src/types/api.ts,
+  or a new component that surfaces a computed value). Verifies the 7-step
+  discipline from CLAUDE.md — pure function, data-layer wiring, API route,
+  TypeScript interface, React component, page integration, and test — plus
+  that formulas carry a source citation and the metric function has no I/O.
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# Metric Addition Reviewer
+
+You review changes that add or modify a training metric end-to-end.
+The project's contract is that every metric must be wired through all 7
+layers in CLAUDE.md, and the computation layer must stay pure and cited.
+
+Assume you are run *after* the edits. You should not attempt to fix
+anything — your job is to report gaps so the primary agent can fix them.
+
+## How to Scope the Review
+
+1. Look at recently modified files (git diff, or the files the primary
+   agent mentions). Identify the metric being added. It will have a
+   name like `compute_<thing>` in `analysis/metrics.py`.
+2. If you cannot identify a single metric under review, ask the user
+   to name it and stop.
+
+## The 7-Step Checklist
+
+For the identified metric, verify each step is in place.
+
+### 1. Pure function in `analysis/metrics.py`
+- [ ] Function exists with type hints on every parameter and return
+- [ ] Docstring explains what it measures
+- [ ] **No I/O**: no `open()`, no `read_csv`, no DB queries, no
+      `requests.*`, no `os.environ`, no `datetime.now()` without it
+      being a parameter. Read the function body and flag any side effect.
+- [ ] Every formula, constant, and algorithm has a **citation comment**
+      (DOI, URL, or named reference). Magic numbers without a citation
+      are the most common bug.
+- [ ] Estimates are flagged with `# ESTIMATE --` prefix.
+
+### 2. Wired in `api/deps.py`
+- [ ] Called from `get_dashboard_data()`
+- [ ] Result added to the returned dict with a stable key
+
+### 3. Exposed via a route in `api/routes/`
+- [ ] A JSON endpoint under `/api/...` returns the metric
+- [ ] Route enforces JWT auth (uses the standard `current_user` dep)
+
+### 4. TypeScript interface in `web/src/types/api.ts`
+- [ ] Interface matches the Python dict shape **exactly** (field names,
+      nullability, nesting)
+- [ ] Grep for the Python dict keys; each should appear as a TS field
+
+### 5. React component in `web/src/components/`
+- [ ] Component uses `useApi<T>` hook for fetching
+- [ ] Loading state uses `Skeleton`, errors use `Alert variant="destructive"`
+- [ ] Numeric values use the `font-data` class
+- [ ] If the metric is a prediction or derived insight, a `ScienceNote`
+      component explains the methodology
+
+### 6. Page integration in `web/src/pages/`
+- [ ] Component is imported and rendered on the appropriate page
+      (Today, Training, Goal, History, Science, or Settings)
+
+### 7. Test in `tests/`
+- [ ] At least one unit test covers the happy path
+- [ ] Edge cases considered: empty input, single sample, missing fields
+
+## Output Format
+
+```
+## Metric Addition Review: <metric_name>
+
+### ✅ Verified
+- [x] <step N>: <file:line> — <short note>
+
+### ❌ Gaps
+- [ ] <step N>: <what is missing and where>
+
+### ⚠️ Concerns
+- <non-blocking observations: convention drift, TS/Py shape mismatches,
+  citations that look shaky>
+
+### Summary
+<N of 7 steps complete. Blockers: ...>
+```
+
+Be concrete about file paths and line numbers. If a step is partial,
+list it under Gaps with what is missing, not under Verified.

--- a/.claude/hooks/block_secrets.py
+++ b/.claude/hooks/block_secrets.py
@@ -2,7 +2,7 @@
 """PreToolUse hook: refuse Edit/Write against secret or encrypted surfaces.
 
 Blocks edits to:
-  - .env / .env.local / .env.production (plaintext secrets)
+  - .env and any .env.<anything> (plaintext secrets)
   - trainsight.db and SQLite companion files (Fernet-encrypted credentials,
     multi-user state)
   - data/garmin/** data/stryd/** data/oura/** (raw synced data)
@@ -11,6 +11,10 @@ Rationale: these are managed by sync scripts, the UI, or explicit developer
 action. Claude editing them directly tends to corrupt state.
 
 Exit 0 = allow the tool call. Exit 2 = block it and show stderr to Claude.
+
+Security posture: this hook is a guardrail. On malformed input, unknown
+tool names, or missing fields it fails CLOSED (exit 2) — a mute guardrail
+is worse than a noisy one.
 """
 from __future__ import annotations
 
@@ -19,27 +23,55 @@ import os.path
 import sys
 
 
+KNOWN_WRITE_TOOLS = {"Edit", "Write"}
+
+
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        return 0  # fail-open: never block on a malformed payload
+    except json.JSONDecodeError as exc:
+        _deny(
+            f"could not parse hook payload ({exc.msg}). "
+            "Denying to fail safe — the guardrail cannot make a decision."
+        )
+        return 2
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in KNOWN_WRITE_TOOLS:
+        _deny(
+            f"matcher fired for tool '{tool_name}' but this hook only "
+            "understands Edit/Write. Denying to fail safe. Narrow the "
+            "matcher in .claude/settings.json or extend this hook."
+        )
+        return 2
 
     raw = payload.get("tool_input", {}).get("file_path", "")
     if not raw:
-        return 0
+        _deny(
+            "tool_input.file_path was missing or empty. "
+            "Denying to fail safe — the guardrail cannot verify the target."
+        )
+        return 2
 
     norm = raw.replace("\\", "/").lower()
     base = os.path.basename(norm)
 
-    blocked_basenames = {".env", ".env.local", ".env.production"}
-    if base in blocked_basenames or base.startswith("trainsight.db"):
-        _deny(f"secret/db file '{base}'")
+    if base == ".env" or base.startswith(".env."):
+        _deny(f"env file '{base}'")
         return 2
 
-    for seg in ("/data/garmin/", "/data/stryd/", "/data/oura/"):
-        if seg in norm:
-            _deny(f"synced data under '{seg.strip('/')}'")
+    if (
+        base == "trainsight.db"
+        or base.startswith("trainsight.db-")
+        or base.startswith("trainsight.db.")
+    ):
+        _deny(f"sqlite file '{base}'")
+        return 2
+
+    parts = norm.split("/")
+    for i in range(len(parts) - 1):
+        if parts[i] == "data" and parts[i + 1] in ("garmin", "stryd", "oura"):
+            _deny(f"synced data under 'data/{parts[i + 1]}'")
             return 2
 
     return 0

--- a/.claude/hooks/block_secrets.py
+++ b/.claude/hooks/block_secrets.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""PreToolUse hook: refuse Edit/Write against secret or encrypted surfaces.
+
+Blocks edits to:
+  - .env / .env.local / .env.production (plaintext secrets)
+  - trainsight.db and SQLite companion files (Fernet-encrypted credentials,
+    multi-user state)
+  - data/garmin/** data/stryd/** data/oura/** (raw synced data)
+
+Rationale: these are managed by sync scripts, the UI, or explicit developer
+action. Claude editing them directly tends to corrupt state.
+
+Exit 0 = allow the tool call. Exit 2 = block it and show stderr to Claude.
+"""
+from __future__ import annotations
+
+import json
+import os.path
+import sys
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0  # fail-open: never block on a malformed payload
+
+    raw = payload.get("tool_input", {}).get("file_path", "")
+    if not raw:
+        return 0
+
+    norm = raw.replace("\\", "/").lower()
+    base = os.path.basename(norm)
+
+    blocked_basenames = {".env", ".env.local", ".env.production"}
+    if base in blocked_basenames or base.startswith("trainsight.db"):
+        _deny(f"secret/db file '{base}'")
+        return 2
+
+    for seg in ("/data/garmin/", "/data/stryd/", "/data/oura/"):
+        if seg in norm:
+            _deny(f"synced data under '{seg.strip('/')}'")
+            return 2
+
+    return 0
+
+
+def _deny(reason: str) -> None:
+    print(
+        f"Blocked: refusing to Edit/Write {reason}. "
+        f"These paths are managed by sync scripts or the UI. "
+        f"If you really need to change this file, do it outside Claude Code "
+        f"or temporarily disable .claude/hooks/block_secrets.py.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/pytest_on_py.py
+++ b/.claude/hooks/pytest_on_py.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""PostToolUse hook: run pytest when a .py file is edited.
+
+Replaces the previous inline shell pipeline in .claude/settings.json,
+which had three problems:
+  1. Trailing `|| true` swallowed pytest's non-zero exit so Claude never
+     saw the failure.
+  2. `tail -20` is unavailable on stock Windows shells.
+  3. It called bare `python`, not the project venv — producing
+     ModuleNotFoundError when venv is not pre-activated.
+
+This script resolves the venv Python, runs pytest with fail-fast, and
+surfaces failures via stderr + exit 2 (PostToolUse feedback signal).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+TAIL_LINES = 30
+PYTEST_TIMEOUT_SEC = 110
+HOOK_PATH = Path(__file__).resolve()
+PROJECT_ROOT = HOOK_PATH.parents[2]
+
+
+def _resolve_venv_python() -> str:
+    """Locate the project venv's python, falling back to sys.executable."""
+    candidates = [
+        PROJECT_ROOT / ".venv" / "Scripts" / "python.exe",  # Windows
+        PROJECT_ROOT / ".venv" / "bin" / "python",          # Unix
+    ]
+    for c in candidates:
+        if c.exists():
+            return str(c)
+    return sys.executable
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    raw = payload.get("tool_input", {}).get("file_path", "")
+    if not raw.endswith(".py"):
+        return 0
+
+    python = _resolve_venv_python()
+    try:
+        result = subprocess.run(
+            [python, "-m", "pytest", "tests/", "-x", "-q", "--tb=short"],
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=PYTEST_TIMEOUT_SEC,
+            shell=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"pytest_on_py: test suite exceeded {PYTEST_TIMEOUT_SEC}s — skipping.",
+            file=sys.stderr,
+        )
+        return 0
+    except (FileNotFoundError, OSError) as exc:
+        print(
+            f"pytest_on_py: could not launch pytest ({exc.__class__.__name__}: "
+            f"{exc}). Ensure .venv exists and requirements are installed.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if result.returncode == 0:
+        return 0
+
+    output = (result.stdout + result.stderr).strip()
+    lines = output.splitlines()[-TAIL_LINES:] if output else [
+        f"pytest exited {result.returncode} with no output"
+    ]
+    print(f"pytest failed (last {len(lines)} lines):", file=sys.stderr)
+    print("\n".join(lines), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/web_lint.py
+++ b/.claude/hooks/web_lint.py
@@ -3,10 +3,16 @@
 
 Runs fast (per-file, not the whole project), gives Claude immediate
 feedback on rule violations and import errors. Silent when the edit is
-not a .ts/.tsx file inside web/.
+not a .ts/.tsx file inside the project's web/ directory.
 
 Does not run tsc -b: that's a project-wide check best left to CI and
 `npm run build`. Per-file eslint catches the majority of issues.
+
+Behavior:
+  - Lint errors: print to stderr, exit 2 so Claude sees the feedback.
+  - Tooling missing (no node_modules, no npx): print a one-line notice
+    to stderr, exit 0. A silent skip would hide the hook's no-op.
+  - Anything else (not a TS file, not under web/): exit 0 silently.
 """
 from __future__ import annotations
 
@@ -17,50 +23,92 @@ from pathlib import Path
 
 
 TAIL_LINES = 25
+HOOK_PATH = Path(__file__).resolve()
+PROJECT_ROOT = HOOK_PATH.parents[2]
+WEB_ROOT = PROJECT_ROOT / "web"
+
+
+def _resolve_in_project(raw: str) -> Path | None:
+    """Resolve a Claude-supplied file_path against the project root.
+
+    Returns None if it can't be resolved. Accepts absolute paths,
+    repo-relative paths (``web/src/Foo.tsx``), and ``./``-prefixed paths.
+    """
+    try:
+        p = Path(raw)
+        if not p.is_absolute():
+            p = PROJECT_ROOT / p
+        return p.resolve(strict=False)
+    except (OSError, ValueError):
+        return None
 
 
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except json.JSONDecodeError:
-        return 0
+        return 0  # post-hook: silently skip on bad payload (tool already ran)
 
     raw = payload.get("tool_input", {}).get("file_path", "")
     if not raw:
         return 0
 
-    path = raw.replace("\\", "/")
-    if not (path.endswith((".ts", ".tsx")) and "/web/" in path):
+    abs_path = _resolve_in_project(raw)
+    if abs_path is None:
         return 0
 
-    idx = path.index("/web/")
-    web_root = Path(path[: idx + len("/web")])
-    rel = path[idx + len("/web/"):]
+    web_root_resolved = WEB_ROOT.resolve(strict=False)
+    try:
+        rel_path = abs_path.relative_to(web_root_resolved)
+    except ValueError:
+        return 0  # not under project's web/
 
-    if not (web_root / "package.json").exists():
+    rel = rel_path.as_posix()
+    if not rel.endswith((".ts", ".tsx")):
         return 0
 
-    cmd = f'npx --no-install eslint "{rel}"'
+    if not (WEB_ROOT / "package.json").exists():
+        return 0
+    if not (WEB_ROOT / "node_modules").exists():
+        print(
+            "web_lint: web/node_modules missing — skipping ESLint. "
+            "Run `cd web && npm install` to enable this hook.",
+            file=sys.stderr,
+        )
+        return 0
+
+    npx = "npx.cmd" if sys.platform == "win32" else "npx"
     try:
         result = subprocess.run(
-            cmd,
-            cwd=str(web_root),
+            [npx, "--no-install", "eslint", rel],
+            cwd=str(WEB_ROOT),
             capture_output=True,
             text=True,
             timeout=45,
-            shell=True,
+            shell=False,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return 0  # never block the edit on tooling failure
-
-    output = (result.stdout + result.stderr).strip()
-    if not output or result.returncode == 0:
+    except subprocess.TimeoutExpired:
+        print("web_lint: ESLint timed out after 45s — skipping.", file=sys.stderr)
+        return 0
+    except (FileNotFoundError, OSError) as exc:
+        print(
+            f"web_lint: could not run ESLint ({exc.__class__.__name__}: {exc}). "
+            "Install node + npm so `npx` is on PATH.",
+            file=sys.stderr,
+        )
         return 0
 
-    lines = output.splitlines()[-TAIL_LINES:]
-    print(f"ESLint ({rel}):")
-    print("\n".join(lines))
-    return 0  # never block — report-only
+    output = (result.stdout + result.stderr).strip()
+
+    if result.returncode == 0:
+        return 0
+
+    lines = output.splitlines()[-TAIL_LINES:] if output else [
+        f"eslint exited {result.returncode} with no output"
+    ]
+    print(f"ESLint ({rel}):", file=sys.stderr)
+    print("\n".join(lines), file=sys.stderr)
+    return 2  # PostToolUse exit 2 surfaces stderr to Claude as feedback
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/web_lint.py
+++ b/.claude/hooks/web_lint.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""PostToolUse hook: run ESLint on the single web/ file just edited.
+
+Runs fast (per-file, not the whole project), gives Claude immediate
+feedback on rule violations and import errors. Silent when the edit is
+not a .ts/.tsx file inside web/.
+
+Does not run tsc -b: that's a project-wide check best left to CI and
+`npm run build`. Per-file eslint catches the majority of issues.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+TAIL_LINES = 25
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    raw = payload.get("tool_input", {}).get("file_path", "")
+    if not raw:
+        return 0
+
+    path = raw.replace("\\", "/")
+    if not (path.endswith((".ts", ".tsx")) and "/web/" in path):
+        return 0
+
+    idx = path.index("/web/")
+    web_root = Path(path[: idx + len("/web")])
+    rel = path[idx + len("/web/"):]
+
+    if not (web_root / "package.json").exists():
+        return 0
+
+    cmd = f'npx --no-install eslint "{rel}"'
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(web_root),
+            capture_output=True,
+            text=True,
+            timeout=45,
+            shell=True,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return 0  # never block the edit on tooling failure
+
+    output = (result.stdout + result.stderr).strip()
+    if not output or result.returncode == 0:
+        return 0
+
+    lines = output.splitlines()[-TAIL_LINES:]
+    print(f"ESLint ({rel}):")
+    print("\n".join(lines))
+    return 0  # never block — report-only
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,8 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python -c \"import sys,json; d=json.load(sys.stdin); p=d.get('tool_input',{}).get('file_path',''); sys.exit(0 if p.endswith('.py') else 1)\" && python -m pytest tests/ -x -q --tb=short 2>&1 | tail -20 || true",
-            "timeout": 60,
+            "command": "python .claude/hooks/pytest_on_py.py",
+            "timeout": 120,
             "statusMessage": "Running pytest..."
           },
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/block_secrets.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
@@ -9,6 +21,12 @@
             "command": "python -c \"import sys,json; d=json.load(sys.stdin); p=d.get('tool_input',{}).get('file_path',''); sys.exit(0 if p.endswith('.py') else 1)\" && python -m pytest tests/ -x -q --tb=short 2>&1 | tail -20 || true",
             "timeout": 60,
             "statusMessage": "Running pytest..."
+          },
+          {
+            "type": "command",
+            "command": "python .claude/hooks/web_lint.py",
+            "timeout": 60,
+            "statusMessage": "Linting web file..."
           }
         ]
       }

--- a/.claude/skills/seed-and-preview/SKILL.md
+++ b/.claude/skills/seed-and-preview/SKILL.md
@@ -47,8 +47,8 @@ intentional processes, ask before killing them.
 ### 2. Reset the DB and seed sample data
 
 ```bash
-# trainsight.db is blocked by the PreToolUse hook — deletion must be done
-# in the shell, not via the Write tool
+# trainsight.db is blocked from Edit/Write by the PreToolUse hook.
+# The hook does not gate Bash, so `rm` in the shell works fine.
 rm -f trainsight.db trainsight.db-journal trainsight.db-wal trainsight.db-shm
 python scripts/seed_sample_data.py
 ```
@@ -58,23 +58,28 @@ from `data/sample/`, and leaves a fresh DB ready for registration.
 
 ### 3. Start the API server (background)
 
-Run in the background so you can continue with the frontend:
+Launch uvicorn with the Bash tool's `run_in_background: true` so the
+conversation stays responsive. A plain foreground command here will
+block the session until the user aborts it.
 
 ```bash
 python -m uvicorn api.main:app --reload --port 8000
 ```
 
-Watch the log line `Uvicorn running on http://127.0.0.1:8000`. If it
-fails to bind, check for stale `uvicorn.exe` processes.
+Then use `BashOutput` to watch for the line `Uvicorn running on
+http://127.0.0.1:8000`. If it fails to bind, check for stale
+`uvicorn.exe` processes.
 
 ### 4. Start the Vite dev server (background)
+
+Again use `run_in_background: true`:
 
 ```bash
 cd web && npm run dev
 ```
 
-Vite binds to `http://localhost:5173` and proxies `/api/*` to the
-backend (see `web/vite.config.ts`).
+Poll with `BashOutput` until Vite prints `Local: http://localhost:5173`.
+Vite proxies `/api/*` to the backend (see `web/vite.config.ts`).
 
 ### 5. Report back to the user
 

--- a/.claude/skills/seed-and-preview/SKILL.md
+++ b/.claude/skills/seed-and-preview/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: seed-and-preview
+description: >-
+  Reset the local SQLite DB to sample data and launch the API + Vite dev
+  servers for manual verification. Use when the developer asks to "try
+  the app", "preview a UI change", "boot the dashboard", or after changes
+  to sample data, initial-migration flow, seed scripts, or the
+  registration/invitation path. User-invocable only because it has side
+  effects on local state.
+disable-model-invocation: true
+---
+
+# Seed and Preview
+
+Side-effecting ritual: wipes the local DB and brings up a fresh dev
+environment for manual testing. Not destructive to remote state, but it
+will overwrite `trainsight.db` in the project root, so confirm before
+running if the user has unsaved local data.
+
+## Prerequisites (verify these first)
+
+Run these checks and report any that fail. Do not proceed past a failure.
+
+1. Virtualenv exists:
+   ```bash
+   test -d .venv || echo "MISSING: .venv — run 'python -m venv .venv' first"
+   ```
+2. Activate venv for the current shell:
+   - Windows (Git Bash): `source .venv/Scripts/activate`
+   - Unix: `source .venv/bin/activate`
+3. `.env` exists and has a Fernet key:
+   ```bash
+   test -f .env && grep -q TRAINSIGHT_LOCAL_ENCRYPTION_KEY .env || \
+     echo "MISSING: .env or TRAINSIGHT_LOCAL_ENCRYPTION_KEY — see CLAUDE.md 'First-time setup'"
+   ```
+4. Python deps installed (`pip show fastapi >/dev/null 2>&1` or
+   `pip install -r requirements.txt`).
+5. Frontend deps installed (`test -d web/node_modules || (cd web && npm install)`).
+
+## Ritual
+
+### 1. Stop any running dev servers
+
+Kill anything holding ports 8000 (API) or 5173 (Vite). If the user has
+intentional processes, ask before killing them.
+
+### 2. Reset the DB and seed sample data
+
+```bash
+# trainsight.db is blocked by the PreToolUse hook — deletion must be done
+# in the shell, not via the Write tool
+rm -f trainsight.db trainsight.db-journal trainsight.db-wal trainsight.db-shm
+python scripts/seed_sample_data.py
+```
+
+The seed script creates tables, seeds synthetic Garmin/Stryd/Oura data
+from `data/sample/`, and leaves a fresh DB ready for registration.
+
+### 3. Start the API server (background)
+
+Run in the background so you can continue with the frontend:
+
+```bash
+python -m uvicorn api.main:app --reload --port 8000
+```
+
+Watch the log line `Uvicorn running on http://127.0.0.1:8000`. If it
+fails to bind, check for stale `uvicorn.exe` processes.
+
+### 4. Start the Vite dev server (background)
+
+```bash
+cd web && npm run dev
+```
+
+Vite binds to `http://localhost:5173` and proxies `/api/*` to the
+backend (see `web/vite.config.ts`).
+
+### 5. Report back to the user
+
+Tell the user:
+- API: `http://127.0.0.1:8000` (OpenAPI at `/docs`)
+- App: `http://localhost:5173`
+- **First register** — on a fresh DB the first registered user becomes
+  admin without needing an invitation code (CLAUDE.md § First-time setup).
+- Sample credentials to use for Garmin/Stryd/Oura are not needed — the
+  DB is already populated with synthetic data. The Settings page will
+  show "connected" for sources covered by the sample set.
+
+### 6. If verifying a specific UI change
+
+Ask the user which page and interaction to exercise. Default pages:
+Today → Training → Goal → History → Science → Settings.
+
+## Teardown
+
+When the user is done, stop the two background servers. Do not delete
+`trainsight.db` unless they ask — they may want to inspect it.
+
+## Troubleshooting
+
+- **Registration fails with "invitation required"**: the DB isn't
+  actually empty. Delete `trainsight.db*` and re-seed.
+- **Blank Today page after login**: known class of bug; see commit
+  `85ea764`. Check `/api/sync/status` is responding.
+- **Vite 500 on a specific page**: run `npm run build` in `web/` to
+  surface type errors (`tsc -b` runs first in the build script).
+- **Hook blocks a .env edit**: expected. `.env` is protected by
+  `.claude/hooks/block_secrets.py`. Edit it in a plain terminal.

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ web/dist/
 !.claude/agents/**
 !.claude/skills/
 !.claude/skills/**
+!.claude/hooks/
+!.claude/hooks/**
 .playwright-mcp/
 
 # Git worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,11 +222,11 @@ Project-level automations live in `.claude/`. They are committed to the repo so 
 
 | When | What | Script |
 |------|------|--------|
-| `PreToolUse` on `Edit`/`Write` | Block edits to `.env*`, `trainsight.db*`, `data/garmin/**`, `data/stryd/**`, `data/oura/**` | `.claude/hooks/block_secrets.py` |
-| `PostToolUse` on `Edit`/`Write` of `*.py` | Run full pytest with fail-fast | inline in `settings.json` |
-| `PostToolUse` on `Edit`/`Write` of `web/**/*.ts(x)` | ESLint the single edited file | `.claude/hooks/web_lint.py` |
+| `PreToolUse` on `Edit`/`Write` | Block edits to `.env` / `.env.*`, `trainsight.db` + SQLite companions, and anything under `data/garmin/`, `data/stryd/`, `data/oura/` | `.claude/hooks/block_secrets.py` |
+| `PostToolUse` on `Edit`/`Write` of `*.py` | Run pytest with fail-fast via the project venv; surface failures via stderr + exit 2 | `.claude/hooks/pytest_on_py.py` |
+| `PostToolUse` on `Edit`/`Write` of files under project `web/` ending in `.ts(x)` | Per-file ESLint; surface violations via stderr + exit 2 | `.claude/hooks/web_lint.py` |
 
-The block hook exits 2 and prints a reason, which Claude surfaces and respects. To edit a protected file, use a terminal outside Claude Code or temporarily disable the hook in `settings.json`.
+The block hook **fails closed** — on malformed payloads, unknown tool names, or a missing `file_path` it denies with a stderr explanation rather than letting the edit through. To edit a protected file, use a terminal outside Claude Code or temporarily disable the hook in `settings.json`.
 
 ### Subagents (`.claude/agents/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,38 @@ Keep docs in sync with code — stale docs are worse than no docs. See `docs/dev
 
 Key files: `README.md` (quick start), `docs/*.md` (user guides), `docs/dev/*.md` (architecture + API reference + contributing), `plugins/trainsight/skills/*/SKILL.md` (skill instructions).
 
+## Claude Code Automations
+
+Project-level automations live in `.claude/`. They are committed to the repo so every contributor using Claude Code gets the same behavior.
+
+### Hooks (`.claude/settings.json`)
+
+| When | What | Script |
+|------|------|--------|
+| `PreToolUse` on `Edit`/`Write` | Block edits to `.env*`, `trainsight.db*`, `data/garmin/**`, `data/stryd/**`, `data/oura/**` | `.claude/hooks/block_secrets.py` |
+| `PostToolUse` on `Edit`/`Write` of `*.py` | Run full pytest with fail-fast | inline in `settings.json` |
+| `PostToolUse` on `Edit`/`Write` of `web/**/*.ts(x)` | ESLint the single edited file | `.claude/hooks/web_lint.py` |
+
+The block hook exits 2 and prints a reason, which Claude surfaces and respects. To edit a protected file, use a terminal outside Claude Code or temporarily disable the hook in `settings.json`.
+
+### Subagents (`.claude/agents/`)
+
+| Agent | Trigger |
+|-------|---------|
+| `science-reviewer` | Edits to `analysis/` or `data/science/` — citation completeness, published values, flagged estimates |
+| `metric-addition-reviewer` | New or modified training metric — enforces the 7-step checklist end-to-end plus purity and citation |
+| `api-contract-reviewer` | Edits to `api/routes/*`, `api/deps.py`, `api/views.py`, or `web/src/types/api.ts` — verifies Python response shape matches TS interfaces |
+
+All three are read-only (Read/Grep/Glob) — they report gaps; the primary agent fixes them.
+
+### Project skills (`.claude/skills/`)
+
+| Skill | Invocation | Purpose |
+|-------|-----------|---------|
+| `seed-and-preview` | User-only | Reset local DB to sample data and boot API + Vite for manual verification |
+
+Training-domain skills live in `plugins/trainsight/skills/` (see "AI Skills" below). Dev-workflow skills live in `.claude/skills/`.
+
 ## AI Skills
 
 8 skills in `plugins/trainsight/skills/` provide training features via the Trainsight plugin (MCP server + skills):

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -164,10 +164,10 @@ When making changes, update the relevant docs:
 The repo ships committed Claude Code automations in `.claude/`. Full inventory is in `CLAUDE.md` under "Claude Code Automations". Quick reference:
 
 - **Hooks** run automatically on every `Edit`/`Write`:
-  - `.claude/hooks/block_secrets.py` — refuses to touch `.env*`, `trainsight.db*`, or raw synced data under `data/{garmin,stryd,oura}/`. If you genuinely need to edit one of these, do it in a plain terminal.
-  - `.claude/hooks/web_lint.py` — runs ESLint on a single edited `.ts`/`.tsx` file under `web/`.
-  - Inline pytest hook in `.claude/settings.json` — runs the full test suite on every `.py` edit.
-- **Reviewer agents** (read-only, invoked via the `Agent` tool or `subagent_type`):
+  - `.claude/hooks/block_secrets.py` (PreToolUse) — refuses to touch `.env` / `.env.*`, `trainsight.db` + SQLite companions, or anything under `data/{garmin,stryd,oura}/`. Fails closed on malformed payloads or unknown tool names. If you genuinely need to edit one of these, do it in a plain terminal.
+  - `.claude/hooks/pytest_on_py.py` (PostToolUse, `.py` files) — runs pytest via the project venv with fail-fast and surfaces failures to Claude via stderr + exit 2.
+  - `.claude/hooks/web_lint.py` (PostToolUse, `.ts(x)` under project `web/`) — per-file ESLint; lint errors go to stderr + exit 2 so Claude sees them and can self-correct.
+- **Reviewer agents** (read-only; auto-triggered by Claude when their description matches the current change, or invoked explicitly via the `Agent` tool / `subagent_type`):
   - `science-reviewer` — citation and published-value checks for `analysis/` and `data/science/`.
   - `metric-addition-reviewer` — verifies the 7-step add-metric checklist is complete.
   - `api-contract-reviewer` — cross-reads Python response shapes against TS interfaces.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -26,6 +26,8 @@ How to extend Trainsight with new features.
 
 8. **Update docs**: Add to `CLAUDE.md` if it changes the architecture, `docs/features.md` for user-facing description, `docs/dev/api-reference.md` for the endpoint.
 
+> **Claude Code tip:** after the edits, ask the `metric-addition-reviewer` subagent to verify the 7-step checklist is complete and that your formula has a citation. The `api-contract-reviewer` subagent will cross-check that your new field in `api/deps.py` matches the TS interface in `web/src/types/api.ts`.
+
 ## Adding a New Data Source
 
 1. **Create sync script** `sync/{source}_sync.py`:
@@ -155,3 +157,20 @@ When making changes, update the relevant docs:
 | Setup changes | `README.md`, `docs/getting-started.md` |
 | Convention changes | `CLAUDE.md` |
 | DB model changes | `CLAUDE.md` data sources |
+| New Claude automation (hook, agent, dev skill) | `CLAUDE.md` "Claude Code Automations" section |
+
+## Claude Code Dev Tooling
+
+The repo ships committed Claude Code automations in `.claude/`. Full inventory is in `CLAUDE.md` under "Claude Code Automations". Quick reference:
+
+- **Hooks** run automatically on every `Edit`/`Write`:
+  - `.claude/hooks/block_secrets.py` — refuses to touch `.env*`, `trainsight.db*`, or raw synced data under `data/{garmin,stryd,oura}/`. If you genuinely need to edit one of these, do it in a plain terminal.
+  - `.claude/hooks/web_lint.py` — runs ESLint on a single edited `.ts`/`.tsx` file under `web/`.
+  - Inline pytest hook in `.claude/settings.json` — runs the full test suite on every `.py` edit.
+- **Reviewer agents** (read-only, invoked via the `Agent` tool or `subagent_type`):
+  - `science-reviewer` — citation and published-value checks for `analysis/` and `data/science/`.
+  - `metric-addition-reviewer` — verifies the 7-step add-metric checklist is complete.
+  - `api-contract-reviewer` — cross-reads Python response shapes against TS interfaces.
+- **Dev skill** `seed-and-preview` — resets the local DB to sample data and boots API + Vite. User-invocable only (has side effects). See `.claude/skills/seed-and-preview/SKILL.md`.
+
+If a hook is getting in your way, edit `.claude/settings.json`. If a reviewer agent misses a pattern, extend its prompt in `.claude/agents/<name>.md` — they are just markdown with YAML frontmatter.


### PR DESCRIPTION
## Summary
- **Hook: block secrets** — `PreToolUse` refuses Edit/Write on `.env*`, `trainsight.db*`, and `data/{garmin,stryd,oura}/**`. Stops Claude from corrupting Fernet-encrypted credentials or raw synced data.
- **Hook: web lint** — `PostToolUse` runs ESLint per-file on `web/**/*.ts(x)` edits. Pairs with the existing pytest-on-`.py`-edit hook so frontend edits also get a feedback loop.
- **Agent: `metric-addition-reviewer`** — read-only review that enforces the 7-step metric checklist (pure function, `deps.py`, route, TS type, component, page, test) plus citation and purity.
- **Agent: `api-contract-reviewer`** — read-only review that cross-reads Python response shapes (`api/deps.py`, `api/views.py`, `api/routes/*`) against TS interfaces in `web/src/types/api.ts` to catch silent drift.
- **Skill: `seed-and-preview`** (user-only) — resets local DB to sample data and boots API + Vite for manual verification.
- **`.gitignore`** — un-ignores `.claude/hooks/` so the hook scripts are tracked and ship with the repo (existing `.claude/*` rule was too broad).
- **Docs** — new `Claude Code Automations` section in `CLAUDE.md` and `Claude Code Dev Tooling` reference in `docs/dev/contributing.md`, plus a metric-flow tip pointing at the reviewer agents.

## Test plan
- [x] Block hook denies `.env`, `trainsight.db`, `data/garmin/activities.csv` (exit 2 with reason on stderr).
- [x] Block hook allows `analysis/metrics.py`, `data/sample/garmin/activities.csv`, `.env.example`.
- [x] Web-lint hook silent on a clean `web/src/App.tsx` and on non-web files.
- [ ] In a fresh Claude Code session: verify `PreToolUse` fires on an attempted `.env` edit.
- [ ] In a fresh Claude Code session: trigger `metric-addition-reviewer` after a sample metric edit and confirm output format.
- [ ] Run `seed-and-preview` end-to-end and hit the dashboard on `http://localhost:5173`.

## Notes
- Does not include `data/config.json`, which has an unrelated local modification.
- The `sqlite` MCP server was considered but not wired — writing to the live DB risks corrupting encrypted credentials. It remains a documented opt-in for developers who want to point it at a read-only copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)