### PR TITLE
Wire Azure Application Insights into FastAPI backend (managed identity)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,17 @@ PRAXYS_LOCAL_ENCRYPTION_KEY=
 # Optional: Override the callback URL used in the Strava OAuth flow.
 # Leave unset in local dev to use the app's detected callback route.
 # PRAXYS_STRAVA_REDIRECT_URI=https://your-api.example.com/api/settings/connections/strava/callback
+
+# Optional: Azure Application Insights connection string for production
+# observability (traces, metrics, logs). When set, the app auto-ships
+# per-request timings + DB dependency spans + Python logs to the
+# configured App Insights resource. Leave unset locally — app runs fine
+# without it. Copy from the "Connection String" field on the Overview
+# blade of your Application Insights resource in the Azure portal.
+#
+# On Azure App Service, the server authenticates to App Insights via the
+# App Service's system-assigned managed identity (no secret in app
+# settings); the connection string is only used for routing. The MI must
+# hold the "Monitoring Metrics Publisher" role on the AI resource — see
+# docs/perf-baselines/azure-provisioning.md.
+# APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=...

--- a/api/main.py
+++ b/api/main.py
@@ -4,9 +4,42 @@ import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+# Configure stdout logging before anything else — once configure_azure_monitor
+# attaches its own handler to the root logger, a later basicConfig() call is a
+# no-op (basicConfig only runs when no handlers are present).
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
 # Load .env from project root for local config (encryption key, JWT secret, etc.)
 from dotenv import load_dotenv
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+# Wire Azure Monitor before framework imports so auto-instrumentation
+# (FastAPI, requests, SQLAlchemy, logging) hooks correctly. On App Service
+# (detected via WEBSITE_SITE_NAME — the same signal CORS uses below) we
+# authenticate to Application Insights via the system-assigned managed
+# identity, so no instrumentation key or secret lives in app settings; the
+# connection-string env var only names the routing endpoint. Off Azure the
+# SDK falls back to connection-string auth if the env var happens to be
+# set (useful for a contributor pointing at a dev resource). No-op when
+# APPLICATIONINSIGHTS_CONNECTION_STRING is unset.
+if os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING"):
+    from azure.monitor.opentelemetry import configure_azure_monitor
+    if os.environ.get("WEBSITE_SITE_NAME"):
+        from azure.identity import ManagedIdentityCredential
+        # client_id=None → system-assigned MI. Set AZURE_CLIENT_ID in App
+        # Service config to switch to a user-assigned MI later.
+        _mi_client_id = os.environ.get("AZURE_CLIENT_ID")
+        _credential = (
+            ManagedIdentityCredential(client_id=_mi_client_id)
+            if _mi_client_id
+            else ManagedIdentityCredential()
+        )
+        configure_azure_monitor(credential=_credential)
+    else:
+        configure_azure_monitor()
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -18,11 +51,6 @@ from api.views import utc_isoformat
 from db.session import get_db
 
 from db.session import init_db
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(name)s %(levelname)s %(message)s",
-)
 
 
 @asynccontextmanager

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,8 @@ azure-keyvault-keys>=4.9.0
 gunicorn>=22.0.0
 PyJWT>=2.8.0
 httpx>=0.27.0
+# Observability — ships traces, metrics, and logs to Azure Application
+# Insights. No-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset, so
+# local dev is unaffected. The distro bundles the OTel instrumentations
+# for FastAPI, requests, SQLAlchemy, and logging.
+azure-monitor-opentelemetry>=1.6.0


### PR DESCRIPTION
## Summary

First of three PRs that land the observability fabric before we start optimizing for mainland-China perf. This one handles the **server side**: `azure-monitor-opentelemetry` distro, auto-instrumented FastAPI requests, outbound HTTP, SQLAlchemy, and Python logs, shipped to an Application Insights resource using **managed identity** auth on App Service.

Companion PRs (kept separate for easier review):
- PR-B — `perf/appinsights-client` — client SPA wiring + web-vitals
- PR-C — `perf/baseline-docs` — measurement scenario docs + WPT checklist + Azure provisioning steps

## What's happening under the hood

- `configure_azure_monitor()` is called before the FastAPI import so the auto-instrumentation hooks catch the app factory.
- Conditional on `APPLICATIONINSIGHTS_CONNECTION_STRING` — no env var → no-op. Local dev and tests stay clean with zero Azure dependencies.
- On App Service (detected via `WEBSITE_SITE_NAME`, the same signal the CORS block already uses) the exporter authenticates via `ManagedIdentityCredential`. **No instrumentation key, access key, or other sensitive value in App Service app settings** — the connection-string env var is used only to name the routing endpoint.
- Off Azure but with the env var set (a contributor pointing at a dev resource), the SDK falls back to connection-string auth automatically.
- `AZURE_CLIENT_ID` is picked up if present, so switching to a user-assigned MI later doesn't require a code change.

## Why the frontend is different (no MI there)

Browsers are not Azure workloads — there is no managed-identity flow for client-side code. The companion SPA wire (PR-B) uses the connection string as a write-only ingestion token, which is Microsoft's intended pattern for browser telemetry. The AI resource therefore keeps local-authentication enabled; disabling it would break that path.

Full split-auth write-up lives in `docs/perf-baselines/azure-provisioning.md` (PR-C).

## One-time Azure steps this PR depends on (will be merged with PR-C but listed here for visibility)

1. Create Application Insights resource in East Asia (workspace-based), leave local auth enabled.
2. Enable system-assigned MI on App Service `trainsight-app`.
3. Grant that MI the **Monitoring Metrics Publisher** role on the AI resource.
4. Set `APPLICATIONINSIGHTS_CONNECTION_STRING` in App Service app settings.
5. Redeploy.

## Test plan

- [x] `pytest tests/ -v` → 396 passed, 1 skipped
- [x] Module imports cleanly with env vars unset (default local dev path)
- [x] Module imports cleanly with connection string set but no `WEBSITE_SITE_NAME` (contributor-with-dev-resource path) → connection-string auth
- [x] Module imports cleanly with both env vars set (simulated App Service) → `ManagedIdentityCredential` constructed, fails gracefully without a real IMDS endpoint without crashing the app
- [ ] Post-merge smoke: after Azure resources are provisioned + redeploy runs, hit Live Metrics in the portal and confirm requests land within 2–5 min