### PR TITLE
Fix Garmin cross-user data leak (#56)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -221,6 +221,10 @@ def delete_user(
     db.delete(user)
     db.commit()
 
+    # Wipe cached Garmin OAuth tokens on disk for this user
+    from api.routes.sync import clear_garmin_tokens
+    clear_garmin_tokens(target_user_id)
+
     return {"status": "deleted", "email": email}
 
 

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -221,9 +221,18 @@ def delete_user(
     db.delete(user)
     db.commit()
 
-    # Wipe cached Garmin OAuth tokens on disk for this user
+    # Best-effort disk cleanup: the user is already gone from the DB, so an
+    # orphaned token directory can't be resolved to a live account. Don't 500
+    # the request for a filesystem glitch — just log it.
     from api.routes.sync import clear_garmin_tokens
-    clear_garmin_tokens(target_user_id)
+    try:
+        clear_garmin_tokens(target_user_id)
+    except OSError:
+        import logging
+        logging.getLogger(__name__).exception(
+            "User %s deleted but Garmin tokenstore cleanup failed — orphan directory left on disk.",
+            target_user_id,
+        )
 
     return {"status": "deleted", "email": email}
 

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -331,13 +331,16 @@ def connect_platform(
         )
         db.add(conn)
 
-    # Garmin caches OAuth tokens on disk — invalidate them whenever credentials
-    # change so the next sync re-authenticates with the new username/password.
+    db.commit()
+
+    # Invalidate cached OAuth tokens AFTER the new credentials are persisted:
+    # if we cleared first and the commit then failed, the next sync would
+    # re-auth with the old DB credentials and repopulate the tokenstore with
+    # the old account's session — exactly the leak this guards against.
     if platform == "garmin":
         from api.routes.sync import clear_garmin_tokens
         clear_garmin_tokens(user_id)
 
-    db.commit()
     return {"status": "connected", "platform": platform}
 
 

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -331,6 +331,12 @@ def connect_platform(
         )
         db.add(conn)
 
+    # Garmin caches OAuth tokens on disk — invalidate them whenever credentials
+    # change so the next sync re-authenticates with the new username/password.
+    if platform == "garmin":
+        from api.routes.sync import clear_garmin_tokens
+        clear_garmin_tokens(user_id)
+
     db.commit()
     return {"status": "connected", "platform": platform}
 
@@ -351,4 +357,9 @@ def disconnect_platform(
     if conn:
         db.delete(conn)
         db.commit()
+
+    if platform == "garmin":
+        from api.routes.sync import clear_garmin_tokens
+        clear_garmin_tokens(user_id)
+
     return {"status": "disconnected", "platform": platform}

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -71,20 +71,38 @@ def _garmin_token_root() -> str:
 
 
 def _garmin_token_dir(user_id: str) -> str:
-    """Per-user Garmin tokenstore path. Isolating per user is critical — see issue #56."""
+    """Per-user Garmin tokenstore path.
+
+    garminconnect.Garmin.login() loads any tokens it finds at this path from
+    disk without validating whose Garmin account they belong to, so a shared
+    directory would leak one user's authenticated session to the next caller.
+    """
     return os.path.join(_garmin_token_root(), user_id)
 
 
 def clear_garmin_tokens(user_id: str) -> None:
     """Remove cached Garmin OAuth tokens for a user.
 
-    Call this whenever credentials change (connect with new creds, disconnect)
-    so the next sync forces a fresh login instead of reusing stale tokens.
+    Call whenever cached tokens should no longer be trusted: credential
+    rotation on connect, explicit disconnect, or user deletion. Leaves the
+    token root intact. Raises OSError on filesystem failure — callers decide
+    whether that's fatal (connect flow) or best-effort (post-delete cleanup).
+    Silencing failures here would re-open the cross-user leak the helper exists
+    to prevent.
     """
     import shutil
     path = _garmin_token_dir(user_id)
-    if os.path.isdir(path):
-        shutil.rmtree(path, ignore_errors=True)
+    if not os.path.isdir(path):
+        return
+    try:
+        shutil.rmtree(path)
+    except OSError:
+        logger.exception(
+            "Failed to clear Garmin tokenstore for user %s at %s — "
+            "stale tokens may still be reused on next sync.",
+            user_id, path,
+        )
+        raise
 
 
 def _get_credentials(user_id: str, platform: str, db: Session) -> dict | None:
@@ -212,10 +230,11 @@ def _sync_garmin(user_id: str, creds: dict, from_date: str | None,
 
     client = Garmin(creds["email"], creds["password"],
                     is_cn=creds.get("is_cn", False))
-    # Garmin OAuth tokens must be scoped per user. garminconnect.Garmin.login()
-    # reuses whatever tokens are already in the tokenstore and only falls back
-    # to username/password if they fail to load — so a shared token_dir causes
-    # every user's sync to fetch the first user's Garmin data. See issue #56.
+    # The tokenstore must be per-user: garminconnect.Garmin.login() loads any
+    # tokens at that path without validating the account they belong to and
+    # only falls back to username/password if the files themselves are missing
+    # or malformed. A shared path would have every user's sync fetching the
+    # first-authenticated user's Garmin data.
     token_dir = _garmin_token_dir(user_id)
     os.makedirs(token_dir, exist_ok=True)
     client.login(token_dir)

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -63,6 +63,30 @@ def _get_data_dir() -> str:
     )
 
 
+def _garmin_token_root() -> str:
+    """Root directory that holds per-user Garmin token sub-directories."""
+    return os.path.join(
+        os.path.dirname(_get_data_dir()), "sync", ".garmin_tokens",
+    )
+
+
+def _garmin_token_dir(user_id: str) -> str:
+    """Per-user Garmin tokenstore path. Isolating per user is critical — see issue #56."""
+    return os.path.join(_garmin_token_root(), user_id)
+
+
+def clear_garmin_tokens(user_id: str) -> None:
+    """Remove cached Garmin OAuth tokens for a user.
+
+    Call this whenever credentials change (connect with new creds, disconnect)
+    so the next sync forces a fresh login instead of reusing stale tokens.
+    """
+    import shutil
+    path = _garmin_token_dir(user_id)
+    if os.path.isdir(path):
+        shutil.rmtree(path, ignore_errors=True)
+
+
 def _get_credentials(user_id: str, platform: str, db: Session) -> dict | None:
     """Get decrypted credentials for a user's platform connection.
 
@@ -188,8 +212,12 @@ def _sync_garmin(user_id: str, creds: dict, from_date: str | None,
 
     client = Garmin(creds["email"], creds["password"],
                     is_cn=creds.get("is_cn", False))
-    data_dir = _get_data_dir()
-    token_dir = os.path.join(os.path.dirname(data_dir), "sync", ".garmin_tokens")
+    # Garmin OAuth tokens must be scoped per user. garminconnect.Garmin.login()
+    # reuses whatever tokens are already in the tokenstore and only falls back
+    # to username/password if they fail to load — so a shared token_dir causes
+    # every user's sync to fetch the first user's Garmin data. See issue #56.
+    token_dir = _garmin_token_dir(user_id)
+    os.makedirs(token_dir, exist_ok=True)
     client.login(token_dir)
     try:
         client.garth.dump(token_dir)

--- a/plugins/praxys/mcp-server/server.py
+++ b/plugins/praxys/mcp-server/server.py
@@ -462,6 +462,15 @@ def connect_platform(platform: str, credentials: dict) -> str:
                 )
                 db.add(conn)
             db.commit()
+            # Invalidate cached Garmin OAuth tokens so the next sync re-auths
+            # with the new credentials. Mirrors the API route — skipping this
+            # would reproduce the shared-tokenstore leak for local MCP users.
+            if platform == "garmin":
+                from api.routes.sync import clear_garmin_tokens
+                try:
+                    clear_garmin_tokens(_local_user_id())
+                except OSError:
+                    pass  # logged inside clear_garmin_tokens; treat as best-effort here
             data = {"status": "connected", "platform": platform}
         finally:
             db.close()
@@ -484,6 +493,12 @@ def disconnect_platform(platform: str) -> str:
             if conn:
                 db.delete(conn)
                 db.commit()
+            if platform == "garmin":
+                from api.routes.sync import clear_garmin_tokens
+                try:
+                    clear_garmin_tokens(_local_user_id())
+                except OSError:
+                    pass
             data = {"status": "disconnected", "platform": platform}
         finally:
             db.close()

--- a/scripts/cleanup_garmin_token_bug.py
+++ b/scripts/cleanup_garmin_token_bug.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""One-shot cleanup for the shared-Garmin-token bug (issue #56).
+
+Background
+----------
+Before the fix, every user's Garmin sync wrote OAuth tokens to a shared
+``sync/.garmin_tokens/`` directory. `garminconnect.Garmin.login()` reuses
+tokens from its tokenstore and only falls back to username/password if
+loading fails — so after the first user authenticated, every subsequent
+user's sync fetched that first user's Garmin data and stored it under
+their own user_id. The result: multiple users seeing identical activities.
+
+What this script does
+---------------------
+1. Deletes Garmin-sourced rows in ``activities``, ``activity_splits``, and
+   ``fitness_data`` for every user *except* the admin(s). The admin's own
+   data was correct (their tokens stayed valid for themselves); everyone
+   else's "Garmin" rows are suspect and should be re-fetched after the fix.
+2. Resets ``user_connections.last_sync`` to NULL for those users so the
+   background scheduler treats them as stale and re-syncs promptly.
+3. Removes the shared token directory so nothing stale lingers on disk.
+
+Run with ``--dry-run`` first to see per-user counts. Add ``--apply`` to
+commit the deletions. Safe to re-run: deletes are keyed on non-admin users
+only, so repeated runs are idempotent once users re-sync with the fix.
+
+Usage
+-----
+    python scripts/cleanup_garmin_token_bug.py --dry-run
+    python scripts/cleanup_garmin_token_bug.py --apply
+"""
+import argparse
+import os
+import shutil
+import sys
+
+# Make ``db`` / ``api`` importable when run from the project root on Azure
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from db import session as db_session  # noqa: E402
+from db.models import (  # noqa: E402
+    Activity, ActivitySplit, FitnessData, User, UserConnection,
+)
+
+
+def _find_admin_ids(db) -> list[str]:
+    """Admins keep their own Garmin rows — everyone else's are suspect."""
+    rows = db.query(User.id).filter(User.is_superuser == True).all()  # noqa: E712
+    return [r[0] for r in rows]
+
+
+def _summarize(db, admin_ids: list[str]) -> dict:
+    """Count rows the script would delete, grouped by user."""
+    summary: dict = {"users": [], "totals": {"activities": 0, "splits": 0, "fitness": 0}}
+    users = db.query(User).filter(~User.id.in_(admin_ids)).all()
+    for u in users:
+        acts = db.query(Activity).filter(
+            Activity.user_id == u.id, Activity.source == "garmin",
+        ).count()
+        splits = db.query(ActivitySplit).filter(
+            ActivitySplit.user_id == u.id,
+            ActivitySplit.activity_id.in_(
+                db.query(Activity.activity_id).filter(
+                    Activity.user_id == u.id, Activity.source == "garmin",
+                )
+            ),
+        ).count()
+        fitness = db.query(FitnessData).filter(
+            FitnessData.user_id == u.id, FitnessData.source == "garmin",
+        ).count()
+        if acts or splits or fitness:
+            summary["users"].append({
+                "email": u.email,
+                "activities": acts,
+                "splits": splits,
+                "fitness": fitness,
+            })
+            summary["totals"]["activities"] += acts
+            summary["totals"]["splits"] += splits
+            summary["totals"]["fitness"] += fitness
+    return summary
+
+
+def _apply(db, admin_ids: list[str]) -> dict:
+    """Delete suspect Garmin rows and reset last_sync so re-sync fires."""
+    # Splits FK the activity_id; delete them via a subquery keyed on suspect
+    # activities rather than blanket-deleting so Stryd-sourced splits survive.
+    suspect_activity_ids = db.query(Activity.activity_id).filter(
+        ~Activity.user_id.in_(admin_ids),
+        Activity.source == "garmin",
+    ).subquery()
+
+    split_count = db.query(ActivitySplit).filter(
+        ActivitySplit.activity_id.in_(suspect_activity_ids),
+    ).delete(synchronize_session=False)
+
+    act_count = db.query(Activity).filter(
+        ~Activity.user_id.in_(admin_ids),
+        Activity.source == "garmin",
+    ).delete(synchronize_session=False)
+
+    fit_count = db.query(FitnessData).filter(
+        ~FitnessData.user_id.in_(admin_ids),
+        FitnessData.source == "garmin",
+    ).delete(synchronize_session=False)
+
+    conn_count = db.query(UserConnection).filter(
+        ~UserConnection.user_id.in_(admin_ids),
+        UserConnection.platform == "garmin",
+    ).update({"last_sync": None, "status": "connected"}, synchronize_session=False)
+
+    db.commit()
+    return {
+        "activities_deleted": act_count,
+        "splits_deleted": split_count,
+        "fitness_deleted": fit_count,
+        "connections_reset": conn_count,
+    }
+
+
+def _purge_shared_token_dir() -> bool:
+    """Remove the old shared token directory if it still exists on disk."""
+    data_dir = os.environ.get(
+        "DATA_DIR",
+        os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data"),
+    )
+    shared = os.path.join(os.path.dirname(data_dir), "sync", ".garmin_tokens")
+    # After the fix, per-user dirs live *under* this path. Only remove loose
+    # token files at the root — leave sub-directories (they are per-user now).
+    if not os.path.isdir(shared):
+        return False
+    removed_any = False
+    for entry in os.listdir(shared):
+        full = os.path.join(shared, entry)
+        if os.path.isfile(full):
+            os.remove(full)
+            removed_any = True
+    return removed_any
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="Show counts only; do not delete.")
+    ap.add_argument("--apply", action="store_true", help="Apply deletions.")
+    args = ap.parse_args()
+
+    if not args.dry_run and not args.apply:
+        ap.error("specify --dry-run or --apply")
+    if args.dry_run and args.apply:
+        ap.error("--dry-run and --apply are mutually exclusive")
+
+    db_session.init_db()
+    db = db_session.SessionLocal()
+    try:
+        admin_ids = _find_admin_ids(db)
+        if not admin_ids:
+            print("ERROR: no admin users found (is_superuser=True). Aborting so we", file=sys.stderr)
+            print("don't accidentally wipe the only Garmin rows in the database.", file=sys.stderr)
+            return 2
+
+        print(f"Admins kept: {len(admin_ids)} user(s).")
+        summary = _summarize(db, admin_ids)
+
+        if not summary["users"]:
+            print("No suspect Garmin rows found — nothing to do.")
+            return 0
+
+        print("\nSuspect Garmin rows by user:")
+        for u in summary["users"]:
+            print(f"  {u['email']}: activities={u['activities']} "
+                  f"splits={u['splits']} fitness_rows={u['fitness']}")
+        print(f"\nTotals: {summary['totals']}")
+
+        if args.dry_run:
+            print("\n[dry-run] no rows deleted. Re-run with --apply to commit.")
+            return 0
+
+        result = _apply(db, admin_ids)
+        print(f"\nDeleted: {result}")
+
+        purged = _purge_shared_token_dir()
+        print(f"Shared tokenstore cleanup: {'removed stale files' if purged else 'nothing to clean'}")
+        print("\nDone. Affected users will be picked up by the sync scheduler;")
+        print("encourage them to run Settings → Backfill for ≥180 days.")
+        return 0
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cleanup_garmin_token_bug.py
+++ b/scripts/cleanup_garmin_token_bug.py
@@ -1,28 +1,38 @@
 #!/usr/bin/env python3
-"""One-shot cleanup for the shared-Garmin-token bug (issue #56).
+"""One-shot cleanup for the shared-Garmin-token cross-user data leak.
 
 Background
 ----------
 Before the fix, every user's Garmin sync wrote OAuth tokens to a shared
-``sync/.garmin_tokens/`` directory. `garminconnect.Garmin.login()` reuses
-tokens from its tokenstore and only falls back to username/password if
-loading fails — so after the first user authenticated, every subsequent
-user's sync fetched that first user's Garmin data and stored it under
-their own user_id. The result: multiple users seeing identical activities.
+``sync/.garmin_tokens/`` directory. garminconnect loads any tokens it finds
+at that path without re-validating them against Garmin's API, so after the
+first user authenticated, every subsequent user's sync silently reused that
+session and fetched *their* data — storing it under the requester's user_id.
 
 What this script does
 ---------------------
 1. Deletes Garmin-sourced rows in ``activities``, ``activity_splits``, and
-   ``fitness_data`` for every user *except* the admin(s). The admin's own
-   data was correct (their tokens stayed valid for themselves); everyone
-   else's "Garmin" rows are suspect and should be re-fetched after the fix.
+   ``fitness_data`` for every user *except* the admin(s). See the assumption
+   below.
 2. Resets ``user_connections.last_sync`` to NULL for those users so the
    background scheduler treats them as stale and re-syncs promptly.
-3. Removes the shared token directory so nothing stale lingers on disk.
+3. Removes loose token files at the legacy shared-root path, leaving the
+   per-user subdirectories the fix creates in place.
 
 Run with ``--dry-run`` first to see per-user counts. Add ``--apply`` to
 commit the deletions. Safe to re-run: deletes are keyed on non-admin users
-only, so repeated runs are idempotent once users re-sync with the fix.
+only, so repeated runs converge once users re-sync with the fix.
+
+Assumption: admin authenticated first
+-------------------------------------
+The script preserves every ``is_superuser=True`` user's Garmin rows because
+in the common deployment flow the admin is the first user on the box and
+their tokens sat in the shared path from then on — so their rows were never
+overwritten by someone else's data. **If a non-admin actually authenticated
+before the admin did, the admin's rows are the poisoned ones** and this
+script will preserve bad data while discarding the non-admin's (correct)
+data. Before ``--apply`` on a deployment where that ordering is uncertain,
+inspect ``user_connections.last_sync`` and decide manually.
 
 Usage
 -----
@@ -83,14 +93,17 @@ def _summarize(db, admin_ids: list[str]) -> dict:
 
 def _apply(db, admin_ids: list[str]) -> dict:
     """Delete suspect Garmin rows and reset last_sync so re-sync fires."""
-    # Splits FK the activity_id; delete them via a subquery keyed on suspect
-    # activities rather than blanket-deleting so Stryd-sourced splits survive.
-    suspect_activity_ids = db.query(Activity.activity_id).filter(
+    # Non-admin users' "Garmin" activities carry the admin's own activity_ids
+    # (that's the bug — they fetched admin data). Filter splits by BOTH the
+    # activity_id AND user_id so the admin's matching splits survive.
+    from sqlalchemy import select
+    suspect_activity_ids = select(Activity.activity_id).where(
         ~Activity.user_id.in_(admin_ids),
         Activity.source == "garmin",
-    ).subquery()
+    )
 
     split_count = db.query(ActivitySplit).filter(
+        ~ActivitySplit.user_id.in_(admin_ids),
         ActivitySplit.activity_id.in_(suspect_activity_ids),
     ).delete(synchronize_session=False)
 

--- a/tests/test_cleanup_garmin_token_bug.py
+++ b/tests/test_cleanup_garmin_token_bug.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/cleanup_garmin_token_bug.py.
+
+The script is a one-shot, destructive operation. The dangerous properties to
+lock down:
+ - never deletes rows belonging to any admin user,
+ - preserves non-Garmin sources (Stryd splits, Oura recovery),
+ - refuses to run when no admin exists (otherwise a missing admin flag would
+   cause the script to wipe every user's Garmin data).
+"""
+from datetime import date
+
+import pytest
+
+
+@pytest.fixture
+def seeded_db(tmp_path, monkeypatch):
+    """Yield a session against a temp SQLite DB with admin + non-admin users."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY", "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o="
+    )
+
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from db.models import (
+        Activity, ActivitySplit, FitnessData, User, UserConnection,
+    )
+
+    admin_id = "admin-1"
+    user_id = "user-1"
+
+    with db_session.SessionLocal() as db:
+        db.add(User(id=admin_id, email="admin@x", hashed_password="x",
+                    is_active=True, is_superuser=True))
+        db.add(User(id=user_id, email="u1@x", hashed_password="x",
+                    is_active=True, is_superuser=False))
+        # Shared activity_id across admin + non-admin — this is the pathological
+        # case: the non-admin's Garmin rows carry the admin's activity_id.
+        shared_id = "shared-act-42"
+        db.add(Activity(user_id=admin_id, activity_id=shared_id,
+                        date=date(2026, 4, 1), source="garmin"))
+        db.add(Activity(user_id=user_id, activity_id=shared_id,
+                        date=date(2026, 4, 1), source="garmin"))
+        # Admin also has a Stryd activity that must survive the cleanup.
+        db.add(Activity(user_id=admin_id, activity_id="stryd-1",
+                        date=date(2026, 4, 2), source="stryd"))
+        # Splits: one row per user against the shared activity_id.
+        db.add(ActivitySplit(user_id=admin_id, activity_id=shared_id, split_num=1))
+        db.add(ActivitySplit(user_id=user_id, activity_id=shared_id, split_num=1))
+        # Fitness data: both users have Garmin VO2max, only non-admin's should go.
+        db.add(FitnessData(user_id=admin_id, date=date(2026, 4, 1),
+                           metric_type="vo2max", value=55.0, source="garmin"))
+        db.add(FitnessData(user_id=user_id, date=date(2026, 4, 1),
+                           metric_type="vo2max", value=55.0, source="garmin"))
+        # Non-admin Garmin connection — should get last_sync=NULL after apply.
+        db.add(UserConnection(user_id=user_id, platform="garmin",
+                              status="connected"))
+        db.commit()
+
+    try:
+        yield db_session
+    finally:
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+
+
+def test_apply_preserves_admin_rows_across_all_tables(seeded_db):
+    """Admin's activities, splits, AND fitness rows must survive _apply()."""
+    from db.models import Activity, ActivitySplit, FitnessData
+    from scripts.cleanup_garmin_token_bug import _apply
+
+    admin_id = "admin-1"
+    user_id = "user-1"
+
+    with seeded_db.SessionLocal() as db:
+        result = _apply(db, [admin_id])
+
+    with seeded_db.SessionLocal() as db:
+        # Admin side — nothing lost.
+        assert db.query(Activity).filter(
+            Activity.user_id == admin_id, Activity.source == "garmin",
+        ).count() == 1, "admin Garmin activity must survive"
+        assert db.query(ActivitySplit).filter(
+            ActivitySplit.user_id == admin_id,
+        ).count() == 1, "admin splits must survive (this was the reviewed bug)"
+        assert db.query(FitnessData).filter(
+            FitnessData.user_id == admin_id,
+        ).count() == 1, "admin Garmin fitness row must survive"
+        # Admin's Stryd row is also untouched.
+        assert db.query(Activity).filter(
+            Activity.user_id == admin_id, Activity.source == "stryd",
+        ).count() == 1
+
+        # Non-admin side — everything Garmin is gone.
+        assert db.query(Activity).filter(
+            Activity.user_id == user_id, Activity.source == "garmin",
+        ).count() == 0
+        assert db.query(ActivitySplit).filter(
+            ActivitySplit.user_id == user_id,
+        ).count() == 0
+        assert db.query(FitnessData).filter(
+            FitnessData.user_id == user_id, FitnessData.source == "garmin",
+        ).count() == 0
+
+    assert result["activities_deleted"] == 1
+    assert result["splits_deleted"] == 1
+    assert result["fitness_deleted"] == 1
+    assert result["connections_reset"] == 1
+
+
+def test_apply_is_idempotent(seeded_db):
+    """Second run should delete zero additional rows and not raise."""
+    from scripts.cleanup_garmin_token_bug import _apply
+
+    with seeded_db.SessionLocal() as db:
+        _apply(db, ["admin-1"])
+
+    with seeded_db.SessionLocal() as db:
+        result = _apply(db, ["admin-1"])
+
+    assert result == {
+        "activities_deleted": 0,
+        "splits_deleted": 0,
+        "fitness_deleted": 0,
+        # last_sync is already NULL from the first run, but the UPDATE still
+        # matches the row — so connections_reset may be 1 again. We only
+        # require no data loss.
+        "connections_reset": result["connections_reset"],
+    }
+
+
+def test_main_aborts_when_no_admin_exists(seeded_db, monkeypatch):
+    """Without this guard an admin-less DB would have EVERY Garmin row wiped."""
+    from db.models import User, Activity
+    from scripts import cleanup_garmin_token_bug
+
+    # Strip admin status from the seeded admin.
+    with seeded_db.SessionLocal() as db:
+        admin = db.query(User).filter(User.id == "admin-1").first()
+        admin.is_superuser = False
+        db.commit()
+
+    # Argv patched so argparse sees --apply (the dangerous path).
+    monkeypatch.setattr("sys.argv", ["cleanup_garmin_token_bug.py", "--apply"])
+
+    exit_code = cleanup_garmin_token_bug.main()
+    assert exit_code == 2
+
+    # No rows were deleted.
+    with seeded_db.SessionLocal() as db:
+        assert db.query(Activity).filter(
+            Activity.source == "garmin",
+        ).count() == 2, "abort path must not delete any rows"

--- a/tests/test_garmin_token_invalidation_api.py
+++ b/tests/test_garmin_token_invalidation_api.py
@@ -1,0 +1,170 @@
+"""End-to-end invalidation tests: connect / disconnect / delete_user.
+
+Locks down the contract that every credential-change endpoint clears the
+per-user Garmin tokenstore. Regressions here would reproduce the cross-user
+leak through a different code path than the original fix.
+"""
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def api_client(monkeypatch):
+    """Yield a TestClient + helpers that isolate API under a temp DB + DATA_DIR."""
+    from fastapi.testclient import TestClient
+
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_SYNC_SCHEDULER", "false")
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY", "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o="
+    )
+
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from api.main import app
+    from api.auth import get_current_user_id, get_data_user_id, require_write_access
+    from db.session import get_db
+
+    test_user_id = "test-user-tokens"
+    admin_user_id = "test-admin-tokens"
+
+    def _override_current_user():
+        return test_user_id
+
+    def _override_admin_user():
+        return admin_user_id
+
+    def _override_db():
+        db = db_session.SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # Seed both users so role-based endpoints can look them up.
+    from db.models import User
+    with db_session.SessionLocal() as db:
+        db.add(User(
+            id=test_user_id, email="user@test.local",
+            hashed_password="x", is_active=True, is_superuser=False,
+        ))
+        db.add(User(
+            id=admin_user_id, email="admin@test.local",
+            hashed_password="x", is_active=True, is_superuser=True,
+        ))
+        db.commit()
+
+    app.dependency_overrides[get_current_user_id] = _override_current_user
+    app.dependency_overrides[get_data_user_id] = _override_current_user
+    app.dependency_overrides[require_write_access] = _override_current_user
+    app.dependency_overrides[get_db] = _override_db
+
+    client = TestClient(app)
+    try:
+        yield {
+            "client": client,
+            "user_id": test_user_id,
+            "admin_id": admin_user_id,
+            "override_admin": _override_admin_user,
+        }
+    finally:
+        app.dependency_overrides.clear()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _seed_token_dir(user_id: str) -> str:
+    """Drop a dummy tokenstore on disk and return its path."""
+    from api.routes.sync import _garmin_token_dir
+
+    path = _garmin_token_dir(user_id)
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, "oauth2_token.json"), "w") as f:
+        f.write("{}")
+    assert os.path.isdir(path)
+    return path
+
+
+def test_connect_garmin_clears_existing_tokens(api_client):
+    path = _seed_token_dir(api_client["user_id"])
+    res = api_client["client"].post(
+        "/api/settings/connections/garmin",
+        json={"email": "new@example.com", "password": "newpw"},
+    )
+    assert res.status_code == 200
+    assert not os.path.isdir(path)
+
+
+def test_connect_non_garmin_does_not_touch_garmin_tokens(api_client):
+    """Guards against a future invert-the-if regression."""
+    path = _seed_token_dir(api_client["user_id"])
+    res = api_client["client"].post(
+        "/api/settings/connections/oura",
+        json={"token": "sk-fake"},
+    )
+    assert res.status_code == 200
+    assert os.path.isdir(path), "Oura connect must not wipe the Garmin tokenstore"
+
+
+def test_disconnect_garmin_clears_tokens(api_client):
+    """Connect first (so there's a DB row to delete), then disconnect."""
+    api_client["client"].post(
+        "/api/settings/connections/garmin",
+        json={"email": "a@example.com", "password": "pw"},
+    )
+    path = _seed_token_dir(api_client["user_id"])
+    res = api_client["client"].delete("/api/settings/connections/garmin")
+    assert res.status_code == 200
+    assert not os.path.isdir(path)
+
+
+def test_admin_delete_user_clears_tokens(api_client):
+    """Admin deletion is a privacy boundary — cached OAuth tokens must go too."""
+    from api.auth import get_current_user_id
+
+    path = _seed_token_dir(api_client["user_id"])
+    # Swap in the admin override so the admin route passes _require_admin.
+    api_client["client"].app.dependency_overrides[get_current_user_id] = (
+        api_client["override_admin"]
+    )
+    res = api_client["client"].delete(f"/api/admin/users/{api_client['user_id']}")
+    assert res.status_code == 200
+    assert not os.path.isdir(path)
+
+
+def test_admin_delete_user_survives_token_cleanup_failure(api_client, monkeypatch):
+    """User deletion must succeed even if filesystem cleanup errors — the user
+    is already gone from the DB and the endpoint shouldn't 500 the admin."""
+    from api.auth import get_current_user_id
+
+    _seed_token_dir(api_client["user_id"])
+
+    def _boom(user_id):
+        raise OSError("simulated")
+
+    monkeypatch.setattr("api.routes.sync.clear_garmin_tokens", _boom)
+
+    api_client["client"].app.dependency_overrides[get_current_user_id] = (
+        api_client["override_admin"]
+    )
+    res = api_client["client"].delete(f"/api/admin/users/{api_client['user_id']}")
+    assert res.status_code == 200

--- a/tests/test_garmin_token_isolation.py
+++ b/tests/test_garmin_token_isolation.py
@@ -1,11 +1,14 @@
 """Regression tests for the Garmin per-user token directory.
 
-Issue #56: a single shared `.garmin_tokens/` directory caused every user's
-sync to reuse the first authenticated user's OAuth session and fetch that
-person's data. The fix scopes tokens per user_id and invalidates them when
+A single shared `.garmin_tokens/` directory caused every user's sync to reuse
+the first authenticated user's OAuth session and fetch that person's data
+(garminconnect loads tokens from disk without validating whose account they
+belong to). The fix scopes tokens per user_id and invalidates them when
 credentials change.
 """
 import os
+
+import pytest
 
 from api.routes.sync import (
     _garmin_token_dir,
@@ -15,7 +18,6 @@ from api.routes.sync import (
 
 
 def test_token_dir_is_unique_per_user() -> None:
-    """Two users must not share a tokenstore path."""
     a = _garmin_token_dir("user-a")
     b = _garmin_token_dir("user-b")
     assert a != b
@@ -23,10 +25,15 @@ def test_token_dir_is_unique_per_user() -> None:
     assert b.startswith(_garmin_token_root())
 
 
-def test_token_dir_is_nested_under_user_id() -> None:
-    """The per-user directory name must be the user_id itself — no shared prefix."""
-    path = _garmin_token_dir("abc-123")
-    assert os.path.basename(path) == "abc-123"
+def test_token_dir_is_nested_directly_under_root_as_user_id() -> None:
+    """Strong invariant: the path under the root is exactly the user_id.
+
+    Rejects sharded variants like `root/first-char/full-id` that could collapse
+    for IDs sharing a prefix.
+    """
+    uid = "abc-123"
+    path = _garmin_token_dir(uid)
+    assert os.path.relpath(path, _garmin_token_root()) == uid
 
 
 def test_clear_garmin_tokens_removes_directory(tmp_path, monkeypatch) -> None:
@@ -44,7 +51,117 @@ def test_clear_garmin_tokens_removes_directory(tmp_path, monkeypatch) -> None:
     assert not os.path.isdir(path)
 
 
-def test_clear_garmin_tokens_is_idempotent(tmp_path, monkeypatch) -> None:
-    """Clearing a non-existent directory must not raise."""
+def test_clear_garmin_tokens_is_noop_when_dir_missing(tmp_path, monkeypatch) -> None:
+    """Clearing a non-existent directory must not raise — the connect-flow
+    calls this unconditionally on first-ever Garmin connect."""
     monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
     clear_garmin_tokens("never-synced-user")
+
+
+def test_clear_garmin_tokens_propagates_filesystem_errors(tmp_path, monkeypatch) -> None:
+    """Silencing rmtree failures would re-open the leak. Callers must see them."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+
+    user_id = "user-err"
+    os.makedirs(_garmin_token_dir(user_id), exist_ok=True)
+
+    def _boom(*args, **kwargs):
+        raise OSError("simulated permission denied")
+
+    monkeypatch.setattr("shutil.rmtree", _boom)
+
+    with pytest.raises(OSError):
+        clear_garmin_tokens(user_id)
+
+
+def test_sync_garmin_passes_per_user_path_to_login(tmp_path, monkeypatch) -> None:
+    """The actual call site — not just the helper — must scope the token dir.
+
+    A future refactor that inlined the path to a shared value would re-create
+    the bug and every helper-level test would still pass. This test patches
+    garminconnect.Garmin and asserts `login(token_dir)` receives a per-user
+    path for two different user_ids.
+    """
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+
+    recorded: list[tuple[str, str]] = []
+
+    class _FakeGarth:
+        def dump(self, path: str) -> None:
+            pass
+
+    class _FakeGarminClient:
+        def __init__(self, email: str, password: str, is_cn: bool = False):
+            self.email = email
+            self.garth = _FakeGarth()
+
+        def login(self, token_dir: str) -> None:
+            recorded.append((self.email, token_dir))
+
+        def get_activities_by_date(self, start, end, activitytype=None):
+            return []
+
+        def get_activity_splits(self, aid):
+            return {}
+
+        def get_lactate_threshold(self, latest=False, start_date=None, end_date=None):
+            return []
+
+        def get_training_status(self, d):
+            return {}
+
+        def get_training_readiness(self, d):
+            return None
+
+        def get_race_predictions(self):
+            return None
+
+        def get_hrv_data(self, d):
+            return None
+
+        def get_sleep_data(self, d):
+            return None
+
+    monkeypatch.setattr("garminconnect.Garmin", _FakeGarminClient)
+
+    # Stub DB-touching helpers so we don't need a full session
+    monkeypatch.setattr("db.sync_writer.write_activities", lambda *a, **k: 0)
+    monkeypatch.setattr("db.sync_writer.write_splits", lambda *a, **k: 0)
+    monkeypatch.setattr("db.sync_writer.write_lactate_threshold", lambda *a, **k: 0)
+    monkeypatch.setattr("db.sync_writer.write_daily_metrics", lambda *a, **k: 0)
+    monkeypatch.setattr("db.sync_writer.write_recovery", lambda *a, **k: 0)
+
+    class _FakeConfig:
+        source_options = {"garmin_activity_categories": ["running"]}
+
+    monkeypatch.setattr(
+        "analysis.config.load_config_from_db", lambda user_id, db: _FakeConfig()
+    )
+
+    from api.routes.sync import _sync_garmin
+
+    class _NullDB:
+        def query(self, *a, **k):
+            class _Q:
+                def filter(self, *a, **k):
+                    return self
+
+                def first(self):
+                    return None
+
+            return _Q()
+
+        def commit(self):
+            pass
+
+    creds_a = {"email": "a@example.com", "password": "pw"}
+    creds_b = {"email": "b@example.com", "password": "pw"}
+    _sync_garmin("user-a", creds_a, None, _NullDB())
+    _sync_garmin("user-b", creds_b, None, _NullDB())
+
+    assert len(recorded) == 2
+    email_a, path_a = recorded[0]
+    email_b, path_b = recorded[1]
+    assert path_a != path_b
+    assert path_a.endswith(os.sep + "user-a")
+    assert path_b.endswith(os.sep + "user-b")

--- a/tests/test_garmin_token_isolation.py
+++ b/tests/test_garmin_token_isolation.py
@@ -1,0 +1,50 @@
+"""Regression tests for the Garmin per-user token directory.
+
+Issue #56: a single shared `.garmin_tokens/` directory caused every user's
+sync to reuse the first authenticated user's OAuth session and fetch that
+person's data. The fix scopes tokens per user_id and invalidates them when
+credentials change.
+"""
+import os
+
+from api.routes.sync import (
+    _garmin_token_dir,
+    _garmin_token_root,
+    clear_garmin_tokens,
+)
+
+
+def test_token_dir_is_unique_per_user() -> None:
+    """Two users must not share a tokenstore path."""
+    a = _garmin_token_dir("user-a")
+    b = _garmin_token_dir("user-b")
+    assert a != b
+    assert a.startswith(_garmin_token_root())
+    assert b.startswith(_garmin_token_root())
+
+
+def test_token_dir_is_nested_under_user_id() -> None:
+    """The per-user directory name must be the user_id itself — no shared prefix."""
+    path = _garmin_token_dir("abc-123")
+    assert os.path.basename(path) == "abc-123"
+
+
+def test_clear_garmin_tokens_removes_directory(tmp_path, monkeypatch) -> None:
+    """Invalidation must delete the tokenstore so the next login re-auths."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+
+    user_id = "user-x"
+    path = _garmin_token_dir(user_id)
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, "oauth1_token.json"), "w") as f:
+        f.write("{}")
+    assert os.path.isdir(path)
+
+    clear_garmin_tokens(user_id)
+    assert not os.path.isdir(path)
+
+
+def test_clear_garmin_tokens_is_idempotent(tmp_path, monkeypatch) -> None:
+    """Clearing a non-existent directory must not raise."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    clear_garmin_tokens("never-synced-user")


### PR DESCRIPTION
## Summary
- Scope Garmin OAuth tokenstore per `user_id` — previously every user shared `sync/.garmin_tokens/`, causing `garminconnect.Garmin.login()` to reuse the first authenticated user's session and write their activity data into every subsequent user's rows.
- Invalidate a user's tokenstore on `connect`, `disconnect`, and admin delete so changed credentials always trigger a fresh login.
- Add `scripts/cleanup_garmin_token_bug.py` with `--dry-run` / `--apply` to remove the mis-attributed Garmin activities / splits / fitness_data for non-admin users and reset their `last_sync` so the scheduler re-syncs them. After deploy I'll SSH in and run it.

## Root cause
`garminconnect.Garmin.login(tokenstore)` loads tokens if the path already has them and only falls back to username/password on load failure. A shared tokenstore meant user B's `client.login(...)` silently reused user A's OAuth session, so all of A's activities were fetched and written under B's `user_id`.

## Test plan
- [x] New regression tests (`tests/test_garmin_token_isolation.py`) cover per-user path uniqueness, user_id-scoped naming, and idempotent invalidation.
- [x] Full pytest suite: 227 passed, 1 skipped.
- [x] Cleanup script dry-run smoke-tested against local dev DB.
- [ ] Post-merge: SSH into App Service, run `python scripts/cleanup_garmin_token_bug.py --dry-run`, eyeball counts, then `--apply`.
- [ ] Affected users hit Settings → Backfill (≥180 days) to repopulate their real Garmin history.

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)