### PR TITLE
Fix timezone handling in sync + other server timestamps

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user_id
+from api.views import utc_isoformat
 from db.session import get_db
 
 from db.session import init_db
@@ -115,5 +116,5 @@ def get_me(
         "email": user.email,
         "is_superuser": user.is_superuser,
         "is_demo": user.is_demo,
-        "created_at": user.created_at.isoformat() if user.created_at else None,
+        "created_at": utc_isoformat(user.created_at),
     }

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user_id
+from api.views import utc_isoformat
 from db.session import get_db
 
 router = APIRouter(prefix="/admin")
@@ -91,9 +92,9 @@ def list_invitations(
             "code": inv.code,
             "note": inv.note,
             "is_active": inv.is_active,
-            "created_at": inv.created_at.isoformat() if inv.created_at else None,
+            "created_at": utc_isoformat(inv.created_at),
             "used_by": used_email,
-            "used_at": inv.used_at.isoformat() if inv.used_at else None,
+            "used_at": utc_isoformat(inv.used_at),
         })
     return {"invitations": result}
 
@@ -143,7 +144,7 @@ def list_users(
                 "is_demo": u.is_demo,
                 "demo_of": u.demo_of,
                 "demo_of_email": user_emails.get(u.demo_of) if u.demo_of else None,
-                "created_at": u.created_at.isoformat() if u.created_at else None,
+                "created_at": utc_isoformat(u.created_at),
             }
             for u in users
         ]

--- a/api/routes/insights.py
+++ b/api/routes/insights.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id, require_write_access
+from api.views import utc_isoformat
 from db.session import get_db
 
 router = APIRouter()
@@ -85,7 +86,7 @@ def get_insights(
                 "findings": row.findings or [],
                 "recommendations": row.recommendations or [],
                 "meta": row.meta or {},
-                "generated_at": row.generated_at.isoformat() if row.generated_at else None,
+                "generated_at": utc_isoformat(row.generated_at),
             }
             for row in rows
         }
@@ -116,6 +117,6 @@ def get_insight(
             "findings": row.findings or [],
             "recommendations": row.recommendations or [],
             "meta": row.meta or {},
-            "generated_at": row.generated_at.isoformat() if row.generated_at else None,
+            "generated_at": utc_isoformat(row.generated_at),
         }
     }

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -26,6 +26,7 @@ from analysis.providers import available_providers
 from analysis.thresholds import detect_thresholds
 from analysis.training_base import get_display_config
 from api.auth import get_data_user_id, require_write_access
+from api.views import utc_isoformat
 from db.session import get_db
 from db.sync_scheduler import (
     ALLOWED_SYNC_INTERVAL_HOURS,
@@ -254,7 +255,7 @@ def get_connections(
     for conn in connections:
         result[conn.platform] = {
             "status": conn.status,
-            "last_sync": conn.last_sync.isoformat() if conn.last_sync else None,
+            "last_sync": utc_isoformat(conn.last_sync),
             "has_credentials": conn.encrypted_credentials is not None,
         }
     return {"connections": result}

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import threading
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +16,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id, require_write_access
+from api.views import utc_isoformat
 from db.session import get_db
 
 router = APIRouter()
@@ -146,7 +147,7 @@ def _run_sync(user_id: str, source: str, creds: dict,
         with _sync_lock:
             status[source] = {
                 "status": "done",
-                "last_sync": datetime.now().isoformat(),
+                "last_sync": utc_isoformat(datetime.now(timezone.utc)),
                 "error": None,
             }
 
@@ -465,7 +466,7 @@ def get_sync_status(
         runtime = runtime_snapshot.get(src, {})
         result[src] = {
             "status": runtime.get("status", "idle"),
-            "last_sync": conn.last_sync.isoformat() if conn.last_sync else runtime.get("last_sync"),
+            "last_sync": utc_isoformat(conn.last_sync) or runtime.get("last_sync"),
             "error": runtime.get("error"),
             "connected": conn.status in ("connected", "error"),
             "progress": runtime.get("progress"),

--- a/api/views.py
+++ b/api/views.py
@@ -3,9 +3,30 @@
 These functions extract presentation-ready data from get_dashboard_data().
 Both web API routes and CLI skill scripts import from here to stay in sync.
 """
-from datetime import date
+from datetime import date, datetime, timezone
 
 import pandas as pd
+
+
+def utc_isoformat(dt: datetime | None) -> str | None:
+    """Serialize a UTC datetime as an ISO-8601 string with a UTC offset.
+
+    DB-stored timestamps (``User.created_at``, ``UserConnection.last_sync``,
+    etc.) are naive ``datetime.utcnow()`` values — no tzinfo, just the wall
+    clock in UTC. Calling ``.isoformat()`` on those produces a string like
+    ``"2026-04-18T12:34:56"``. Per the ECMAScript spec, browsers parse such
+    strings as *local* time, which makes the UI display a time that differs
+    from the server's actual UTC moment by the viewer's UTC offset.
+
+    Treat naive inputs as UTC and always emit the ``+00:00`` suffix so
+    ``new Date()`` on the frontend lands on the correct instant regardless of
+    the viewer's timezone.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
 
 
 def last_activity(activities: list[dict]) -> dict | None:

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,103 @@
+"""Tests for UTC timestamp serialization.
+
+Regression guard for a class of bugs where naive UTC datetimes stored in the
+DB (``datetime.utcnow()``) were serialized with ``.isoformat()`` and shipped to
+the browser without a timezone marker. Per the ECMAScript spec,
+``new Date("2026-04-18T12:34:56")`` (no tz suffix) is parsed as **local** time,
+so users on non-UTC clocks saw "Last synced" stamps that were off by their UTC
+offset.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from api.views import utc_isoformat
+
+
+def test_utc_isoformat_returns_none_for_none() -> None:
+    assert utc_isoformat(None) is None
+
+
+def test_utc_isoformat_tags_naive_datetime_as_utc() -> None:
+    """Naive datetimes (``datetime.utcnow()``) must be labelled UTC on output.
+
+    Without a suffix, JavaScript ``new Date()`` would interpret the string as
+    local time. The ``+00:00`` offset pins the moment unambiguously.
+    """
+    naive = datetime(2026, 4, 18, 12, 34, 56)
+    out = utc_isoformat(naive)
+    assert out is not None
+    assert out.endswith("+00:00"), out
+    assert out.startswith("2026-04-18T12:34:56")
+
+
+def test_utc_isoformat_preserves_aware_utc_datetime() -> None:
+    aware = datetime(2026, 4, 18, 12, 34, 56, tzinfo=timezone.utc)
+    assert utc_isoformat(aware) == "2026-04-18T12:34:56+00:00"
+
+
+def test_utc_isoformat_normalizes_non_utc_timezone() -> None:
+    """A tz-aware datetime in another zone must be normalized to UTC."""
+    tz = timezone(timedelta(hours=8))  # e.g. Asia/Shanghai-ish
+    aware = datetime(2026, 4, 18, 20, 34, 56, tzinfo=tz)
+    out = utc_isoformat(aware)
+    assert out == "2026-04-18T12:34:56+00:00"
+
+
+@pytest.mark.parametrize("sample", [
+    "2026-04-18T12:34:56+00:00",
+    "2026-04-18T12:34:56.789012+00:00",
+])
+def test_utc_isoformat_output_is_parseable_as_utc(sample: str) -> None:
+    """Round-trip the output back through ``fromisoformat`` and confirm UTC.
+
+    This is the contract the frontend relies on: ``new Date(s)`` in JS lands
+    on the same absolute moment regardless of the viewer's local timezone.
+    """
+    parsed = datetime.fromisoformat(sample)
+    assert parsed.utcoffset() == timedelta(0)
+
+
+def test_sync_status_last_sync_is_tz_aware(api_client, monkeypatch) -> None:
+    """Integration guard: ``/api/sync/status`` must emit tz-aware timestamps.
+
+    Stores a naive UTC ``last_sync`` (mirroring what the scheduler writes) and
+    then hits the status endpoint. The serialized timestamp must round-trip
+    back to a UTC-offset datetime; a failure here means the browser would
+    interpret the value as local time again.
+    """
+    client, user_id = api_client
+
+    # Seed a UserConnection with a naive UTC last_sync, just like the scheduler
+    # writes via ``datetime.utcnow()``.
+    from db import session as db_session
+    from db.models import UserConnection
+
+    naive_utc = datetime(2026, 4, 18, 12, 34, 56)
+    sess = db_session.SessionLocal()
+    try:
+        sess.add(UserConnection(
+            user_id=user_id,
+            platform="garmin",
+            preferences={},
+            last_sync=naive_utc,
+            status="connected",
+        ))
+        sess.commit()
+    finally:
+        sess.close()
+
+    res = client.get("/api/sync/status")
+    assert res.status_code == 200, res.text
+    payload = res.json()
+    stamp = payload.get("garmin", {}).get("last_sync")
+    assert stamp is not None, payload
+    # Must carry a UTC offset so JS ``new Date()`` doesn't fall back to local.
+    parsed = datetime.fromisoformat(stamp)
+    assert parsed.utcoffset() == timedelta(0), stamp
+    # And point at the same instant we wrote.
+    assert parsed.replace(tzinfo=None) == naive_utc
+
+
+# Reuse the fully-configured test client fixture from the settings-API tests.
+from tests.test_settings_api import api_client  # noqa: E402,F401


### PR DESCRIPTION
## Summary
- `datetime.utcnow().isoformat()` produced naive ISO strings (`"2026-04-18T12:34:56"`) that browsers parse as **local time** per the ECMAScript spec, so the Settings "Last synced" timestamp (and other audit stamps) was off by the viewer's UTC offset.
- Add `api.views.utc_isoformat(dt)` helper that treats naive inputs as UTC and always emits `+00:00`, then apply it at every timestamp-serializing API site (`sync`, `settings`, `admin`, `insights`, `auth/me`).
- Replace a stray `datetime.now()` (server local clock) in the sync route's in-memory runtime status with `datetime.now(timezone.utc)` so runtime and DB values agree.

## Root cause (how a China-time server produced a "wrong" clock on PST browsers)
1. Scheduler writes `conn.last_sync = datetime.utcnow()` → naive UTC datetime in SQLite.
2. `/api/sync/status` serializes it as `conn.last_sync.isoformat()` → `"2026-04-18T12:34:56"` (no tz suffix).
3. Frontend parses via `new Date(s).toLocaleString()`. Per ES spec, strings without a timezone suffix are interpreted as local time, so a PST viewer saw "12:34 PM PST" — 8 hours later than the actual UTC moment (`04:34 PST`).

The fix keeps DB columns naive (no migration) and adds tz info at the serialization boundary — a pure view-layer change.

## Test plan
- [x] `python -m pytest tests/test_timezone.py -v` — new helper + integration round-trip via `/api/sync/status` (7 passed)
- [x] `python -m pytest tests/ -v` — full suite (198 passed, 1 skipped)
- [ ] Manual: hit Settings page, confirm "Last synced" matches browser-local clock on a non-UTC machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)