### PR TITLE
docs: finish rebrand copy (plugin install + MCP example)

### DIFF
--- a/.claude/agents/science-reviewer.md
+++ b/.claude/agents/science-reviewer.md
@@ -12,7 +12,7 @@ tools:
 
 # Science Reviewer
 
-You review code changes in trainsight's analysis layer for scientific rigor.
+You review code changes in Praxys's analysis layer for scientific rigor.
 The project's core rule: all training metrics, predictions, and insights must
 be grounded in exercise science.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -267,7 +267,7 @@ After deploying, users connect their CLI tools to the deployed backend:
 claude plugin marketplace add ./plugins/marketplace.json
 
 # Install the plugin
-claude plugin install trainsight
+claude plugin install praxys
 
 # The MCP server's PRAXYS_URL env var (in .mcp.json) routes
 # requests to the deployed API with JWT authentication.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,7 +17,7 @@ Skills are packaged as a Claude Code plugin in `plugins/praxys/`.
 claude plugin marketplace add ./plugins/marketplace.json
 
 # Install the plugin
-claude plugin install trainsight
+claude plugin install praxys
 
 # Reload plugins (in Claude Code)
 /reload-plugins
@@ -34,7 +34,7 @@ The default `.mcp.json` ships with cloud URLs pre-configured:
 ```json
 {
   "mcpServers": {
-    "trainsight": {
+    "praxys": {
       "command": "python",
       "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/server.py"],
       "env": {

--- a/tests/plugin-scenarios/README.md
+++ b/tests/plugin-scenarios/README.md
@@ -6,7 +6,7 @@ test case that can be executed in Claude Code or Copilot CLI.
 ## Prerequisites
 
 - Backend running: `python -m uvicorn api.main:app --reload`
-- Plugin installed: `claude plugin marketplace add ./plugins/marketplace.json && claude plugin install trainsight`
+- Plugin installed: `claude plugin marketplace add ./plugins/marketplace.json && claude plugin install praxys`
 - At least one platform connected and synced
 
 ## How to Run


### PR DESCRIPTION
## Summary
Follow-up to #54. Fixes stale \`trainsight\` references in user-facing docs and one agent prompt that predate the rebrand PRs and would actively break the instructions they contain (the plugin manifest is \`praxys\`, so \`claude plugin install trainsight\` fails).

- \`docs/skills.md\`, \`docs/deployment.md\`, \`tests/plugin-scenarios/README.md\` — install command uses the correct plugin name
- \`docs/skills.md\` — example MCP server key matches the real \`.mcp.json\`
- \`.claude/agents/science-reviewer.md\` — brand name in the system prompt

Out of scope (kept as-is): migration-window compat (env vars, localStorage, \`~/.trainsight\`), the on-disk DB filename \`trainsight.db\`, and Azure resource names.

## Test plan
- [ ] \`claude plugin install praxys\` matches the name in \`plugins/praxys/.claude-plugin/plugin.json\`
- [ ] Example \`.mcp.json\` snippet in \`docs/skills.md\` matches the real \`plugins/praxys/.mcp.json\` server key
- [ ] \`git grep\` shows zero user-facing \`trainsight\` references outside the intentional migration scaffolding

🤖 Generated with [Claude Code](https://claude.com/claude-code)