### PR TITLE
build(deps): bump lucide-react from 0.577.0 to 1.8.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-query": "^5.99.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
@@ -5458,9 +5458,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "@tanstack/react-query": "^5.99.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary

Bumps \`lucide-react\` through its first stable release (0.x → 1.x).

Supersedes #33. Dependabot's \`web/package-lock.json\` branch would conflict with other in-flight web deps; this branch was regenerated against current main.

## Breaking-change notes

- The 1.x cycle renamed a handful of icons (e.g. \`text-select\` → \`square-dashed-text\`). The repo uses ~40 icons across 18 files; none of them are in the renamed set — TypeScript compile passes without changes.

## Test plan

- [x] \`npm run build\` — tsc + Vite succeed across all icon import sites
- [x] \`npm run lint\` — no new errors vs. main

⚠️ I did **not** start the dev server and visually verify icon rendering. Icons could shift subtly at the SVG level even with the same component name. Recommend eyeballing one page (Today or Sidebar is the highest-traffic set) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)