### PR TITLE
Simplify CLAUDE.md; extract design system and gotchas to docs/dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,260 +22,145 @@ Garmin/Stryd/Oura APIs → sync/*.py → db/sync_writer.py → SQLite (trainsigh
 
 | Directory | Owns | Key Files |
 |-----------|------|-----------|
-| `sync/` | API sync scripts | `garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`, `csv_utils.py`, `sync_all.py` (orchestrator), `bootstrap_garmin_tokens.py` |
-| `analysis/` | Metric computation | `metrics.py` (pure functions), `data_loader.py` (CSV I/O + merge), `science.py` (theory YAML loader), `config.py` (UserConfig dataclass), `zones.py`, `thresholds.py`, `training_base.py` |
-| `analysis/providers/` | Pluggable data sources | `base.py` (abstract provider ABCs), `garmin.py`, `stryd.py`, `oura.py`, `ai.py` (AI plan CSV loader), `models.py` |
-| `db/` | Database layer (SQLite) | `models.py` (SQLAlchemy models), `session.py` (engine + session factory), `crypto.py` (Fernet credential encryption), `sync_writer.py` (upsert sync data), `csv_import.py` (one-time CSV migration), `sync_scheduler.py` (background sync jobs) |
-| `api/` | FastAPI backend | `main.py` (app), `deps.py` (data layer), `auth.py` (JWT auth), `users.py`, `views.py` (shared view helpers), `routes/` (endpoints incl. `admin.py`, `register.py`) |
-| `web/src/` | React frontend | `pages/` (6 pages: Today, Training, Goal, History, Science, Settings), `components/` (UI + `charts/` sub-dir), `hooks/` (`useApi`, `useChartColors`, `useTheme`, `use-mobile`), `contexts/` (`ScienceContext`, `SettingsContext`), `types/` (API contracts), `lib/` (`chart-theme`, `format`, `utils`, `workout-parser`) |
-| `plugins/` | Praxys plugin | `praxys/skills/` (8 SKILL.md files), `praxys/mcp-server/` (MCP server: `server.py`, `auth.py`) |
-| `tests/` | pytest suite | `test_metrics.py`, `test_integration.py`, etc. |
-| `data/` | Sample + science data | `sample/` (tracked synthetic CSVs), `science/` (theory YAMLs: load, recovery, prediction, zones, labels) |
-| `scripts/` | Utility + skill helper scripts | `seed_sample_data.py`, `generate_sample_data.py`, `build_training_context.py`, `daily_brief.py`, `race_forecast.py`, `sync_report.py`, `run_diagnosis.py` |
-| `docs/` | Documentation | `docs/` (user guides), `docs/dev/` (developer docs) |
+| `sync/` | Platform fetch + parse | `garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`, `csv_utils.py`, `bootstrap_garmin_tokens.py` |
+| `analysis/` | Metric computation | `metrics.py` (pure functions), `data_loader.py` (loads from DB), `science.py` (theory YAML loader), `config.py` (`UserConfig`), `zones.py`, `thresholds.py`, `training_base.py` |
+| `analysis/providers/` | Pluggable data sources | `base.py` (ABCs), `garmin.py`, `stryd.py`, `oura.py`, `ai.py`, `models.py` |
+| `db/` | SQLite layer | `models.py` (SQLAlchemy), `session.py`, `crypto.py` (Fernet credential encryption), `sync_writer.py` (upserts), `sync_scheduler.py` |
+| `api/` | FastAPI backend | `main.py`, `deps.py` (data layer — `get_dashboard_data()`), `auth.py` (JWT), `users.py`, `views.py`, `routes/` |
+| `web/src/` | React SPA | `pages/` (Today, Training, Goal, History, Science, Settings, Admin, Login, Setup), `components/`, `hooks/`, `contexts/`, `types/api.ts`, `lib/` |
+| `plugins/praxys/` | Praxys plugin | `skills/` (8 SKILL.md), `mcp-server/` (local + remote MCP) |
+| `tests/` | pytest suite | |
+| `data/` | Fixtures + science YAML | `sample/` (test CSVs — not live data), `science/` (theory YAMLs) |
+| `scripts/` | Utility + skill helpers | |
+| `docs/` | User + dev docs | `docs/dev/` (architecture, API reference, design system, gotchas, contributing) |
 
-### Data Sources
+### Data storage
 
-- `data/garmin/activities.csv` — activity-level data (distance, duration, HR, training effect)
-- `data/garmin/activity_splits.csv` — per-interval data within activities (split power, duration, pace)
-- `data/garmin/daily_metrics.csv` — VO2max, training status, resting HR
-- `data/stryd/power_data.csv` — power metrics per activity (avg/max power, RSS, CP estimate)
-- `data/stryd/training_plan.csv` — planned workouts from Stryd
-- `data/oura/sleep.csv` — sleep scores and stages
-- `data/oura/readiness.csv` — readiness score, HRV
+Sync pipelines write directly to SQLite (`trainsight.db`) via `db/sync_writer.py` — there are no live CSVs. Tables: `activities`, `activity_splits`, `recovery_data`, `fitness_data`, `training_plans`, `users`, `user_config`, `user_connections`. `data/sample/` holds synthetic CSVs used only by tests and seed scripts.
 
 ## Scientific Rigor
 
 All training metrics, predictions, and insights must be grounded in exercise science:
 - **Cite sources** in code comments for formulas and constants (paper DOI or URL)
-- **Show methodology** in the UI — every prediction/insight should have an expandable "How this is calculated" note with source links (use `ScienceNote` component)
-- **Use published values** over guesswork (e.g., Stryd's race power percentages, Riegel's formula, Banister TRIMP)
-- **Flag estimates** — if a value lacks strong research backing (e.g., ultra distance fractions), note it as an estimate in both code and UI
+- **Show methodology** in the UI — use the `ScienceNote` component with source links
+- **Use published values** over guesswork (Stryd race power percentages, Riegel, Banister TRIMP)
+- **Flag estimates** — values without strong research backing noted as estimates in code and UI
+
+## Gotchas
+
+- **Activity `avg_power` is diluted** by warmup / cooldown / recovery jogs. Always use `activity_splits` for intensity analysis — `diagnose_training()` in `metrics.py` does this correctly.
+- **Per-user Garmin tokenstore is load-bearing for security.** `sync/.garmin_tokens/<user_id>/` — `garminconnect.Garmin.login()` loads whatever OAuth tokens it finds without validating the account, so a shared directory would cross-leak authenticated sessions. Anything touching sync/auth must preserve this invariant.
+
+Domain-specific gotchas (Garmin sync quirks, CIQ field conventions, CN endpoint parity, region model): `docs/dev/gotchas.md`.
 
 ## Conventions
 
 ### Python
-- **Type hints** on all function signatures
-- **Docstrings** on public functions
-- Metrics in `analysis/metrics.py` must be **pure functions** (no I/O, no side effects)
-- Data loading in `analysis/data_loader.py` — all CSV I/O goes here
-- API routes are thin wrappers calling `get_dashboard_data()` from `api/deps.py`
-- Shared view helpers in `api/views.py` — used by both API routes and CLI skill scripts to avoid duplication
+- **Type hints** on every function signature; **docstrings** on public functions.
+- `analysis/metrics.py` must be **pure** — no I/O, no side effects.
+- All data loading goes through `analysis/data_loader.py`.
+- API routes are thin wrappers around `get_dashboard_data()` in `api/deps.py`.
+- Shared view helpers in `api/views.py` — used by routes and CLI skill scripts to avoid duplication.
 
 ### Frontend
-- **TypeScript strict** — all API responses typed in `web/src/types/api.ts`
-- **`useApi<T>` hook** for data fetching (loading/error/data states)
-- **shadcn/ui** as the component library (base-nova style, dark-first)
-- **Tailwind CSS v4** with OKLCH color variables in `web/src/index.css`
-- **Recharts** for all charts — colors from `web/src/lib/chart-theme.ts`
-- Data numbers use `font-data` CSS class (JetBrains Mono, tabular-nums)
+- **TypeScript strict** — all API responses typed in `web/src/types/api.ts`.
+- `useApi<T>` hook for data fetching (loading / error / data states).
+- shadcn/ui + Tailwind v4. Never use raw hex — use CSS variables or `chartColors` from `@/lib/chart-theme.ts`.
+- Every numeric value uses the `.font-data` class (JetBrains Mono, tabular-nums).
+- **Semantic palette, not just accents**: `primary` (green) = action / positive signal; `accent-cobalt` is reserved for **reasoning** surfaces (`ScienceNote`, "why this", citations). Don't use cobalt for informational chrome and don't use green for reasoning.
+- Authoritative brand guide: `docs/brand/index.html`. Implementation rules: `docs/dev/design-system.md`.
 
 ### Git
 - **Commit / PR subjects state what the change does**, e.g. `Fix Garmin first-time sync…`. This repo is standalone (pushes to `dddtc2005/praxys`) — don't prefix with the folder name. The outer pensieve repo's `trail-running:` convention exists because that repo hosts multiple top-level projects; it doesn't apply here.
 - Commit body explains the *why* (motivation, root cause, trade-off). The diff shows the *what*.
 - Never put sensitive content (credentials, `.env` values, personal data) in commit messages or PR descriptions.
 
-## Frontend Design System
-
-### Theme
-- **Light + dark** themes via `.dark` class on `<html>`. Default stored preference is dark.
-- `:root` = light theme (warm paper tones), `.dark` = dark theme (deep navy tones)
-- Theme toggle in sidebar footer cycles: Dark → Light → System
-- User preference persisted in `localStorage` key `praxys-theme` (legacy `trainsight-theme` is dual-read for 90 days post-rebrand)
-- Inline script in `index.html` prevents flash of wrong theme on load
-- shadcn's CSS variable system (`--background`, `--card`, `--primary`, etc.) is the **single source of truth** for surface colors
-- Brand accent: `--primary` is darkened green in light, vivid neon-green in dark
-- Semantic accent colors (`--color-accent-green`, etc.) use CSS custom property indirection (`--accent-green-val`) so `.dark` can override them
-- Chart colors use `useChartColors()` hook which returns theme-appropriate hex values for Recharts
-
-### Color Usage Rules
-| Token | Usage |
-|-------|-------|
-| `primary` | Positive signals, active states, brand accent (green) |
-| `destructive` | Negative signals, errors, high-intensity zones, rest signals |
-| `accent-amber` | Warnings, threshold zones, caution signals |
-| `accent-blue` | Informational, TSB/form, moderate zones |
-| `accent-purple` | Projections, sleep/recovery data, AI features |
-| `muted-foreground` | Secondary text, labels, descriptions |
-| `foreground` | Primary text, data values, headings |
-
-**Rule:** Never use raw hex colors in components. Use CSS variables, Tailwind color utilities, or the `chartColors` constants from `@/lib/chart-theme.ts`.
-
-### Typography
-- **Body text:** DM Sans (via `--font-sans`, loaded from Google Fonts in `index.html`)
-- **Data numbers:** `.font-data` class (JetBrains Mono, `tabular-nums`). Use for **all** numeric values: metrics, dates, percentages, chart labels
-- **Section headers:** `text-xs font-semibold uppercase tracking-wider text-muted-foreground`
-- **Headings:** Same as body font (DM Sans)
-
-### Component Rules (shadcn/ui)
-| Pattern | Component |
-|---------|-----------|
-| Page sections | `Card` with `CardHeader` + `CardContent` |
-| Loading states | `Skeleton` matching the shape of content (never "Loading..." text) |
-| Error states | `Alert variant="destructive"` |
-| Warnings | `Alert` with amber accent styling |
-| Editing forms | `Dialog` (modal overlay) |
-| Expandable sections | `Collapsible` |
-| Data tables | `Table` / `TableHeader` / `TableBody` / `TableRow` / `TableCell` |
-| Dropdowns | `Select` (never raw `<select>`) |
-| Buttons | `Button` with variants (never raw `<button>`) |
-| Form fields | `Input` + `Label` (never raw `<input>`) |
-| Status indicators | `Badge` with severity-based variants |
-| Progress bars | `Progress` |
-| Navigation | `Sidebar` (collapsible, sheet drawer on mobile) |
-
-### Chart Conventions
-- Import colors from `@/lib/chart-theme.ts` — **single source of truth** for chart colors
-- Chart tooltips use `bg-popover border-border text-popover-foreground rounded-lg shadow-xl`
-- Grid lines use `chartColors.grid`, axis ticks use `chartColors.tick` with `font-data`
-- All charts wrapped in a shadcn `Card`
-- Gradient stops reference `chartColors.*` constants (not raw hex)
-
-### Mobile Patterns
-- Sidebar renders as Sheet drawer on mobile (via shadcn Sidebar component with `collapsible="icon"`)
-- Sticky mobile header with `SidebarTrigger` (hamburger menu)
-- Content uses responsive grid: `grid-cols-1 lg:grid-cols-2`
-- Cards stack vertically on mobile
-- Padding: `px-4 py-6 sm:px-6 lg:px-8`
-
 ### API
-- All endpoints under `/api/` prefix
-- **All API endpoints require JWT auth** (`Authorization: Bearer <token>` header) except `/api/register` and `/api/token`
-- `api/deps.py` recomputes all data fresh on each request (`get_dashboard_data()`)
-- User config (goal, thresholds, sources) stored in the database, managed via Settings/Goal page UI
-- Platform credentials (Garmin/Stryd/Oura) encrypted at rest via `db/crypto.py` (Fernet)
-
-## Critical: Split-Level Power Analysis
-
-**Activity `avg_power` is diluted by warmup, cooldown, and recovery jogs.** A threshold session with 2x20min intervals at 248W will show ~210-220W activity average because it includes 15min warmup at 180W and recovery jogs at 130W.
-
-**Always use `activity_splits.csv` for intensity analysis.** This file has per-split power and duration, which reveals actual interval power. The `diagnose_training()` function in `metrics.py` does this correctly.
+- All endpoints under `/api/`. All require JWT auth (`Authorization: Bearer <token>`) except `/api/register` and `/api/token`.
+- `get_dashboard_data()` recomputes all data fresh per request.
+- User config stored in DB; platform credentials Fernet-encrypted via `db/crypto.py`.
 
 ## Dashboard Modes
 
-Goal configuration is managed via the Goal page UI and stored in the database:
-- **Race Goal:** race date + optional target time + distance — shows countdown, predicted time, CP gap
-- **Continuous Improvement (default):** optional target time + distance — shows CP progress, milestones, trend
-- Distance options: 5K, 10K, Half Marathon, Marathon, 50K, 50 Mile, 100K, 100 Mile
+Goal configuration stored in DB, managed via the Goal page:
+- **Race Goal**: race date + optional target time + distance → countdown, predicted time, CP gap.
+- **Continuous Improvement** (default): optional target time + distance → CP progress, milestones, trend.
+- Distances: 5K, 10K, Half Marathon, Marathon, 50K, 50 Mile, 100K, 100 Mile.
 
 ## How to Add a New Metric
 
-1. Add a pure function to `analysis/metrics.py` (with type hints + docstring)
-2. Call it from `api/deps.py` `get_dashboard_data()`, add result to the returned dict
-3. Expose via the appropriate route in `api/routes/` (or create a new route file)
-4. Add TypeScript interface to `web/src/types/api.ts`
-5. Build component in `web/src/components/`
-6. Add to the relevant page in `web/src/pages/`
-7. Add test in `tests/`
+1. Pure function in `analysis/metrics.py` (type hints + docstring + source citation).
+2. Call it from `get_dashboard_data()` in `api/deps.py`; add to returned dict.
+3. Expose via the appropriate route in `api/routes/`.
+4. Add TypeScript interface to `web/src/types/api.ts`.
+5. Build a component in `web/src/components/`.
+6. Wire into the relevant page in `web/src/pages/`.
+7. Add a test in `tests/`.
+
+The `metric-addition-reviewer` agent enforces this 7-step checklist.
 
 ## How to Add a New Data Source
 
-1. Create `sync/{source}_sync.py` following the pattern in `garmin_sync.py`
-2. Add SQLAlchemy model to `db/models.py` and upsert logic to `db/sync_writer.py`
-3. Register in `data_loader.py` `load_all_data()` dict
-4. Update `data/sample/{source}/` with synthetic CSVs for testing
-5. Update `scripts/generate_sample_data.py` with the new source
+1. `sync/{source}_sync.py` — follow `garmin_sync.py` pattern.
+2. SQLAlchemy model in `db/models.py`; upsert logic in `db/sync_writer.py`.
+3. Register provider in `analysis/providers/` and `data_loader.py::load_all_data()`.
+4. Add synthetic fixtures in `data/sample/{source}/`.
+5. Update `scripts/generate_sample_data.py`.
 
 ## Running
 
-**Always use the project venv for Python commands.** The venv is at `.venv/`.
+Always use the project venv at `.venv/` for Python commands.
 
 ```bash
-# Activate venv first (all Python commands below assume venv is active)
-# Windows: .venv\Scripts\activate
-# Unix: source .venv/bin/activate
-
-# First-time setup: copy .env.example and generate encryption key
+# First time: copy .env and generate encryption key
 cp .env.example .env
 python -c "from cryptography.fernet import Fernet; print(f'PRAXYS_LOCAL_ENCRYPTION_KEY={Fernet.generate_key().decode()}')" >> .env
 
-# API server
+# Activate venv: .venv\Scripts\activate (Windows) or source .venv/bin/activate (Unix)
 pip install -r requirements.txt
+
+# API server
 python -m uvicorn api.main:app --reload
 
 # Frontend dev server (separate terminal)
 cd web && npm install && npm run dev
 
-# Tests
+# Tests / lint
 python -m pytest tests/ -v
+cd web && npx eslint src/
 ```
 
-### First-time setup
-
-1. Copy `.env.example` to `.env` and generate an encryption key (see commands above)
-2. Start the server and frontend dev server
-3. Open the app, register -- the first user on a fresh DB becomes admin (no invitation code needed)
-4. Admin can generate invitation codes for others via the Admin page (`/admin`)
-
-### Invitation system and admin
-
-- Registration requires a valid invitation code (except for the first user and `PRAXYS_ADMIN_EMAIL`)
-- Admin page (`/admin`) lets admins generate invitation codes and manage users
-- Admin status is granted to: the first registered user, and any user matching `PRAXYS_ADMIN_EMAIL`
+On a fresh DB the first registered user becomes admin (no invitation code). Subsequent users need invitation codes, generated from the Admin page. `PRAXYS_ADMIN_EMAIL` always gets admin rights.
 
 ## Documentation
 
-Keep docs in sync with code — stale docs are worse than no docs. See `docs/dev/contributing.md` for which files to update when making changes.
-
-Key files: `README.md` (quick start), `docs/*.md` (user guides), `docs/dev/*.md` (architecture + API reference + contributing), `plugins/praxys/skills/*/SKILL.md` (skill instructions).
+See `docs/dev/contributing.md` for which files to update with code changes. Key dev docs:
+- `docs/brand/index.html` — Praxys brand guideline (interactive, authoritative visual source)
+- `docs/dev/architecture.md` — detailed architecture
+- `docs/dev/api-reference.md` — API endpoint contracts
+- `docs/dev/design-system.md` — design system implementation rules (translates brand guide → `web/src/`)
+- `docs/dev/gotchas.md` — domain-specific traps
+- `plugins/praxys/skills/*/SKILL.md` — skill instructions
 
 ## Claude Code Automations
 
-Project-level automations live in `.claude/`. They are committed to the repo so every contributor using Claude Code gets the same behavior.
-
-### Hooks (`.claude/settings.json`)
-
-| When | What | Script |
-|------|------|--------|
-| `PreToolUse` on `Edit`/`Write` | Block edits to `.env` / `.env.*`, `trainsight.db` + SQLite companions, and anything under `data/garmin/`, `data/stryd/`, `data/oura/` | `.claude/hooks/block_secrets.py` |
-| `PostToolUse` on `Edit`/`Write` of `*.py` | Run pytest with fail-fast via the project venv; surface failures via stderr + exit 2 | `.claude/hooks/pytest_on_py.py` |
-| `PostToolUse` on `Edit`/`Write` of files under project `web/` ending in `.ts(x)` | Per-file ESLint; surface violations via stderr + exit 2 | `.claude/hooks/web_lint.py` |
-
-The block hook **fails closed** — on malformed payloads, unknown tool names, or a missing `file_path` it denies with a stderr explanation rather than letting the edit through. To edit a protected file, use a terminal outside Claude Code or temporarily disable the hook in `settings.json`.
-
-### Subagents (`.claude/agents/`)
-
-| Agent | Trigger |
-|-------|---------|
-| `science-reviewer` | Edits to `analysis/` or `data/science/` — citation completeness, published values, flagged estimates |
-| `metric-addition-reviewer` | New or modified training metric — enforces the 7-step checklist end-to-end plus purity and citation |
-| `api-contract-reviewer` | Edits to `api/routes/*`, `api/deps.py`, `api/views.py`, or `web/src/types/api.ts` — verifies Python response shape matches TS interfaces |
-
-All three are read-only (Read/Grep/Glob) — they report gaps; the primary agent fixes them.
-
-### Project skills (`.claude/skills/`)
-
-| Skill | Invocation | Purpose |
-|-------|-----------|---------|
-| `seed-and-preview` | User-only | Reset local DB to sample data and boot API + Vite for manual verification |
-
-Training-domain skills live in `plugins/praxys/skills/` (see "AI Skills" below). Dev-workflow skills live in `.claude/skills/`.
+Automations live in `.claude/` and are committed so every contributor using Claude Code sees the same behavior. See `.claude/settings.json` for hooks (block edits to secrets; run pytest on Python changes; run ESLint on web TS changes), `.claude/agents/` for subagents (`science-reviewer`, `metric-addition-reviewer`, `api-contract-reviewer` — all read-only), and `.claude/skills/` for dev-workflow skills.
 
 ## AI Skills
 
-8 skills in `plugins/praxys/skills/` provide training features via the Praxys plugin (MCP server + skills):
+8 skills in `plugins/praxys/skills/` expose training features via the Praxys plugin (MCP server + skills):
 
 | Skill | Purpose |
 |-------|---------|
-| `setup` | Configure connections, training base, thresholds, goals |
-| `science` | Browse and select training science theories |
-| `sync-data` | Sync data from Garmin/Stryd/Oura |
-| `daily-brief` | Today's training signal, recovery, upcoming workouts |
-| `training-review` | Multi-week training diagnosis and suggestions |
+| `setup` | Connections, training base, thresholds, goals |
+| `science` | Browse / select training science theories |
+| `sync-data` | Trigger Garmin / Stryd / Oura sync |
+| `daily-brief` | Today's signal, recovery, upcoming workouts |
+| `training-review` | Multi-week diagnosis + suggestions |
 | `training-plan` | Generate 4-week AI training plan |
-| `race-forecast` | Race time prediction and goal feasibility |
-| `add-metric` | Scaffold a new metric end-to-end (7-step guide) |
+| `race-forecast` | Race prediction + goal feasibility |
+| `add-metric` | Scaffold a new metric end-to-end |
 
-Skills use MCP tools provided by the Praxys plugin MCP server (`plugins/praxys/mcp-server/server.py`). The server runs in dual mode: local (direct DB access) or remote (HTTP API with JWT auth via `PRAXYS_URL`).
+The MCP server (`plugins/praxys/mcp-server/server.py`) runs in dual mode — local (direct DB) or remote (HTTP + JWT via `PRAXYS_URL`).
 
-## AI Features
-
-### Implemented
-- **`api/ai.py`** — `build_training_context()` serializes all computed metrics to a structured dict for LLM consumption; `validate_plan()` checks AI-generated plans (date ranges, power targets, distribution) before CSV write; `check_plan_staleness()` detects stale plans (>28 days or CP drift >3%)
-- **`analysis/providers/ai.py`** — `AiPlanProvider` loads AI-generated plans from `data/ai/training_plan.csv`
-- **`analysis/science.py`** — Theory framework loads YAML from `data/science/` (10 theories across 4 pillars + 2 label sets)
-- **Design principle:** AI is always optional. The app must function fully without `ANTHROPIC_API_KEY`
-
-### Not yet built
-- **Frontend:** `useAiStatus()` hook to gate AI UI — not implemented yet
-- **Possible features:** AI coaching narratives, natural language training queries, AI-enhanced weekly summaries
+AI features are always optional; the app works fully without `ANTHROPIC_API_KEY`. When present, AI powers the training-context builder (`api/ai.py`), plan validator, and the `AiPlanProvider` that loads `data/ai/training_plan.csv`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,11 @@ All training metrics, predictions, and insights must be grounded in exercise sci
 - **Recharts** for all charts — colors from `web/src/lib/chart-theme.ts`
 - Data numbers use `font-data` CSS class (JetBrains Mono, tabular-nums)
 
+### Git
+- **Commit / PR subjects state what the change does**, e.g. `Fix Garmin first-time sync…`. This repo is standalone (pushes to `dddtc2005/praxys`) — don't prefix with the folder name. The outer pensieve repo's `trail-running:` convention exists because that repo hosts multiple top-level projects; it doesn't apply here.
+- Commit body explains the *why* (motivation, root cause, trade-off). The diff shows the *what*.
+- Never put sensitive content (credentials, `.env` values, personal data) in commit messages or PR descriptions.
+
 ## Frontend Design System
 
 ### Theme

--- a/docs/dev/design-system.md
+++ b/docs/dev/design-system.md
@@ -1,0 +1,113 @@
+# Frontend Design System
+
+Aligned with the **Praxys Brand Guideline v1.0** (`docs/brand/index.html`) — the interactive guide is the authoritative visual source. This doc translates it into implementation rules for `web/src/`.
+
+If the code in `web/src/index.css` diverges from this, the brand guide wins and the code is pending an update; items still in transition are marked **→ brand target**.
+
+## Theme
+
+- Light + dark themes via `.dark` class on `<html>`. Default stored preference is dark (the brand guide shows light as the print default; the product runs dark-first).
+- Theme is 3-state (`light` | `dark` | `system`) via `useTheme`; toggle in the sidebar footer cycles Dark → Light → System.
+- `localStorage` key: `praxys-theme` (legacy `trainsight-theme` dual-read for 90 days post-rebrand).
+- An inline script in `index.html` prevents flash-of-wrong-theme on load.
+- shadcn's CSS variable system (`--background`, `--card`, `--primary`, etc.) is the single source of truth for surface colors.
+
+## Color system
+
+Two-track palette — a single green carries *action*, cobalt is reserved for *reasoning* surfaces. The separation is deliberate: the user should see at a glance whether something is a signal to act or a signal to reflect.
+
+| Role | Token | Usage |
+|------|-------|-------|
+| **Action** | `primary` (green) | Positive signals, active states, brand accent, go/follow-plan recommendations, positive deltas |
+| **Reasoning** | `accent-cobalt` | "Why this recommendation", citations, science notes, methodology hints — anywhere the system explains itself |
+| **Caution** | `accent-amber` | Warnings, threshold zones, caution signals |
+| **Rest / high-intensity** | `accent-red` *(→ brand target: `rust`)* | Rest signals and high-intensity zones share a visual weight — "this costs you" |
+| Surface | `background` / `card` | Paper tones — warm, slightly off-white in light; deep navy in dark |
+| Text | `foreground` / `muted-foreground` | Primary + secondary text |
+
+**Rule:** never use raw hex in components. Use CSS variables, Tailwind color utilities, or the `chartColors` constants from `@/lib/chart-theme.ts`.
+
+**Deprecated (do not use in new code):** `accent-blue`, `accent-purple`. The brand guide consolidates the palette; blue's informational role moved to cobalt when it's reasoning, or to `muted-foreground` when it's just metadata. Existing usages should migrate as components are touched.
+
+## Typography
+
+- **Body / UI / headings:** currently DM Sans (`--font-sans`). **→ brand target: Geist** (to be swapped across `index.html` font preconnects and `--font-sans`).
+- **Data numbers:** `.font-data` class — JetBrains Mono, `tabular-nums`, `font-feature-settings: 'tnum' 1, 'zero' 1`. Use for **every** numeric value: metrics, dates, percentages, chart labels. Tabular digits matter because column alignment is the point.
+- **Chinese:** body uses Noto Sans SC (via the `--font-sans` fallback chain and explicit `.font-sc` class); quotes / display uses Noto Serif SC (`.font-serif-sc` in the brand guide, should be added to `index.css`).
+- **Section labels:** `text-xs font-semibold uppercase tracking-wider text-muted-foreground` (JetBrains Mono also acceptable per brand guide for eyebrow labels).
+- **Headings:** same family as body.
+
+## Bilingual rules
+
+Surface purpose determines language strategy — never always-both by default.
+
+| Context | Strategy | Example |
+|---------|----------|---------|
+| Brand moments | **Always both** | Hero, App Store splash, brand posters — EN + 中文 together |
+| Product chrome | **Locale only** | Sidebar, page headers, toasts, onboarding — respect user's selected locale |
+| Marketing copy | **Primary with subtitle** | One language primary, the other as a smaller subtitle |
+
+Detection: `LocaleContext` + `detectBrowserLocale`. Stored preference overrides browser.
+
+## Wordmark & mark
+
+- **Wordmark:** `Pra` + `x` + `ys`. The `x` uses the primary green accent color; all other letters use `foreground`. Geist weight 500, letter-spacing `-0.055em` at display size.
+- **Mark:** a stylized race flag — cobalt pole + green flag with inward-pinched trailing edge. Defined on a 48×48 grid; scales from a 16px favicon to hero marketing without re-drawing. SVG assets in `public/logos/`; construction and clear-space rules in `docs/brand/index.html` § II.
+- **Full form:** "Praxys Endurance" — used where discovery needs the category signal (App Store, marketing headers, cold introductions). Short form "Praxys" elsewhere.
+
+## Component patterns (shadcn/ui)
+
+| Pattern | Component |
+|---------|-----------|
+| Page sections | `Card` with `CardHeader` + `CardContent` |
+| Loading states | `Skeleton` matching the shape of content (never "Loading..." text) |
+| Error states | `Alert variant="destructive"` |
+| Warnings | `Alert` with amber accent styling |
+| Editing forms | `Dialog` (modal overlay) |
+| Expandable sections | `Collapsible` |
+| Data tables | `Table` / `TableHeader` / `TableBody` / `TableRow` / `TableCell` |
+| Dropdowns | `Select` (never raw `<select>`) |
+| Buttons | `Button` with variants (never raw `<button>`) |
+| Form fields | `Input` + `Label` (never raw `<input>`) |
+| Status indicators | `Badge` with severity-based variants |
+| Progress bars | `Progress` |
+| Navigation | `Sidebar` (collapsible, sheet drawer on mobile) |
+
+### The Science Note
+
+The reasoning surface. Used by the `ScienceNote` component to answer "why did the system recommend this?" — plan rationale, metric explanations, citation of the underlying theory.
+
+Visual spec (brand guide § V):
+- Cobalt tint background: `bg-[color-mix(in_oklab,var(--accent-cobalt)_5%,var(--card))]` (or the semantic class once tokenized).
+- Cobalt-tinted border; solid cobalt 3px left border (the "reasoning rail").
+- Eyebrow label in cobalt, uppercase, JetBrains Mono, wide tracking: *WHY THIS RECOMMENDATION* / *METHODOLOGY* / *CITATION*.
+- Body in `foreground` text at normal weight.
+- Dashed border separator above the citation block; citation in `muted-foreground` with italicized source titles.
+
+Never use the cobalt-bordered note style for anything that isn't reasoning / methodology / citation. Don't tint user-actionable surfaces with cobalt.
+
+## Chart conventions
+
+- Import colors from `@/lib/chart-theme.ts` — single source of truth for chart colors.
+- Tooltips use `bg-popover border-border text-popover-foreground rounded-lg shadow-xl`.
+- Grid lines use `chartColors.grid`; axis ticks use `chartColors.tick` with `font-data`.
+- All charts wrapped in a shadcn `Card`.
+- Gradient stops reference `chartColors.*` constants (not raw hex).
+
+## Mobile patterns
+
+- Sidebar renders as a Sheet drawer on mobile (shadcn Sidebar with `collapsible="icon"`).
+- Sticky mobile header with `SidebarTrigger` (hamburger menu).
+- Content uses a responsive grid: `grid-cols-1 lg:grid-cols-2`.
+- Cards stack vertically on mobile.
+- Padding: `px-4 py-6 sm:px-6 lg:px-8`.
+
+## Brand-alignment open items
+
+Tracked here so they don't get lost. When picking up any of these, update this section and mark the brand-target line in the relevant table.
+
+- [ ] Swap body font from DM Sans to Geist across `index.html` preconnects and `--font-sans`.
+- [ ] Rename `--accent-red-val` → `--accent-rust-val` (and the semantic class) to match brand naming, or accept the rename as alias only.
+- [ ] Remove `--accent-blue-val` / `--accent-purple-val` usages: migrate TSB/form displays to cobalt (if reasoning) or primary (if positive), move sleep/recovery off purple.
+- [ ] Add the `.font-serif-sc` utility class for Chinese display/quote contexts.
+- [ ] Verify all existing `ScienceNote` callers render with the cobalt-rail treatment from brand § V.

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -1,0 +1,77 @@
+# Domain Gotchas
+
+Non-obvious traps this codebase has hit in production. The severe, always-relevant ones (split-level power dilution, per-user tokenstore isolation) live inline in `CLAUDE.md`; the rest are here so Claude and future contributors can pull them in when working on the relevant subsystem.
+
+## Garmin sync
+
+### Garmin International and Garmin China are separate accounts
+
+`garmin.com` and `garmin.cn` are different SSO domains with different account tables. A user cannot simply "switch region" — the credentials that work on one don't authenticate on the other. `is_cn` is captured at connect time and lives inside the encrypted credentials blob *and* mirrored in `user_config.source_options.garmin_region`.
+
+- Sync reads region from `source_options.garmin_region` first (what the UI writes), falling back to `creds.is_cn` for legacy connections that predate the toggle.
+- The Settings page shows region read-only. To change region, the user disconnects and reconnects with the other account's credentials.
+- If these two values drift (old bug: an editable region toggle in Settings updated `source_options` but not `is_cn`), the sync client hits the wrong SSO domain and Garmin rate-limits the account with 429s.
+
+### ConnectIQ field 10 is Stryd's convention, not a standard
+
+Garmin lap DTOs expose a `connectIQMeasurement` array. Each entry has `developerFieldNumber`, `developerFieldName`, and `value`. **Field number 10 is Stryd's convention for power** — but any CIQ app can register a field with number 10 for anything (e.g., Leg Spring Stiffness). `parse_splits` in `sync/garmin_sync.py` checks `developerFieldName` before accepting a field-10 value as power.
+
+Priority order in `parse_splits`:
+1. Native `lap.averagePower` — present on modern Garmin watches (Fenix 6+, FR 255+/955+/965, Epix) and when HRM-Pro / Stryd pod is paired via ANT+.
+2. ConnectIQ field 10 with a name that contains "power" (or no name — Stryd's historical payload).
+3. Otherwise empty.
+
+Same priority applies to activity-level `averagePower` / `maxPower` in `parse_activities`.
+
+### Garmin CN endpoint parity is incomplete
+
+Expect individual endpoints to 400/404 on `connectapi.garmin.cn` even when the account is healthy. Confirmed patchy endpoints as of 2026-04:
+
+- `get_lactate_threshold` — may 404; LTHR may need manual entry in Settings.
+- `get_activities_by_date` with `activitytype=strength_training` — 400.
+- Some `get_training_status` shapes differ.
+- HRV / sleep can return `{"hrvSummary": null}` / `{"dailySleepDTO": null}` on days the watch collected nothing.
+
+`_sync_garmin` mitigations:
+- Each endpoint is in its own try/except logging at `warning` — one failure doesn't hide the rest.
+- The recovery loop has per-endpoint consecutive-failure circuit breakers (5 strikes → stop calling that endpoint for the remaining days).
+- `parse_garmin_recovery` uses `isinstance` guards + `or`-coalesce on every nested `.get()` — `dict.get(k, default)` returns `None`, not the default, for a present-but-null key, and the legacy code's crash here used to abort the whole recovery loop.
+
+### Recovery RHR vs TRIMP threshold RHR
+
+Two different RHR values for two different purposes:
+
+- `recovery_data.resting_hr` — per-day overnight RHR from sleep data. Drives the HRV / recovery chart. Varies with sleep quality.
+- `fitness_data.rest_hr_bpm` — configured profile RHR from `get_user_profile()`. Stable. Used as the TRIMP `rest_hr` threshold input.
+
+Don't cross-wire them: overnight RHR as the TRIMP threshold would inject daily noise into every workout's load calculation.
+
+### Max HR resolution
+
+`_resolve_thresholds` in `api/deps.py` resolves `max_hr_bpm` in this order:
+
+1. `config.thresholds.max_hr_bpm` (manual user override in Settings).
+2. `fitness_data.max_hr_bpm` row for this user (written by `write_profile_thresholds` from Garmin user profile).
+3. `max(Activity.max_hr)` across the user's activities — last-resort fallback for users with no profile value.
+
+Without #3, HR-base users with Garmin-only sync had `thresholds.max_hr_bpm = None` → TRIMP returned `None` → every daily load was 0 → empty fitness/fatigue chart.
+
+### Tokenstore lifecycle
+
+- First sync: no tokens present → `has_tokens = False` → `client.login(None)` uses credentials flow → `garth.dump(token_dir)` writes `oauth1_token.json` + `oauth2_token.json`.
+- Subsequent syncs: files exist → `has_tokens = True` → `client.login(token_dir)` loads cached tokens, skips SSO.
+- `clear_garmin_tokens(user_id)` is called on credential rotation / disconnect / user deletion. It must propagate OSError — silencing it would re-open the cross-user leak the per-user path exists to prevent.
+
+## Backfill semantics
+
+- `write_activities` / `write_splits` are **fill-only upserts** for a whitelisted set of columns (`avg_power`, `max_power`). If a row already exists and a column is NULL, a re-sync fills it; non-null values are preserved verbatim. This lets users benefit from parser improvements (e.g. native Garmin power) without deleting their existing data, *and* protects against clobbering Stryd-sourced power with a different Garmin reading in dual-sync scenarios.
+- `write_lactate_threshold` and `write_daily_metrics` are insert-only (existing rows skipped) — they're time-series of fresh values, so per-date idempotency is the right semantics.
+- Recovery (`recovery_data`) is update-capable per date (see `write_recovery`'s Garmin branch) so a partial first-sync row can be topped up on a later sync that returns HRV where the first didn't.
+
+## Sync status observability
+
+All per-source sync errors surface at `logger.warning` or above, not `debug`. Debug-level was the pattern that silently hid real failures on Garmin CN for months. Per-day failures inside loops (HRV, sleep) still log at `debug`, but counters aggregate into a single `warning` when a meaningful fraction fail:
+
+- Splits: warning when ≥ max(3, total/2) activities fail.
+- Recovery parse: warning when ≥ max(3, total/2) days fail.
+- HRV / sleep endpoints: circuit-break + warning after 5 consecutive failures.


### PR DESCRIPTION
## Summary
CLAUDE.md had grown to 281 lines; ~30% was bulk Claude didn't need on every turn (a 69-line Frontend Design System block, a stale CSV-path data-sources list, duplicated first-time-setup, over-detailed Claude Code Automations). Every session paid that context cost.

- **CLAUDE.md: 281 → 164 lines (~42% smaller).**
- **New `docs/dev/design-system.md`** — aligned with `docs/brand/index.html` (Praxys Brand Guideline v1.0). Captures the semantic palette (green = action, cobalt = reasoning — not just another accent), bilingual surface rules (always-both / locale-only / primary-with-subtitle), wordmark and mark specs, and the Science Note component pattern. In-transition items (Geist swap, rust rename, deprecate blue/purple) listed as a tracked checklist.
- **New `docs/dev/gotchas.md`** — consolidates domain-specific traps from PRs #58/#62/#64/#65/#66/#67: Garmin International vs CN account model, CIQ field-10 Stryd convention, CN endpoint parity, tokenstore lifecycle, recovery vs TRIMP RHR split, max-HR resolution order, backfill semantics, sync observability rules.

Two must-know invariants stay inline in CLAUDE.md because their violation causes data loss or security issues: split-level power dilution and per-user Garmin tokenstore isolation. Everything else is one Read away when relevant.

### Other cleanups
- Replace stale CSV "Data Sources" block with a correct "Data storage" note listing real SQLite tables.
- Update pages list to include Admin, Login, Setup (was stale at 6).
- Fold first-time-setup into the Running command block.
- Drop "AI Features → Not yet built" (rot-prone).
- Compress Claude Code Automations to one paragraph with pointers into `.claude/`.
- Git conventions (positive framing, no machine paths, inherited from stacked PR #67).
- CLAUDE.md Frontend section now carries the semantic-palette rule (cobalt reserved for reasoning) and points at both `docs/brand/index.html` and `docs/dev/design-system.md`.

## Stacked on
`docs/drop-folder-prefix-in-commits` (PR #67). If #67 merges first this PR rebases cleanly onto main.

## Test plan
- [ ] 293 Python tests pass (no code referenced the moved sections)
- [ ] `docs/dev/design-system.md` matches `docs/brand/index.html` intent; open items checklist reflects the code's in-transition state (DM Sans → Geist, `--accent-red` → `rust`, deprecate blue/purple, add `.font-serif-sc`)
- [ ] Future CLAUDE.md-based sessions load a focused file and follow pointers into `docs/brand/` and `docs/dev/` when subsystem-specific knowledge is needed