### PR TITLE
Add perf-baseline docs, scenario template, and WPT run checklist

### DIFF
--- a/docs/perf-baselines/README.md
+++ b/docs/perf-baselines/README.md
@@ -43,7 +43,7 @@ For each scenario × probe location:
 | **Protocol** | Proves HTTP/3 rollout | `h2` / `h3` |
 | **Font CSS TTFB** (isolated) | Specifically catches the Google Fonts block | ms or `timeout` |
 
-For RUM, additionally segment by `navigator.connection.effectiveType` (4g / 3g / slow-2g / wifi). The telemetry initializer in `web/src/lib/appinsights.ts` attaches this to every event.
+For RUM, additionally segment by `customDimensions.netinfo_effectiveType` (4g / 3g / slow-2g / wifi). The telemetry initializer in `web/src/lib/appinsights.ts` attaches the full `navigator.connection` snapshot to every event, namespaced under `netinfo_*` to avoid shadowing SDK-native envelope fields.
 
 ## Directory layout
 
@@ -60,7 +60,7 @@ docs/perf-baselines/
 │   └── ... (one HAR / LH / filmstrip per scenario × probe)
 ├── 2026-MM-DD-<sha>/      — after Phase 1 fix #1 (self-host fonts)
 │   └── ...
-└── summary.md             — running table of all baselines, diff by phase
+└── summary.md             — running table of all baselines (created on first real baseline run)
 ```
 
 Each phase's PR description cites the row in `summary.md` that names the metrics that moved, by how much, and any that didn't move in the expected direction (= the fix didn't do what we thought).

--- a/docs/perf-baselines/README.md
+++ b/docs/perf-baselines/README.md
@@ -1,0 +1,70 @@
+# Performance Baselines
+
+Numbers, not opinions. Every performance fix lands with a before/after row in this directory so we can attribute each change to a measurable delta.
+
+## Why this exists
+
+Mainland-China users cross the Great Firewall to hit our Azure East Asia deployment. Perceived slowness has multiple causes (render-blocking Google Fonts, no API compression, 1.3 MB monolithic bundle, 7-request Training waterfall, HTTP/2-over-lossy-TCP, no PWA). To know which fix bought which seconds, we need reproducible before/after measurements.
+
+## Three measurement layers
+
+| Layer | Purpose | Tool | When |
+|---|---|---|---|
+| **Lab synthetic** | Catch code regressions in controlled conditions | Lighthouse CI in GitHub Actions | On every `web/**` PR (added in a later phase) |
+| **Multi-region synthetic** | Ground truth for each phase's delta | WebPageTest — Beijing, Shanghai, Hong Kong, US West | Before & after each phase merges |
+| **Production RUM** | Real user experience over time | Azure Application Insights (wired in `api/main.py` + `web/src/lib/appinsights.ts`) | Continuous, once `APPLICATIONINSIGHTS_CONNECTION_STRING` is set |
+
+Azure Availability Tests (cheap URL pings from multiple Azure regions) provide an always-on uptime + TTFB baseline — see [`azure-provisioning.md`](./azure-provisioning.md) to set them up.
+
+## The three scenarios
+
+Run all three for every baseline. Identical inputs → deltas attribute to code changes, not measurement noise.
+
+- **S1 — Cold first load of Today page.** Empty cache, no service worker. Navigate to the homepage → log in → Today paints. The "new user" path.
+- **S2 — Cold first load of Training page.** Same pre-conditions as S1 but navigate to `/training` — currently fires 7 API round-trips, our worst offender.
+- **S3 — Warm repeat visit to Today.** Authenticated, cache populated (service worker active once Phase 2 #7 lands), tab revisit. The "daily use" path.
+
+## What to capture per run
+
+For each scenario × probe location:
+
+| Metric | Why it matters | Units |
+|---|---|---|
+| **FCP** (First Contentful Paint) | Catches Google Fonts blocking, render-blocking CSS | ms |
+| **LCP** (Largest Contentful Paint) | Overall page readiness | ms |
+| **TTI** (Time to Interactive) | When JS is done parsing & handlers are wired | ms |
+| **TTFB** (Time to First Byte) for HTML | Server + GFW crossing | ms |
+| **Transferred bytes — static** | Bundle + CSS + fonts on the wire (post-compression) | KB |
+| **Transferred bytes — API** | Sum of all API responses during load | KB |
+| **# requests — total** | Proxy for round-trip count across GFW | count |
+| **# requests — API** | Specifically the API waterfall | count |
+| **API p50 TTFB** | Median cross-GFW API time | ms |
+| **API p95 TTFB** | Tail of cross-GFW API time (sensitive to packet loss) | ms |
+| **Protocol** | Proves HTTP/3 rollout | `h2` / `h3` |
+| **Font CSS TTFB** (isolated) | Specifically catches the Google Fonts block | ms or `timeout` |
+
+For RUM, additionally segment by `navigator.connection.effectiveType` (4g / 3g / slow-2g / wifi). The telemetry initializer in `web/src/lib/appinsights.ts` attaches this to every event.
+
+## Directory layout
+
+```
+docs/perf-baselines/
+├── README.md              — this file
+├── TEMPLATE.md            — copy per run
+├── azure-provisioning.md  — one-time user setup steps
+├── 2026-04-24-<sha>/      — baseline before any optimization
+│   ├── s1-beijing.har
+│   ├── s1-beijing.lighthouse.json
+│   ├── s1-beijing.filmstrip.png
+│   ├── s2-shanghai.har
+│   └── ... (one HAR / LH / filmstrip per scenario × probe)
+├── 2026-MM-DD-<sha>/      — after Phase 1 fix #1 (self-host fonts)
+│   └── ...
+└── summary.md             — running table of all baselines, diff by phase
+```
+
+Each phase's PR description cites the row in `summary.md` that names the metrics that moved, by how much, and any that didn't move in the expected direction (= the fix didn't do what we thought).
+
+## How to run a baseline
+
+See [`../../scripts/run-baseline.md`](../../scripts/run-baseline.md) for the step-by-step WebPageTest checklist.

--- a/docs/perf-baselines/TEMPLATE.md
+++ b/docs/perf-baselines/TEMPLATE.md
@@ -1,0 +1,72 @@
+# Baseline: YYYY-MM-DD — `<short-sha>`
+
+**Purpose of this run:** e.g. "Anchor before any optimization" / "After Phase 1 #1 (self-host fonts)"
+**Deploy state:** prod commit `<full-sha>`, frontend build `<hash>`, backend build `<hash>`
+**Run started at:** `YYYY-MM-DD HH:mm:ss Asia/Shanghai` (note: peak GFW congestion ≈ 20:00–23:00 Beijing; pick a consistent slot across baselines)
+**Operator:** `<name>`
+
+## Environment fingerprint
+
+| Field | Value |
+|---|---|
+| Frontend URL | |
+| API URL | |
+| CDN / Front Door | `none` / `AFD Standard` / ... |
+| SWA compression | `auto-brotli` |
+| API GZip middleware | `off` / `on` |
+| Font hosting | `Google Fonts` / `self-hosted` |
+| Route code splitting | `none` / `React.lazy` |
+| PWA / service worker | `off` / `on` |
+
+## Measurements
+
+Record the median of 3 runs per cell (WPT "Median" column, First View). Highlight anything that looks like a flaky outlier with `(flaky)` and note below.
+
+### S1 — Cold first load, Today page
+
+| Probe | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB (ms) | Static KB | API KB | # reqs | # API reqs | API p50 | API p95 | Protocol | Font CSS TTFB |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Beijing  | | | | | | | | | | | | |
+| Shanghai | | | | | | | | | | | | |
+| Hong Kong| | | | | | | | | | | | |
+| US West  | | | | | | | | | | | | |
+
+### S2 — Cold first load, Training page
+
+| Probe | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB (ms) | Static KB | API KB | # reqs | # API reqs | API p50 | API p95 | Protocol | Font CSS TTFB |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Beijing  | | | | | | | | | | | | |
+| Shanghai | | | | | | | | | | | | |
+| Hong Kong| | | | | | | | | | | | |
+| US West  | | | | | | | | | | | | |
+
+### S3 — Warm repeat visit, Today page
+
+| Probe | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB (ms) | Static KB | API KB | # reqs | # API reqs | API p50 | API p95 | Protocol |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Beijing  | | | | | | | | | | | |
+| Shanghai | | | | | | | | | | | |
+| Hong Kong| | | | | | | | | | | |
+| US West  | | | | | | | | | | | |
+
+## Observations
+
+- Surprising values (+ why you think it happened)
+- Flaky runs (+ what you did about them)
+- Anything that looks broken (e.g. "font CSS timed out at 30s in Shanghai")
+
+## Diff vs previous baseline
+
+If this is a "before" anchor, skip. If this is "after Phase X #Y", name the previous baseline here and list metrics that moved:
+
+- `FCP Beijing: 12800ms → 3100ms (-9700ms, -76%)` ✅ matches prediction
+- `API KB Training: 48 KB → 11 KB (-77%)` ✅ matches gzip prediction
+- `p95 API Beijing: no change` ⚠️ expected move from Phase 2 #4 — investigate
+
+## Raw artifacts
+
+Saved in this directory:
+- `sX-<probe>.har` — full network HAR export
+- `sX-<probe>.lighthouse.json` — Lighthouse JSON report
+- `sX-<probe>.filmstrip.png` — filmstrip screenshot strip (visual sanity check)
+- `sX-<probe>.wpt-link` — permalink to the WebPageTest result page

--- a/docs/perf-baselines/azure-provisioning.md
+++ b/docs/perf-baselines/azure-provisioning.md
@@ -1,0 +1,126 @@
+# Azure provisioning for observability
+
+One-time steps to stand up the Azure resources that make the RUM fabric work. After these, redeploy frontend + backend once and data starts flowing.
+
+**Prereqs:** you already have the App Service (`trainsight-app` in `rg-trainsight`) and the Static Web App live.
+
+## Auth model summary
+
+Two different auth paths in the same fabric, and that's intentional:
+
+- **Backend → App Insights:** App Service system-assigned **managed identity**. No secret in app settings; the `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is only used for routing (endpoint URL). Steps 2 + 4 below.
+- **Browser → App Insights:** build-time-embedded **connection string** as a write-only ingestion token (Microsoft's intended pattern — no MI flow exists for browsers). Step 5 below.
+
+Because the browser path needs ingestion-key auth, the App Insights resource **must leave local authentication enabled** (step 1d). Granting the backend a Monitor-Publisher role alongside doesn't weaken that; both paths coexist.
+
+## 1. Create the Application Insights resource
+
+1. Azure Portal → **Create a resource** → search **Application Insights** → Create.
+2. Settings:
+   - **Name:** `praxys-appinsights` (or your preference)
+   - **Region:** **East Asia** (same as App Service — minimises ingestion latency)
+   - **Resource group:** `rg-trainsight`
+   - **Resource mode:** **Workspace-based** (the only supported mode — picks or creates a Log Analytics workspace)
+   - **Log Analytics workspace:** create new `praxys-logs` in East Asia, or reuse an existing one
+3. Review + Create.
+4. Once deployed, open the resource → **Properties** blade → confirm **Local Authentication** is **Enabled**. Leave it as-is. (Disabling it would force AAD-only ingestion, which breaks the browser SDK — see auth model summary above.)
+5. Open **Overview** → copy the **Connection String** (a long `InstrumentationKey=...;IngestionEndpoint=...;...` blob). You'll paste it into App Service and GitHub in the next steps.
+
+## 2. Enable system-assigned managed identity on App Service
+
+1. Azure Portal → App Service `trainsight-app` → **Settings** → **Identity**.
+2. **System assigned** tab → Status: **On** → Save → confirm.
+3. Once enabled, the portal shows an **Object (principal) ID** — you'll need it in step 3. (The UI also offers direct "Azure role assignments" as a shortcut; step 3 uses the App Insights side of the assignment, which is simpler to reason about.)
+
+## 3. Grant the App Service MI the Monitoring Metrics Publisher role on App Insights
+
+1. Azure Portal → Application Insights `praxys-appinsights` → **Access control (IAM)** → **Add** → **Add role assignment**.
+2. **Role:** search for **Monitoring Metrics Publisher** → Next.
+3. **Members:** **Managed identity** → **Select members** → App Service → `trainsight-app` → Select → Next.
+4. Review + assign.
+5. Propagation usually takes <60s; give it a minute before redeploying.
+
+## 4. Wire the routing endpoint into App Service (backend)
+
+Even with MI auth, the backend still needs to know _where_ to send telemetry — that's what the connection string is for.
+
+1. App Service `trainsight-app` → **Settings** → **Environment variables** (or **Configuration** → **Application settings** on older portal UI).
+2. Add:
+   - **Name:** `APPLICATIONINSIGHTS_CONNECTION_STRING`
+   - **Value:** the connection string from step 1.5
+3. **Save** → confirm restart.
+
+`api/main.py` detects that `WEBSITE_SITE_NAME` is set (→ we're on App Service) and calls `configure_azure_monitor(credential=ManagedIdentityCredential())`. The InstrumentationKey portion of the env var is used only to route; auth is an AAD token from the MI.
+
+> If you ever switch to user-assigned MI: also add `AZURE_CLIENT_ID` to app settings with the UAMI's client ID. The code picks it up automatically.
+
+## 5. Wire the connection string into GitHub (frontend)
+
+The frontend value is a **repository variable**, not a secret — connection strings are write-only ingestion tokens and ship in every client bundle by design. Browsers have no MI path, so this is the correct pattern (see auth model summary above and the comment at the top of `web/src/lib/appinsights.ts`).
+
+1. GitHub → `dddtc2005/praxys` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab.
+2. **New repository variable:**
+   - **Name:** `VITE_APPINSIGHTS_CONNECTION_STRING`
+   - **Value:** the same connection string from step 1.5
+3. Save.
+
+The `.github/workflows/deploy-frontend.yml` workflow already references this variable in its `env:` block — the next deploy picks it up automatically.
+
+## 6. Kick a redeploy
+
+Easiest: push any small change that triggers both workflows, or manually trigger them via **Actions** tab → select workflow → **Run workflow** (the deploy backend workflow doesn't have a manual trigger yet, so the push route is simpler).
+
+## 7. Verify data is flowing
+
+Wait 2–5 minutes after the deploys finish, then:
+
+1. Browse the production site once — hit the homepage, log in, open Today, navigate to Training.
+2. Azure Portal → Application Insights `praxys-appinsights` → **Investigate** → **Live Metrics**. You should see the request come through in near real-time.
+3. **Logs** blade, run:
+   ```kusto
+   customMetrics
+   | where name startswith "WebVitals."
+   | order by timestamp desc
+   | take 20
+   ```
+   You should see FCP / LCP / INP / CLS / TTFB events with `effectiveType` / `downlink` / `rtt` in `customDimensions`.
+4. Confirm server-side:
+   ```kusto
+   requests
+   | where timestamp > ago(15m)
+   | project timestamp, name, duration, resultCode, cloud_RoleName
+   | order by timestamp desc
+   | take 20
+   ```
+
+If either side is empty after 10 minutes, check: env-var name spelling, workflow ran & succeeded, Python package install included `azure-monitor-opentelemetry`, MI role assignment propagated (check `AZ-ARM` logs if a `401` shows up on the exporter side), and — for the frontend — that the connection string made it into the built bundle (search `dist/assets/*.js` for the ingestion endpoint hostname).
+
+## 8. Create Availability Tests
+
+Always-on uptime + TTFB trend from Azure POPs. Free-ish (a few cents per month per test at 5-min cadence).
+
+1. Application Insights → **Availability** → **+ Add Standard test**.
+2. Test 1: **Frontend homepage**
+   - Name: `prod-homepage`
+   - URL: `https://<your-custom-domain>/`
+   - Test frequency: 5 minutes
+   - Test locations: **West US**, **North Europe**, **East Asia** (three is fine — more just costs more without adding much signal for our use case)
+   - Success criteria: HTTP 200, timeout 30s, parse dependent requests **off**
+   - Alerts: enable, route to your email
+3. Test 2: **Backend health endpoint**
+   - Same settings but URL `https://<your-api-domain>/api/health`
+4. Save both.
+
+After 15 minutes you'll have first data points; after 24 hours you'll have usable trend lines on the Availability blade.
+
+**Note:** Azure has no mainland China POPs, so these tests run from Hong Kong at closest. They complement but don't replace the WebPageTest probes run from inside mainland China — see `scripts/run-baseline.md`.
+
+## 9. (Later) Dashboards
+
+Once data's flowing, build an Azure Workbook that pivots by:
+- `customDimensions.effectiveType` — 4g / 3g / slow-2g / wifi
+- `client_CountryOrRegion` — CN vs rest
+- `cloud_RoleName` — frontend vs backend
+- Scenario (add a `scenario` custom dimension from client code if useful)
+
+Can be scaffolded later — not blocking any Phase 1 fix.

--- a/docs/perf-baselines/azure-provisioning.md
+++ b/docs/perf-baselines/azure-provisioning.md
@@ -83,7 +83,7 @@ Wait 2–5 minutes after the deploys finish, then:
    | order by timestamp desc
    | take 20
    ```
-   You should see FCP / LCP / INP / CLS / TTFB events with `effectiveType` / `downlink` / `rtt` in `customDimensions`.
+   You should see FCP / LCP / INP / CLS / TTFB events with `netinfo_effectiveType` / `netinfo_downlink` / `netinfo_rtt` in `customDimensions`. The telemetry initializer prefixes these with `netinfo_` to avoid shadowing SDK-native envelope fields — see the module header in `web/src/lib/appinsights.ts`.
 4. Confirm server-side:
    ```kusto
    requests
@@ -95,9 +95,9 @@ Wait 2–5 minutes after the deploys finish, then:
 
 If either side is empty after 10 minutes, check: env-var name spelling, workflow ran & succeeded, Python package install included `azure-monitor-opentelemetry`, MI role assignment propagated (check `AZ-ARM` logs if a `401` shows up on the exporter side), and — for the frontend — that the connection string made it into the built bundle (search `dist/assets/*.js` for the ingestion endpoint hostname).
 
-## 8. Create Availability Tests
+## 8. Create Standard availability tests
 
-Always-on uptime + TTFB trend from Azure POPs. Free-ish (a few cents per month per test at 5-min cadence).
+Always-on uptime + TTFB trend from Azure POPs. Free-ish (a few cents per month per test at 5-min cadence). Use **Standard tests**; the legacy "URL ping test" is retiring 30 Sept 2026.
 
 1. Application Insights → **Availability** → **+ Add Standard test**.
 2. Test 1: **Frontend homepage**
@@ -118,7 +118,7 @@ After 15 minutes you'll have first data points; after 24 hours you'll have usabl
 ## 9. (Later) Dashboards
 
 Once data's flowing, build an Azure Workbook that pivots by:
-- `customDimensions.effectiveType` — 4g / 3g / slow-2g / wifi
+- `customDimensions.netinfo_effectiveType` — 4g / 3g / slow-2g / wifi (note the prefix — `effectiveType` on its own won't match)
 - `client_CountryOrRegion` — CN vs rest
 - `cloud_RoleName` — frontend vs backend
 - Scenario (add a `scenario` custom dimension from client code if useful)

--- a/scripts/run-baseline.md
+++ b/scripts/run-baseline.md
@@ -9,12 +9,16 @@ Step-by-step for capturing a before/after snapshot using WebPageTest. Expect ~30
 
 ## Probe locations (in order)
 
-| Location | Role | WPT location string (verify current availability) |
+WPT's hosted location IDs drift as contributors come and go. Re-check `https://www.webpagetest.org/getLocations.php` before each run — don't assume any specific ID below is still live.
+
+| Location | Role | Example WPT location string (verify before run) |
 |---|---|---|
-| Beijing | Real CN mobile, China Mobile/Unicom backbone | `Beijing:Chrome` (availability varies — try `China:Chrome` as fallback) |
+| Beijing | Real CN mobile, China Mobile/Unicom backbone | `Beijing:Chrome` (availability varies; try `China:Chrome`) |
 | Shanghai | Real CN mobile, China Telecom backbone | `Shanghai:Chrome` |
 | Hong Kong | Azure origin region — isolates server/bundle from GFW | `HongKong:Chrome` |
-| US West | Global control — catches regressions that hurt everyone | `us-west-1:Chrome` or `Dulles_USWest:Chrome` |
+| US West | Global control — catches regressions that hurt everyone | `ec2-us-west-1:Chrome` (AWS-hosted WPT nodes use `ec2-<region>:Chrome`) |
+
+Note: `Dulles:Chrome` is WPT's default but it's on the US **East** Coast (Dulles, VA) — don't use it as a "US West" fallback. If `ec2-us-west-1` isn't currently offered, pick any West-Coast equivalent from the live list (Oregon, California) and record the exact ID in the baseline doc so future runs reproduce.
 
 If a CN location is flaky or unavailable on the day, note it in the baseline doc and fall back to 17ce.com for TTFB-only, or spin up an Alibaba Cloud Beijing VM with headless Chrome + Lighthouse as a one-off (~1 hour setup). Don't substitute a different city silently — consistency across baselines matters.
 

--- a/scripts/run-baseline.md
+++ b/scripts/run-baseline.md
@@ -1,0 +1,100 @@
+# Running a Performance Baseline
+
+Step-by-step for capturing a before/after snapshot using WebPageTest. Expect ~30–40 minutes end-to-end for 3 scenarios × 4 probe locations.
+
+## Tools
+
+- **WebPageTest** (webpagetest.org) — free tier gives 200 runs/month; paid API is ~$0.10–0.30/run if you blow through the free tier. Create an account to get an API key for scripted use.
+- **17ce.com** or **boce.com** (optional fallback) — free CN-only TTFB probe if WPT Beijing/Shanghai are unavailable. Doesn't give LCP/FCP.
+
+## Probe locations (in order)
+
+| Location | Role | WPT location string (verify current availability) |
+|---|---|---|
+| Beijing | Real CN mobile, China Mobile/Unicom backbone | `Beijing:Chrome` (availability varies — try `China:Chrome` as fallback) |
+| Shanghai | Real CN mobile, China Telecom backbone | `Shanghai:Chrome` |
+| Hong Kong | Azure origin region — isolates server/bundle from GFW | `HongKong:Chrome` |
+| US West | Global control — catches regressions that hurt everyone | `us-west-1:Chrome` or `Dulles_USWest:Chrome` |
+
+If a CN location is flaky or unavailable on the day, note it in the baseline doc and fall back to 17ce.com for TTFB-only, or spin up an Alibaba Cloud Beijing VM with headless Chrome + Lighthouse as a one-off (~1 hour setup). Don't substitute a different city silently — consistency across baselines matters.
+
+## Timing discipline
+
+Run all probes in the same calendar hour, **every baseline**. Recommended slot: **20:00–21:00 Asia/Shanghai** (Beijing evening peak — GFW is at its worst, so your numbers reflect the pessimistic real-user case).
+
+## The three scenarios
+
+Definitions live in `docs/perf-baselines/README.md`. Quick recap:
+- **S1** — Cold Today page (fresh profile, logged out → login → Today paint)
+- **S2** — Cold Training page (fresh profile, logged out → login → Training paint)
+- **S3** — Warm Today page (logged in, cache warm, tab revisit)
+
+## Script per scenario (WebPageTest UI)
+
+Use **Scripted** test mode for S1 and S2 (to chain login + navigate). S3 uses **Repeat View** of S1's script.
+
+### S1 script (paste into "Script" field)
+
+```
+setEventName Step1_Homepage
+navigate https://<your-production-domain>/
+
+setEventName Step2_Login
+setValue name=email your-perf-test@example.com
+setValue name=password <test-password>
+submitForm
+
+setEventName Step3_Today
+waitFor document.readyState == "complete"
+```
+
+Set advanced options:
+- **Connection:** `Native Connection` (don't throttle; you want real CN-mobile reality from the probe)
+- **Number of runs:** 3 (WPT medians for you)
+- **Capture Video:** on (for filmstrips)
+- **Capture HAR:** on
+- **Lighthouse:** on (captures the Lighthouse audit at the end)
+
+### S2 script
+
+Same as S1 but replace the final navigate with `navigate https://<your-production-domain>/training`.
+
+### S3 script
+
+Use WPT's **"Repeat View"** feature on the S1 script — it re-runs the test with cache populated from the first-view. Capture the Repeat View metrics row only.
+
+## What to save per run
+
+Create `docs/perf-baselines/<YYYY-MM-DD>-<short-sha>/` first. Then for each scenario × probe:
+
+- **HAR file:** WPT result page → "Export HAR" → save as `s1-beijing.har`
+- **Lighthouse JSON:** WPT result page → "Lighthouse" tab → download JSON → save as `s1-beijing.lighthouse.json`
+- **Filmstrip:** WPT result page → "Filmstrip View" → right-click save the composite image → save as `s1-beijing.filmstrip.png`
+- **WPT permalink:** copy the `https://www.webpagetest.org/result/...` URL → save as plain text in `s1-beijing.wpt-link`
+
+## Filling in TEMPLATE.md
+
+1. `cp docs/perf-baselines/TEMPLATE.md docs/perf-baselines/<YYYY-MM-DD>-<sha>/README.md`
+2. Fill the environment fingerprint from the current deploy state.
+3. For each row (probe × scenario), read values from the Lighthouse JSON and the HAR:
+   - **FCP / LCP / TTI / HTML TTFB** — Lighthouse JSON → `audits.metrics.details.items[0]`
+   - **Static KB / API KB** — HAR → sum `response.content.size` where `request.url` matches domain vs `/api/*`
+   - **# reqs / # API reqs** — HAR → count entries, split on `/api/*`
+   - **API p50 / p95** — HAR → for entries matching `/api/*`, compute percentiles of `timings.wait + timings.receive`
+   - **Protocol** — HAR → `_securityState` or `response.httpVersion` (look for `h2` / `h3`)
+   - **Font CSS TTFB** — HAR → row for `fonts.googleapis.com/css2?...` → `timings.wait` (if timeout, write `timeout`)
+4. Note observations + flaky cells at the bottom.
+5. Update `docs/perf-baselines/summary.md` with a one-row-per-phase rollup (create if missing).
+
+## Commit convention
+
+Each baseline lands in its own commit — not bundled with the code PR it measures. The code PR description links to the baseline commit for the "after" numbers.
+
+Commit subject: `Perf baseline: <reason>` — e.g. `Perf baseline: anchor before optimization` or `Perf baseline: after Phase 1 #1 (self-host fonts)`.
+
+## If you hit weirdness
+
+- **WPT probe queue is backed up** — try 30 min later. Beijing/Shanghai queues spike during APAC business hours.
+- **Lighthouse score looks crazy (e.g. 0 for everything)** — probe likely hit a 5xx or a TLS error during the run. Check the HAR before trusting the numbers.
+- **Different # of requests across runs** — usually retries or CORS preflight variance. Take the median or note the variance.
+- **CN probe TLS-handshakes are slower than expected** — that's the GFW. It's the point of running from CN. The numbers are valid.


### PR DESCRIPTION
## Summary

Third and final PR of the observability fabric. This one is **docs-only** — no code change — and closes out the measurement story so every upcoming perf fix can point at a concrete before/after row rather than relying on "it feels faster."

Companion PRs (shipping together):
- PR-A ✅ merged — `5c0267b` — FastAPI + App Insights with managed identity (also edited `.env.example` to document the backend env var)
- PR-B ✅ merged — `5a91ee4` — SPA + App Insights + web-vitals (namespaces custom dimensions under `netinfo_*`)
- **PR-C (this)** — baseline discipline + Azure provisioning checklist

## What's added

- `docs/perf-baselines/README.md` — layer model (lab Lighthouse CI / multi-region WebPageTest / production Azure Application Insights RUM), the three scenarios (S1 cold Today / S2 cold Training / S3 warm Today), and the metric table with units and the reason each metric matters.
- `docs/perf-baselines/TEMPLATE.md` — copy-per-run skeleton with the probe × scenario matrix pre-wired. Forces consistent capture so baselines across phases are apples-to-apples comparable.
- `docs/perf-baselines/azure-provisioning.md` — numbered portal checklist covering the split auth model:
  - Backend → App Insights via **system-assigned managed identity** + "Monitoring Metrics Publisher" role (no secret in app settings).
  - Browser → App Insights via **connection string** as a write-only ingestion token (the only pattern Microsoft supports for client-side; no MI flow exists in browsers).
  - Local authentication on the AI resource stays **enabled** because disabling it breaks the browser path.
  - Availability Tests setup from West US / North Europe / East Asia, with an explicit note that Azure has no mainland China POPs — these complement but don't replace the WPT-from-CN probes.
- `scripts/run-baseline.md` — WPT run recipe for Beijing + Shanghai + Hong Kong + US West, scripted login chain, what to export, naming convention, exact HAR / Lighthouse fields to read for each metric cell, fallback paths when WPT CN probes are unavailable.

## Baseline timing discipline

Every run happens in the same calendar hour (recommended 20:00-21:00 Asia/Shanghai — CN evening peak, when the GFW is at its worst) so day-to-day network variance doesn't masquerade as a fix delta.

## Review feedback addressed (commit `e15dd0c`)

Four doc-only corrections that would have bitten a reader following the steps verbatim:

1. **KQL field names.** Verification step 7.3 and Dashboards §9 wrote `customDimensions.effectiveType` — but PR-B's telemetry initializer prefixes every field with `netinfo_` to avoid shadowing SDK-native envelope fields. A copy-paste would return empty rows. Renamed to `netinfo_effectiveType` etc. in both docs and in the README segmentation note.
2. **"Standard URL ping" isn't a real feature name.** The current Azure Monitor feature is "Standard test"; the legacy "URL ping test" is being retired 30 Sept 2026. §8 renamed + one-liner added so the reader knows which to pick.
3. **`Dulles_USWest:Chrome` is WPT's US East Coast node** (Dulles, VA). Replaced with `ec2-us-west-1:Chrome` and added a note pointing at `webpagetest.org/getLocations.php` as the canonical source, since hosted WPT locations drift.
4. **`summary.md` annotation** — directory-layout tree now shows it as "(created on first real baseline run)" so nobody hunts for a file that doesn't exist yet.

## What happens next (not in this PR)

Once this merges, the user-owned steps kick in:

1. Create the Application Insights resource + workspace in East Asia
2. Enable system-assigned MI on App Service + grant Monitoring Metrics Publisher role
3. Set `APPLICATIONINSIGHTS_CONNECTION_STRING` in App Service app settings (routing only)
4. Set `VITE_APPINSIGHTS_CONNECTION_STRING` as a GitHub repo var
5. Redeploy, verify data flowing
6. Create Standard availability tests from three regions

Then capture the first baseline with WPT before any Phase 1 optimization PR touches code. Each subsequent perf fix lands with a new baseline row so we can attribute gains.

## Test plan

- [x] Rebased onto post-PR-B `main` (`5a91ee4`)
- [x] All four markdown files render correctly on GitHub
- [x] Cross-references between docs resolve (`README` → `TEMPLATE` / `azure-provisioning` / `scripts/run-baseline`)
- [x] All `customDimensions.*` field names in the docs match what PR-B's `web/src/lib/appinsights.ts` actually ships (`netinfo_*` prefix)
- [ ] Post-merge: run the first baseline and fill in the TEMPLATE → commit into `docs/perf-baselines/<YYYY-MM-DD>-<sha>/` as a follow-up PR