### PR TITLE
Fix og:url / og:image to use www.praxys.run (apex not live)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,8 +16,8 @@
     <meta property="og:site_name"    content="Praxys" />
     <meta property="og:title"        content="Praxys — Train like a pro. Whatever your level." />
     <meta property="og:description"  content="Science-grounded insights, personalized zones, and a plan that evolves with you. For every runner — road to trail." />
-    <meta property="og:url"          content="https://praxys.run/" />
-    <meta property="og:image"        content="https://praxys.run/og-card.png" />
+    <meta property="og:url"          content="https://www.praxys.run/" />
+    <meta property="og:image"        content="https://www.praxys.run/og-card.png" />
     <meta property="og:image:width"  content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt"    content="Praxys — sports science that meets you where you are. Every step, reasoned." />
@@ -26,11 +26,11 @@
     <meta name="twitter:card"        content="summary_large_image" />
     <meta name="twitter:title"       content="Praxys — Train like a pro. Whatever your level." />
     <meta name="twitter:description" content="Science-grounded insights, personalized zones, and a plan that evolves with you." />
-    <meta name="twitter:image"       content="https://praxys.run/og-card.png" />
+    <meta name="twitter:image"       content="https://www.praxys.run/og-card.png" />
 
     <meta itemprop="name"        content="Praxys" />
     <meta itemprop="description" content="Sports science that meets you where you are. Every step, reasoned." />
-    <meta itemprop="image"       content="https://praxys.run/og-card.png" />
+    <meta itemprop="image"       content="https://www.praxys.run/og-card.png" />
     <script>
       // Apply theme before first paint to prevent flash. Dual-reads the
       // legacy 'trainsight-theme' key until the 90-day migration window closes.


### PR DESCRIPTION
## Summary

LinkedIn Post Inspector (and Facebook / Twitter validators) report "No image found" and show a broken canonical URL for the site. Reason:

- The page is served at `https://www.praxys.run/`.
- But `og:url` and three `og:image` / `twitter:image` / `itemprop=image` tags all point at `https://praxys.run/…` (apex).
- The apex has no public DNS yet. Crawlers fetch the page from www successfully, then try to validate the image at the apex URL → DNS failure → "No image found".

Fix: point all OG-visible URLs at `www.praxys.run`, the only host that actually resolves.

Apex support can land later (SWA `stableInboundIP` A-record, or a DNS move away from DNSPod free tier which doesn't support ALIAS). When that happens, `www` is already the canonical we advertise — no further edit required.

## Test Plan

- [ ] After deploy: paste `https://www.praxys.run/` into LinkedIn Post Inspector → image renders, canonical reads `https://www.praxys.run/`.
- [ ] Facebook Sharing Debugger → scrape again → image preview visible.
- [ ] Twitter Card Validator → `summary_large_image` with image shown.
- [ ] WeChat chat paste → thumbnail still works (was working; no regression expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)