### PR TITLE
Fix HR/pace training paths: split CP watts from base-native threshold

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -320,8 +320,18 @@ def compute_trimp(
 ) -> float:
     """Banister TRIMP (HR-based load).
 
-    Uses exponential weighting of HR intensity.
-    k values can be overridden from a science theory.
+    Exponential weighting of HR reserve:
+        TRIMP = minutes × HRR_frac × 0.64 × exp(k × HRR_frac)
+
+    Sex-specific ``k`` reflects the blood-lactate → HR response (males have
+    a steeper curve). Defaults 1.92 / 1.67 from Banister's 1991 formulation;
+    theories may override via YAML params.
+
+    Source: Banister EW (1991), "Modeling elite athletic performance." In
+    *Physiological Testing of Elite Athletes*, Human Kinetics, pp. 403-424.
+    See also Morton, Fitz-Clarke & Banister (1990),
+    https://doi.org/10.1152/jappl.1990.69.3.1171 for the impulse-response
+    model that consumes TRIMP.
     """
     if duration_sec <= 0 or max_hr <= rest_hr:
         return 0.0
@@ -339,8 +349,16 @@ def compute_rtss(
 ) -> float:
     """Running TSS from normalized graded pace (pace-based load).
 
-    rTSS = (duration/3600) * (threshold_pace/actual_pace)^2 * 100
+    rTSS = (duration/3600) × (threshold_pace / actual_pace)² × 100
+
     Faster pace = lower sec/km, so threshold/actual > 1 when running hard.
+    Mirrors TrainingPeaks' rTSS definition (Skiba / McGregor), the pace-side
+    equivalent of power-based TSS.
+
+    Source: Skiba PF, "Calculation of Power Output and Quantification of
+    Training Stress in Distance Runners" (PhysFarm technical note),
+    https://www.physfarm.com/rtss.pdf — see also TrainingPeaks' rTSS
+    explainer https://www.trainingpeaks.com/learn/articles/running-training-stress-score/.
     """
     if duration_sec <= 0 or avg_pace_sec_km <= 0 or threshold_pace_sec_km <= 0:
         return 0.0

--- a/api/deps.py
+++ b/api/deps.py
@@ -28,6 +28,8 @@ from analysis.metrics import (
     diagnose_training,
     get_distance_config,
     compute_rss,
+    compute_trimp,
+    compute_rtss,
     analyze_recovery,
     project_tsb,
 )
@@ -208,6 +210,130 @@ def _compute_daily_load(
     return daily.astype(float)
 
 
+def _parse_pace_str(value) -> float | None:
+    """Parse a plan pace string ("4:30", "4:30/km", "4:30 min/km") → sec/km.
+
+    Also accepts a bare number interpreted as sec/km. Returns None for
+    empty / unparseable values.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        v = float(value)
+        return v if v > 0 else None
+    text = str(value).strip()
+    if not text:
+        return None
+    # Strip trailing units (most-specific first so "min/km" goes before "/km").
+    for suffix in ("min/km", "mi/km", "/km", "min", "sec"):
+        while text.endswith(suffix):
+            text = text[: -len(suffix)].strip()
+    if ":" in text:
+        try:
+            minutes, seconds = text.split(":", 1)
+            total = int(minutes) * 60 + float(seconds)
+            return total if total > 0 else None
+        except ValueError:
+            return None
+    try:
+        v = float(text)
+        return v if v > 0 else None
+    except ValueError:
+        return None
+
+
+def _plan_workout_load(
+    row, dur_sec: float, training_base: str, thresholds: ThresholdEstimate,
+) -> float:
+    """Estimate the load score (RSS / TRIMP / rTSS) for one planned workout.
+
+    Uses the midpoint of the target range for the configured base. Falls
+    back to a flat ~60 units/hour estimate when the plan row has no
+    targets for the active base (we still don't want the CTL/ATL projection
+    to flatline just because the plan lacks intensity hints).
+    """
+    if dur_sec <= 0:
+        return 0.0
+
+    def _midpoint(lo, hi) -> float | None:
+        if lo is not None and hi is not None and lo > 0 and hi > 0:
+            return (lo + hi) / 2
+        if hi is not None and hi > 0:
+            return hi * 0.85  # conservative fallback when only max is set
+        if lo is not None and lo > 0:
+            return lo
+        return None
+
+    def _num(v) -> float | None:
+        if v is None:
+            return None
+        try:
+            n = pd.to_numeric(pd.Series([v]), errors="coerce").iloc[0]
+        except (TypeError, ValueError):
+            return None
+        if pd.isna(n) or n <= 0:
+            return None
+        return float(n)
+
+    if training_base == "power" and thresholds.cp_watts and thresholds.cp_watts > 0:
+        avg_p = _midpoint(_num(row.get("target_power_min")), _num(row.get("target_power_max")))
+        if avg_p:
+            return compute_rss(dur_sec, avg_p, thresholds.cp_watts)
+    elif training_base == "hr" and thresholds.max_hr_bpm and thresholds.max_hr_bpm > 0:
+        avg_hr = _midpoint(_num(row.get("target_hr_min")), _num(row.get("target_hr_max")))
+        if avg_hr:
+            rest_hr = thresholds.rest_hr_bpm or 60
+            return compute_trimp(dur_sec, avg_hr, rest_hr, thresholds.max_hr_bpm)
+    elif training_base == "pace" and thresholds.threshold_pace_sec_km:
+        p_fast = _parse_pace_str(row.get("target_pace_min"))
+        p_slow = _parse_pace_str(row.get("target_pace_max"))
+        avg_pace = _midpoint(p_fast, p_slow)
+        if avg_pace:
+            return compute_rtss(dur_sec, avg_pace, thresholds.threshold_pace_sec_km)
+
+    # ESTIMATE: plan row has no targets we can use for this base — assume
+    # a moderate ~60 units/hour. Note that RSS / TRIMP / rTSS are NOT
+    # formally equated at 60 units/hour; 60 lands in a roughly tempo-ish
+    # band for each scale (RSS and rTSS at IF ≈ 0.77; TRIMP at ~0.70 HR
+    # reserve) which is coincidence, not derivation. Use this only so the
+    # projection curve keeps moving when we have no better signal, and
+    # flag the compliance chart via ``planned_estimated`` so the user
+    # knows the number is a placeholder.
+    return (dur_sec / 3600) * 60
+
+
+def _plan_row_duration_sec(row) -> float:
+    dur_min = pd.to_numeric(
+        pd.Series([row.get("planned_duration_min", 0)]), errors="coerce"
+    ).iloc[0]
+    return float(dur_min) * 60 if pd.notna(dur_min) and dur_min > 0 else 0.0
+
+
+def _has_base_targets(row, training_base: str) -> bool:
+    """Whether the plan row provides usable intensity targets for ``training_base``.
+
+    Used to flag ``planned_estimated`` when we had to fall back to a flat
+    units-per-hour rate instead of computing from real targets.
+    """
+    def _pos(v) -> bool:
+        try:
+            n = pd.to_numeric(pd.Series([v]), errors="coerce").iloc[0]
+        except (TypeError, ValueError):
+            return False
+        return bool(pd.notna(n) and n > 0)
+
+    if training_base == "power":
+        return _pos(row.get("target_power_min")) or _pos(row.get("target_power_max"))
+    if training_base == "hr":
+        return _pos(row.get("target_hr_min")) or _pos(row.get("target_hr_max"))
+    if training_base == "pace":
+        return (
+            _parse_pace_str(row.get("target_pace_min")) is not None
+            or _parse_pace_str(row.get("target_pace_max")) is not None
+        )
+    return False
+
+
 def _estimate_plan_daily_loads(
     plan: pd.DataFrame,
     start_date: date,
@@ -217,8 +343,8 @@ def _estimate_plan_daily_loads(
 ) -> list[float]:
     """Estimate daily load for each of the next *days* days from the plan.
 
-    For days with no planned workout, load is 0.
-    Uses target power midpoint × planned duration to estimate RSS.
+    For days with no planned workout, load is 0. The load unit follows
+    ``training_base``: RSS for power, TRIMP for HR, rTSS for pace.
     """
     loads = [0.0] * days
     if plan.empty:
@@ -231,28 +357,8 @@ def _estimate_plan_daily_loads(
             continue
         day_load = 0.0
         for _, row in day_plan.iterrows():
-            dur_min = pd.to_numeric(
-                pd.Series([row.get("planned_duration_min", 0)]), errors="coerce"
-            ).iloc[0]
-            dur_sec = float(dur_min) * 60 if pd.notna(dur_min) and dur_min > 0 else 0
-            if dur_sec <= 0:
-                continue
-
-            # Estimate power from plan targets
-            p_min = pd.to_numeric(pd.Series([row.get("target_power_min")]), errors="coerce").iloc[0]
-            p_max = pd.to_numeric(pd.Series([row.get("target_power_max")]), errors="coerce").iloc[0]
-            if pd.notna(p_min) and pd.notna(p_max) and p_min > 0:
-                avg_power = (float(p_min) + float(p_max)) / 2
-            elif pd.notna(p_max) and p_max > 0:
-                avg_power = float(p_max) * 0.85  # conservative estimate
-            else:
-                avg_power = None
-
-            if avg_power and thresholds.cp_watts and thresholds.cp_watts > 0:
-                day_load += compute_rss(dur_sec, avg_power, thresholds.cp_watts)
-            elif dur_sec > 0:
-                # Fallback: estimate ~60 RSS per hour (moderate effort)
-                day_load += (dur_sec / 3600) * 60
+            dur_sec = _plan_row_duration_sec(row)
+            day_load += _plan_workout_load(row, dur_sec, training_base, thresholds)
         loads[i] = day_load
     return loads
 
@@ -296,11 +402,21 @@ def _build_compliance(
     plan: pd.DataFrame,
     training_base: str = "power",
     daily_load: pd.Series | None = None,
-    thresholds: "ThresholdConfig | None" = None,
+    thresholds: ThresholdEstimate | None = None,
 ) -> dict:
-    """Build weekly compliance data for chart using the configured training base."""
+    """Build weekly compliance data for chart using the configured training base.
+
+    ``actual_load`` / ``planned_load`` carry the load in the unit appropriate
+    to the training base (RSS for power, TRIMP for HR, rTSS for pace). The
+    frontend pairs the numbers with ``display.load_label``.
+    """
     if merged.empty:
-        return {"weeks": [], "planned_rss": [], "actual_rss": []}
+        return {
+            "weeks": [],
+            "planned_load": [],
+            "actual_load": [],
+            "planned_estimated": False,
+        }
 
     # Use the computed daily load series if available
     if daily_load is not None and not daily_load.empty:
@@ -325,7 +441,9 @@ def _build_compliance(
         else []
     )
 
-    # Compute planned weekly RSS from training plan
+    # Compute planned weekly load from training plan — in the unit of the
+    # active training base (RSS / TRIMP / rTSS). Uses the same per-workout
+    # estimator as the projection (``_plan_workout_load``) so the two agree.
     planned_weekly: list[float] = []
     planned_estimated = False
     plan_copy = pd.DataFrame()
@@ -337,32 +455,18 @@ def _build_compliance(
             plan_copy["_week"] = plan_copy["_date"].dt.isocalendar().week
             plan_copy["_year"] = plan_copy["_date"].dt.isocalendar().year
 
-            # Estimate per-workout load from plan targets
             plan_loads = []
             for _, row in plan_copy.iterrows():
-                dur_min = pd.to_numeric(
-                    pd.Series([row.get("planned_duration_min", 0)]), errors="coerce"
-                ).iloc[0]
-                dur_sec = float(dur_min) * 60 if pd.notna(dur_min) and dur_min > 0 else 0
+                dur_sec = _plan_row_duration_sec(row)
                 if dur_sec <= 0:
                     plan_loads.append(0.0)
                     continue
-                p_min = pd.to_numeric(pd.Series([row.get("target_power_min")]), errors="coerce").iloc[0]
-                p_max = pd.to_numeric(pd.Series([row.get("target_power_max")]), errors="coerce").iloc[0]
-                if pd.notna(p_min) and pd.notna(p_max) and p_min > 0:
-                    avg_power = (float(p_min) + float(p_max)) / 2
-                elif pd.notna(p_max) and p_max > 0:
-                    avg_power = float(p_max) * 0.85
-                else:
-                    avg_power = None
-                cp = thresholds.cp_watts if thresholds and thresholds.cp_watts else None
-                if avg_power and cp and cp > 0:
-                    plan_loads.append(compute_rss(dur_sec, avg_power, cp))
-                else:
-                    # Fallback: ~60 RSS per hour. This is a rough estimate
-                    # when power targets are unavailable.
-                    plan_loads.append((dur_sec / 3600) * 60)
+                # Detect fallback so the frontend can caveat "estimated" plans.
+                before_fallback = _has_base_targets(row, training_base)
+                load = _plan_workout_load(row, dur_sec, training_base, thresholds)
+                if not before_fallback:
                     planned_estimated = True
+                plan_loads.append(load)
             plan_copy["_load"] = plan_loads
             weekly_planned = plan_copy.groupby(["_year", "_week"])["_load"].sum()
 
@@ -386,8 +490,8 @@ def _build_compliance(
 
     return {
         "weeks": weeks[-8:],
-        "actual_rss": [round(float(v), 1) for v in weekly_actual.values][-8:],
-        "planned_rss": aligned_planned[-8:] if aligned_planned else [],
+        "actual_load": [round(float(v), 1) for v in weekly_actual.values][-8:],
+        "planned_load": aligned_planned[-8:] if aligned_planned else [],
         "planned_estimated": planned_estimated,
     }
 
@@ -464,10 +568,31 @@ def _build_workout_flags(
     return flags[-10:]
 
 
-def _build_sleep_perf(merged: pd.DataFrame, sleep: pd.DataFrame) -> list:
-    """Build sleep score vs power output scatter data."""
-    if merged.empty or sleep.empty or "avg_power" not in merged.columns:
-        return []
+def _build_sleep_perf(
+    merged: pd.DataFrame, sleep: pd.DataFrame, training_base: str = "power",
+) -> dict:
+    """Build sleep score vs performance-metric scatter data.
+
+    The Y-axis metric follows the user's training base:
+      - power: ``avg_power`` (W)
+      - hr:    ``avg_hr`` (bpm)
+      - pace:  ``avg_pace_sec_km`` (lower = better)
+
+    Returns ``{"pairs": [[sleep, metric], ...], "metric_label", "metric_unit"}``.
+    An empty ``pairs`` list with the correct metadata is returned when no
+    paired rows are available, so the frontend can still label the
+    empty-state hint correctly.
+    """
+    if training_base == "hr":
+        metric_col, unit, label = "avg_hr", "bpm", "Avg HR"
+    elif training_base == "pace":
+        metric_col, unit, label = "avg_pace_sec_km", "sec/km", "Avg Pace"
+    else:
+        metric_col, unit, label = "avg_power", "W", "Avg Power"
+
+    empty: dict = {"pairs": [], "metric_label": label, "metric_unit": unit}
+    if merged.empty or sleep.empty or metric_col not in merged.columns:
+        return empty
     merged_copy = merged.copy()
     sleep_copy = sleep.copy()
     merged_copy["_date"] = pd.to_datetime(merged_copy["date"]).dt.date
@@ -480,23 +605,63 @@ def _build_sleep_perf(merged: pd.DataFrame, sleep: pd.DataFrame) -> list:
         suffixes=("", "_sleep"),
     )
     if joined.empty or "sleep_score" not in joined.columns:
-        return []
+        return empty
     pairs: list[list] = []
     for _, row in joined.iterrows():
         try:
             score = float(row["sleep_score"])
-            power = float(row["avg_power"])
-            if score > 0 and power > 0:
-                pairs.append([score, round(power, 1)])
+            value = float(row[metric_col])
+            if score > 0 and value > 0:
+                pairs.append([score, round(value, 1)])
         except (ValueError, TypeError):
             continue
-    return pairs
+    return {"pairs": pairs, "metric_label": label, "metric_unit": unit}
+
+
+def _select_prediction_method(
+    training_base: str,
+    prediction_theory_id: str | None,
+    *,
+    has_cp: bool,
+    has_pace: bool,
+) -> str | None:
+    """Pick a race-prediction model for the given training base and data.
+
+    This is a **data-provenance safety gate**, not a physiological claim.
+    A CP-model prediction is scientifically fine for an HR-trained athlete
+    who has a clean Stryd power meter; the reason we still refuse it is
+    that we can't yet distinguish "real Stryd CP" from "Garmin native FTP
+    estimate" in ``cp_watts``. Pairing an inflated Garmin FTP with
+    Stryd-via-CIQ activity-level power produces wildly-fast bogus
+    predictions (the 2:22 marathon bug), so for non-power bases we stay on
+    Riegel until a proper ``cp_source`` provenance field exists.
+
+    - **power** users run the CP model when CP watts are available. If they
+      have explicitly picked ``riegel`` and have a threshold pace, honor it.
+      Otherwise fall back to Riegel, or None.
+    - **hr / pace** users only ever use Riegel. ``critical_power`` being
+      the global default science theory is not a reliable opt-in signal,
+      so we don't honor it here.
+    """
+    if training_base == "power":
+        if prediction_theory_id == "riegel" and has_pace:
+            return "riegel"
+        if has_cp:
+            return "critical_power"
+        if has_pace:
+            return "riegel"
+        return None
+    # HR / pace
+    if has_pace:
+        return "riegel"
+    return None
 
 
 def _build_race_countdown(
     race_date_str: str,
     target_time_sec: int | None,
-    latest_cp: float | None,
+    latest_threshold: float | None,
+    latest_cp_watts: float | None,
     power_pace_pairs: list[tuple[float, float]],
     cp_trend_data: dict,
     today: date,
@@ -507,30 +672,41 @@ def _build_race_countdown(
     training_base: str = "power",
     threshold_pace: float | None = None,
     riegel_exponent: float | None = None,
+    prediction_method: str | None = None,
     prediction_theory_name: str | None = None,
 ) -> dict:
     """Build race countdown / CP milestone payload depending on config.
 
-    For power base: uses power-pace model for predictions.
-    For HR/pace bases: uses Riegel formula from threshold pace.
-    The prediction method is determined by the user's science theory selection.
+    ``training_base`` (power/hr/pace) controls display units and which target
+    threshold (if any) is meaningful — LTHR is never a race-pace target, so
+    HR-base users get no ``target_cp``. ``prediction_method`` selects the
+    prediction MODEL ("critical_power" or "riegel") independently of the
+    training base: a power-base user may have picked Riegel, and an HR-base
+    user falls back to Riegel because the CP model needs watts.
+
+    ``latest_threshold`` is the display value in base-native units
+    (W / bpm / sec·km⁻¹). ``latest_cp_watts`` is CP in watts or ``None`` —
+    used for all power-based formulas so LTHR/LT pace are never treated as
+    watts.
     """
     is_inverted = training_base == "pace"
 
-    # Predicted time — uses prediction theory selection
+    # Predicted time — pick the MODEL requested, regardless of training_base
     predicted_time: float | None = None
-    prediction_method = "none"
-    if training_base == "power" and latest_cp:
-        predicted_time = predict_marathon_time(latest_cp, power_pace_pairs, power_fraction, distance_km)
-        prediction_method = "critical_power"
-    elif threshold_pace:
-        predicted_time = predict_time_from_pace(threshold_pace, distance_km, riegel_exponent)
-        prediction_method = "riegel"
+    if prediction_method == "critical_power" and latest_cp_watts:
+        predicted_time = predict_marathon_time(
+            latest_cp_watts, power_pace_pairs, power_fraction, distance_km,
+        )
+    elif prediction_method == "riegel" and threshold_pace:
+        predicted_time = predict_time_from_pace(
+            threshold_pace, distance_km, riegel_exponent,
+        )
+    effective_method = prediction_method if predicted_time is not None else "none"
 
     common = {
         "distance": distance_key,
         "distance_label": distance_label,
-        "prediction_method": prediction_method,
+        "prediction_method": effective_method,
         "prediction_theory": prediction_theory_name,
     }
 
@@ -550,16 +726,25 @@ def _build_race_countdown(
             else:
                 race_status = "behind"
 
-        # Needed threshold — only for power/pace (LTHR can't be meaningfully targeted)
+        # Needed threshold matches training_base display units.
+        # Power: watts (needs CP + power-pace pairs). Pace: sec/km (Riegel
+        # inversion). HR: no meaningful target — LTHR isn't a trainable
+        # race-pace knob.
         needed_threshold: float | None = None
-        if target_time_sec and training_base != "hr":
-            if training_base == "power" and power_pace_pairs:
-                needed_threshold = required_cp_for_time(target_time_sec, power_pace_pairs, power_fraction, distance_km)
-            elif threshold_pace:
+        current_for_check: float | None = None
+        if training_base == "power" and latest_cp_watts and power_pace_pairs:
+            current_for_check = latest_cp_watts
+            if target_time_sec:
+                needed_threshold = required_cp_for_time(
+                    target_time_sec, power_pace_pairs, power_fraction, distance_km,
+                )
+        elif training_base == "pace" and threshold_pace:
+            current_for_check = threshold_pace
+            if target_time_sec:
                 needed_threshold = required_pace_for_time(target_time_sec, distance_km)
 
         race_reality = race_honesty_check(
-            latest_cp,
+            current_for_check,
             needed_threshold,
             days_left,
             cp_trend_data,
@@ -579,8 +764,9 @@ def _build_race_countdown(
         }
 
     if target_time_sec:
-        # Continuous improvement with a time target
-        # For HR base: show time predictions only (LTHR can't be meaningfully targeted)
+        # Continuous improvement with a time target.
+        # HR base: LTHR is not a trainable race-pace target — surface the
+        # predicted time only and let the trend do the talking.
         if training_base == "hr":
             direction = cp_trend_data.get("direction", "unknown")
             severity = "on_track" if direction == "rising" else ("behind" if direction == "falling" else "close")
@@ -600,16 +786,22 @@ def _build_race_countdown(
                 },
             }
 
-        # For power/pace: derive threshold target and track progress
+        # Power / pace: derive the target threshold in base-native units.
         target_threshold: float | None = None
-        if training_base == "power" and power_pace_pairs:
-            target_threshold = required_cp_for_time(target_time_sec, power_pace_pairs, power_fraction, distance_km)
-        elif threshold_pace:
+        current_for_milestone: float | None = None
+        if training_base == "power" and latest_cp_watts and power_pace_pairs:
+            target_threshold = required_cp_for_time(
+                target_time_sec, power_pace_pairs, power_fraction, distance_km,
+            )
+            current_for_milestone = latest_cp_watts
+        elif training_base == "pace" and threshold_pace:
             target_threshold = required_pace_for_time(target_time_sec, distance_km)
+            current_for_milestone = threshold_pace
 
-        if target_threshold and latest_cp:
+        if target_threshold and current_for_milestone:
             milestone_result = cp_milestone_check(
-                latest_cp, target_threshold, cp_trend_data, threshold_inverted=is_inverted,
+                current_for_milestone, target_threshold, cp_trend_data,
+                threshold_inverted=is_inverted,
             )
         else:
             milestone_result = {
@@ -620,7 +812,7 @@ def _build_race_countdown(
         return {
             **common,
             "mode": "cp_milestone",
-            "current_cp": latest_cp,
+            "current_cp": current_for_milestone,
             "target_cp": target_threshold,
             "target_time_sec": target_time_sec,
             "predicted_time_sec": predicted_time,
@@ -631,7 +823,7 @@ def _build_race_countdown(
             "reality_check": milestone_result,
         }
 
-    # Continuous improvement, no target
+    # Continuous improvement, no target — show current threshold in base units.
     direction = cp_trend_data.get("direction", "unknown")
     slope = cp_trend_data.get("slope_per_month", 0)
     severity = "on_track" if direction == "rising" else ("behind" if direction == "falling" else "close")
@@ -639,7 +831,7 @@ def _build_race_countdown(
         **common,
         "mode": "continuous",
         "status": severity,
-        "current_cp": latest_cp,
+        "current_cp": latest_threshold,
         "predicted_time_sec": predicted_time,
         "cp_trend_summary": {
             "direction": direction,
@@ -964,9 +1156,16 @@ def _build_threshold_trend_chart(
 
 def _build_warnings(
     recovery_analysis: dict, current_tsb: float,
-    config, data_dir: str = None, latest_cp: float | None = None,
+    config, data_dir: str = None, latest_cp_watts: float | None = None,
 ) -> list[str]:
-    """Collect health/training warnings."""
+    """Collect health/training warnings.
+
+    ``latest_cp_watts`` must be CP in watts (not a base-native threshold):
+    ``check_plan_staleness`` compares it against ``cp_at_generation`` which
+    is stored in watts at plan-generation time. Passing an LTHR in bpm here
+    produces a nonsense drift percentage and a "power targets may be
+    inaccurate" warning on HR-base users who have no power targets at all.
+    """
     warnings: list[str] = []
     hrv_info = recovery_analysis.get("hrv") or {}
     if hrv_info.get("trend") == "declining":
@@ -977,7 +1176,7 @@ def _build_warnings(
         warnings.append(f"High fatigue (TSB = {current_tsb:.0f})")
     if config.preferences.get("plan") == "ai" and data_dir:
         from api.ai import check_plan_staleness
-        warnings.extend(check_plan_staleness(data_dir, latest_cp))
+        warnings.extend(check_plan_staleness(data_dir, latest_cp_watts))
     return warnings
 
 
@@ -1110,9 +1309,18 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
         for i in range(projection_days)
     ]
 
-    # Threshold data (CP / LTHR / pace trend)
+    # Threshold data (CP / LTHR / pace trend). ``latest_cp`` here is the
+    # base-native threshold: watts for power, bpm for HR, sec/km for pace.
     latest_cp, cp_trend_data, cp_values, power_pace_pairs = _compute_threshold_data(
         merged, config, data_dir=data_dir, user_id=user_id, db=db,
+    )
+
+    # CP-in-watts for power-based formulas. HR/pace users' ``latest_cp`` is
+    # NOT watts (it's LTHR or LT pace), so we must never feed it into
+    # predict_marathon_time / required_cp_for_time. The source of truth for
+    # actual CP watts is the resolved threshold from sensor data.
+    latest_cp_watts = (
+        thresholds.cp_watts if thresholds.cp_watts and thresholds.cp_watts > 0 else None
     )
 
     # Goal + race prediction
@@ -1135,34 +1343,28 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
             dist_config = {**dist_config, "power_fraction": theory_fraction}
         theory_exponent = prediction_theory.params.get("riegel_exponent")
 
-    # Determine prediction method based on science theory selection.
-    # The prediction theory is independent of training base:
-    # - "critical_power" theory → uses CP + power-pace model (requires power data)
-    # - "riegel" theory → uses threshold pace + Riegel formula (requires pace data)
-    # Falls back to the other model if the selected one lacks data.
-    if prediction_theory_id == "critical_power" and latest_cp:
-        prediction_base = "power"
-    elif prediction_theory_id == "riegel" and threshold_pace:
-        prediction_base = "pace"
-    elif latest_cp:
-        # Fallback: user selected Riegel but no pace data, use CP if available
-        prediction_base = "power"
-    elif threshold_pace:
-        # Fallback: user selected CP but no power data, use Riegel if pace available
-        prediction_base = "pace"
-    else:
-        prediction_base = config.training_base
+    prediction_method = _select_prediction_method(
+        config.training_base,
+        prediction_theory_id,
+        has_cp=bool(latest_cp_watts),
+        has_pace=bool(threshold_pace),
+    )
 
     race_countdown = _build_race_countdown(
-        race_date_str, target_time_sec, latest_cp, power_pace_pairs,
-        cp_trend_data, today,
+        race_date_str, target_time_sec,
+        latest_threshold=latest_cp,
+        latest_cp_watts=latest_cp_watts,
+        power_pace_pairs=power_pace_pairs,
+        cp_trend_data=cp_trend_data,
+        today=today,
         distance_km=dist_config["km"],
         power_fraction=dist_config["power_fraction"],
         distance_label=dist_config["label"],
         distance_key=distance_key,
-        training_base=prediction_base,
+        training_base=config.training_base,
         threshold_pace=threshold_pace,
         riegel_exponent=theory_exponent,
+        prediction_method=prediction_method,
         prediction_theory_name=prediction_theory.name if prediction_theory else None,
     )
 
@@ -1213,8 +1415,8 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
     # Supplementary data
     weekly_review = _build_compliance(merged, plan, config.training_base, daily_load, thresholds)
     workout_flags = _build_workout_flags(merged, recovery, config.training_base)
-    sleep_perf = _build_sleep_perf(merged, recovery)
-    warnings = _build_warnings(recovery_analysis, current_tsb, config, data_dir=data_dir, latest_cp=latest_cp)
+    sleep_perf = _build_sleep_perf(merged, recovery, config.training_base)
+    warnings = _build_warnings(recovery_analysis, current_tsb, config, data_dir=data_dir, latest_cp_watts=latest_cp_watts)
 
     # Diagnosis
     splits = data["splits"]

--- a/api/views.py
+++ b/api/views.py
@@ -82,8 +82,8 @@ def upcoming_workouts(plan_df: pd.DataFrame | None, limit: int = 3) -> list[dict
 def week_load(weekly_review: dict) -> dict | None:
     """Extract current week load vs plan."""
     weeks = weekly_review.get("weeks", [])
-    actual = weekly_review.get("actual_rss", [])
-    planned = weekly_review.get("planned_rss", [])
+    actual = weekly_review.get("actual_load", [])
+    planned = weekly_review.get("planned_load", [])
     if not weeks or not actual:
         return None
     return {

--- a/data/science/load/banister_pmc.yaml
+++ b/data/science/load/banister_pmc.yaml
@@ -34,6 +34,10 @@ advanced_description: |
 
   **References:**
   - Banister (1975) "A systems model of training for athletic performance"
+  - Banister (1991) "Modeling elite athletic performance" — source of the
+    exponential k-weighted TRIMP (k_male 1.92, k_female 1.67)
+  - Morton, Fitz-Clarke & Banister (1990) "Modeling human performance in
+    running" — impulse-response model that consumes TRIMP
   - TrainingPeaks, "The Science of the Performance Manager"
 
 citations:
@@ -41,6 +45,15 @@ citations:
     title: "A systems model of training for athletic performance"
     year: 1975
     journal: "Australian Journal of Sports Medicine"
+  - key: banister1991
+    title: "Modeling elite athletic performance"
+    year: 1991
+    journal: "Physiological Testing of Elite Athletes (Human Kinetics), pp. 403–424"
+  - key: morton1990
+    title: "Modeling human performance in running"
+    year: 1990
+    journal: "Journal of Applied Physiology 69(3):1171-1177"
+    url: "https://doi.org/10.1152/jappl.1990.69.3.1171"
   - key: trainingpeaks_pmc
     title: "The Science of the Performance Manager"
     url: "https://www.trainingpeaks.com/learn/articles/the-science-of-the-performance-manager/"

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -261,9 +261,18 @@ Training analysis and diagnosis.
     "projected_tsb": ["..."]
   },
   "cp_trend": { "dates": ["..."], "values": ["..."] },
-  "weekly_review": { "weeks": ["W10", "..."], "actual_rss": ["..."], "planned_rss": ["..."] },
+  "weekly_review": {
+    "weeks": ["W10", "..."],
+    "actual_load": ["..."],
+    "planned_load": ["..."],
+    "planned_estimated": false
+  },
   "workout_flags": [{ "date": "...", "flag": "good|bad", "reason": "..." }],
-  "sleep_perf": { "..." : "..." },
+  "sleep_perf": {
+    "pairs": [[85, 240.3], ["..."]],
+    "metric_label": "Avg Power",
+    "metric_unit": "W"
+  },
   "training_base": "power",
   "display": { "..." : "..." }
 }
@@ -281,13 +290,17 @@ Race prediction and goal tracking.
   "race_countdown": {
     "distance": "marathon",
     "distance_label": "Marathon",
-    "mode": "race_goal|cp_milestone",
+    "mode": "race_date|cp_milestone|continuous|none",
     "current_cp": 247.8,
+    "target_cp": 280.0,
     "predicted_time_sec": 13852,
     "target_time_sec": 10800,
     "cp_gap_watts": 70.0,
-    "status": "on_track|behind|unlikely",
-    "milestones": [{ "cp": 270, "marathon": "~3:50", "reached": false }]
+    "status": "on_track|close|behind|unlikely",
+    "prediction_method": "critical_power|riegel|none",
+    "prediction_theory": "Critical Power (Stryd Race Power)",
+    "milestones": [{ "cp": 270, "marathon": "~3:50", "reached": false }],
+    "reality_check": { "assessment": "...", "severity": "..." }
   },
   "cp_trend": { "dates": ["..."], "values": ["..."] },
   "cp_trend_data": { "direction": "improving|stable|falling", "slope_per_month": -3.9 },
@@ -296,6 +309,12 @@ Race prediction and goal tracking.
   "display": { "..." : "..." }
 }
 ```
+
+> **Units.** `latest_cp`, `current_cp`, `target_cp`, `cp_trend.values` are in the user's
+> base-native threshold unit (watts for power, bpm for HR, sec/km for pace).
+> Pair with `display.threshold_unit` to format. `actual_load` / `planned_load`
+> similarly carry RSS / TRIMP / rTSS depending on the training base; pair with
+> `display.load_label`.
 
 ## History
 

--- a/plugins/praxys/skills/training-review/SKILL.md
+++ b/plugins/praxys/skills/training-review/SKILL.md
@@ -99,8 +99,9 @@ Present findings with visual indicators:
 
 From `weekly_review`:
 - `weeks`: week labels
-- `actual_rss`: actual weekly load
-- `planned_rss`: planned weekly load (if plan exists)
+- `actual_load`: actual weekly load (RSS for power base, TRIMP for HR, rTSS for pace)
+- `planned_load`: planned weekly load (if plan exists), same unit as actual_load
+- `planned_estimated`: `true` when plan targets were missing for the base and we used a fallback rate
 
 Show last 4-8 weeks as a compact comparison.
 

--- a/tests/test_plan_load_base.py
+++ b/tests/test_plan_load_base.py
@@ -1,0 +1,118 @@
+"""Regression tests for per-training-base plan load estimation.
+
+Historical bug: ``_estimate_plan_daily_loads`` and the planned half of
+``_build_compliance`` only looked at ``target_power_*`` columns, so HR-base
+and pace-base plans defaulted every workout to a flat ~60 RSS/hour. The
+projected fitness-fatigue curve and compliance chart both used the wrong
+number, and the weekly "planned" bar collapsed to a generic value.
+"""
+from datetime import date, timedelta
+
+import pandas as pd
+
+from analysis.providers.models import ThresholdEstimate
+from api.deps import (
+    _estimate_plan_daily_loads,
+    _parse_pace_str,
+    _plan_workout_load,
+    _has_base_targets,
+)
+
+
+def _mk_plan_row(**overrides):
+    base = {
+        "date": date(2026, 4, 23),
+        "planned_duration_min": 60.0,
+        "target_power_min": None,
+        "target_power_max": None,
+        "target_hr_min": None,
+        "target_hr_max": None,
+        "target_pace_min": None,
+        "target_pace_max": None,
+    }
+    base.update(overrides)
+    return pd.Series(base)
+
+
+def test_parse_pace_str_handles_common_formats():
+    assert _parse_pace_str("4:30") == 270.0
+    assert _parse_pace_str("5:00") == 300.0
+    assert _parse_pace_str("4:30/km") == 270.0
+    assert _parse_pace_str("4:30 min/km") == 270.0
+    assert _parse_pace_str("") is None
+    assert _parse_pace_str(None) is None
+    # Bare number interpreted as sec/km.
+    assert _parse_pace_str("270") == 270.0
+    assert _parse_pace_str(280.5) == 280.5
+
+
+def test_power_plan_uses_rss_formula():
+    thresholds = ThresholdEstimate()
+    thresholds.cp_watts = 260.0
+    row = _mk_plan_row(target_power_min=210, target_power_max=230)
+    load = _plan_workout_load(row, 3600.0, "power", thresholds)
+    # RSS = 1h * (220/260)^2 * 100 ≈ 71.6
+    assert 65 < load < 80, f"power plan should produce RSS-shaped load, got {load}"
+
+
+def test_hr_plan_uses_trimp_formula():
+    thresholds = ThresholdEstimate()
+    thresholds.max_hr_bpm = 185.0
+    thresholds.rest_hr_bpm = 50.0
+    row = _mk_plan_row(target_hr_min=140, target_hr_max=160)
+    load = _plan_workout_load(row, 3600.0, "hr", thresholds)
+    # 60 min at avg HR 150 → delta_ratio = 100/135 = 0.7407 → Banister
+    # TRIMP = 60 × 0.7407 × 0.64 × exp(1.92 × 0.7407) ≈ 117.9. Narrow 110–125
+    # window pins the formula; the 60/hr flat fallback (the regression we
+    # care about) cannot reach 110.
+    assert 110 < load < 125, f"HR plan should produce ~118 TRIMP, got {load:.1f}"
+
+
+def test_pace_plan_uses_rtss_formula():
+    thresholds = ThresholdEstimate()
+    thresholds.threshold_pace_sec_km = 260.0  # 4:20/km threshold
+    row = _mk_plan_row(target_pace_min="4:30", target_pace_max="5:00")
+    load = _plan_workout_load(row, 3600.0, "pace", thresholds)
+    # 60-min run at ~4:45/km average (285 sec/km) vs threshold 260:
+    # intensity = 260/285 ≈ 0.912 → rTSS ≈ 83.2
+    assert 70 < load < 95, f"pace plan should produce rTSS-shaped load, got {load}"
+
+
+def test_hr_plan_without_targets_falls_back_to_flat_rate():
+    """A plan row with no HR targets can't compute TRIMP — fall back to a flat rate."""
+    thresholds = ThresholdEstimate()
+    thresholds.max_hr_bpm = 185.0
+    row = _mk_plan_row()  # no targets at all
+    load = _plan_workout_load(row, 3600.0, "hr", thresholds)
+    assert abs(load - 60.0) < 0.001, "expected the 60 units/hour fallback for untargeted rows"
+
+
+def test_estimate_plan_daily_loads_hr_base():
+    """Full daily-load loop for an HR-base user over a 3-day window."""
+    thresholds = ThresholdEstimate()
+    thresholds.max_hr_bpm = 185.0
+    thresholds.rest_hr_bpm = 50.0
+
+    start = date(2026, 4, 22)
+    plan = pd.DataFrame([
+        # Day 1 — hard HR workout
+        {"date": start + timedelta(days=1), "planned_duration_min": 60.0,
+         "target_hr_min": 170.0, "target_hr_max": 180.0},
+        # Day 2 — no workout
+        # Day 3 — easy HR workout
+        {"date": start + timedelta(days=3), "planned_duration_min": 45.0,
+         "target_hr_min": 120.0, "target_hr_max": 135.0},
+    ])
+    loads = _estimate_plan_daily_loads(plan, start, days=3, thresholds=thresholds, training_base="hr")
+    assert len(loads) == 3
+    assert loads[0] > loads[2] > 0, "hard day must beat easy day, both non-zero"
+    assert loads[1] == 0.0, "rest day stays at zero"
+
+
+def test_has_base_targets_detects_missing_data():
+    assert _has_base_targets(_mk_plan_row(target_power_min=200), "power") is True
+    assert _has_base_targets(_mk_plan_row(), "power") is False
+    assert _has_base_targets(_mk_plan_row(target_hr_max=160), "hr") is True
+    assert _has_base_targets(_mk_plan_row(), "hr") is False
+    assert _has_base_targets(_mk_plan_row(target_pace_max="5:00"), "pace") is True
+    assert _has_base_targets(_mk_plan_row(), "pace") is False

--- a/tests/test_race_countdown_base.py
+++ b/tests/test_race_countdown_base.py
@@ -1,0 +1,235 @@
+"""Regression tests for _build_race_countdown per training base.
+
+Historical bug: an HR-base user's LTHR (bpm) was passed as ``latest_cp``
+into power formulas, yielding a nonsensical "172 → 235 bpm" target on the
+Goal page and an absurd race prediction. Every case here exercises one
+(training_base, has_cp_watts, has_threshold_pace) combination to pin the
+dispatch down.
+"""
+from datetime import date
+
+from api.deps import _build_race_countdown, _select_prediction_method
+
+
+_TODAY = date(2026, 4, 22)
+_TREND = {"direction": "rising", "slope_per_month": 0.5}
+# Pairs roughly match a 4:30/km runner at 230W.
+_POWER_PACE_PAIRS = [(230.0, 270.0), (235.0, 265.0), (225.0, 275.0)]
+
+
+def _call(
+    *,
+    training_base: str,
+    latest_threshold: float | None,
+    latest_cp_watts: float | None,
+    threshold_pace: float | None = None,
+    target_time_sec: int | None = 10_800,  # 3:00 marathon
+    race_date_str: str = "",
+    prediction_method: str | None = "critical_power",
+) -> dict:
+    return _build_race_countdown(
+        race_date_str=race_date_str,
+        target_time_sec=target_time_sec,
+        latest_threshold=latest_threshold,
+        latest_cp_watts=latest_cp_watts,
+        power_pace_pairs=_POWER_PACE_PAIRS,
+        cp_trend_data=_TREND,
+        today=_TODAY,
+        training_base=training_base,
+        threshold_pace=threshold_pace,
+        prediction_method=prediction_method,
+    )
+
+
+def test_hr_base_with_target_has_no_cp_target():
+    """LTHR is not a trainable race-pace target — never surface a ``target_cp``."""
+    result = _call(
+        training_base="hr",
+        latest_threshold=172.0,   # LTHR in bpm
+        latest_cp_watts=None,     # HR user has no CP watts
+        threshold_pace=None,
+        prediction_method=None,
+    )
+    assert result["mode"] == "cp_milestone"
+    assert result["current_cp"] is None, "HR user has no trainable threshold target"
+    assert result["target_cp"] is None, "must never render an LTHR target — no such formula exists"
+
+
+def test_hr_base_never_feeds_lthr_into_power_formula():
+    """Even if prediction_method resolves to critical_power (e.g. because a
+    Garmin-native FTP is present), an HR-base user's LTHR must not be used
+    as the watts input. ``latest_cp_watts`` is the only path for that.
+    """
+    # HR user whose Garmin also wrote a native FTP: latest_cp_watts=260.
+    # Their LTHR is 172 bpm. The prediction uses CP watts; the display uses
+    # LTHR. They must stay in separate lanes.
+    result = _call(
+        training_base="hr",
+        latest_threshold=172.0,
+        latest_cp_watts=260.0,
+        threshold_pace=None,
+        prediction_method="critical_power",
+    )
+    assert result["target_cp"] is None, "HR base: no target_cp regardless of CP availability"
+    # Prediction used CP watts, not the LTHR. For avg_k across our fixture
+    # pairs ≈ 62083 and the function's default power_fraction=0.80, predicted
+    # pace ≈ 62083 / (260 × 0.80) ≈ 298 sec/km → marathon ≈ 298 × 42.195
+    # ≈ 12_582 s ≈ 3:30. A 3:15–3:45 window pins this path while rejecting
+    # both the 4:50 regression (treating 172 bpm as watts → ~4:49) and the
+    # 2:22 regression (overshooting CP via wrong-source pairs → ~2:22).
+    t = result["predicted_time_sec"]
+    assert t is not None
+    assert 3 * 3600 + 15 * 60 < t < 3 * 3600 + 45 * 60, (
+        f"expected ~3:30 from 260W path, got {t/3600:.2f}h — the 4:50 regression "
+        f"(treating 172 bpm as watts) or the 2:22 regression (overshooting CP) "
+        f"would both fall outside this window"
+    )
+
+
+def test_hr_base_falls_back_to_riegel_when_only_pace_available():
+    """HR user with no CP watts but a threshold pace — use Riegel."""
+    result = _call(
+        training_base="hr",
+        latest_threshold=172.0,
+        latest_cp_watts=None,
+        threshold_pace=280.0,  # ~4:40/km threshold
+        prediction_method="riegel",
+    )
+    assert result["prediction_method"] == "riegel"
+    assert result["predicted_time_sec"] is not None
+    # Riegel from 4:40/km threshold → marathon well over 3:00 but under 5:00.
+    assert 3 * 3600 < result["predicted_time_sec"] < 5 * 3600
+    assert result["target_cp"] is None
+
+
+def test_power_base_with_cp_produces_watts_target():
+    """Power user: target_cp is in watts, computed from power-pace inversion."""
+    result = _call(
+        training_base="power",
+        latest_threshold=260.0,    # CP in watts
+        latest_cp_watts=260.0,
+        threshold_pace=None,
+        prediction_method="critical_power",
+    )
+    assert result["mode"] == "cp_milestone"
+    assert result["current_cp"] == 260.0
+    assert result["target_cp"] is not None
+    # For a 3:00 marathon target, required CP must exceed current (else user
+    # would already be on pace). Sanity-check the unit is watts, not bpm.
+    assert 150 < result["target_cp"] < 500, "target_cp must be a plausible watts value"
+
+
+def test_pace_base_with_threshold_pace_produces_pace_target():
+    """Pace user: target is a threshold pace in sec/km (inverse Riegel)."""
+    result = _call(
+        training_base="pace",
+        latest_threshold=280.0,    # LT pace sec/km
+        latest_cp_watts=None,
+        threshold_pace=280.0,
+        prediction_method="riegel",
+    )
+    assert result["mode"] == "cp_milestone"
+    assert result["current_cp"] == 280.0
+    assert result["target_cp"] is not None
+    # For a 3:00 marathon target the needed threshold pace is well under 280 sec/km.
+    assert 150 < result["target_cp"] < 280
+
+
+def test_continuous_mode_shows_base_native_threshold():
+    """No target time — ``current_cp`` is the base-native value (bpm for HR)."""
+    result = _call(
+        training_base="hr",
+        latest_threshold=172.0,
+        latest_cp_watts=None,
+        threshold_pace=None,
+        target_time_sec=None,
+        prediction_method=None,
+    )
+    assert result["mode"] == "continuous"
+    assert result["current_cp"] == 172.0, (
+        "continuous mode must expose the base-native display value (LTHR 172 bpm)"
+    )
+
+
+def test_select_prediction_method_hr_user_with_garmin_ftp_only():
+    """Regression for the 2:22 marathon bug.
+
+    HR user whose config picked no pace test but whose Garmin wrote a
+    native FTP (``has_cp=True``). Even with the default ``critical_power``
+    science theory, we must NOT select the CP model — pairing inflated
+    Garmin FTP with Stryd-via-CIQ activity power produces garbage.
+    """
+    assert _select_prediction_method(
+        "hr",
+        "critical_power",
+        has_cp=True,
+        has_pace=False,
+    ) is None
+    # And with a pace measurement, Riegel should win over CP.
+    assert _select_prediction_method(
+        "hr",
+        "critical_power",
+        has_cp=True,
+        has_pace=True,
+    ) == "riegel"
+
+
+def test_select_prediction_method_power_user_default():
+    """Power user with CP available: default is the CP model."""
+    assert _select_prediction_method(
+        "power",
+        "critical_power",
+        has_cp=True,
+        has_pace=False,
+    ) == "critical_power"
+
+
+def test_select_prediction_method_power_user_explicit_riegel():
+    """Power user who explicitly picked Riegel honors that choice when pace is available."""
+    assert _select_prediction_method(
+        "power",
+        "riegel",
+        has_cp=True,
+        has_pace=True,
+    ) == "riegel"
+    # But if the pace data is missing, Riegel can't run — fall back to CP.
+    assert _select_prediction_method(
+        "power",
+        "riegel",
+        has_cp=True,
+        has_pace=False,
+    ) == "critical_power"
+
+
+def test_select_prediction_method_pace_user_always_riegel():
+    """Pace user: always Riegel, never CP."""
+    assert _select_prediction_method(
+        "pace",
+        "critical_power",
+        has_cp=True,
+        has_pace=True,
+    ) == "riegel"
+    # No pace data → no prediction.
+    assert _select_prediction_method(
+        "pace",
+        "critical_power",
+        has_cp=True,
+        has_pace=False,
+    ) is None
+
+
+def test_race_date_mode_hr_base_has_no_reality_check_threshold():
+    """With a race date set, HR users still have no meaningful needed-threshold."""
+    result = _call(
+        training_base="hr",
+        latest_threshold=172.0,
+        latest_cp_watts=None,
+        threshold_pace=280.0,
+        race_date_str="2026-06-01",
+        prediction_method="riegel",
+    )
+    assert result["mode"] == "race_date"
+    # race_honesty_check returns "Insufficient data" when current is None,
+    # which is what we want for HR users — no pretend target.
+    reality = result["reality_check"]
+    assert "needed_cp" not in reality or reality.get("needed_cp") is None

--- a/web/src/components/charts/ComplianceChart.tsx
+++ b/web/src/components/charts/ComplianceChart.tsx
@@ -25,8 +25,8 @@ export default function ComplianceChart({ data, loadLabel }: Props) {
   const label = loadLabel || 'RSS';
 
   const chartData = data.weeks.map((week, i) => {
-    const planned = data.planned_rss[i] ?? 0;
-    const actual = data.actual_rss[i] ?? 0;
+    const planned = data.planned_load[i] ?? 0;
+    const actual = data.actual_load[i] ?? 0;
     const compliance = planned > 0 ? Math.round((actual / planned) * 100) : null;
     return { week, planned, actual, compliance };
   });
@@ -37,6 +37,14 @@ export default function ComplianceChart({ data, loadLabel }: Props) {
         <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           <Trans>Weekly Load Compliance</Trans>
         </CardTitle>
+        {data.planned_estimated && (
+          <p className="text-[11px] text-muted-foreground mt-1">
+            <Trans>
+              Planned bars are estimated — your plan has no {label} targets
+              for the current training base.
+            </Trans>
+          </p>
+        )}
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={300}>

--- a/web/src/components/charts/SleepPerfChart.tsx
+++ b/web/src/components/charts/SleepPerfChart.tsx
@@ -9,25 +9,29 @@ import {
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/useChartColors';
+import { formatPace } from '@/lib/format';
+import type { SleepPerfData } from '@/types/api';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 interface Props {
-  data: [number, number][];
+  data: SleepPerfData;
 }
 
 export default function SleepPerfChart({ data }: Props) {
   const chartColors = useChartColors();
   const { t } = useLingui();
-  const chartData = data.map(([sleep, power]) => ({
-    sleep,
-    power,
-  }));
+  const pairs = data?.pairs ?? [];
+  const unit = data?.metric_unit ?? 'W';
+  const metricLabel = data?.metric_label ?? 'Avg Power';
+  const isPace = unit === 'sec/km';
+  const chartData = pairs.map(([sleep, metric]) => ({ sleep, metric }));
+  const yLabel = `${metricLabel} (${unit})`;
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          <Trans>Sleep Score vs Power</Trans>
+          <Trans>Sleep Score vs {metricLabel}</Trans>
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -42,11 +46,12 @@ export default function SleepPerfChart({ data }: Props) {
               label={{ value: t`Sleep Score`, position: 'insideBottom', offset: -2, fill: chartColors.tickLight, fontSize: 11 }}
             />
             <YAxis
-              dataKey="power"
-              name={t`Avg Power (W)`}
+              dataKey="metric"
+              name={yLabel}
               tick={{ fill: chartColors.tickLight, fontSize: 11 }}
               type="number"
-              label={{ value: t`Avg Power (W)`, angle: -90, position: 'insideLeft', fill: chartColors.tickLight, fontSize: 11 }}
+              tickFormatter={isPace ? (v: number) => formatPace(v) : undefined}
+              label={{ value: yLabel, angle: -90, position: 'insideLeft', fill: chartColors.tickLight, fontSize: 11 }}
             />
             <Tooltip
               contentStyle={{
@@ -55,10 +60,21 @@ export default function SleepPerfChart({ data }: Props) {
                 borderRadius: 8,
               }}
               labelStyle={{ color: chartColors.tickLight }}
-              formatter={(value, name) => [
-                `${value}${name === 'power' ? 'W' : ''}`,
-                name === 'power' ? t`Avg Power` : t`Sleep Score`,
-              ]}
+              formatter={(value, _name, item) => {
+                // When both axes set a `name` prop, recharts passes the
+                // axis name into the formatter for every tooltip row, so
+                // keying on `name` collapses both rows to the same label.
+                // The payload item's `dataKey` is the stable identifier.
+                const key =
+                  (item as { dataKey?: string } | undefined)?.dataKey;
+                if (key === 'metric') {
+                  const display = isPace
+                    ? formatPace(Number(value))
+                    : `${value}${unit}`;
+                  return [display, metricLabel];
+                }
+                return [value, t`Sleep Score`];
+              }}
             />
             <Scatter data={chartData} fill={chartColors.projection} />
           </ScatterChart>

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -123,9 +123,9 @@ export default function Training() {
           <ComplianceChart data={data.weekly_review} loadLabel={activeDisplay?.load_label} />
         </DataHint>
         <DataHint
-          sufficient={!!(data.data_meta?.has_recovery && (data.sleep_perf?.length ?? 0) >= 2)}
+          sufficient={!!(data.data_meta?.has_recovery && (data.sleep_perf?.pairs?.length ?? 0) >= 2)}
           message={t`Not enough data to show sleep vs performance`}
-          hint={t`Connect a recovery source (like Oura Ring) and sync activities with power data.`}
+          hint={t`Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date.`}
         >
           <SleepPerfChart data={data.sleep_perf} />
         </DataHint>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -321,8 +321,9 @@ export interface CpTrendChart {
 
 export interface WeeklyReview {
   weeks: string[];
-  actual_rss: number[];
-  planned_rss: number[];
+  actual_load: number[];
+  planned_load: number[];
+  planned_estimated?: boolean;
 }
 
 export interface WorkoutFlag {
@@ -348,13 +349,19 @@ export interface ScienceNoteInfo {
 
 export type ScienceNotes = Record<string, ScienceNoteInfo>;
 
+export interface SleepPerfData {
+  pairs: [number, number][];
+  metric_label: string;
+  metric_unit: string;
+}
+
 export interface TrainingResponse {
   diagnosis: DiagnosisData;
   fitness_fatigue: TimeSeriesData;
   cp_trend: CpTrendChart;
   weekly_review: WeeklyReview;
   workout_flags: WorkoutFlag[];
-  sleep_perf: [number, number][];
+  sleep_perf: SleepPerfData;
   training_base?: TrainingBase;
   display?: DisplayConfig;
   data_meta?: DataMeta;
@@ -371,16 +378,24 @@ export interface RaceCountdown {
   mode: 'race_date' | 'cp_milestone' | 'continuous' | 'none';
   race_date?: string;
   days_left?: number;
-  predicted_time_sec?: number;
-  target_time_sec?: number;
-  current_cp?: number;
-  target_cp?: number;
-  cp_gap_watts?: number;
+  predicted_time_sec?: number | null;
+  target_time_sec?: number | null;
+  /** Current threshold in base-native units (W / bpm / sec·km⁻¹).
+   *  Pair with `display.threshold_unit` to format. */
+  current_cp?: number | null;
+  /** Target threshold in the same base-native units as `current_cp`.
+   *  Always null for HR-base users (LTHR is not a trainable race target). */
+  target_cp?: number | null;
+  cp_gap_watts?: number | null;
   status: string;
   milestones?: Milestone[];
   estimated_months?: number | null;
   distance?: string;
   distance_label?: string;
+  /** Which prediction MODEL actually produced `predicted_time_sec`. */
+  prediction_method?: 'critical_power' | 'riegel' | 'none';
+  /** Display name of the science theory, if the active set has one. */
+  prediction_theory?: string | null;
   cp_trend_summary?: {
     direction: string;
     slope_per_month: number;
@@ -389,10 +404,10 @@ export interface RaceCountdown {
     assessment: string;
     severity: string;
     trend_note?: string;
-    cp_gap_watts?: number;
-    cp_gap_pct?: number;
-    current_cp?: number;
-    needed_cp?: number;
+    cp_gap_watts?: number | null;
+    cp_gap_pct?: number | null;
+    current_cp?: number | null;
+    needed_cp?: number | null;
     realistic_targets?: {
       comfortable: number;
       stretch: number;
@@ -412,6 +427,10 @@ export interface GoalResponse {
   race_countdown: RaceCountdown;
   cp_trend: CpTrendChart;
   cp_trend_data: CpTrendData;
+  /** Current threshold in base-native units (W / bpm / sec·km⁻¹).
+   *  Name kept as `latest_cp` for backwards compatibility — pair with
+   *  `display.threshold_unit` to format. Do NOT feed directly into any
+   *  power formula: for that, use the backend-computed watts path. */
   latest_cp: number | null;
   training_base?: TrainingBase;
   display?: DisplayConfig;


### PR DESCRIPTION
## Summary

Four user-reported bugs on HR-based Garmin-only setup, all anchored in the same root cause: `latest_cp` was a base-native threshold (W / bpm / sec·km⁻¹ per `training_base`) but was silently fed into power-only formulas downstream.

**Before:**
- Goal page showed "172 → 235 bpm" (LTHR piped through `required_cp_for_time`)
- Marathon prediction showed 4:49 (LTHR treated as CP watts) or 2:22 (Garmin-native FTP + Stryd-via-CIQ power-pace pairs, when default `critical_power` theory silently selected the CP model for non-power users)
- Sleep-vs-performance chart empty because it was hard-gated on `avg_power`
- Weekly compliance / plan projection defaulted every HR/pace workout to 60 RSS/hour

**After:**
- `_build_race_countdown` split signature: `latest_threshold` (display) and `latest_cp_watts` (power-formula input) stay in separate lanes.
- New pure helper `_select_prediction_method(training_base, theory, has_cp, has_pace)` — HR/pace users only ever use Riegel (framed as a data-provenance safety gate).
- `_build_sleep_perf` and `SleepPerfChart` base-aware.
- `_build_compliance` returns generic `actual_load` / `planned_load` with `planned_estimated` flag; ComplianceChart surfaces the caveat.
- `_estimate_plan_daily_loads` + `_plan_workout_load` compute TRIMP / rTSS instead of 60 RSS/hr fallback.
- `check_plan_staleness` now receives `latest_cp_watts` so the drift comparison is unit-safe.

## Test plan

- [x] `pytest tests/` — 346 passed (18 new regression cases across `test_race_countdown_base.py` and `test_plan_load_base.py`)
- [x] `eslint src/` on changed files — clean
- [x] `tsc --noEmit` — only pre-existing `baseUrl` deprecation warning
- [x] Verify on the live HR-based Garmin-only account:
  - Goal page no longer shows "172 → 235 bpm" or an implausible prediction
  - Training page sleep-vs-performance chart shows "Sleep Score vs Avg HR" (HR on Y-axis, correct tooltip labels)
  - Compliance chart reflects TRIMP-scale loads, not flat 60/hr bars

## Follow-up (separate PR)

Derive CP from activity power observations (mean-max / 2-parameter hyperbolic) so CP always tracks whatever power field the activities actually carry. Then rename `latest_cp` → `latest_threshold` codebase-wide. Discussion in the preceding conversation on Scenario 3 (Stryd-via-CIQ without direct Stryd sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)