### PR TITLE
Expand perf-baseline matrix: desktop + mobile, Tier 1-3, S4 Landing

### DIFF
--- a/docs/perf-baselines/README.md
+++ b/docs/perf-baselines/README.md
@@ -16,17 +16,59 @@ Mainland-China users cross the Great Firewall to hit our Azure East Asia deploym
 
 Azure Availability Tests (cheap URL pings from multiple Azure regions) provide an always-on uptime + TTFB baseline — see [`azure-provisioning.md`](./azure-provisioning.md) to set them up.
 
-## The three scenarios
+## The scenarios
 
-Run all three for every baseline. Identical inputs → deltas attribute to code changes, not measurement noise.
+Run all four for every baseline. Identical inputs → deltas attribute to code changes, not measurement noise.
 
 - **S1 — Cold first load of Today page.** Empty cache, no service worker. Navigate to the homepage → log in → Today paints. The "new user" path.
 - **S2 — Cold first load of Training page.** Same pre-conditions as S1 but navigate to `/training` — currently fires 7 API round-trips, our worst offender.
 - **S3 — Warm repeat visit to Today.** Authenticated, cache populated (service worker active once Phase 2 #7 lands), tab revisit. The "daily use" path.
+- **S4 — Anonymous Landing page.** Empty cache, not logged in. Navigate to `/` and measure. Critical for seeing Google Fonts blocking in isolation — this is the first impression for every new visitor, and it's also what WeChat-shared links open into.
+
+## Test-matrix tiers
+
+You can't meaningfully run every (geography × device × browser × network × scenario) combination for every PR. The matrix below is split by cost-of-drift: Tier 1 runs for every baseline so deltas are attributable; Tier 2 runs periodically to catch drift the core misses; Tier 3 is ad-hoc when investigating a specific bug.
+
+### Tier 1 — every baseline (before/after each perf fix)
+
+| Axis | Value |
+|---|---|
+| Geography | Beijing, Shanghai, Hong Kong, US West |
+| Device | Desktop Chrome (1920×1080), Mobile Chrome (iPhone 14-class emulation) |
+| Browser | Chrome latest |
+| Network | Native (the probe's real connection — not throttled) |
+| Scenario | S1, S2, S3, S4 |
+| Time-of-day | 20:00–21:00 Asia/Shanghai (CN evening peak when GFW is worst) |
+| Runs per cell | 3 (WPT computes median) |
+
+**Cell count:** 4 geographies × 2 devices × 4 scenarios = **32 cells per baseline**. Both desktop and mobile are non-optional — users hit this app from both laptops (training analysis) and phones (daily check-in), and they can regress independently.
+
+### Tier 2 — periodic (every 2–4 baselines or pre-release)
+
+Catches what Tier 1 misses without bloating the per-fix loop:
+
+- **WeChat embedded browser (X5) from Beijing + Shanghai** — uniquely Chinese reality. Shared links from WeChat open in the X5 in-app browser, which has its own font-loading, cache, and JS-bridge quirks. WPT doesn't ship a WeChat-browser location, so this runs via an Alibaba Cloud Beijing VM with Android + WeChat + remote-DevTools capture. One-time setup, then scriptable.
+- **Safari (iOS emulation) from 2 probes** — iOS users are a big CN segment; catches WebKit-specific bundle / CSS / Intl issues.
+- **Tablet viewport from 1 probe** — catches responsive-layout regressions on charts and grids.
+- **Throttled 3G from Hong Kong** — stress test for payload size, isolated from GFW noise by using HK as the base probe.
+
+### Tier 3 — ad-hoc investigations
+
+Use when chasing a specific bug, rolling a region, or answering a targeted question. Not run on every baseline.
+
+- Other CN cities (Shenzhen, Chengdu, Chongqing) — different ISP peering
+- Edge, Firefox, UC Browser, QQ Browser
+- Off-peak comparison (07:00 Asia/Shanghai) to quantify GFW variance
+- Accessibility / reduced-motion profile audits
+- Custom HAR + devtools-protocol trace capture for deep-dive diffs
+
+### What RUM covers automatically
+
+The Application Insights wire (backend + SPA) segments the real user population by browser, OS, device type, country, and `customDimensions.netinfo_effectiveType`. Every real browser / network shows up in production data without us synthesizing it. The synthetic Tier 1/2/3 matrix exists for **reproducibility** (a fix's delta must be attributable), not for coverage of every user configuration.
 
 ## What to capture per run
 
-For each scenario × probe location:
+For each Tier 1 cell (scenario × probe × device — 32 cells total):
 
 | Metric | Why it matters | Units |
 |---|---|---|

--- a/docs/perf-baselines/TEMPLATE.md
+++ b/docs/perf-baselines/TEMPLATE.md
@@ -53,13 +53,13 @@ Record the median of 3 runs per cell (WPT "Median" column, First View). Highligh
 | Probe | Device | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB | Static KB | API KB | # reqs | # API | API p50 | API p95 | Protocol |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
 | Beijing   | Desktop | | | | | | | | | | | |
-| Beijing   | Mobile  | | | | | | | | | | | | |
-| Shanghai  | Desktop | | | | | | | | | | | | |
-| Shanghai  | Mobile  | | | | | | | | | | | | |
-| Hong Kong | Desktop | | | | | | | | | | | | |
-| Hong Kong | Mobile  | | | | | | | | | | | | |
-| US West   | Desktop | | | | | | | | | | | | |
-| US West   | Mobile  | | | | | | | | | | | | |
+| Beijing   | Mobile  | | | | | | | | | | | |
+| Shanghai  | Desktop | | | | | | | | | | | |
+| Shanghai  | Mobile  | | | | | | | | | | | |
+| Hong Kong | Desktop | | | | | | | | | | | |
+| Hong Kong | Mobile  | | | | | | | | | | | |
+| US West   | Desktop | | | | | | | | | | | |
+| US West   | Mobile  | | | | | | | | | | | |
 
 ### S4 — Anonymous Landing page
 

--- a/docs/perf-baselines/TEMPLATE.md
+++ b/docs/perf-baselines/TEMPLATE.md
@@ -18,36 +18,67 @@
 | Route code splitting | `none` / `React.lazy` |
 | PWA / service worker | `off` / `on` |
 
-## Measurements
+## Measurements (Tier 1)
 
-Record the median of 3 runs per cell (WPT "Median" column, First View). Highlight anything that looks like a flaky outlier with `(flaky)` and note below.
+Record the median of 3 runs per cell (WPT "Median" column, First View). Highlight anything that looks like a flaky outlier with `(flaky)` and note in the Observations section. Tier 1 matrix is 4 probes × 2 devices × 4 scenarios = 32 cells.
 
-### S1 — Cold first load, Today page
+### S1 — Cold first load, Today page (via login)
 
-| Probe | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB (ms) | Static KB | API KB | # reqs | # API reqs | API p50 | API p95 | Protocol | Font CSS TTFB |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Beijing  | | | | | | | | | | | | |
-| Shanghai | | | | | | | | | | | | |
-| Hong Kong| | | | | | | | | | | | |
-| US West  | | | | | | | | | | | | |
+| Probe | Device | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB | Static KB | API KB | # reqs | # API | API p50 | API p95 | Protocol | Font CSS TTFB |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Beijing   | Desktop | | | | | | | | | | | | |
+| Beijing   | Mobile  | | | | | | | | | | | | |
+| Shanghai  | Desktop | | | | | | | | | | | | |
+| Shanghai  | Mobile  | | | | | | | | | | | | |
+| Hong Kong | Desktop | | | | | | | | | | | | |
+| Hong Kong | Mobile  | | | | | | | | | | | | |
+| US West   | Desktop | | | | | | | | | | | | |
+| US West   | Mobile  | | | | | | | | | | | | |
 
-### S2 — Cold first load, Training page
+### S2 — Cold first load, Training page (via login)
 
-| Probe | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB (ms) | Static KB | API KB | # reqs | # API reqs | API p50 | API p95 | Protocol | Font CSS TTFB |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Beijing  | | | | | | | | | | | | |
-| Shanghai | | | | | | | | | | | | |
-| Hong Kong| | | | | | | | | | | | |
-| US West  | | | | | | | | | | | | |
+| Probe | Device | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB | Static KB | API KB | # reqs | # API | API p50 | API p95 | Protocol | Font CSS TTFB |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Beijing   | Desktop | | | | | | | | | | | | |
+| Beijing   | Mobile  | | | | | | | | | | | | |
+| Shanghai  | Desktop | | | | | | | | | | | | |
+| Shanghai  | Mobile  | | | | | | | | | | | | |
+| Hong Kong | Desktop | | | | | | | | | | | | |
+| Hong Kong | Mobile  | | | | | | | | | | | | |
+| US West   | Desktop | | | | | | | | | | | | |
+| US West   | Mobile  | | | | | | | | | | | | |
 
 ### S3 — Warm repeat visit, Today page
 
-| Probe | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB (ms) | Static KB | API KB | # reqs | # API reqs | API p50 | API p95 | Protocol |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| Beijing  | | | | | | | | | | | |
-| Shanghai | | | | | | | | | | | |
-| Hong Kong| | | | | | | | | | | |
-| US West  | | | | | | | | | | | |
+| Probe | Device | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB | Static KB | API KB | # reqs | # API | API p50 | API p95 | Protocol |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Beijing   | Desktop | | | | | | | | | | | |
+| Beijing   | Mobile  | | | | | | | | | | | | |
+| Shanghai  | Desktop | | | | | | | | | | | | |
+| Shanghai  | Mobile  | | | | | | | | | | | | |
+| Hong Kong | Desktop | | | | | | | | | | | | |
+| Hong Kong | Mobile  | | | | | | | | | | | | |
+| US West   | Desktop | | | | | | | | | | | | |
+| US West   | Mobile  | | | | | | | | | | | | |
+
+### S4 — Anonymous Landing page
+
+No login, no API calls (or one public health ping). Font CSS TTFB is the critical cell here — it's where Google-Fonts blocking in CN shows up loudest.
+
+| Probe | Device | FCP (ms) | LCP (ms) | TTI (ms) | HTML TTFB | Static KB | # reqs | Protocol | Font CSS TTFB |
+|---|---|---|---|---|---|---|---|---|---|
+| Beijing   | Desktop | | | | | | | | |
+| Beijing   | Mobile  | | | | | | | | |
+| Shanghai  | Desktop | | | | | | | | |
+| Shanghai  | Mobile  | | | | | | | | |
+| Hong Kong | Desktop | | | | | | | | |
+| Hong Kong | Mobile  | | | | | | | | |
+| US West   | Desktop | | | | | | | | |
+| US West   | Mobile  | | | | | | | | |
+
+## Tier 2 / Tier 3 runs (if any were done this baseline)
+
+Tier 2 and Tier 3 are optional per baseline — only fill in if actually captured. Use free-form tables or prose; link artifact paths in this directory.
 
 ## Observations
 
@@ -57,16 +88,20 @@ Record the median of 3 runs per cell (WPT "Median" column, First View). Highligh
 
 ## Diff vs previous baseline
 
-If this is a "before" anchor, skip. If this is "after Phase X #Y", name the previous baseline here and list metrics that moved:
+If this is a "before" anchor, skip. If this is "after Phase X #Y", name the previous baseline here and list metrics that moved. Call out desktop vs mobile separately where they diverge — fixes often land on one form factor before the other.
 
-- `FCP Beijing: 12800ms → 3100ms (-9700ms, -76%)` ✅ matches prediction
-- `API KB Training: 48 KB → 11 KB (-77%)` ✅ matches gzip prediction
-- `p95 API Beijing: no change` ⚠️ expected move from Phase 2 #4 — investigate
+- `S4 FCP Beijing Desktop: 8400ms → 820ms (-7580ms, -90%)` ✅ matches font-self-host prediction
+- `S4 FCP Beijing Mobile:  11200ms → 1150ms (-10050ms, -90%)` ✅ same pattern, worse baseline
+- `S2 API KB Training (any device): 48 KB → 11 KB (-77%)` ✅ matches gzip prediction
+- `S2 p95 API Beijing Mobile: no change` ⚠️ expected move from Phase 2 #4 — investigate
 
 ## Raw artifacts
 
-Saved in this directory:
-- `sX-<probe>.har` — full network HAR export
-- `sX-<probe>.lighthouse.json` — Lighthouse JSON report
-- `sX-<probe>.filmstrip.png` — filmstrip screenshot strip (visual sanity check)
-- `sX-<probe>.wpt-link` — permalink to the WebPageTest result page
+Saved in this directory. Naming convention: `sN-<probe>-<device>.<ext>`.
+
+- `sN-<probe>-<device>.har` — full network HAR export
+- `sN-<probe>-<device>.lighthouse.json` — Lighthouse JSON report
+- `sN-<probe>-<device>.filmstrip.png` — filmstrip strip (visual sanity check)
+- `sN-<probe>-<device>.wpt-link` — permalink to the WebPageTest result page
+
+Example: `s1-beijing-mobile.har`, `s4-hongkong-desktop.lighthouse.json`.

--- a/scripts/run-baseline.md
+++ b/scripts/run-baseline.md
@@ -1,6 +1,8 @@
 # Running a Performance Baseline
 
-Step-by-step for capturing a before/after snapshot using WebPageTest. Expect ~30–40 minutes end-to-end for 3 scenarios × 4 probe locations.
+Step-by-step for capturing a before/after snapshot using WebPageTest. The **Tier 1 matrix** (defined in `docs/perf-baselines/README.md#test-matrix-tiers`) is **4 probes × 2 devices × 4 scenarios = 32 cells**, 3 runs per cell → ~90 minutes of wall clock time, most of it waiting on queues rather than hands-on work.
+
+Tier 2 / Tier 3 runs (WeChat X5, Safari, tablet viewport, throttled 3G, etc.) are separate protocols — see the "Tier 2 specifics" section at the bottom.
 
 ## Tools
 
@@ -24,18 +26,49 @@ If a CN location is flaky or unavailable on the day, note it in the baseline doc
 
 ## Timing discipline
 
-Run all probes in the same calendar hour, **every baseline**. Recommended slot: **20:00–21:00 Asia/Shanghai** (Beijing evening peak — GFW is at its worst, so your numbers reflect the pessimistic real-user case).
+Run all probes in the same calendar hour, **every baseline**. Recommended slot: **20:00–21:00 Asia/Shanghai** (Beijing evening peak — GFW is at its worst, so your numbers reflect the pessimistic real-user case). Don't split desktop across 20:00 and mobile across 21:00 — that's how you end up attributing a GFW burst to a "fix."
 
-## The three scenarios
+## The four scenarios
 
 Definitions live in `docs/perf-baselines/README.md`. Quick recap:
 - **S1** — Cold Today page (fresh profile, logged out → login → Today paint)
 - **S2** — Cold Training page (fresh profile, logged out → login → Training paint)
 - **S3** — Warm Today page (logged in, cache warm, tab revisit)
+- **S4** — Anonymous Landing page (logged out, navigate to `/`, no login)
+
+## Desktop vs Mobile settings (run each scenario twice)
+
+Both form factors are Tier 1. Same WPT script, different run-level options. Keep the location string identical across the desktop/mobile pair from the same probe so the only variable is the device.
+
+### Desktop (1920×1080 Chrome)
+
+| WPT option | Value |
+|---|---|
+| Location | the Tier 1 probe (Beijing / Shanghai / HongKong / ec2-us-west-1) |
+| Browser | `Chrome` |
+| Connection | **Native Connection** (do NOT throttle — we want the probe's real network) |
+| Mobile | **off** (no emulation) |
+| Viewport | default (1920×1080 — WPT desktop default) |
+| Number of runs | 3 |
+| Capture Video / HAR / Lighthouse | on / on / on |
+
+### Mobile (iPhone-class Chrome on Android emulation)
+
+| WPT option | Value |
+|---|---|
+| Location | same as desktop pair |
+| Browser | `Chrome` |
+| Connection | **Native Connection** (explicitly override WPT's default mobile throttle — we want real CN-mobile reality, not WPT's fixed "Mobile 4G" profile of 1.6 Mbps / 150 ms) |
+| Mobile | **on** (emulation) |
+| Emulated device | iPhone 14 or equivalent (check "Emulate Mobile Browser" → pick from device list) |
+| Number of runs | 3 |
+| Capture Video / HAR / Lighthouse | on / on / on |
+
+The Mobile/Native combination is deliberate: it gives us a real-world answer to "what does a CN user on their phone actually see," not the lab-ideal "what would a CN user on a fixed-profile 4G see." If you want the throttled-4G stress view, that lives in Tier 2.
 
 ## Script per scenario (WebPageTest UI)
 
-Use **Scripted** test mode for S1 and S2 (to chain login + navigate). S3 uses **Repeat View** of S1's script.
+Use **Scripted** test mode for S1 / S2 (to chain login + navigate). S3 uses **Repeat View** of the S1 script. S4 is a plain **URL test** (no script needed).
 
 ### S1 script (paste into "Script" field)
 
@@ -52,42 +85,43 @@ setEventName Step3_Today
 waitFor document.readyState == "complete"
 ```
 
-Set advanced options:
-- **Connection:** `Native Connection` (don't throttle; you want real CN-mobile reality from the probe)
-- **Number of runs:** 3 (WPT medians for you)
-- **Capture Video:** on (for filmstrips)
-- **Capture HAR:** on
-- **Lighthouse:** on (captures the Lighthouse audit at the end)
-
 ### S2 script
 
 Same as S1 but replace the final navigate with `navigate https://<your-production-domain>/training`.
 
 ### S3 script
 
-Use WPT's **"Repeat View"** feature on the S1 script — it re-runs the test with cache populated from the first-view. Capture the Repeat View metrics row only.
+Use WPT's **"Repeat View"** feature on the S1 script — it re-runs the test with cache populated from the first-view. Capture the Repeat View metrics row only. Once Phase 2 #7 (PWA) lands, S3 is where the service-worker win shows up most clearly — expect the sharpest desktop vs. mobile divergence here because mobile devices have tighter SW cache quotas.
+
+### S4 (no script — plain URL test)
+
+URL: `https://<your-production-domain>/`
+Runs: 3
+Settings: identical to S1, minus the script (it's a single-page load with no login). Font CSS TTFB is the critical cell in S4.
 
 ## What to save per run
 
-Create `docs/perf-baselines/<YYYY-MM-DD>-<short-sha>/` first. Then for each scenario × probe:
+Create `docs/perf-baselines/<YYYY-MM-DD>-<short-sha>/` first. Then for each cell (scenario × probe × device — 32 total for Tier 1):
 
-- **HAR file:** WPT result page → "Export HAR" → save as `s1-beijing.har`
-- **Lighthouse JSON:** WPT result page → "Lighthouse" tab → download JSON → save as `s1-beijing.lighthouse.json`
-- **Filmstrip:** WPT result page → "Filmstrip View" → right-click save the composite image → save as `s1-beijing.filmstrip.png`
-- **WPT permalink:** copy the `https://www.webpagetest.org/result/...` URL → save as plain text in `s1-beijing.wpt-link`
+- **HAR file:** WPT result page → "Export HAR" → save as `s1-beijing-desktop.har`
+- **Lighthouse JSON:** WPT result page → "Lighthouse" tab → download JSON → save as `s1-beijing-desktop.lighthouse.json`
+- **Filmstrip:** WPT result page → "Filmstrip View" → right-click save the composite image → save as `s1-beijing-desktop.filmstrip.png`
+- **WPT permalink:** copy the `https://www.webpagetest.org/result/...` URL → save as plain text in `s1-beijing-desktop.wpt-link`
+
+Naming is strict: `s<1-4>-<probe>-<desktop|mobile>.<ext>`. If you hand-name one artifact differently, the diff script later won't line up desktop-vs-mobile deltas automatically.
 
 ## Filling in TEMPLATE.md
 
 1. `cp docs/perf-baselines/TEMPLATE.md docs/perf-baselines/<YYYY-MM-DD>-<sha>/README.md`
 2. Fill the environment fingerprint from the current deploy state.
-3. For each row (probe × scenario), read values from the Lighthouse JSON and the HAR:
+3. For each cell (probe × device × scenario), read values from the Lighthouse JSON and the HAR:
    - **FCP / LCP / TTI / HTML TTFB** — Lighthouse JSON → `audits.metrics.details.items[0]`
    - **Static KB / API KB** — HAR → sum `response.content.size` where `request.url` matches domain vs `/api/*`
    - **# reqs / # API reqs** — HAR → count entries, split on `/api/*`
    - **API p50 / p95** — HAR → for entries matching `/api/*`, compute percentiles of `timings.wait + timings.receive`
    - **Protocol** — HAR → `_securityState` or `response.httpVersion` (look for `h2` / `h3`)
    - **Font CSS TTFB** — HAR → row for `fonts.googleapis.com/css2?...` → `timings.wait` (if timeout, write `timeout`)
-4. Note observations + flaky cells at the bottom.
+4. Note observations + flaky cells at the bottom. Desktop vs mobile divergence is worth calling out explicitly when it happens.
 5. Update `docs/perf-baselines/summary.md` with a one-row-per-phase rollup (create if missing).
 
 ## Commit convention
@@ -102,3 +136,29 @@ Commit subject: `Perf baseline: <reason>` — e.g. `Perf baseline: anchor before
 - **Lighthouse score looks crazy (e.g. 0 for everything)** — probe likely hit a 5xx or a TLS error during the run. Check the HAR before trusting the numbers.
 - **Different # of requests across runs** — usually retries or CORS preflight variance. Take the median or note the variance.
 - **CN probe TLS-handshakes are slower than expected** — that's the GFW. It's the point of running from CN. The numbers are valid.
+- **Mobile emulation LCP is higher than desktop from the same probe** — expected. Smaller viewport = different "largest element," CPU throttle on mobile emulation, slower paint. The gap itself is the signal — if the gap *widens* after a fix, something went wrong.
+
+## Tier 2 specifics (when you run them)
+
+These aren't part of the standard Tier 1 loop. Run them periodically (every 2–4 baselines) or before a release.
+
+### WeChat embedded browser (X5) — Beijing + Shanghai
+
+WPT doesn't offer X5. Workflow:
+1. Provision an Alibaba Cloud ECS in Beijing (smallest burstable tier; ~¥0.5/hr) with Android-x86 or Genymotion.
+2. Install WeChat on the emulator; log in with a throwaway account.
+3. Share the production URL into a personal WeChat chat (to yourself), tap the link to open it in WeChat's embedded browser.
+4. Capture via Chrome DevTools remote debugging against the X5 rendering engine — HAR + performance trace.
+5. Save as `tier2-wechat-s4-beijing.har` etc.
+
+### Safari (iOS emulation) — 2 probes
+
+In WPT, select Browser: `Safari` + Mobile emulation on. Available from `Dulles:Safari` historically; availability varies — check getLocations.php. If no Safari from your chosen CN probes, run from Dulles as a WebKit-behavior control and accept that it won't capture GFW effects.
+
+### Tablet viewport — 1 probe
+
+Any probe. In WPT "Emulate Mobile Browser" field, pick "iPad" or similar. Run S1 and S4 only.
+
+### Throttled 3G from Hong Kong
+
+HK + **Slow 3G** connection profile (400 Kbps / 400 Kbps / 400 ms RTT). HK isolates payload-size effects from GFW noise so you can see if Phase 1 #2 (code splitting) actually helps slow connections. Run S1 + S2 only.

--- a/scripts/run-baseline.md
+++ b/scripts/run-baseline.md
@@ -1,6 +1,6 @@
 # Running a Performance Baseline
 
-Step-by-step for capturing a before/after snapshot using WebPageTest. The **Tier 1 matrix** (defined in `docs/perf-baselines/README.md#test-matrix-tiers`) is **4 probes × 2 devices × 4 scenarios = 32 cells**, 3 runs per cell → ~90 minutes of wall clock time, most of it waiting on queues rather than hands-on work.
+Step-by-step for capturing a before/after snapshot using WebPageTest. The **Tier 1 matrix** (defined in `docs/perf-baselines/README.md#test-matrix-tiers`) is **4 probes × 2 devices × 4 scenarios = 32 cells**, 3 runs per cell → **~90–150 minutes** of wall clock time, most of it WPT queue wait (CN probes at 20:00 Asia/Shanghai routinely run 5–10 min per submission).
 
 Tier 2 / Tier 3 runs (WeChat X5, Safari, tablet viewport, throttled 3G, etc.) are separate protocols — see the "Tier 2 specifics" section at the bottom.
 
@@ -59,8 +59,8 @@ Both form factors are Tier 1. Same WPT script, different run-level options. Keep
 | Location | same as desktop pair |
 | Browser | `Chrome` |
 | Connection | **Native Connection** (explicitly override WPT's default mobile throttle — we want real CN-mobile reality, not WPT's fixed "Mobile 4G" profile of 1.6 Mbps / 150 ms) |
-| Mobile | **on** (emulation) |
-| Emulated device | iPhone 14 or equivalent (check "Emulate Mobile Browser" → pick from device list) |
+| Mobile | check **"Emulate Mobile Browser"** |
+| Device | iPhone 14 (or the latest iPhone profile in the WPT device dropdown — WPT pulls the list from Chrome DevTools) |
 | Number of runs | 3 |
 | Capture Video / HAR / Lighthouse | on / on / on |
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to PR-C. Clarifies that the baseline test matrix covers **both desktop and mobile** (not just mobile as the original docs implied), and adds Tier 1 / Tier 2 / Tier 3 structure so we're explicit about which cells run every baseline vs. periodic vs. ad-hoc.

Also adds **S4 Anonymous Landing** as a Tier 1 scenario — it's where Google-Fonts render-blocking shows up most visibly (no authenticated API waterfall muddying the picture), and it's what WeChat-shared links open into for CN users.

## The Tier 1 matrix — every baseline

| Axis | Value |
|---|---|
| Geography | Beijing, Shanghai, Hong Kong, US West |
| Device | **Desktop Chrome 1920×1080** + **Mobile Chrome iPhone-14-class emulation** |
| Browser | Chrome latest |
| Network | Native (probe's real connection; throttling lives in Tier 2) |
| Scenario | S1 Cold Today, S2 Cold Training, S3 Warm Today, **S4 Anonymous Landing** |
| Time | 20:00–21:00 Asia/Shanghai (CN evening peak) |

**32 cells per baseline.** Both form factors are non-optional because users hit this app from both laptops (training analysis, Setup) and phones (daily check-in), and they can regress independently.

## Tier 2 — periodic

WeChat embedded browser (X5) from Beijing + Shanghai, Safari iOS, tablet viewport, throttled 3G from HK. These capture CN-specific realities WPT can't map cleanly into the standard UI — the WeChat-X5 path in particular requires an Alibaba Cloud Beijing VM + Android emulator + remote DevTools capture. Spelled out in `scripts/run-baseline.md`.

## Tier 3 — ad-hoc

Other CN cities, alternate browsers, off-peak comparisons, accessibility audits. Not run on every baseline.

## What RUM already covers (and what we don't need to synthesize)

App Insights (wired in PR-A + PR-B) automatically segments the real user population by browser, OS, device type, country, and `customDimensions.netinfo_effectiveType`. Synthetic Tier 1–3 probes exist for **reproducibility** (attributable before/after deltas), not for user-configuration coverage.

## Changes in this PR

- `docs/perf-baselines/README.md` — Device axis + Tier 1/2/3 structure + S4 scenario + "What RUM covers automatically" note
- `docs/perf-baselines/TEMPLATE.md` — every scenario table gets a Device column (desktop + mobile rows per probe); new S4 Landing table; Tier 2/3 notes; artifact naming now `sN-<probe>-<device>.<ext>`
- `scripts/run-baseline.md` — new "Desktop vs Mobile settings" section with explicit WPT options for each form factor; S4 plain-URL test added; Tier 2 specifics section with WeChat / Safari / tablet / throttled-3G workflows; updated artifact naming

## Test plan

- [x] All four markdown files render correctly on GitHub
- [x] Device column + S4 Landing table appear in TEMPLATE
- [x] Cross-references between docs resolve (README ↔ TEMPLATE ↔ run-baseline.md)
- [ ] Post-merge, gets used by the first real baseline run (Task #5) which anchors before any Phase 1 optimization