### PR TITLE
Unblock SWA deploy + fix training-page zone distribution

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -1163,12 +1163,15 @@ def diagnose_training(
             if pd.notna(cp_val) and cp_val > 0:
                 _cp_by_aid[aid] = float(cp_val)
 
+    # For pace, lower value = harder, so compare ratio (threshold/value)
+    # against the reciprocal of the boundary fractions.
+    inv_bounds = [1.0 / b if b > 0 else 0.0 for b in bounds] if base == "pace" else []
+
     def _classify(val: float, act_cp: float) -> int:
         if act_cp <= 0 or val <= 0:
             return 0
         if base == "pace":
             ratio = act_cp / val
-            inv_bounds = [1.0 / b if b > 0 else 0 for b in bounds]
             for i in range(len(inv_bounds) - 1, -1, -1):
                 if ratio >= inv_bounds[i]:
                     return i + 1
@@ -1185,12 +1188,16 @@ def diagnose_training(
     # counting activities per zone inflates higher zones whenever the
     # athlete does any short stride or interval, which made the displayed
     # distribution nonsensical for mixed easy + interval weeks.
+    #
+    # metric_col / duration_sec were coerced to numeric on splits_copy above
+    # before recent_splits was sliced out, so values read back as floats or
+    # NaN without re-coercing here.
     zone_time = [0.0] * n_zones
     total_time = 0.0
-    if not recent_splits.empty and current_cp > 0:
+    if not recent_splits.empty:
         for _, srow in recent_splits.iterrows():
-            val = pd.to_numeric(pd.Series([srow.get(metric_col)]), errors="coerce").iloc[0]
-            dur = pd.to_numeric(pd.Series([srow.get("duration_sec")]), errors="coerce").iloc[0]
+            val = srow.get(metric_col)
+            dur = srow.get("duration_sec")
             if pd.isna(val) or pd.isna(dur) or val <= 0 or dur <= 0:
                 continue
             aid = str(srow.get("activity_id", ""))

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -1153,14 +1153,6 @@ def diagnose_training(
     names = zone_names if (zone_names and len(zone_names) == n_zones) else _ZONE_DEFAULT_NAMES.get(base, [f"Zone {i+1}" for i in range(n_zones)])
     targets = [round(t * 100) for t in target_distribution] if target_distribution and len(target_distribution) == n_zones else [None] * n_zones
 
-    if "activity_id" in recent_splits.columns:
-        if base == "pace":
-            activity_best = recent_splits.groupby(recent_splits["activity_id"].astype(str))[metric_col].min()
-        else:
-            activity_best = recent_splits.groupby(recent_splits["activity_id"].astype(str))[metric_col].max()
-    else:
-        activity_best = pd.Series(dtype=float)
-
     # Build per-activity threshold lookup for date-relative zone classification.
     # For power base, use cp_estimate from each activity's date rather than a single
     # current CP — a session at 240W when CP was 260W is Threshold, not VO2max.
@@ -1171,36 +1163,46 @@ def diagnose_training(
             if pd.notna(cp_val) and cp_val > 0:
                 _cp_by_aid[aid] = float(cp_val)
 
-    total_activities = len(recent)
-    if total_activities > 0 and not activity_best.empty and current_cp > 0:
-        # Classify each activity into a zone based on its best split value
-        zone_counts = [0] * n_zones
-        for aid, val in activity_best.items():
-            # Use per-activity threshold when available, fall back to current
-            act_cp = _cp_by_aid.get(str(aid), current_cp)
-            if base == "pace":
-                # For pace: lower value = faster = harder. Compute ratio as threshold/value.
-                ratio = act_cp / val if val > 0 else 0
-                inv_bounds = [1.0 / b if b > 0 else 0 for b in bounds]
-                assigned = 0
-                for i in range(len(inv_bounds) - 1, -1, -1):
-                    if ratio >= inv_bounds[i]:
-                        assigned = i + 1
-                        break
-            else:
-                # For power/HR: higher = harder
-                ratio = val / act_cp if act_cp > 0 else 0
-                assigned = 0
-                for i in range(len(bounds) - 1, -1, -1):
-                    if ratio >= bounds[i]:
-                        assigned = i + 1
-                        break
-            zone_counts[assigned] += 1
+    def _classify(val: float, act_cp: float) -> int:
+        if act_cp <= 0 or val <= 0:
+            return 0
+        if base == "pace":
+            ratio = act_cp / val
+            inv_bounds = [1.0 / b if b > 0 else 0 for b in bounds]
+            for i in range(len(inv_bounds) - 1, -1, -1):
+                if ratio >= inv_bounds[i]:
+                    return i + 1
+            return 0
+        ratio = val / act_cp
+        for i in range(len(bounds) - 1, -1, -1):
+            if ratio >= bounds[i]:
+                return i + 1
+        return 0
 
+    # Time-in-zone from split durations. Target distributions (Coggan /
+    # Seiler 2006 / Filipas 2022) are defined as fraction of training TIME
+    # in each zone. Classifying each activity by its peak split and then
+    # counting activities per zone inflates higher zones whenever the
+    # athlete does any short stride or interval, which made the displayed
+    # distribution nonsensical for mixed easy + interval weeks.
+    zone_time = [0.0] * n_zones
+    total_time = 0.0
+    if not recent_splits.empty and current_cp > 0:
+        for _, srow in recent_splits.iterrows():
+            val = pd.to_numeric(pd.Series([srow.get(metric_col)]), errors="coerce").iloc[0]
+            dur = pd.to_numeric(pd.Series([srow.get("duration_sec")]), errors="coerce").iloc[0]
+            if pd.isna(val) or pd.isna(dur) or val <= 0 or dur <= 0:
+                continue
+            aid = str(srow.get("activity_id", ""))
+            act_cp = _cp_by_aid.get(aid, current_cp)
+            zone_time[_classify(float(val), act_cp)] += float(dur)
+            total_time += float(dur)
+
+    if total_time > 0:
         result["distribution"] = [
             {
                 "name": names[i],
-                "actual_pct": round(zone_counts[i] / total_activities * 100),
+                "actual_pct": round(zone_time[i] / total_time * 100),
                 "target_pct": targets[i],
             }
             for i in range(n_zones)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -420,3 +420,53 @@ def test_diagnose_zone_ranges_included():
     assert result["zone_ranges"][0]["name"] == "Easy"
     assert result["zone_ranges"][0]["unit"] == "W"
     assert result["theory_name"] == "Seiler Polarized 3-Zone"
+
+
+def test_diagnose_distribution_is_time_in_zone():
+    """Distribution must be split-duration-weighted time-in-zone, not
+    activity-count-by-peak-zone.
+
+    Coggan / Seiler target distributions (70/10/10/5/5) are defined as the
+    fraction of TIME an athlete spends in each zone. Classifying an activity
+    by its single hardest split and then counting activities per zone
+    inflates higher zones whenever the athlete does any short stride or
+    interval — a mostly-easy run with one 20-second sprint gets tallied as
+    VO2max. See Seiler 2006 and Filipas et al. 2022 (both cited by
+    `data/science/zones/coggan_5zone.yaml`), which measure training
+    intensity distribution in minutes, not sessions.
+
+    Scenario: a 2-session week with CP = 250 W, Coggan 5-zone boundaries
+    [0.55, 0.75, 0.90, 1.05].
+      - Day 1: 60 min easy @ 175 W (70% CP → Endurance).
+      - Day 2: classic interval workout — 10 min warmup @ 175 W (Endurance),
+        10 × 1 min @ 280 W (112% CP → VO2max) with 1 min recovery @ 130 W
+        (52% CP → Recovery), 10 min cooldown @ 175 W (Endurance).
+    Total split time is 100 min: 80 min Endurance, 10 min VO2max, 10 min
+    Recovery. Peak-based classification would instead report one activity
+    per zone → ~50% Endurance / 50% VO2max, which is scientifically wrong.
+    """
+    today = date(2026, 3, 23)
+    dates = [date(2026, 3, 20), date(2026, 3, 22)]
+    activities = _make_activities(dates, [12, 15])
+    easy_splits = [("0", 175, 3600)]
+    interval_splits = [("1", 175, 600)]
+    for _ in range(10):
+        interval_splits.append(("1", 280, 60))
+        interval_splits.append(("1", 130, 60))
+    interval_splits.append(("1", 175, 600))
+    aids, powers, durations = zip(*(easy_splits + interval_splits))
+    splits = _make_splits(list(aids), list(powers), list(durations))
+    trend = {"current": 250.0, "direction": "flat", "slope_per_month": 0.5}
+
+    result = diagnose_training(
+        activities, splits, trend,
+        lookback_weeks=4, current_date=today,
+    )
+    dist = {d["name"]: d["actual_pct"] for d in result["distribution"]}
+
+    # Endurance dominates — 80 of 100 minutes — not 50%.
+    assert dist["Endurance"] >= 75, f"expected Endurance ~80%, got {dist}"
+    assert dist["VO2max"] <= 15, f"expected VO2max ~10%, got {dist}"
+    assert dist["Recovery"] <= 15, f"expected Recovery ~10%, got {dist}"
+    assert dist["Tempo"] == 0
+    assert dist["Threshold"] == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -470,3 +470,52 @@ def test_diagnose_distribution_is_time_in_zone():
     assert dist["Recovery"] <= 15, f"expected Recovery ~10%, got {dist}"
     assert dist["Tempo"] == 0
     assert dist["Threshold"] == 0
+
+
+def test_diagnose_distribution_pace_base_inverts_ratio():
+    """Pace base: lower value = faster = harder zone. The classifier must
+    invert the ratio (threshold_pace / split_pace) and compare against
+    reciprocal boundary fractions, otherwise a 5:00 min/km split vs a
+    4:20 threshold pace would read as Endurance instead of Recovery.
+
+    Scenario: threshold pace = 260 s/km (4:20/km), Coggan pace boundaries
+    [1.29, 1.14, 1.06, 1.00] (multipliers of threshold pace — higher =
+    slower, so values well above 1.29x belong to Recovery).
+      - Day 1: 60 min easy @ 350 s/km (5:50/km, 350/260 = 1.35x → Recovery).
+      - Day 2: tempo workout — 10 min warmup @ 350 s/km (Recovery),
+        20 min @ 285 s/km (285/260 = 1.10x → Tempo), 10 min cooldown
+        @ 350 s/km (Recovery).
+    Total split time is 100 min: 80 min Recovery, 20 min Tempo. A
+    non-inverted (power-style) ratio would misplace these in the opposite
+    end of the scale, so this test locks in the inversion.
+    """
+    today = date(2026, 3, 23)
+    dates = [date(2026, 3, 20), date(2026, 3, 22)]
+    activities = _make_activities(dates, [10, 12])
+    rows = [
+        ("0", 350.0, 3600),
+        ("1", 350.0, 600),
+        ("1", 285.0, 1200),
+        ("1", 350.0, 600),
+    ]
+    aids, paces, durations = zip(*rows)
+    splits = pd.DataFrame({
+        "activity_id": list(aids),
+        "avg_pace_sec_km": list(paces),
+        "duration_sec": list(durations),
+    })
+    trend = {"current": 260.0, "direction": "flat", "slope_per_month": 0.0}
+
+    result = diagnose_training(
+        activities, splits, trend,
+        lookback_weeks=4, current_date=today,
+        base="pace",
+    )
+    dist = {d["name"]: d["actual_pct"] for d in result["distribution"]}
+
+    # Recovery dominates because splits are slower than threshold.
+    assert dist["Recovery"] >= 75, f"expected Recovery ~80%, got {dist}"
+    assert dist["Tempo"] >= 15, f"expected Tempo ~20%, got {dist}"
+    assert dist["VO2max"] == 0
+    assert dist["Endurance"] == 0
+    assert dist["Threshold"] == 0

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSettings } from '@/contexts/SettingsContext';
 import { API_BASE, getAuthHeaders, extractErrorMessage } from '@/hooks/useApi';
-import type { TrainingBase, SyncStatusResponse, SettingsConfig } from '@/types/api';
+import type { TrainingBase, SyncStatusResponse } from '@/types/api';
 import {
   buildStravaReturnTo,
   getStravaOAuthMessage,
@@ -371,12 +371,12 @@ export default function Settings() {
   ) => {
     setSaving(true);
     try {
-      const current = (config.preferences?.threshold_sources as Record<string, string>) || {};
+      const current = config.preferences?.threshold_sources ?? {};
       await updateSettings({
         preferences: {
           ...config.preferences,
           threshold_sources: { ...current, [metricType]: source },
-        } as SettingsConfig['preferences'],
+        },
       });
       flash('Saved');
     } catch (err) {
@@ -1241,7 +1241,7 @@ export default function Settings() {
                   {options.length > 1 ? (
                     <Select
                       value={currentSource ?? options[0].source}
-                      onValueChange={(v) => handleThresholdSourceChange(metricType, v)}
+                      onValueChange={(v) => v && handleThresholdSourceChange(metricType, v)}
                       disabled={saving}
                     >
                       <SelectTrigger className="h-7 text-[11px] mt-auto">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -55,11 +55,20 @@ export type UnitSystem = 'metric' | 'imperial';
 
 export type UiLanguage = 'en' | 'zh';
 
+/** User's preferred source for each data category plus an optional
+ *  per-metric override map. Category keys (activities / recovery / fitness
+ *  / plan) carry a single provider name; `threshold_sources` carries the
+ *  user's chosen source per threshold metric (e.g. `cp_estimate: "stryd"`)
+ *  when the auto-selected source isn't what they want. */
+export interface SettingsPreferences extends Partial<Record<DataCategory, PlatformName | PlanSourceName>> {
+  threshold_sources?: Partial<Record<string, string>>;
+}
+
 export interface SettingsConfig {
   display_name: string;
   unit_system: UnitSystem;
   connections: PlatformName[];
-  preferences: Partial<Record<DataCategory, PlatformName | PlanSourceName>>;
+  preferences: SettingsPreferences;
   training_base: TrainingBase;
   thresholds: Record<string, number | string | null>;
   zones: Record<string, number[]>;


### PR DESCRIPTION
## What fixes the prod crash

On 2026-04-23 the Training page in production crashed with
`Cannot read properties of undefined (reading '0')` inside
`ComplianceChart`'s `data.weeks.map`. Traced to:

1. **`tsc -b` has been failing on `main` since PR #70 (Apr 22)** on two Settings.tsx type errors: `preferences.threshold_sources` isn't in the `SettingsConfig.preferences` type, and a recent shadcn `onValueChange` type change now emits `string | null`.
2. Because `npm run build` dies, Oryx inside the Azure SWA action falls back to "pre-built" mode and tries to upload the whole `web/` directory (`node_modules` included) — the Free-tier 250 MB limit rejects it. Every `deploy-frontend` run since Apr 22 has failed for this reason.
3. Production has therefore been serving the last-successful bundle from before PR #73, which still looks up `e.planned_rss[n]` / `e.actual_rss[n]`. PR #73 renamed those API fields to `planned_load` / `actual_load` (so the same chart works for HR and pace bases). Current API returns `planned_load`, old bundle reads `e.planned_rss` → `undefined[0]` → crash.

This PR fixes both type errors at the root so `tsc -b` passes, `npm run build` succeeds, `dist/` (~1.3 MB) uploads, and production gets a bundle that matches the current API contract.

- `web/src/types/api.ts`: new `SettingsPreferences` interface that keeps the four category keys and adds an optional `threshold_sources`.
- `web/src/pages/Settings.tsx`: drop the two casts it needed to compile through the old type; null-guard the `onValueChange` value.

## What also improves

While chasing the crash, also fixed a wildly-misleading display: the Zone Analysis actuals were counting activities-by-peak-zone against Coggan / Seiler / Filipas time-in-zone targets. Split-duration weighted time-in-zone now. On a real 6-week sample, VO2max went from an absurd 35% to 2% and Endurance from 16% → 47% (see table below).

| Zone | Target | Before | After |
|------|-------:|-------:|------:|
| Recovery  | 5%  | 0%  | 1%  |
| Endurance | 70% | 16% | 47% |
| Tempo     | 10% | 42% | 40% |
| Threshold | 10% | 6%  | 9%  |
| VO2max    | 5%  | 35% | 2%  |

Note on resolution: Stryd / Garmin / intervals.icu compute time-in-zone from per-second streams, which our DB doesn't currently store. Our implementation weights each split by its `duration_sec`, which is the per-second equivalent assuming constant intensity within a split. Splits from Garmin/Stryd are typically 400m–1km or per-lap, so this under-resolves brief strides — improving this properly means ingesting the per-second stream from the source APIs, which is a larger change.

## Test plan
- [x] `pytest tests/` — 396 passed (was 394; two new tests)
- [x] `npx tsc -b` passes clean
- [x] `npm run build` produces `dist/` at ~1.3 MB
- [x] New `test_diagnose_distribution_is_time_in_zone` and `test_diagnose_distribution_pace_base_inverts_ratio` both fail on `main`, pass on this branch
- [x] Live `/api/training` on real 3-source DB shows the corrected distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)