### PR TITLE
Wire Application Insights + web-vitals into the SPA

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -26,3 +26,4 @@ jobs:
           output_location: "dist"
         env:
           VITE_API_URL: ${{ vars.VITE_API_URL }}
+          VITE_APPINSIGHTS_CONNECTION_STRING: ${{ vars.VITE_APPINSIGHTS_CONNECTION_STRING }}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,15 @@
+# Frontend build-time env. Vite substitutes these at build into the bundle,
+# so the values ship to the browser — never put secrets here. For local dev,
+# copy to .env.local (gitignored) and fill in; for CI the deploy workflow
+# injects from repository variables.
+
+# Base URL for the Praxys API. Empty string → same-origin requests via the
+# SWA proxy. Set to a full https://... URL to hit a cross-origin App Service.
+VITE_API_URL=
+
+# Azure Application Insights connection string for client-side RUM (page
+# views, Core Web Vitals, fetch dependency timings). Leave unset locally
+# to disable telemetry. The connection string is not a secret — it's a
+# write-only ingestion token that ships in every client bundle by design.
+# Copy from the Application Insights resource → Overview blade.
+VITE_APPINSIGHTS_CONNECTION_STRING=

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "@lingui/core": "^5.9.5",
         "@lingui/detect-locale": "^5.9.5",
         "@lingui/react": "^5.9.5",
+        "@microsoft/applicationinsights-web": "^3.4.1",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query": "^5.99.2",
         "class-variance-authority": "^0.7.1",
@@ -27,7 +28,8 @@
         "shadcn": "^4.4.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "web-vitals": "^5.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -76,6 +78,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -689,29 +692,6 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1573,6 +1553,7 @@
       "integrity": "sha512-TDIrOa2hAz8kXrZ0JfMGaIiFIE4TEdqI2he4OpkTSCfBh3ec/gSCn1kNW5HdviO7x46Gvy567YOgHNOI9/e4Fg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/runtime": "^7.20.13",
@@ -1911,6 +1892,7 @@
       "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.9.5.tgz",
       "integrity": "sha512-Y+iZq9NqnqZOqHNgPomUFP21KH/zs4oTTizWoz0AKAkBbq9T9yb1DSz/ugtBRjF1YLtKMF9tq28v3thMHANSiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@lingui/message-utils": "5.9.5"
@@ -2076,6 +2058,138 @@
         "moo": "^0.5.1"
       }
     },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.4.1.tgz",
+      "integrity": "sha512-zdxZzu50/gsE2JWrzeviHloFZu9r5/x2+OLD0TIYHhvrod321AKkStmKlDoep1JAsSephjxBfwTjciKiFXXyGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.4.1.tgz",
+      "integrity": "sha512-ifNgSIisKM/rZoLdpzS6sIQqBBRNXXAhiazZizwoP2MLdK93Z8JcPNi6eXkKPhW0Fi3SuoUivCaM7GgAMgVEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.4.1.tgz",
+      "integrity": "sha512-cnjVVTxSeavmwCoOwXi/ZQuCcjo7SnYYRWyS+GsMCrTRTItVHZlVj6NHgmFEQZWNybrM+U1RgwZE2wXn1/Liyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.4.1.tgz",
+      "integrity": "sha512-s2cUuknjazaoCbh9i6ljymeZqeQqpyAE8v2ZUxCkAwRuxbonAvZWQtEr4QQmEHWJIdbWgn0Ge+OOlMtMkh+Ixg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.4.1.tgz",
+      "integrity": "sha512-gdYLIYkP11D+V71nNCupYsmWE8LAL9EpIR2Q7+B3n6dpck7tgaYMXFN3S5ZrOh3yxLAwt7GVXZoDcN2mGkagxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "3.4.1",
+        "@microsoft/applicationinsights-cfgsync-js": "3.4.1",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-dependencies-js": "3.4.1",
+        "@microsoft/applicationinsights-properties-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
+      "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -2173,11 +2287,27 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
+      "license": "MIT"
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3403,6 +3533,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -3412,6 +3543,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3512,6 +3644,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3752,6 +3885,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4050,6 +4184,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5088,6 +5223,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6013,6 +6149,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8814,6 +8951,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8823,6 +8961,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8869,6 +9008,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9016,7 +9156,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9907,7 +10048,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -9966,6 +10108,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10259,6 +10402,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10349,6 +10493,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10592,6 +10742,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "@lingui/core": "^5.9.5",
     "@lingui/detect-locale": "^5.9.5",
     "@lingui/react": "^5.9.5",
+    "@microsoft/applicationinsights-web": "^3.4.1",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query": "^5.99.2",
     "class-variance-authority": "^0.7.1",
@@ -31,7 +32,8 @@
     "shadcn": "^4.4.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "web-vitals": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/web/src/lib/appinsights.ts
+++ b/web/src/lib/appinsights.ts
@@ -1,0 +1,104 @@
+/**
+ * Azure Application Insights + web-vitals wiring. No-op when
+ * VITE_APPINSIGHTS_CONNECTION_STRING is not set at build time, so local
+ * dev and un-instrumented previews never ship telemetry.
+ *
+ * What gets captured when enabled:
+ *   - Auto page views + SPA route changes (enableAutoRouteTracking)
+ *   - Uncaught exceptions
+ *   - fetch / XHR dependencies — each API call gets its own timing span
+ *     correlated to the server-side OTel trace via CORS correlation
+ *     headers (server wiring lives in api/main.py)
+ *   - Core Web Vitals (LCP, FCP, INP, CLS, TTFB) as custom metrics
+ *
+ * Every telemetry item is enriched with the current navigator.connection
+ * snapshot so we can segment by effectiveType (4g / 3g / slow-2g) and
+ * compare mainland-China-mobile reality against everyone else.
+ *
+ * Why a connection string and not managed identity: browsers are not
+ * Azure workloads — there is no managed identity flow available to
+ * client-side code. Microsoft's intended pattern for browser telemetry
+ * is a build-time-embedded connection string, which acts as a write-
+ * only ingestion token (rate-limited by resource quota; unable to read
+ * anything back). The backend (api/main.py) uses managed identity.
+ */
+import { ApplicationInsights, type ITelemetryItem } from '@microsoft/applicationinsights-web'
+import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from 'web-vitals'
+
+const CONNECTION_STRING = import.meta.env.VITE_APPINSIGHTS_CONNECTION_STRING ?? ''
+
+type NetworkConnection = {
+  effectiveType?: string
+  downlink?: number
+  rtt?: number
+  saveData?: boolean
+}
+
+let appInsights: ApplicationInsights | null = null
+
+export function initAppInsights(): ApplicationInsights | null {
+  if (!CONNECTION_STRING) return null
+  if (appInsights) return appInsights
+
+  appInsights = new ApplicationInsights({
+    config: {
+      connectionString: CONNECTION_STRING,
+      enableAutoRouteTracking: true,
+      enableCorsCorrelation: true,
+      disableFetchTracking: false,
+      disableAjaxTracking: false,
+      autoTrackPageVisitTime: true,
+    },
+  })
+  appInsights.loadAppInsights()
+  appInsights.addTelemetryInitializer(attachNetworkContext)
+  appInsights.trackPageView()
+  reportWebVitals()
+
+  return appInsights
+}
+
+export function getAppInsights(): ApplicationInsights | null {
+  return appInsights
+}
+
+function getNetworkSnapshot(): NetworkConnection | null {
+  const conn = (navigator as unknown as { connection?: NetworkConnection }).connection
+  return conn ?? null
+}
+
+function attachNetworkContext(envelope: ITelemetryItem): void {
+  const conn = getNetworkSnapshot()
+  if (!conn) return
+  const baseData = (envelope.baseData ??= {})
+  baseData.properties = {
+    ...(baseData.properties ?? {}),
+    effectiveType: conn.effectiveType,
+    downlink: conn.downlink,
+    rtt: conn.rtt,
+    saveData: conn.saveData,
+  }
+}
+
+function reportWebVitals(): void {
+  if (!appInsights) return
+  const send = (metric: Metric): void => {
+    const conn = getNetworkSnapshot() ?? {}
+    appInsights!.trackMetric(
+      { name: `WebVitals.${metric.name}`, average: metric.value },
+      {
+        rating: metric.rating,
+        navigationType: metric.navigationType,
+        id: metric.id,
+        effectiveType: conn.effectiveType,
+        downlink: conn.downlink,
+        rtt: conn.rtt,
+      },
+    )
+  }
+  onCLS(send)
+  onFCP(send)
+  onINP(send)
+  onLCP(send)
+  onTTFB(send)
+}

--- a/web/src/lib/appinsights.ts
+++ b/web/src/lib/appinsights.ts
@@ -70,13 +70,17 @@ function getNetworkSnapshot(): NetworkConnection | null {
 function attachNetworkContext(envelope: ITelemetryItem): void {
   const conn = getNetworkSnapshot()
   if (!conn) return
+  // Prefix with netinfo_ so we don't shadow any field the SDK populates
+  // on its own envelopes (e.g. dependency spans spread into baseData.
+  // properties). Same prefix on trackMetric below keeps App Insights
+  // queries consistent — filter on netinfo_effectiveType everywhere.
   const baseData = (envelope.baseData ??= {})
   baseData.properties = {
     ...(baseData.properties ?? {}),
-    effectiveType: conn.effectiveType,
-    downlink: conn.downlink,
-    rtt: conn.rtt,
-    saveData: conn.saveData,
+    netinfo_effectiveType: conn.effectiveType,
+    netinfo_downlink: conn.downlink,
+    netinfo_rtt: conn.rtt,
+    netinfo_saveData: conn.saveData,
   }
 }
 
@@ -90,9 +94,9 @@ function reportWebVitals(): void {
         rating: metric.rating,
         navigationType: metric.navigationType,
         id: metric.id,
-        effectiveType: conn.effectiveType,
-        downlink: conn.downlink,
-        rtt: conn.rtt,
+        netinfo_effectiveType: conn.effectiveType,
+        netinfo_downlink: conn.downlink,
+        netinfo_rtt: conn.rtt,
       },
     )
   }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,12 @@ import App from './App'
 import { i18n, activateLocale, DEFAULT_LOCALE, isSupportedLocale, type SupportedLocale } from './i18n/init'
 import { detectLocaleFromTag } from './lib/locale-detect'
 import { KEYS, getCompatItem } from './lib/storage-compat'
+import { initAppInsights } from './lib/appinsights'
+
+// Fire before render so the SDK captures the first page view + web vitals
+// from the initial paint. No-op when VITE_APPINSIGHTS_CONNECTION_STRING
+// is unset at build time.
+initAppInsights()
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary

Second of three PRs for the observability fabric. This one handles **client side**: `@microsoft/applicationinsights-web` + `web-vitals`, ships Core Web Vitals + fetch dependency timings + page views from real users' browsers, segmented by `navigator.connection` so "CN 4g" can be queried separately from "wifi."

Builds on PR-A (#105) — the backend FastAPI wiring with managed identity, now on `main`.

Companion PRs (shipping together):
- PR-A ✅ merged — `5c0267b`
- **PR-B (this)** — client SPA wiring
- PR-C — `perf/baseline-docs` — measurement docs + WPT checklist + Azure provisioning (opened after this merges)

## What gets captured when `VITE_APPINSIGHTS_CONNECTION_STRING` is set

- Auto page views + SPA route-change events via `enableAutoRouteTracking`
- Uncaught exceptions (SDK default)
- Every fetch / XHR gets its own dependency span, CORS-correlated to the server-side OTel trace from PR-A → end-to-end view in App Insights
- Core Web Vitals: **LCP, FCP, INP, CLS, TTFB** reported as custom metrics
- Every telemetry item enriched with `netinfo_effectiveType` / `netinfo_downlink` / `netinfo_rtt` / `netinfo_saveData` via a telemetry initializer, so we can filter CN-mobile reality from everything else when reading the data

## Why a connection string here, not managed identity

Browsers are not Azure workloads — there is **no MI flow for client-side code**. Microsoft's intended pattern for browser telemetry is a build-time-embedded connection string, which acts as a **write-only ingestion token** (rate-limited by resource quota; cannot read anything back). Documented in the module header of `web/src/lib/appinsights.ts` and in `web/.env.example`. The App Insights resource therefore keeps local-authentication enabled; disabling it would break this path. (The backend continues to use MI — see PR-A.)

## Build behavior & bundle cost

- `VITE_APPINSIGHTS_CONNECTION_STRING` injected at build time via `deploy-frontend.yml` from a GitHub repository variable (not a secret — the workflow already carried this pattern for `VITE_API_URL`).
- Empty → `initAppInsights()` returns `null` and Rolldown DCE-drops the SDK entirely. No dead code in the bundle.
- Bundle measurements (main chunk, gzipped):
  - **Unconfigured build:** 376.77 KB — identical to pre-PR baseline, SDK fully tree-shaken
  - **Configured build:** 453.86 KB — **+77.09 KB gzipped** for the SDK + web-vitals
- `initAppInsights()` called at module scope before `createRoot()` so the first page view + first-paint web vitals are captured.
- No React provider / context — one-shot module-level side effect. Components that want to log custom events can `import { getAppInsights } from '@/lib/appinsights'`.

## Review feedback addressed (commit `5296c6c`)

The telemetry initializer was spreading `effectiveType`/`downlink`/`rtt`/`saveData` directly into `baseData.properties`. The SDK's dependency-span builder writes to the same object, so any future SDK field with the same name would silently shadow ours. Prefixed all four fields with `netinfo_` in both the telemetry initializer and the web-vitals `trackMetric` custom dimensions. Same prefix in both places keeps queries uniform (`customDimensions.netinfo_effectiveType` everywhere).

## One-time user action this PR depends on

Set GitHub repo variable `VITE_APPINSIGHTS_CONNECTION_STRING` on `dddtc2005/praxys`. Step-by-step walkthrough lands in PR-C (`docs/perf-baselines/azure-provisioning.md`).

## Test plan

- [x] `eslint src/lib/appinsights.ts src/main.tsx` → clean
- [x] `npm run build` → green on both unconfigured (376.77 KB gz) and configured (453.86 KB gz) paths
- [x] Rebased onto post-merge `main` (`5c0267b`); re-verified build after rebase
- [ ] Post-merge smoke: after `VITE_APPINSIGHTS_CONNECTION_STRING` is set in repo vars and the next deploy runs, browse the prod site once, then query App Insights `customMetrics | where name startswith "WebVitals."` — should see LCP/FCP/INP/CLS/TTFB with `customDimensions.netinfo_*` populated
- [ ] Post-merge smoke: confirm App Service CORS allows `request-id` + `traceparent` headers so `enableCorsCorrelation: true` doesn't break the fetch path (if it does, either add the headers to the Access-Control-Allow-Headers list or flip the flag off)