### PR TITLE
Drop folder-name prefix in commits/PR titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,11 @@ All training metrics, predictions, and insights must be grounded in exercise sci
 - **Recharts** for all charts — colors from `web/src/lib/chart-theme.ts`
 - Data numbers use `font-data` CSS class (JetBrains Mono, tabular-nums)
 
+### Git
+- **Commit / PR subjects state what the change does**, e.g. `Fix Garmin first-time sync…`. This repo is standalone (pushes to `dddtc2005/praxys`) — don't prefix with the folder name. The outer pensieve repo's `trail-running:` convention exists because that repo hosts multiple top-level projects; it doesn't apply here.
+- Commit body explains the *why* (motivation, root cause, trade-off). The diff shows the *what*.
+- Never put sensitive content (credentials, `.env` values, personal data) in commit messages or PR descriptions.
+
 ## Frontend Design System
 
 ### Theme


### PR DESCRIPTION
## Summary
The outer pensieve repo's \`CLAUDE.md\` prescribes a \`trail-running:\` prefix for commit messages. That rule makes sense there because the pensieve repo hosts several top-level project folders. It does **not** apply to this repo — \`dddtc2005/praxys\` is standalone, every commit is trail-running by definition, and the prefix becomes pure noise (\"trail-running what?\" is a natural reaction to seeing it on a Praxys PR).

Add a \`### Git\` subsection under \`## Conventions\` in this repo's \`CLAUDE.md\` that explicitly overrides the outer rule, gives a concrete good/bad example, and restates the no-sensitive-content rule so it survives the override.

## Test plan
- [ ] Future commits in this repo land without the prefix
- [ ] AI assistants (Claude Code) picking up this repo's \`CLAUDE.md\` see the override and stop adding \`trail-running:\` to commits and PR titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)