### PR TITLE
chore: update references after repo rename to praxys

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Praxys training dashboard — MCP tools for training data, daily briefs, race forecasts, and AI plan management",
       "source": "./plugins/praxys",
       "category": "productivity",
-      "homepage": "https://github.com/dddtc2005/trainsight"
+      "homepage": "https://github.com/dddtc2005/praxys"
     }
   ]
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,7 +73,7 @@ The database (`data/trainsight.db`) is created automatically on first startup. N
 ## Prerequisites (Azure)
 
 - Azure subscription
-- GitHub repository (dddtc2005/trainsight)
+- GitHub repository (dddtc2005/praxys)
 - Azure CLI installed locally
 
 ## Azure Setup (One-Time)
@@ -158,7 +158,7 @@ az role assignment create \
 az staticwebapp create \
   --name swa-trainsight \
   --resource-group rg-trainsight \
-  --source https://github.com/dddtc2005/trainsight \
+  --source https://github.com/dddtc2005/praxys \
   --branch main \
   --app-location "web" \
   --output-location "dist"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,8 +85,8 @@ Run everything on your machine. Same features, same auth flow.
 ### 1. Clone and Install
 
 ```bash
-git clone https://github.com/dddtc2005/trainsight.git
-cd trainsight
+git clone https://github.com/dddtc2005/praxys.git
+cd praxys
 
 # Python dependencies
 pip install -r requirements.txt

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Praxys training dashboard — MCP tools for training data, daily briefs, race forecasts, and AI plan management",
       "source": "./plugins/praxys",
       "category": "productivity",
-      "homepage": "https://github.com/dddtc2005/trainsight"
+      "homepage": "https://github.com/dddtc2005/praxys"
     }
   ]
 }

--- a/plugins/praxys/.claude-plugin/plugin.json
+++ b/plugins/praxys/.claude-plugin/plugin.json
@@ -4,8 +4,8 @@
   "description": "Praxys training dashboard — MCP tools for training data, daily briefs, race forecasts, and AI plan management",
   "author": {
     "name": "Fei Tao",
-    "url": "https://github.com/dddtc2005/trainsight"
+    "url": "https://github.com/dddtc2005/praxys"
   },
-  "repository": "https://github.com/dddtc2005/trainsight",
+  "repository": "https://github.com/dddtc2005/praxys",
   "keywords": ["training", "running", "power", "stryd", "garmin", "oura", "fitness"]
 }

--- a/plugins/praxys/.mcp.json
+++ b/plugins/praxys/.mcp.json
@@ -5,9 +5,7 @@
       "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/server.py"],
       "env": {
         "PRAXYS_URL": "${PRAXYS_URL}",
-        "PRAXYS_FRONTEND_URL": "${PRAXYS_FRONTEND_URL}",
-        "TRAINSIGHT_URL": "${TRAINSIGHT_URL}",
-        "TRAINSIGHT_FRONTEND_URL": "${TRAINSIGHT_FRONTEND_URL}"
+        "PRAXYS_FRONTEND_URL": "${PRAXYS_FRONTEND_URL}"
       }
     }
   }

--- a/web/src/components/CliHint.tsx
+++ b/web/src/components/CliHint.tsx
@@ -10,9 +10,7 @@ interface CliHintProps {
   description: string;
 }
 
-// TODO after GitHub repo rename: update to /dddtc2005/praxys. GitHub auto-redirects
-// old URLs, so this works in the interim.
-const PLUGIN_URL = 'https://github.com/dddtc2005/trainsight';
+const PLUGIN_URL = 'https://github.com/dddtc2005/praxys';
 
 /**
  * Prominent card promoting the Claude Code plugin for AI-powered features.


### PR DESCRIPTION
## Summary
- Renamed GitHub repo \`dddtc2005/trainsight\` → \`dddtc2005/praxys\`; updated all repo URL references in plugin/marketplace manifests, docs, and the \`CliHint\` component.
- Dropped legacy \`TRAINSIGHT_URL\` / \`TRAINSIGHT_FRONTEND_URL\` passthrough from \`plugins/praxys/.mcp.json\` (the \`PRAXYS_*\` vars already cover it). The in-process legacy fallbacks in \`server.py\` / \`auth.py\` stay for direct invocations outside the plugin.
- Azure resource names (\`swa-trainsight\`, \`rg-trainsight\`) left untouched — they reference real deployed resources.

## Test plan
- [ ] \`git fetch origin\` works against new remote (verified locally)
- [ ] Plugin loads with only \`PRAXYS_URL\` / \`PRAXYS_FRONTEND_URL\` set
- [ ] \`CliHint\` links resolve to the new repo URL
- [ ] \`docs/getting-started.md\` clone command resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)