### PR TITLE
Threshold source selection; drop arbitrary manual overrides

### DIFF
--- a/analysis/thresholds.py
+++ b/analysis/thresholds.py
@@ -50,30 +50,18 @@ def detect_thresholds(connections: list[str], data_dir: str) -> dict[str, dict[s
 def resolve_thresholds_to_estimate(
     config_thresholds: dict, connections: list[str], data_dir: str,
 ) -> ThresholdEstimate:
-    """Build ThresholdEstimate from auto-detect + manual config overrides.
+    """Build ThresholdEstimate from auto-detected provider values only.
 
-    Auto-detects from connected providers, then applies manual overrides.
-    Used by deps.py for metric computation.
+    File-based fallback path. ``config_thresholds`` is accepted for call-site
+    compatibility with api.deps._resolve_thresholds but its numeric values
+    are **not** applied — manual numeric overrides are no longer supported.
+    Source selection lives in ``preferences.threshold_sources`` on the DB
+    path; the file path doesn't support multi-source disambiguation.
     """
+    _ = config_thresholds  # intentionally unused; see docstring
     detected = detect_thresholds(connections, data_dir)
     result = ThresholdEstimate()
-
-    # Apply auto-detected values
     for key in ("cp_watts", "lthr_bpm", "threshold_pace_sec_km", "max_hr_bpm", "rest_hr_bpm"):
         if key in detected:
             setattr(result, key, detected[key]["value"])
-
-    # Manual overrides from config
-    t = config_thresholds
-    if t.get("cp_watts"):
-        result.cp_watts = float(t["cp_watts"])
-    if t.get("lthr_bpm"):
-        result.lthr_bpm = float(t["lthr_bpm"])
-    if t.get("threshold_pace_sec_km"):
-        result.threshold_pace_sec_km = float(t["threshold_pace_sec_km"])
-    if t.get("max_hr_bpm"):
-        result.max_hr_bpm = float(t["max_hr_bpm"])
-    if t.get("rest_hr_bpm"):
-        result.rest_hr_bpm = float(t["rest_hr_bpm"])
-
     return result

--- a/api/deps.py
+++ b/api/deps.py
@@ -84,7 +84,7 @@ def _resolve_thresholds(
             """Pick the best fitness_data row for this metric.
 
             Preferred-source-first, fall back to latest-by-date if the
-            preferred source has no rows.
+            preferred source has no rows (or its rows have null/zero values).
             """
             preferred = (
                 threshold_sources.get(metric_type)
@@ -103,10 +103,17 @@ def _resolve_thresholds(
                 )
                 if row and row.value:
                     return float(row.value)
+                # Preferred source exists in the user's preferences but has no
+                # rows. Log at debug so the surprising-but-correct fallback
+                # ("I picked Stryd, why am I seeing Garmin's value?") is
+                # visible to anyone tailing the server log.
+                logger.debug(
+                    "_resolve_thresholds: preferred source %r for %s has no "
+                    "data; falling back to latest-by-date", preferred, metric_type,
+                )
             row = base.order_by(FitnessData.date.desc()).first()
             return float(row.value) if row and row.value else None
 
-        # Sensor-derived thresholds (Stryd/Garmin/Oura write into these).
         _METRIC_MAP = {
             "cp_estimate": "cp_watts",
             "lthr_bpm": "lthr_bpm",
@@ -119,11 +126,9 @@ def _resolve_thresholds(
             if val is not None:
                 setattr(result, est_attr, val)
 
-        # Calculated fallback: derive max_hr_bpm from the highest max_hr
-        # recorded across activities when no profile-based value exists.
-        # This is a computation we perform on the user's own data (not a
-        # guess), so it fits the "connected source or calculated by us"
-        # rule even without a dedicated max-HR sensor reading.
+        # Derived fallback: Garmin writes per-activity max_hr but no
+        # max_hr_bpm fitness_data record, so TRIMP would be skipped for
+        # HR-base users without this.
         if result.max_hr_bpm is None:
             from db.models import Activity
             from sqlalchemy import func

--- a/api/deps.py
+++ b/api/deps.py
@@ -54,54 +54,76 @@ def _ensure_env():
 def _resolve_thresholds(
     config, data_dir: str = None, user_id: str = None, db=None,
 ) -> ThresholdEstimate:
-    """Build ThresholdEstimate from config + auto-detect from fitness providers.
+    """Build ThresholdEstimate from sensor data.
 
-    When user_id and db are provided, extracts thresholds from the DB fitness
-    data. Otherwise falls back to file-based provider detection.
+    When ``user_id`` and ``db`` are provided, thresholds come from
+    ``fitness_data`` rows written by the sync pipelines. No arbitrary
+    user-entered numbers are accepted — every value traces back to a
+    connected source (Stryd, Garmin, Oura) or a calculation we perform from
+    that source's data. This is the "no guesswork" rule from CLAUDE.md's
+    Scientific Rigor section, applied to threshold resolution.
+
+    Source preference: when more than one provider writes the same metric
+    (notably CP, where Stryd and Garmin disagree by ~30%), pick the row
+    whose ``source`` matches the user's selection. Selection order:
+
+        1. Explicit: ``preferences.threshold_sources[metric_type]`` if set.
+        2. Default: whichever source produces the athlete's *activity* data
+           (``preferences.activities``). This keeps CP consistent with the
+           activities the user is viewing.
+        3. Fallback: latest row by date regardless of source.
     """
     if user_id and db:
-        # DB path: extract latest thresholds from fitness_data table
         result = ThresholdEstimate()
         from db.models import FitnessData
+
+        activity_source = config.preferences.get("activities") or None
+        threshold_sources = config.preferences.get("threshold_sources") or {}
+
+        def _latest(metric_type: str) -> float | None:
+            """Pick the best fitness_data row for this metric.
+
+            Preferred-source-first, fall back to latest-by-date if the
+            preferred source has no rows.
+            """
+            preferred = (
+                threshold_sources.get(metric_type)
+                or activity_source
+            )
+            base = db.query(FitnessData).filter(
+                FitnessData.user_id == user_id,
+                FitnessData.metric_type == metric_type,
+                FitnessData.value.isnot(None),
+            )
+            if preferred:
+                row = (
+                    base.filter(FitnessData.source == preferred)
+                    .order_by(FitnessData.date.desc())
+                    .first()
+                )
+                if row and row.value:
+                    return float(row.value)
+            row = base.order_by(FitnessData.date.desc()).first()
+            return float(row.value) if row and row.value else None
+
+        # Sensor-derived thresholds (Stryd/Garmin/Oura write into these).
         _METRIC_MAP = {
             "cp_estimate": "cp_watts",
             "lthr_bpm": "lthr_bpm",
             "lt_pace_sec_km": "threshold_pace_sec_km",
+            "max_hr_bpm": "max_hr_bpm",
+            "rest_hr_bpm": "rest_hr_bpm",
         }
         for db_metric, est_attr in _METRIC_MAP.items():
-            row = (
-                db.query(FitnessData)
-                .filter(
-                    FitnessData.user_id == user_id,
-                    FitnessData.metric_type == db_metric,
-                    FitnessData.value.isnot(None),
-                )
-                .order_by(FitnessData.date.desc())
-                .first()
-            )
-            if row and row.value:
-                setattr(result, est_attr, float(row.value))
+            val = _latest(db_metric)
+            if val is not None:
+                setattr(result, est_attr, val)
 
-        # Also look for max_hr and resting_hr
-        for db_metric, est_attr in [("max_hr_bpm", "max_hr_bpm"), ("rest_hr_bpm", "rest_hr_bpm")]:
-            row = (
-                db.query(FitnessData)
-                .filter(
-                    FitnessData.user_id == user_id,
-                    FitnessData.metric_type == db_metric,
-                    FitnessData.value.isnot(None),
-                )
-                .order_by(FitnessData.date.desc())
-                .first()
-            )
-            if row and row.value:
-                setattr(result, est_attr, float(row.value))
-
-        # Fallback: derive max_hr_bpm from the highest max_hr recorded across
-        # activities when fitness_data has no entry. The Garmin sync writes
-        # per-activity max_hr but never a max_hr_bpm fitness record, so HR-based
-        # users would otherwise have no max_hr threshold and TRIMP would be
-        # skipped — leaving the fitness/fatigue chart empty.
+        # Calculated fallback: derive max_hr_bpm from the highest max_hr
+        # recorded across activities when no profile-based value exists.
+        # This is a computation we perform on the user's own data (not a
+        # guess), so it fits the "connected source or calculated by us"
+        # rule even without a dedicated max-HR sensor reading.
         if result.max_hr_bpm is None:
             from db.models import Activity
             from sqlalchemy import func
@@ -111,19 +133,6 @@ def _resolve_thresholds(
             ).scalar()
             if max_hr:
                 result.max_hr_bpm = float(max_hr)
-
-        # Apply manual overrides from config
-        t = config.thresholds
-        if t.get("cp_watts"):
-            result.cp_watts = float(t["cp_watts"])
-        if t.get("lthr_bpm"):
-            result.lthr_bpm = float(t["lthr_bpm"])
-        if t.get("threshold_pace_sec_km"):
-            result.threshold_pace_sec_km = float(t["threshold_pace_sec_km"])
-        if t.get("max_hr_bpm"):
-            result.max_hr_bpm = float(t["max_hr_bpm"])
-        if t.get("rest_hr_bpm"):
-            result.rest_hr_bpm = float(t["rest_hr_bpm"])
 
         return result
 

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -96,14 +96,17 @@ def _detect_thresholds_from_db(user_id: str, db) -> dict:
     ]
 
     for metric_type, threshold_key, default_source in metric_map:
-        # Latest value per distinct source. Use a subquery-less approach: pull
-        # all rows, group in Python. For typical users this is <100 rows.
+        # Filter null-date rows at the DB level so the invariant "rows[0]
+        # is the latest" holds regardless of SQLite's NULL-ordering quirks.
+        # Python-side per-source grouping: <100 rows per user in practice,
+        # so a subquery-less approach keeps this readable.
         rows = (
             db.query(FitnessData)
             .filter(
                 FitnessData.user_id == user_id,
                 FitnessData.metric_type == metric_type,
                 FitnessData.value.isnot(None),
+                FitnessData.date.isnot(None),
             )
             .order_by(FitnessData.date.desc())
             .all()
@@ -117,20 +120,28 @@ def _detect_thresholds_from_db(user_id: str, db) -> dict:
             # the most recent row per source.
             if src not in seen_sources:
                 seen_sources[src] = row
-        options = [
-            {
-                "source": src,
-                "value": round(float(r.value), 1),
-                "date": r.date.isoformat() if r.date else None,
-            }
-            for src, r in seen_sources.items()
-        ]
-        # Sort options by date descending so the UI defaults list to newest-first.
+        options: list[dict] = []
+        for src, r in seen_sources.items():
+            try:
+                options.append({
+                    "source": src,
+                    "value": round(float(r.value), 1),
+                    "date": r.date.isoformat() if r.date else None,
+                })
+            except (TypeError, ValueError) as exc:
+                # One malformed row mustn't blank out the whole Settings page.
+                logger.warning(
+                    "detect_thresholds: skipping row %s for user %s (%s=%r): %s",
+                    r.id, user_id, metric_type, r.value, exc,
+                )
+        if not options:
+            continue
         options.sort(key=lambda o: o["date"] or "", reverse=True)
-        latest = rows[0]
+        # Use options[0] rather than rows[0] so the displayed value always
+        # matches one of the options the UI will render.
         result[threshold_key] = {
-            "value": round(float(latest.value), 1),
-            "source": latest.source or default_source,
+            "value": options[0]["value"],
+            "source": options[0]["source"],
             "options": options,
         }
 
@@ -164,17 +175,20 @@ def resolve_thresholds(
 ) -> dict:
     """Pick the effective value for each threshold from detected sources.
 
-    ``config_thresholds`` is accepted for backwards compat but its numeric
-    values are no longer honoured — the clean-break migration ignores legacy
-    manual overrides. Selection order:
+    ``config_thresholds`` is ignored (kept in the signature so callers don't
+    break; remove on the next major API version). Manual numeric overrides
+    are not supported — source selection lives in ``threshold_sources``.
 
-        1. Explicit: ``threshold_sources[metric_type]`` if the option exists.
-        2. Default: ``activity_source`` — keeps CP consistent with the
+    Selection order:
+        1. Explicit: ``threshold_sources[metric_type]`` if that source has
+           an entry in ``options``.
+        2. Default: ``activity_source`` — keeps CP aligned with the
            activities the user is viewing.
-        3. Fallback: the ``options`` list is already date-sorted, so index 0
-           is the latest row.
+        3. Fallback: ``options[0]``. _detect_thresholds_from_db sorts
+           options by date desc, so this is the most recent row.
     """
-    # metric_type names map 1:1 to threshold keys for everything except CP.
+    _ = config_thresholds  # intentionally unused
+    # metric_type keys match fitness_data.metric_type for all but CP.
     threshold_to_metric = {
         "cp_watts": "cp_estimate",
         "lthr_bpm": "lthr_bpm",
@@ -195,8 +209,19 @@ def resolve_thresholds(
         picked = None
         if preferred:
             picked = next((o for o in options if o["source"] == preferred), None)
+            if picked is None:
+                # User chose a source that has no data yet; log so the
+                # apparent mismatch between selection and displayed value
+                # is visible in server logs.
+                logger.debug(
+                    "resolve_thresholds: preferred source %r for %s has no data; "
+                    "falling back to latest (%s=%s)",
+                    preferred, metric_type, options[0]["source"], options[0]["value"],
+                )
         if picked is None:
-            picked = options[0]  # latest
+            # latest — invariant maintained by _detect_thresholds_from_db's
+            # `options.sort(key=...date, reverse=True)`.
+            picked = options[0]
         effective[key] = {
             "value": picked["value"],
             "origin": f"auto ({picked['source']})",
@@ -257,11 +282,17 @@ def update_settings(
         config.connections = body.connections
     if body.preferences is not None:
         config.preferences.update(body.preferences)
-    # `thresholds` updates are silently ignored: the clean-break migration
-    # (2026-04) removed manual numeric overrides. Source selection now lives
-    # in `preferences.threshold_sources`. Accepting the key keeps the API
-    # compatible with clients that still send it; the body is discarded.
-    _ = body.thresholds  # noqa: intentional no-op
+    # `thresholds` updates are accepted-and-dropped: manual numeric overrides
+    # are no longer supported; source selection lives in
+    # ``preferences.threshold_sources``. Kept in the schema for API compat
+    # with older clients. A non-empty payload means a client still thinks it
+    # can write numeric thresholds — log so we can find it.
+    if body.thresholds:
+        logger.info(
+            "settings.update: discarding legacy thresholds payload "
+            "(user %s, keys=%s)",
+            user_id, sorted(body.thresholds.keys()),
+        )
     if body.zones is not None:
         config.zones.update(body.zones)
     if body.goal is not None:

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -52,7 +52,9 @@ class SettingsUpdate(BaseModel):
     display_name: str | None = None
     unit_system: str | None = None
     connections: list[str] | None = None
-    preferences: dict[str, str] | None = None
+    # dict[str, Any] so the nested `threshold_sources` mapping
+    # (e.g. {"threshold_sources": {"cp_estimate": "stryd"}}) flows through.
+    preferences: dict[str, Any] | None = None
     training_base: TrainingBase | None = None
     thresholds: dict[str, Any] | None = None
     zones: dict[str, list[float]] | None = None
@@ -64,20 +66,39 @@ class SettingsUpdate(BaseModel):
 def _detect_thresholds_from_db(user_id: str, db) -> dict:
     """Auto-detect thresholds from fitness_data in the database.
 
-    Returns dict mapping threshold key -> {"value": float, "source": platform_name}.
+    For each threshold, returns:
+
+        {
+          "value":  latest value (float),           // display convenience
+          "source": source of the latest value,
+          "options": [                              // all known sources
+            {"source": "stryd",  "value": 265.0, "date": "2026-04-20"},
+            {"source": "garmin", "value": 350.0, "date": "2026-04-22"},
+          ]
+        }
+
+    ``options`` powers the Settings UI's source selector when a threshold has
+    multiple provider sources (typically CP — Stryd vs Garmin). With only one
+    source, the selector can stay hidden and the single value is shown as
+    read-only. With zero sources the threshold is simply absent from the
+    result.
     """
     from db.models import FitnessData
 
     result: dict = {}
-    # Map metric_type → threshold key
-    metric_map = {
-        "cp_estimate": ("cp_watts", "stryd"),
-        "lthr_bpm": ("lthr_bpm", "garmin"),
-        "lt_pace_sec_km": ("threshold_pace_sec_km", "garmin"),
-    }
+    # (metric_type, threshold_key, default_source_when_row.source_is_null)
+    metric_map = [
+        ("cp_estimate", "cp_watts", "stryd"),
+        ("lthr_bpm", "lthr_bpm", "garmin"),
+        ("lt_pace_sec_km", "threshold_pace_sec_km", "garmin"),
+        ("max_hr_bpm", "max_hr_bpm", "garmin"),
+        ("rest_hr_bpm", "rest_hr_bpm", "garmin"),
+    ]
 
-    for metric_type, (threshold_key, default_source) in metric_map.items():
-        row = (
+    for metric_type, threshold_key, default_source in metric_map:
+        # Latest value per distinct source. Use a subquery-less approach: pull
+        # all rows, group in Python. For typical users this is <100 rows.
+        rows = (
             db.query(FitnessData)
             .filter(
                 FitnessData.user_id == user_id,
@@ -85,33 +106,37 @@ def _detect_thresholds_from_db(user_id: str, db) -> dict:
                 FitnessData.value.isnot(None),
             )
             .order_by(FitnessData.date.desc())
-            .first()
+            .all()
         )
-        if row and row.value:
-            result[threshold_key] = {
-                "value": round(float(row.value), 1),
-                "source": row.source or default_source,
+        if not rows:
+            continue
+        seen_sources: dict[str, FitnessData] = {}
+        for row in rows:
+            src = row.source or default_source
+            # First occurrence wins — rows are already date-desc, so this is
+            # the most recent row per source.
+            if src not in seen_sources:
+                seen_sources[src] = row
+        options = [
+            {
+                "source": src,
+                "value": round(float(r.value), 1),
+                "date": r.date.isoformat() if r.date else None,
             }
+            for src, r in seen_sources.items()
+        ]
+        # Sort options by date descending so the UI defaults list to newest-first.
+        options.sort(key=lambda o: o["date"] or "", reverse=True)
+        latest = rows[0]
+        result[threshold_key] = {
+            "value": round(float(latest.value), 1),
+            "source": latest.source or default_source,
+            "options": options,
+        }
 
-    # Max HR and resting HR from fitness_data
-    for metric_type, threshold_key in [("max_hr_bpm", "max_hr_bpm"), ("rest_hr_bpm", "rest_hr_bpm")]:
-        row = (
-            db.query(FitnessData)
-            .filter(
-                FitnessData.user_id == user_id,
-                FitnessData.metric_type == metric_type,
-                FitnessData.value.isnot(None),
-            )
-            .order_by(FitnessData.date.desc())
-            .first()
-        )
-        if row and row.value:
-            result[threshold_key] = {
-                "value": round(float(row.value), 1),
-                "source": row.source or "garmin",
-            }
-
-    # Fallback: detect max HR from activities if not in fitness_data
+    # Fallback: derive max HR from activities if fitness_data has no row.
+    # Exposed as a synthetic "activities" source so the UI can still show a
+    # value — users can't select a different source when there isn't one.
     if "max_hr_bpm" not in result:
         from db.models import Activity
         from sqlalchemy import func
@@ -120,42 +145,62 @@ def _detect_thresholds_from_db(user_id: str, db) -> dict:
             Activity.max_hr.isnot(None),
         ).scalar()
         if max_hr:
-            result["max_hr_bpm"] = {"value": round(float(max_hr), 1), "source": "activities"}
+            result["max_hr_bpm"] = {
+                "value": round(float(max_hr), 1),
+                "source": "activities",
+                "options": [
+                    {"source": "activities", "value": round(float(max_hr), 1), "date": None},
+                ],
+            }
 
     return result
 
 
-def resolve_thresholds(config_thresholds: dict, detected: dict) -> dict:
-    """Merge auto-detected thresholds with manual overrides.
+def resolve_thresholds(
+    config_thresholds: dict,
+    detected: dict,
+    threshold_sources: dict | None = None,
+    activity_source: str | None = None,
+) -> dict:
+    """Pick the effective value for each threshold from detected sources.
 
-    Manual overrides (source == 'manual') take precedence.
-    Returns the effective threshold values.
+    ``config_thresholds`` is accepted for backwards compat but its numeric
+    values are no longer honoured — the clean-break migration ignores legacy
+    manual overrides. Selection order:
+
+        1. Explicit: ``threshold_sources[metric_type]`` if the option exists.
+        2. Default: ``activity_source`` — keeps CP consistent with the
+           activities the user is viewing.
+        3. Fallback: the ``options`` list is already date-sorted, so index 0
+           is the latest row.
     """
+    # metric_type names map 1:1 to threshold keys for everything except CP.
+    threshold_to_metric = {
+        "cp_watts": "cp_estimate",
+        "lthr_bpm": "lthr_bpm",
+        "threshold_pace_sec_km": "lt_pace_sec_km",
+        "max_hr_bpm": "max_hr_bpm",
+        "rest_hr_bpm": "rest_hr_bpm",
+    }
+    sources_pref = threshold_sources or {}
     effective: dict[str, Any] = {}
-    is_manual = config_thresholds.get("source") == "manual"
 
-    for key in [
-        "cp_watts",
-        "lthr_bpm",
-        "threshold_pace_sec_km",
-        "max_hr_bpm",
-        "rest_hr_bpm",
-    ]:
-        manual_val = config_thresholds.get(key)
-        auto_val = detected.get(key, {}).get("value") if key in detected else None
-
-        if is_manual and manual_val is not None:
-            effective[key] = {"value": manual_val, "origin": "manual"}
-        elif auto_val is not None:
-            effective[key] = {
-                "value": auto_val,
-                "origin": f"auto ({detected[key]['source']})",
-            }
-        elif manual_val is not None:
-            effective[key] = {"value": manual_val, "origin": "manual"}
-        else:
+    for key, metric_type in threshold_to_metric.items():
+        info = detected.get(key)
+        if not info or not info.get("options"):
             effective[key] = {"value": None, "origin": "none"}
-
+            continue
+        options = info["options"]
+        preferred = sources_pref.get(metric_type) or activity_source
+        picked = None
+        if preferred:
+            picked = next((o for o in options if o["source"] == preferred), None)
+        if picked is None:
+            picked = options[0]  # latest
+        effective[key] = {
+            "value": picked["value"],
+            "origin": f"auto ({picked['source']})",
+        }
     return effective
 
 
@@ -168,7 +213,12 @@ def get_settings(
     config = load_config_from_db(user_id, db)
     avail = available_providers()
     detected = _detect_thresholds_from_db(user_id, db)
-    effective = resolve_thresholds(config.thresholds, detected)
+    effective = resolve_thresholds(
+        config.thresholds,
+        detected,
+        threshold_sources=config.preferences.get("threshold_sources"),
+        activity_source=config.preferences.get("activities"),
+    )
 
     return {
         "config": asdict(config),
@@ -207,8 +257,11 @@ def update_settings(
         config.connections = body.connections
     if body.preferences is not None:
         config.preferences.update(body.preferences)
-    if body.thresholds is not None:
-        config.thresholds.update(body.thresholds)
+    # `thresholds` updates are silently ignored: the clean-break migration
+    # (2026-04) removed manual numeric overrides. Source selection now lives
+    # in `preferences.threshold_sources`. Accepting the key keeps the API
+    # compatible with clients that still send it; the body is discarded.
+    _ = body.thresholds  # noqa: intentional no-op
     if body.zones is not None:
         config.zones.update(body.zones)
     if body.goal is not None:

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -68,25 +68,45 @@ Why they differ:
 
 Neither is "wrong", but **zones calibrated on one don't transfer**.
 Most published training literature and coach references are calibrated
-on Stryd. If a user has both sources connected, the latest write to
-`fitness_data.cp_estimate` wins in `_resolve_thresholds` — which can
-make CP whiplash between the two systems. Open issue: source-aware CP
-resolution (honour `preferences.activities` when picking between Stryd
-and Garmin `cp_estimate` rows) — not implemented yet.
+on Stryd. When a user has both sources connected, the resolver picks
+between them using the threshold-source-selection rules below.
 
 The Settings → Training Base UI shows a cobalt-bordered note when the
 user picks Power without Stryd connected, so the user knows the
 numbers aren't directly comparable to Stryd-calibrated references.
 
-### Max HR resolution
+## Threshold resolution
 
-`_resolve_thresholds` in `api/deps.py` resolves `max_hr_bpm` in this order:
+`_resolve_thresholds` in `api/deps.py` never accepts arbitrary user-entered
+numeric values — every threshold traces back to a connected source or a
+calculation we run on the user's own data. Manual numeric overrides were
+removed from the schema; the `thresholds` field in `PUT /api/settings`
+bodies is accepted for API compat but silently discarded (with an INFO log
+so stragglers are findable).
 
-1. `config.thresholds.max_hr_bpm` (manual user override in Settings).
-2. `fitness_data.max_hr_bpm` row for this user (written by `write_profile_thresholds` from Garmin user profile).
-3. `max(Activity.max_hr)` across the user's activities — last-resort fallback for users with no profile value.
+Selection order for each threshold (`cp_watts`, `lthr_bpm`,
+`threshold_pace_sec_km`, `max_hr_bpm`, `rest_hr_bpm`):
 
-Without #3, HR-base users with Garmin-only sync had `thresholds.max_hr_bpm = None` → TRIMP returned `None` → every daily load was 0 → empty fitness/fatigue chart.
+1. **Explicit** — `preferences.threshold_sources[metric_type]` if that
+   source has any rows for that metric.
+2. **Default** — `preferences.activities` (the primary activity source).
+   Keeps CP aligned with the activities the user is viewing.
+3. **Fallback** — latest `fitness_data` row by date, regardless of source.
+   When the preferred source has no data the resolver falls back here and
+   emits a DEBUG log so the "why am I seeing Garmin's value when I picked
+   Stryd?" case is traceable.
+
+Special case for `max_hr_bpm`: if `fitness_data` has no `max_hr_bpm` row
+at all, the resolver derives it from `max(Activity.max_hr)`. This is a
+calculation on the user's own data (not a guess), so it fits the
+"connected source or calculated by us" rule. Without this, HR-base users
+with Garmin-only sync had `max_hr_bpm = None` → TRIMP returned `None` →
+every daily load was 0 → empty fitness/fatigue chart.
+
+The UI in Settings renders a read-only value plus a source selector
+(populated from `options[]` on the `GET /api/settings` response) when a
+metric has more than one source. Single-source or zero-source metrics
+render read-only with a source badge.
 
 ### Tokenstore lifecycle
 

--- a/tests/test_deps_thresholds.py
+++ b/tests/test_deps_thresholds.py
@@ -48,7 +48,11 @@ def db_with_user(monkeypatch):
         tmpdir.cleanup()
 
 
-def _fake_config(training_base: str = "hr"):
+def _fake_config(
+    training_base: str = "hr",
+    activity_source: str | None = None,
+    threshold_sources: dict | None = None,
+):
     """Minimal config stub matching the fields _resolve_thresholds reads."""
     class _C:
         pass
@@ -56,6 +60,11 @@ def _fake_config(training_base: str = "hr"):
     c.training_base = training_base
     c.thresholds = {}
     c.connections = {}
+    c.preferences = {}
+    if activity_source:
+        c.preferences["activities"] = activity_source
+    if threshold_sources:
+        c.preferences["threshold_sources"] = threshold_sources
     return c
 
 
@@ -113,13 +122,15 @@ def test_resolve_thresholds_prefers_fitness_data_over_activity_fallback(db_with_
     )
 
 
-def test_resolve_thresholds_manual_override_wins_over_activity_fallback(db_with_user):
-    """An explicit config.thresholds override beats every auto-detection path."""
+def test_resolve_thresholds_ignores_legacy_manual_values(db_with_user):
+    """Regression for the clean-break migration: legacy manual values in
+    ``config.thresholds`` are no longer applied. Every threshold must come
+    from a sensor row or a calculation on the user's own data.
+    """
     from db.models import Activity
     from api.deps import _resolve_thresholds
 
     db, user_id = db_with_user
-
     today = date.today()
     db.add(Activity(
         user_id=user_id, activity_id="a1", date=today,
@@ -129,9 +140,74 @@ def test_resolve_thresholds_manual_override_wins_over_activity_fallback(db_with_
     db.commit()
 
     config = _fake_config()
-    config.thresholds = {"max_hr_bpm": 195}
+    # Simulate a user who previously entered 195 as a manual override.
+    # The resolver should ignore this and use the activity fallback (190).
+    config.thresholds = {"max_hr_bpm": 195, "cp_watts": 999, "lthr_bpm": 999}
     result = _resolve_thresholds(config, user_id=user_id, db=db)
-    assert result.max_hr_bpm == 195.0
+    assert result.max_hr_bpm == 190.0, "activity fallback should win over legacy manual value"
+    assert result.cp_watts is None, "legacy manual cp_watts must be ignored"
+    assert result.lthr_bpm is None, "legacy manual lthr_bpm must be ignored"
+
+
+def test_resolve_thresholds_picks_preferred_source_when_multiple_present(db_with_user):
+    """When both Stryd and Garmin write cp_estimate, the explicit
+    threshold_sources preference wins over the latest-by-date default."""
+    from db.models import FitnessData
+    from api.deps import _resolve_thresholds
+
+    db, user_id = db_with_user
+    today = date.today()
+    # Garmin's cp_estimate is newer by date.
+    db.add(FitnessData(
+        user_id=user_id, date=today, metric_type="cp_estimate",
+        value=350.0, source="garmin",
+    ))
+    db.add(FitnessData(
+        user_id=user_id, date=today - timedelta(days=3), metric_type="cp_estimate",
+        value=265.0, source="stryd",
+    ))
+    db.commit()
+
+    # Without preference: latest-by-date wins (Garmin 350).
+    result = _resolve_thresholds(_fake_config(), user_id=user_id, db=db)
+    assert result.cp_watts == 350.0
+
+    # With explicit Stryd preference: stale Stryd value wins over fresh Garmin.
+    cfg = _fake_config(threshold_sources={"cp_estimate": "stryd"})
+    result = _resolve_thresholds(cfg, user_id=user_id, db=db)
+    assert result.cp_watts == 265.0
+
+    # Default to activity source: preferences.activities == "stryd" picks Stryd.
+    cfg = _fake_config(activity_source="stryd")
+    result = _resolve_thresholds(cfg, user_id=user_id, db=db)
+    assert result.cp_watts == 265.0
+
+    # Explicit threshold_sources overrides the activity-source default.
+    cfg = _fake_config(
+        activity_source="stryd",
+        threshold_sources={"cp_estimate": "garmin"},
+    )
+    result = _resolve_thresholds(cfg, user_id=user_id, db=db)
+    assert result.cp_watts == 350.0
+
+
+def test_resolve_thresholds_falls_back_when_preferred_source_has_no_data(db_with_user):
+    """If the preferred source never wrote a row, fall back to the latest
+    from any source rather than returning None."""
+    from db.models import FitnessData
+    from api.deps import _resolve_thresholds
+
+    db, user_id = db_with_user
+    db.add(FitnessData(
+        user_id=user_id, date=date.today(), metric_type="cp_estimate",
+        value=265.0, source="stryd",
+    ))
+    db.commit()
+
+    # Prefer Garmin, but Garmin never wrote — fall back to Stryd.
+    cfg = _fake_config(threshold_sources={"cp_estimate": "garmin"})
+    result = _resolve_thresholds(cfg, user_id=user_id, db=db)
+    assert result.cp_watts == 265.0
 
 
 def test_resolve_thresholds_no_activities_leaves_max_hr_none(db_with_user):

--- a/tests/test_deps_thresholds.py
+++ b/tests/test_deps_thresholds.py
@@ -140,13 +140,22 @@ def test_resolve_thresholds_ignores_legacy_manual_values(db_with_user):
     db.commit()
 
     config = _fake_config()
-    # Simulate a user who previously entered 195 as a manual override.
-    # The resolver should ignore this and use the activity fallback (190).
-    config.thresholds = {"max_hr_bpm": 195, "cp_watts": 999, "lthr_bpm": 999}
+    # Simulate a user who previously entered manual values for every
+    # threshold. The resolver must ignore all of them and use the activity
+    # fallback (190) for max_hr; the other metrics have no data so remain None.
+    config.thresholds = {
+        "max_hr_bpm": 195,
+        "cp_watts": 999,
+        "lthr_bpm": 999,
+        "threshold_pace_sec_km": 240,
+        "rest_hr_bpm": 40,
+    }
     result = _resolve_thresholds(config, user_id=user_id, db=db)
     assert result.max_hr_bpm == 190.0, "activity fallback should win over legacy manual value"
-    assert result.cp_watts is None, "legacy manual cp_watts must be ignored"
-    assert result.lthr_bpm is None, "legacy manual lthr_bpm must be ignored"
+    assert result.cp_watts is None
+    assert result.lthr_bpm is None
+    assert result.threshold_pace_sec_km is None
+    assert result.rest_hr_bpm is None
 
 
 def test_resolve_thresholds_picks_preferred_source_when_multiple_present(db_with_user):

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -107,3 +107,141 @@ def test_get_settings_exposes_sync_interval_options(api_client):
     body = res.json()
     assert body["sync_interval_options_hours"] == [6, 12, 24]
     assert body["default_sync_interval_hours"] == 6
+
+
+# --- Threshold source selection (clean-break: no manual overrides) ---
+
+
+def _seed_cp_rows(user_id: str):
+    """Insert two cp_estimate rows from different sources for the test user."""
+    from datetime import date, timedelta
+
+    from db import session as db_session
+    from db.models import FitnessData
+    db = db_session.SessionLocal()
+    try:
+        today = date.today()
+        db.add(FitnessData(
+            user_id=user_id, date=today,
+            metric_type="cp_estimate", value=350.0, source="garmin",
+        ))
+        db.add(FitnessData(
+            user_id=user_id, date=today - timedelta(days=3),
+            metric_type="cp_estimate", value=265.0, source="stryd",
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_settings_roundtrip_threshold_source_preference(api_client):
+    """Integration: PUT preferences.threshold_sources survives GET and flows
+    through to effective_thresholds.origin. Guards the whole source-selection
+    contract the frontend relies on — the Pydantic widening that lets the
+    nested dict through, the resolver source preference, the response shape.
+    """
+    client, user_id = api_client
+    _seed_cp_rows(user_id)
+
+    # Baseline: latest-by-date wins → Garmin (newer) → 350.
+    res = client.get("/api/settings")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["effective_thresholds"]["cp_watts"]["value"] == 350.0
+    assert body["effective_thresholds"]["cp_watts"]["origin"] == "auto (garmin)"
+    # options[] must include both sources.
+    opts = {o["source"] for o in body["detected_thresholds"]["cp_watts"]["options"]}
+    assert opts == {"garmin", "stryd"}
+
+    # Pick Stryd via preferences.threshold_sources.
+    put = client.put(
+        "/api/settings",
+        json={"preferences": {"threshold_sources": {"cp_estimate": "stryd"}}},
+    )
+    assert put.status_code == 200, put.text
+
+    got = client.get("/api/settings").json()
+    assert got["config"]["preferences"]["threshold_sources"]["cp_estimate"] == "stryd"
+    # Resolver now picks Stryd's value even though Garmin's row is newer.
+    assert got["effective_thresholds"]["cp_watts"]["value"] == 265.0
+    assert got["effective_thresholds"]["cp_watts"]["origin"] == "auto (stryd)"
+
+
+def test_settings_activity_source_defaults_threshold_source(api_client):
+    """If no explicit threshold_sources set, the activity-source preference
+    drives CP selection."""
+    client, user_id = api_client
+    _seed_cp_rows(user_id)
+
+    client.put("/api/settings", json={"preferences": {"activities": "stryd"}})
+    got = client.get("/api/settings").json()
+    assert got["effective_thresholds"]["cp_watts"]["value"] == 265.0
+    assert got["effective_thresholds"]["cp_watts"]["origin"] == "auto (stryd)"
+
+
+def test_put_settings_discards_legacy_thresholds_body(api_client, caplog):
+    """Regression lock: sending thresholds.cp_watts must not persist as a
+    manual override. The server accepts the payload for API compat and logs
+    that it was ignored, but nothing reaches config.thresholds."""
+    import logging
+    client, user_id = api_client
+    _seed_cp_rows(user_id)
+
+    with caplog.at_level(logging.INFO, logger="api.routes.settings"):
+        res = client.put(
+            "/api/settings",
+            json={"thresholds": {"cp_watts": 999, "lthr_bpm": 888}},
+        )
+    assert res.status_code == 200, res.text
+
+    got = client.get("/api/settings").json()
+    # config.thresholds didn't receive the values.
+    stored = got["config"].get("thresholds") or {}
+    assert "cp_watts" not in stored or not stored.get("cp_watts")
+    assert "lthr_bpm" not in stored or not stored.get("lthr_bpm")
+    # effective CP should still come from the seed data, not the bogus 999.
+    assert got["effective_thresholds"]["cp_watts"]["value"] == 350.0
+    # Discard was logged so the next maintainer can spot old clients.
+    assert any(
+        "discarding legacy thresholds" in rec.getMessage() for rec in caplog.records
+    )
+
+
+def test_detect_thresholds_options_deduped_and_date_sorted(api_client):
+    """_detect_thresholds_from_db contract: one entry per source, sorted
+    date-desc, with the newest-per-source value chosen when a source has
+    multiple rows."""
+    from datetime import date, timedelta
+
+    from api.routes.settings import _detect_thresholds_from_db
+    from db import session as db_session
+    from db.models import FitnessData
+
+    _, user_id = api_client
+    db = db_session.SessionLocal()
+    today = date.today()
+    try:
+        # Two Stryd rows (older should lose to newer), plus one Garmin.
+        db.add(FitnessData(
+            user_id=user_id, date=today - timedelta(days=10),
+            metric_type="cp_estimate", value=255.0, source="stryd",
+        ))
+        db.add(FitnessData(
+            user_id=user_id, date=today - timedelta(days=1),
+            metric_type="cp_estimate", value=265.0, source="stryd",
+        ))
+        db.add(FitnessData(
+            user_id=user_id, date=today - timedelta(days=4),
+            metric_type="cp_estimate", value=350.0, source="garmin",
+        ))
+        db.commit()
+        detected = _detect_thresholds_from_db(user_id, db)
+    finally:
+        db.close()
+
+    opts = detected["cp_watts"]["options"]
+    assert len(opts) == 2, "one entry per source, not per row"
+    # Sorted date-desc — Stryd's newer row wins over Garmin.
+    assert [o["source"] for o in opts] == ["stryd", "garmin"]
+    assert opts[0]["value"] == 265.0  # Stryd's newest, not the older 255.
+    assert opts[1]["value"] == 350.0

--- a/web/src/contexts/SettingsContext.tsx
+++ b/web/src/contexts/SettingsContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import type { DisplayConfig, SettingsConfig, SettingsResponse, TrainingBase, ThresholdValue } from '../types/api';
+import type { DisplayConfig, SettingsConfig, SettingsResponse, TrainingBase, ThresholdValue, DetectedThreshold } from '../types/api';
 import { API_BASE, getAuthHeaders } from '../hooks/useApi';
 
 interface SettingsContextValue {
@@ -10,6 +10,7 @@ interface SettingsContextValue {
   availableProviders: Record<string, string[]>;
   availableBases: TrainingBase[];
   effectiveThresholds: Record<string, ThresholdValue>;
+  detectedThresholds: Record<string, DetectedThreshold>;
   loading: boolean;
   error: string | null;
   updateSettings: (update: Partial<SettingsConfig>) => Promise<void>;
@@ -34,6 +35,7 @@ const SettingsContext = createContext<SettingsContextValue>({
   availableProviders: {},
   availableBases: ['power', 'hr', 'pace'],
   effectiveThresholds: {},
+  detectedThresholds: {},
   loading: true,
   error: null,
   updateSettings: async () => {},
@@ -47,6 +49,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [availableProviders, setAvailableProviders] = useState<Record<string, string[]>>({});
   const [availableBases, setAvailableBases] = useState<TrainingBase[]>(['power', 'hr', 'pace']);
   const [effectiveThresholds, setEffectiveThresholds] = useState<Record<string, ThresholdValue>>({});
+  const [detectedThresholds, setDetectedThresholds] = useState<Record<string, DetectedThreshold>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [fetchKey, setFetchKey] = useState(0);
@@ -71,6 +74,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         setAvailableProviders(data.available_providers ?? {});
         setAvailableBases(data.available_bases);
         setEffectiveThresholds(data.effective_thresholds ?? {});
+        setDetectedThresholds(data.detected_thresholds ?? {});
         setLoading(false);
       })
       .catch((err) => {
@@ -112,7 +116,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   return (
     <SettingsContext.Provider
-      value={{ config, display, platformCapabilities, availableProviders, availableBases, effectiveThresholds, loading, error, updateSettings, refetch }}
+      value={{ config, display, platformCapabilities, availableProviders, availableBases, effectiveThresholds, detectedThresholds, loading, error, updateSettings, refetch }}
     >
       {children}
     </SettingsContext.Provider>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSettings } from '@/contexts/SettingsContext';
 import { API_BASE, getAuthHeaders } from '@/hooks/useApi';
-import type { TrainingBase, SyncStatusResponse } from '@/types/api';
+import type { TrainingBase, SyncStatusResponse, SettingsConfig } from '@/types/api';
 import {
   buildStravaReturnTo,
   getStravaOAuthMessage,
@@ -214,7 +214,7 @@ export default function Settings() {
   const navigate = useNavigate();
   const {
     config, platformCapabilities, availableProviders, availableBases,
-    effectiveThresholds, loading, error, updateSettings, refetch,
+    effectiveThresholds, detectedThresholds, loading, error, updateSettings, refetch,
   } = useSettings();
   const { email: authEmail, isDemo } = useAuth();
   const { setLocale } = useLocale();
@@ -222,8 +222,6 @@ export default function Settings() {
 
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState('');
-  const [editingThreshold, setEditingThreshold] = useState<string | null>(null);
-  const [thresholdInput, setThresholdInput] = useState('');
   const [syncStatus, setSyncStatus] = useState<SyncStatusResponse>({});
   const [backfillDate, setBackfillDate] = useState('');
   const [showBackfill, setShowBackfill] = useState(false);
@@ -351,16 +349,29 @@ export default function Settings() {
     setSaving(false);
   };
 
-  const handleThresholdSave = async (key: string) => {
-    const val = parseFloat(thresholdInput);
-    if (isNaN(val) || val <= 0) { setEditingThreshold(null); return; }
+  // Threshold source selection. Manual numeric overrides were removed in
+  // the clean-break migration (2026-04) — every threshold must now come
+  // from a connected source or a calculation we perform on the user's own
+  // data. This handler switches which source to read from; it never writes
+  // a value.
+  const handleThresholdSourceChange = async (
+    metricType: string,
+    source: string,
+  ) => {
     setSaving(true);
     try {
-      await updateSettings({ thresholds: { ...config.thresholds, [key]: val, source: 'manual' } });
+      const current = (config.preferences?.threshold_sources as Record<string, string>) || {};
+      await updateSettings({
+        preferences: {
+          ...config.preferences,
+          threshold_sources: { ...current, [metricType]: source },
+        } as SettingsConfig['preferences'],
+      });
       flash('Saved');
-    } catch { flash('Error'); }
+    } catch {
+      flash('Error');
+    }
     setSaving(false);
-    setEditingThreshold(null);
     refetch();
   };
 
@@ -1127,7 +1138,10 @@ export default function Settings() {
         onSave={handleGoalSave}
       />
 
-      {/* ===== SECTION 5: Thresholds ===== */}
+      {/* ===== SECTION 5: Thresholds =====
+           Read-only by design: every value here comes from a connected
+           source or a calculation on the user's own data. Arbitrary manual
+           numeric overrides were removed in the clean-break migration. */}
       <Card>
         <CardHeader>
           <div className="flex items-center gap-2.5">
@@ -1136,7 +1150,9 @@ export default function Settings() {
             </div>
             <div>
               <CardTitle className="text-sm font-semibold text-foreground"><Trans>Thresholds</Trans></CardTitle>
-              <CardDescription className="text-xs"><Trans>Drive your zone calculations and training load. Click to override.</Trans></CardDescription>
+              <CardDescription className="text-xs">
+                <Trans>Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one.</Trans>
+              </CardDescription>
             </div>
           </div>
         </CardHeader>
@@ -1149,61 +1165,63 @@ export default function Settings() {
                 ? formatPace(value, config.unit_system as 'metric' | 'imperial' || 'metric')
                 : value;
               const origin = effective?.origin ?? 'none';
-              const isEditing = editingThreshold === key;
 
-              let badgeVariant: 'default' | 'secondary' | 'outline' = 'secondary';
-              let badgeText: React.ReactNode = t`Not set`;
-              if (origin.startsWith('auto')) {
-                badgeVariant = 'default';
-                const src = origin.replace('auto (', '').replace(')', '');
-                badgeText = `${t`Auto`} · ${src.charAt(0).toUpperCase() + src.slice(1)}`;
-              } else if (origin === 'manual') {
-                badgeVariant = 'outline';
-                badgeText = t`Manual`;
-              }
+              // Threshold key -> metric_type in fitness_data (used as the
+              // key under preferences.threshold_sources).
+              const metricType = ({
+                cp_watts: 'cp_estimate',
+                lthr_bpm: 'lthr_bpm',
+                threshold_pace_sec_km: 'lt_pace_sec_km',
+                max_hr_bpm: 'max_hr_bpm',
+                rest_hr_bpm: 'rest_hr_bpm',
+              } as Record<string, string>)[key] || key;
+
+              const detected = detectedThresholds[key];
+              const options = detected?.options ?? [];
+              const currentSource = origin.startsWith('auto')
+                ? origin.replace('auto (', '').replace(')', '')
+                : null;
+
+              const badgeText = origin.startsWith('auto') && currentSource
+                ? `${currentSource.charAt(0).toUpperCase()}${currentSource.slice(1)}`
+                : t`Not set`;
+              const badgeVariant: 'default' | 'secondary' = origin.startsWith('auto') ? 'default' : 'secondary';
 
               return (
                 <div key={key} className="rounded-xl bg-muted p-3 flex flex-col">
                   <p className="text-xs text-muted-foreground mb-2">{i18n._(label)}</p>
-
-                  {isEditing ? (
-                    <div className="flex flex-col gap-1.5">
-                      <Input
-                        type="number"
-                        value={thresholdInput}
-                        onChange={(e) => setThresholdInput(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') handleThresholdSave(key);
-                          if (e.key === 'Escape') setEditingThreshold(null);
-                        }}
-                        autoFocus
-                        className="text-xl font-bold font-data"
-                      />
-                      <div className="flex gap-1">
-                        <Button size="sm" className="flex-1" onClick={() => handleThresholdSave(key)}>
-                          <Trans>Save</Trans>
-                        </Button>
-                        <Button variant="ghost" size="sm" className="flex-1" onClick={() => setEditingThreshold(null)}>
-                          <Trans>Cancel</Trans>
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <button
-                      onClick={() => {
-                        setEditingThreshold(key);
-                        setThresholdInput(value != null ? String(value) : '');
-                      }}
-                      className="text-left group flex-1 flex flex-col"
+                  <p className="text-2xl font-bold font-data text-foreground">
+                    {value != null ? (isPace ? displayValue : value) : '\u2014'}
+                    <span className="text-xs font-normal text-muted-foreground ml-1">
+                      {value != null && !isPace ? unit : ''}
+                    </span>
+                  </p>
+                  {options.length > 1 ? (
+                    <Select
+                      value={currentSource ?? options[0].source}
+                      onValueChange={(v) => handleThresholdSourceChange(metricType, v)}
+                      disabled={saving}
                     >
-                      <p className="text-2xl font-bold font-data text-foreground group-hover:text-primary transition-colors">
-                        {value != null ? (isPace ? displayValue : value) : '—'}
-                        <span className="text-xs font-normal text-muted-foreground ml-1">{value != null && !isPace ? unit : ''}</span>
-                      </p>
-                      <Badge variant={badgeVariant} className="mt-auto self-start text-[10px]">
-                        {badgeText}
-                      </Badge>
-                    </button>
+                      <SelectTrigger className="h-7 text-[11px] mt-auto">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {options.map((opt) => (
+                          <SelectItem key={opt.source} value={opt.source} className="text-xs">
+                            {opt.source.charAt(0).toUpperCase()}{opt.source.slice(1)}
+                            <span className="text-muted-foreground ml-1 font-data">
+                              ({isPace
+                                ? formatPace(opt.value, config.unit_system as 'metric' | 'imperial' || 'metric')
+                                : `${opt.value} ${unit}`})
+                            </span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Badge variant={badgeVariant} className="mt-auto self-start text-[10px]">
+                      {badgeText}
+                    </Badge>
                   )}
                 </div>
               );

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -349,11 +349,7 @@ export default function Settings() {
     setSaving(false);
   };
 
-  // Threshold source selection. Manual numeric overrides were removed in
-  // the clean-break migration (2026-04) — every threshold must now come
-  // from a connected source or a calculation we perform on the user's own
-  // data. This handler switches which source to read from; it never writes
-  // a value.
+  // Writes only to preferences.threshold_sources; never to config.thresholds.
   const handleThresholdSourceChange = async (
     metricType: string,
     source: string,
@@ -368,8 +364,10 @@ export default function Settings() {
         } as SettingsConfig['preferences'],
       });
       flash('Saved');
-    } catch {
-      flash('Error');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      console.error('threshold source change failed', { metricType, source, err });
+      flash(`Error saving ${metricType} source: ${msg}`);
     }
     setSaving(false);
     refetch();
@@ -1139,9 +1137,10 @@ export default function Settings() {
       />
 
       {/* ===== SECTION 5: Thresholds =====
-           Read-only by design: every value here comes from a connected
-           source or a calculation on the user's own data. Arbitrary manual
-           numeric overrides were removed in the clean-break migration. */}
+           Read-only by design: every value comes from a connected source
+           or a calculation on the user's own data. When a metric has more
+           than one source (e.g. Stryd + Garmin for CP), the user picks
+           which source to use — they never type a value. */}
       <Card>
         <CardHeader>
           <div className="flex items-center gap-2.5">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -74,9 +74,21 @@ export interface ThresholdValue {
   origin: string;
 }
 
-export interface DetectedThreshold {
-  value: number;
+export interface DetectedThresholdOption {
   source: string;
+  value: number;
+  date: string | null;
+}
+
+export interface DetectedThreshold {
+  /** Latest value across all sources (display convenience). */
+  value: number;
+  /** Source behind the latest value. */
+  source: string;
+  /** All known sources for this threshold. One entry per source,
+   *  each with that source's most recent value. Powers the Settings
+   *  source-selector; a single-entry list renders as read-only. */
+  options: DetectedThresholdOption[];
 }
 
 export interface SettingsResponse {


### PR DESCRIPTION
## Summary
Thresholds (CP, LTHR, threshold pace, max HR, rest HR) are now **read-only** in the UI. Every value traces back to a connected source or a calculation on the user's own data. Arbitrary user-typed numbers — the mechanism that let athletes set aspirational zones with no measurement behind them — are removed.

When two sources provide the same metric (notably CP: Stryd vs Garmin disagree by ~30%), the user picks a source. Default selection follows \`preferences.activities\`, so CP stays consistent with whatever activities the user is looking at.

## Why
The immediate trigger was the CP-whiplash follow-up from PR #66: with both Stryd and Garmin syncing, the latest write to \`fitness_data.cp_estimate\` won — causing CP to flip between ~265W and ~350W depending on which sync ran last. That's a real problem, but the broader fix lines up with CLAUDE.md's Scientific Rigor rule: thresholds are measurements, not preferences.

## Stacked on
PR #66 (\`fix/garmin-region-source-options-precedence\`). Rebases cleanly onto main once #66 merges.

## Changes

### Backend
- \`_resolve_thresholds\` in \`api/deps.py\`: drops the \`config.thresholds.*\` numeric-override branch. Adds source preference (explicit \`preferences.threshold_sources[metric]\`, default to \`preferences.activities\`, fall back to latest-by-date).
- \`_detect_thresholds_from_db\`: returns one entry per source in \`options[]\` per threshold so the UI can build a selector.
- \`resolve_thresholds\` (settings helper): drops manual logic; picks from detected options based on preference.
- \`SettingsUpdate.thresholds\` still accepts values in the request body (API compat) but the server silently discards them.

### Frontend
- \`DetectedThreshold\` type gains \`options: DetectedThresholdOption[]\`.
- \`SettingsContext\` exposes \`detectedThresholds\` alongside \`effectiveThresholds\`.
- Threshold card: removed click-to-edit numeric input. Replaced with read-only value + a \`<Select>\` when multiple sources exist. New \`handleThresholdSourceChange\` writes only to \`preferences.threshold_sources\`.

## Migration (option a: clean break)
Existing \`config.thresholds.*\` numeric values are no longer applied on read. The test \`test_resolve_thresholds_ignores_legacy_manual_values\` locks this in so a future refactor can't re-enable the old behaviour by accident. Users who previously typed a manual value will see the sensor-detected value instead on next Settings load.

## Test plan
- [ ] 308 Python tests pass (2 replaced, 2 added for source preference logic)
- [ ] Settings → Thresholds renders read-only for single-source metrics, as a \`<Select>\` for multi-source metrics
- [ ] Picking a source updates \`preferences.threshold_sources\` and survives a reload
- [ ] \`_resolve_thresholds\` returns the chosen source's value; falls back to latest-by-date when the chosen source has no rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)