### PR TITLE
feat: Add intervals.icu as a training data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Praxys
 
-Sports science that meets you where you are. Praxys syncs data from Garmin, Stryd, and Oura Ring, computes training metrics (fitness/fatigue/form, zone analysis, CP trend, race predictions), and serves a modern web dashboard with AI-powered coaching skills — for elite athletes, serious amateurs, and curious beginners alike.
+Sports science that meets you where you are. Praxys syncs data from Garmin, Stryd, Oura Ring, and intervals.icu, computes training metrics (fitness/fatigue/form, zone analysis, CP trend, race predictions), and serves a modern web dashboard with AI-powered coaching skills — for elite athletes, serious amateurs, and curious beginners alike.
 
 ![Praxys — Sports science that meets you where you are.](data/screenshots/hero-showcase.png)
 

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -37,6 +37,7 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCaps] = {
     "strava": {"activities": True, "recovery": False, "fitness": False, "plan": False},
     "oura":   {"activities": False, "recovery": True, "fitness": False, "plan": False},
     "coros":  {"activities": True, "recovery": False, "fitness": True, "plan": False},
+    "intervals_icu": {"activities": True, "recovery": True, "fitness": True, "plan": False},
 }
 
 

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -9,7 +9,7 @@ from typing_extensions import TypedDict
 logger = logging.getLogger(__name__)
 
 TrainingBase = Literal["power", "hr", "pace"]
-PlatformName = Literal["garmin", "stryd", "strava", "oura", "coros"]
+PlatformName = Literal["garmin", "stryd", "strava", "oura", "coros", "intervals_icu"]
 PlanSource = Literal["garmin", "stryd", "strava", "oura", "coros", "ai"]
 DataCategory = Literal["activities", "recovery", "fitness", "plan"]
 

--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -336,13 +336,24 @@ def load_data_from_db(user_id: str, db: Session) -> dict[str, pd.DataFrame]:
         params={"uid": user_id},
     )
 
-    # Recovery: reconstruct from recovery_data table
-    recovery = pd.read_sql(
-        "SELECT * FROM recovery_data WHERE user_id = :uid ORDER BY date",
-        db.bind,
-        params={"uid": user_id},
-        parse_dates=["date"],
-    )
+    # Recovery: reconstruct from recovery_data table.
+    # When UserConfig.preferences["recovery"] is set, filter to that source
+    # so same-date rows from a secondary source don't pollute the pivot.
+    recovery_source = _recovery_source_for(user_id, db)
+    if recovery_source:
+        recovery = pd.read_sql(
+            "SELECT * FROM recovery_data WHERE user_id = :uid AND source = :src ORDER BY date",
+            db.bind,
+            params={"uid": user_id, "src": recovery_source},
+            parse_dates=["date"],
+        )
+    else:
+        recovery = pd.read_sql(
+            "SELECT * FROM recovery_data WHERE user_id = :uid ORDER BY date",
+            db.bind,
+            params={"uid": user_id},
+            parse_dates=["date"],
+        )
     if "date" in recovery.columns and not recovery.empty:
         recovery["date"] = pd.to_datetime(recovery["date"]).dt.date
 
@@ -378,6 +389,31 @@ def load_data_from_db(user_id: str, db: Session) -> dict[str, pd.DataFrame]:
         "fitness": fitness,
         "plan": plan,
     }
+
+
+def _recovery_source_for(user_id: str, db) -> str | None:
+    """Return UserConfig.preferences['recovery'] for this user, or None.
+
+    Handles the cases where UserConfig is missing, preferences is not a dict,
+    or the key is absent/empty.
+    """
+    try:
+        from db.models import UserConfig
+    except ImportError:
+        return None
+    try:
+        row = db.query(UserConfig.preferences).filter(
+            UserConfig.user_id == user_id,
+        ).first()
+    except Exception:
+        return None
+    if not row:
+        return None
+    prefs = row[0]
+    if not isinstance(prefs, dict):
+        return None
+    value = prefs.get("recovery")
+    return value if value else None
 
 
 def _pivot_fitness(raw: pd.DataFrame) -> pd.DataFrame:

--- a/analysis/providers/__init__.py
+++ b/analysis/providers/__init__.py
@@ -74,4 +74,5 @@ def _ensure_registered() -> None:
     import analysis.providers.strava  # noqa: F401
     import analysis.providers.oura  # noqa: F401
     import analysis.providers.ai  # noqa: F401
+    import analysis.providers.intervals_icu  # noqa: F401
     _registered = True

--- a/analysis/providers/intervals_icu.py
+++ b/analysis/providers/intervals_icu.py
@@ -1,0 +1,45 @@
+"""intervals.icu provider — thin registry stub.
+
+Runtime DB mode reads from the unified ``activities`` / ``recovery_data`` /
+``fitness_data`` tables via ``analysis.data_loader.load_data_from_db``. This
+provider exists for CSV-mode parity and registry symmetry with other
+platforms. It returns empty DataFrames when no CSV is present (the expected
+state in production).
+"""
+import os
+from datetime import date
+
+import pandas as pd
+
+from analysis.data_loader import _read_csv_safe
+from analysis.providers import register_activity
+from analysis.providers.base import ActivityProvider
+
+
+class IntervalsIcuActivityProvider(ActivityProvider):
+    """Load intervals.icu activities and splits from CSV when using file mode."""
+
+    name = "intervals_icu"
+
+    def load_activities(
+        self, data_dir: str, since: date | None = None
+    ) -> pd.DataFrame:
+        df = _read_csv_safe(
+            os.path.join(data_dir, "intervals_icu", "activities.csv")
+        )
+        if since and not df.empty and "date" in df.columns:
+            df = df[df["date"] >= since]
+        return df
+
+    def load_splits(
+        self, data_dir: str, activity_ids: list[str] | None = None
+    ) -> pd.DataFrame:
+        df = _read_csv_safe(
+            os.path.join(data_dir, "intervals_icu", "activity_splits.csv")
+        )
+        if activity_ids and not df.empty and "activity_id" in df.columns:
+            df = df[df["activity_id"].astype(str).isin(activity_ids)]
+        return df
+
+
+register_activity("intervals_icu", IntervalsIcuActivityProvider)

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -688,14 +688,38 @@ def connect_platform(
     return {"status": "connected", "platform": platform}
 
 
+_ACTIVITY_FALLBACK_ORDER = ["stryd", "garmin", "strava"]
+_RECOVERY_FALLBACK_ORDER = ["oura", "garmin"]
+_THRESHOLD_FALLBACK_ORDER = ["stryd", "garmin", "strava"]
+
+
+def _first_connected_from(user_id: str, candidates: list, db) -> str | None:
+    """Return the first connected platform in `candidates`, or None."""
+    from db.models import UserConnection
+    connected = {
+        c.platform for c in db.query(UserConnection).filter(
+            UserConnection.user_id == user_id,
+            UserConnection.status == "connected",
+        ).all()
+    }
+    for p in candidates:
+        if p in connected:
+            return p
+    return None
+
+
 @router.delete("/settings/connections/{platform}")
 def disconnect_platform(
     platform: str,
     user_id: str = Depends(require_write_access),
     db: Session = Depends(get_db),
 ) -> dict:
-    """Disconnect a platform — deletes stored credentials."""
-    from db.models import UserConnection
+    """Disconnect a platform — deletes stored credentials.
+
+    For intervals_icu, also rewrites user preferences that pointed at it
+    to the next connected source (deterministic priority).
+    """
+    from db.models import UserConfig, UserConnection
 
     conn = db.query(UserConnection).filter(
         UserConnection.user_id == user_id,
@@ -708,5 +732,40 @@ def disconnect_platform(
     if platform == "garmin":
         from api.routes.sync import clear_garmin_tokens
         clear_garmin_tokens(user_id)
+
+    if platform == "intervals_icu":
+        cfg = db.query(UserConfig).filter_by(user_id=user_id).first()
+        if cfg is not None:
+            prefs = dict(cfg.preferences or {})
+
+            if prefs.get("activities") == "intervals_icu":
+                fallback = _first_connected_from(user_id, _ACTIVITY_FALLBACK_ORDER, db)
+                if fallback:
+                    prefs["activities"] = fallback
+                else:
+                    prefs.pop("activities", None)
+
+            if prefs.get("recovery") == "intervals_icu":
+                fallback = _first_connected_from(user_id, _RECOVERY_FALLBACK_ORDER, db)
+                if fallback:
+                    prefs["recovery"] = fallback
+                else:
+                    prefs.pop("recovery", None)
+
+            thresholds = dict(prefs.get("threshold_sources") or {})
+            for metric, source in list(thresholds.items()):
+                if source == "intervals_icu":
+                    fallback = _first_connected_from(user_id, _THRESHOLD_FALLBACK_ORDER, db)
+                    if fallback:
+                        thresholds[metric] = fallback
+                    else:
+                        thresholds.pop(metric, None)
+            if thresholds:
+                prefs["threshold_sources"] = thresholds
+            else:
+                prefs.pop("threshold_sources", None)
+
+            cfg.preferences = prefs
+            db.commit()
 
     return {"status": "disconnected", "platform": platform}

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -659,7 +659,7 @@ def connect_platform(
         other_connected = db.query(UserConnection).filter(
             UserConnection.user_id == user_id,
             UserConnection.platform != "intervals_icu",
-            UserConnection.status == "connected",
+            UserConnection.status.in_(["connected", "error"]),
         ).count()
         if other_connected == 0:
             cfg = db.query(UserConfigModel).filter_by(user_id=user_id).first()
@@ -699,7 +699,7 @@ def _first_connected_from(user_id: str, candidates: list, db) -> str | None:
     connected = {
         c.platform for c in db.query(UserConnection).filter(
             UserConnection.user_id == user_id,
-            UserConnection.status == "connected",
+            UserConnection.status.in_(["connected", "error"]),
         ).all()
     }
     for p in candidates:

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -343,8 +343,10 @@ class ConnectPlatformRequest(BaseModel):
     refresh_token: str | None = None
     expires_at: int | None = None
     scope: str | None = None
-    athlete_id: int | None = None
+    athlete_id: int | str | None = None
     athlete_username: str | None = None
+    # intervals.icu
+    api_key: str | None = None
 
 
 class StravaOAuthStartRequest(BaseModel):
@@ -633,11 +635,47 @@ def connect_platform(
                 "username": body.athlete_username,
             },
         }
+    elif platform == "intervals_icu":
+        if not body.athlete_id or not body.api_key:
+            return {"status": "error", "message": "athlete_id and api_key required"}
+        from sync import intervals_icu_sync
+        creds = {"athlete_id": str(body.athlete_id), "api_key": body.api_key}
+        try:
+            intervals_icu_sync.fetch_athlete_profile_api(creds)
+        except intervals_icu_sync.IntervalsIcuUnauthorized:
+            return {"status": "error", "message": "Invalid intervals.icu credentials"}
+        except intervals_icu_sync.IntervalsIcuError as exc:
+            return {"status": "error", "message": f"intervals.icu reachable but errored: {exc}"}
     else:
         return {"status": "error", "message": f"Unsupported platform: {platform}"}
 
     _upsert_connection_credentials(user_id, platform, creds, db)
     db.commit()
+
+    # Auto-populate user preferences on first-connect when no other source
+    # is connected. setdefault preserves existing pins.
+    if platform == "intervals_icu":
+        from db.models import UserConfig as UserConfigModel, UserConnection
+        other_connected = db.query(UserConnection).filter(
+            UserConnection.user_id == user_id,
+            UserConnection.platform != "intervals_icu",
+            UserConnection.status == "connected",
+        ).count()
+        if other_connected == 0:
+            cfg = db.query(UserConfigModel).filter_by(user_id=user_id).first()
+            if cfg is not None:
+                prefs = dict(cfg.preferences or {})
+                prefs.setdefault("activities", "intervals_icu")
+                prefs.setdefault("recovery", "intervals_icu")
+                thresholds = dict(prefs.get("threshold_sources") or {})
+                for metric in (
+                    "cp_estimate", "lthr", "threshold_pace_sec_km",
+                    "max_hr", "running_ftp",
+                ):
+                    thresholds.setdefault(metric, "intervals_icu")
+                prefs["threshold_sources"] = thresholds
+                cfg.preferences = prefs
+                db.commit()
 
     # Invalidate cached OAuth tokens AFTER the new credentials are persisted:
     # if we cleared first and the commit then failed, the next sync would

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -669,8 +669,8 @@ def connect_platform(
                 prefs.setdefault("recovery", "intervals_icu")
                 thresholds = dict(prefs.get("threshold_sources") or {})
                 for metric in (
-                    "cp_estimate", "lthr", "threshold_pace_sec_km",
-                    "max_hr", "running_ftp",
+                    "cp_estimate", "lthr_bpm", "lt_pace_sec_km",
+                    "max_hr_bpm", "rest_hr_bpm",
                 ):
                     thresholds.setdefault(metric, "intervals_icu")
                 prefs["threshold_sources"] = thresholds

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -19,6 +19,7 @@ from api.auth import get_data_user_id, require_write_access
 from api.env_compat import getenv_compat
 from api.views import utc_isoformat
 from db.session import get_db
+from sync import intervals_icu_sync
 
 router = APIRouter()
 
@@ -43,7 +44,7 @@ class SyncRequest(BaseModel):
 _sync_status: dict[str, dict[str, dict]] = {}
 _sync_lock = threading.Lock()
 
-_DEFAULT_SOURCES = ["garmin", "strava", "stryd", "oura"]
+_DEFAULT_SOURCES = ["garmin", "strava", "stryd", "oura", "intervals_icu"]
 
 
 def _get_user_status(user_id: str) -> dict[str, dict]:
@@ -202,6 +203,9 @@ def _run_sync(user_id: str, source: str, creds: dict,
 
         elif source == "oura":
             counts = _sync_oura(user_id, creds, from_date, db)
+
+        elif source == "intervals_icu":
+            counts = _sync_intervals_icu(user_id, creds, from_date, db)
 
         else:
             raise ValueError(f"Unknown source: {source}")
@@ -907,6 +911,34 @@ def _sync_oura(user_id: str, creds: dict, from_date: str | None,
         user_id, readiness_rows, sleep_rows, hrv_by_date, db
     )
     return {"recovery": count}
+
+
+def _sync_intervals_icu(user_id: str, creds: dict, from_date: str | None,
+                        db) -> dict:
+    """Fetch intervals.icu data and write directly to DB.
+
+    Returns a counts dict with the keys the sync-status layer expects:
+    {activities, splits, recovery, fitness}.
+    """
+    from datetime import date as _date, timedelta
+
+    if from_date:
+        since = _date.fromisoformat(from_date)
+    else:
+        since = _date.today() - timedelta(days=180)
+
+    result = intervals_icu_sync.sync_all(
+        user_id=user_id,
+        credentials=creds,
+        db=db,
+        since=since,
+    )
+    return {
+        "activities": result.activities_written,
+        "splits": result.splits_written,
+        "recovery": result.wellness_written,
+        "fitness": result.thresholds_written,
+    }
 
 
 @router.get("/sync/status")

--- a/data/sample/intervals_icu/activities.json
+++ b/data/sample/intervals_icu/activities.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "i9000001",
+    "start_date_local": "2026-04-18T07:05:00",
+    "type": "Run",
+    "distance": 10050.0,
+    "moving_time": 3120,
+    "elapsed_time": 3180,
+    "total_elevation_gain": 65,
+    "average_heartrate": 152,
+    "max_heartrate": 171,
+    "icu_average_watts": 258,
+    "average_watts": 258,
+    "max_watts": 412,
+    "average_cadence": 87.5,
+    "icu_training_load": 62.1
+  },
+  {
+    "id": "i9000002",
+    "start_date_local": "2026-04-20T18:15:00",
+    "type": "Run",
+    "distance": 5020.0,
+    "moving_time": 1800,
+    "elapsed_time": 1820,
+    "total_elevation_gain": 18,
+    "average_heartrate": 138,
+    "max_heartrate": 155,
+    "icu_average_watts": null,
+    "average_watts": null,
+    "max_watts": null,
+    "average_cadence": 83.0,
+    "icu_training_load": 22.4
+  }
+]

--- a/data/sample/intervals_icu/activity_i9000001_intervals.json
+++ b/data/sample/intervals_icu/activity_i9000001_intervals.json
@@ -1,0 +1,44 @@
+{
+  "id": "i9000001",
+  "icu_intervals": [
+    {
+      "distance": 1000.0,
+      "moving_time": 330,
+      "elapsed_time": 330,
+      "average_watts": 240,
+      "average_heartrate": 148,
+      "max_heartrate": 158,
+      "average_cadence": 86.0,
+      "type": "WORK",
+      "label": "warmup",
+      "start_index": 0,
+      "end_index": 329
+    },
+    {
+      "distance": 5000.0,
+      "moving_time": 1500,
+      "elapsed_time": 1500,
+      "average_watts": 275,
+      "average_heartrate": 158,
+      "max_heartrate": 171,
+      "average_cadence": 88.5,
+      "type": "WORK",
+      "label": "tempo",
+      "start_index": 330,
+      "end_index": 1829
+    },
+    {
+      "distance": 4050.0,
+      "moving_time": 1290,
+      "elapsed_time": 1290,
+      "average_watts": 245,
+      "average_heartrate": 150,
+      "max_heartrate": 162,
+      "average_cadence": 87.0,
+      "type": "RECOVERY",
+      "label": "cooldown",
+      "start_index": 1830,
+      "end_index": 3119
+    }
+  ]
+}

--- a/data/sample/intervals_icu/activity_i9000002_intervals.json
+++ b/data/sample/intervals_icu/activity_i9000002_intervals.json
@@ -1,0 +1,18 @@
+{
+  "id": "i9000002",
+  "icu_intervals": [
+    {
+      "distance": 5020.0,
+      "moving_time": 1800,
+      "elapsed_time": 1800,
+      "average_watts": null,
+      "average_heartrate": 138,
+      "max_heartrate": 155,
+      "average_cadence": 83.0,
+      "type": "WORK",
+      "label": null,
+      "start_index": 0,
+      "end_index": 1799
+    }
+  ]
+}

--- a/data/sample/intervals_icu/athlete_profile.json
+++ b/data/sample/intervals_icu/athlete_profile.json
@@ -1,0 +1,19 @@
+{
+  "id": "i123456",
+  "name": "Test Athlete",
+  "sportSettings": [
+    {
+      "types": ["Run", "TrailRun"],
+      "ftp": 270,
+      "lthr": 168,
+      "threshold_pace": 4.08163,
+      "max_hr": 192
+    },
+    {
+      "types": ["Ride", "VirtualRide"],
+      "ftp": 290,
+      "lthr": 170,
+      "max_hr": 194
+    }
+  ]
+}

--- a/data/sample/intervals_icu/wellness.json
+++ b/data/sample/intervals_icu/wellness.json
@@ -1,0 +1,7 @@
+[
+  {"id": "2026-04-16", "readiness": 82, "hrv": 64.2, "restingHR": 48, "sleepScore": 85, "sleepSecs": 27900},
+  {"id": "2026-04-17", "readiness": 75, "hrv": 58.1, "restingHR": 51, "sleepScore": 78, "sleepSecs": 25200},
+  {"id": "2026-04-18", "readiness": 88, "hrv": 66.8, "restingHR": 47, "sleepScore": 90, "sleepSecs": 28800},
+  {"id": "2026-04-19", "readiness": 70, "hrv": 55.4, "restingHR": 53, "sleepScore": 72, "sleepSecs": 24300},
+  {"id": "2026-04-20", "readiness": 80, "hrv": 62.0, "restingHR": 49, "sleepScore": 83, "sleepSecs": 27000}
+]

--- a/db/sync_scheduler.py
+++ b/db/sync_scheduler.py
@@ -174,7 +174,7 @@ def _sync_connection(user_id: str, platform: str, db):
     creds = json.loads(creds_json)
 
     # Use the sync route's direct DB write functions
-    from api.routes.sync import _sync_garmin, _sync_strava, _sync_stryd, _sync_oura
+    from api.routes.sync import _sync_garmin, _sync_strava, _sync_stryd, _sync_oura, _sync_intervals_icu
 
     if platform == "garmin":
         counts = _sync_garmin(user_id, creds, None, db)
@@ -184,6 +184,8 @@ def _sync_connection(user_id: str, platform: str, db):
         counts = _sync_stryd(user_id, creds, None, db)
     elif platform == "oura":
         counts = _sync_oura(user_id, creds, None, db)
+    elif platform == "intervals_icu":
+        counts = _sync_intervals_icu(user_id, creds, None, db)
     else:
         logger.warning("Unknown platform: %s", platform)
         return

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -463,3 +463,111 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
         ))
         count += 1
     return count
+
+
+def write_splits_replace(user_id: str, rows: list[dict], db: Session) -> int:
+    """Replace all splits for the activity_ids appearing in `rows`.
+
+    Unlike ``write_splits`` (which fills missing fields on existing rows),
+    this delete-then-inserts per activity_id. intervals.icu splits may
+    change count across syncs as the user edits intervals.
+    """
+    if not rows:
+        return 0
+    aids = {_str(r.get("activity_id")) for r in rows if r.get("activity_id")}
+    aids.discard(None)
+    db.query(ActivitySplit).filter(
+        ActivitySplit.user_id == user_id,
+        ActivitySplit.activity_id.in_(aids),
+    ).delete(synchronize_session=False)
+
+    count = 0
+    for row in rows:
+        aid = _str(row.get("activity_id"))
+        if not aid:
+            continue
+        db.add(ActivitySplit(
+            user_id=user_id,
+            activity_id=aid,
+            split_num=int(row.get("split_num") or 0),
+            distance_km=_float(row.get("distance_km")),
+            duration_sec=_float(row.get("duration_sec")),
+            avg_power=_float(row.get("avg_power")),
+            avg_hr=_float(row.get("avg_hr")),
+            max_hr=_float(row.get("max_hr")),
+            avg_pace_min_km=_pace_min_str(row),
+            avg_pace_sec_km=_float(row.get("avg_pace_sec_km")),
+            avg_cadence=_float(row.get("avg_cadence")),
+            elevation_change_m=_float(row.get("elevation_change_m")),
+        ))
+        count += 1
+    db.commit()
+    return count
+
+
+def write_recovery_rows(
+    user_id: str, rows: list[dict], source: str, db: Session
+) -> int:
+    """Upsert recovery_data rows by (user_id, date, source).
+
+    Generic per-source writer, as opposed to ``write_recovery`` which has
+    Oura/Garmin-specific row-shape assumptions.
+    """
+    if not rows:
+        return 0
+    count = 0
+    for row in rows:
+        d = _parse_date(row.get("date"))
+        if d is None:
+            continue
+        existing = db.query(RecoveryData).filter_by(
+            user_id=user_id, date=d, source=source,
+        ).first()
+        values = dict(
+            readiness_score=_float(row.get("readiness_score")),
+            hrv_avg=_float(row.get("hrv_avg")),
+            resting_hr=_float(row.get("resting_hr")),
+            sleep_score=_float(row.get("sleep_score")),
+            total_sleep_sec=_float(row.get("total_sleep_sec")),
+            deep_sleep_sec=_float(row.get("deep_sleep_sec")),
+            rem_sleep_sec=_float(row.get("rem_sleep_sec")),
+            body_temp_delta=_float(row.get("body_temp_delta")),
+        )
+        if existing:
+            for k, v in values.items():
+                if v is not None:
+                    setattr(existing, k, v)
+        else:
+            db.add(RecoveryData(user_id=user_id, date=d, source=source, **values))
+        count += 1
+    db.commit()
+    return count
+
+
+def write_fitness(
+    user_id: str, rows: list[dict], source: str, db: Session
+) -> int:
+    """Upsert fitness_data rows by (user_id, date, metric_type, source)."""
+    if not rows:
+        return 0
+    count = 0
+    for row in rows:
+        d = _parse_date(row.get("date"))
+        metric_type = _str(row.get("metric_type"))
+        if d is None or not metric_type:
+            continue
+        existing = db.query(FitnessData).filter_by(
+            user_id=user_id, date=d, metric_type=metric_type, source=source,
+        ).first()
+        value = _float(row.get("value"))
+        if existing:
+            if value is not None:
+                existing.value = value
+        else:
+            db.add(FitnessData(
+                user_id=user_id, date=d, metric_type=metric_type,
+                source=source, value=value, value_str=_str(row.get("value_str")),
+            ))
+        count += 1
+    db.commit()
+    return count

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -498,6 +498,54 @@ Disconnect a platform and delete stored credentials.
 { "status": "disconnected", "platform": "garmin" }
 ```
 
+### POST /api/settings/connections/intervals_icu
+
+Connect intervals.icu by storing Athlete ID and API key.
+
+**Request body:**
+```json
+{
+  "athlete_id": "12345",
+  "api_key": "your-pat-here"
+}
+```
+
+Validates via `GET https://intervals.icu/api/v1/athlete/{id}` with HTTP Basic auth.
+
+**Response:**
+```json
+{ "status": "connected", "platform": "intervals_icu" }
+```
+
+**Error codes:**
+- `400 INVALID_CREDENTIALS` — API key or athlete ID invalid (validation failed)
+- `409 ALREADY_CONNECTED` — intervals.icu already connected for this user
+
+### DELETE /api/settings/connections/intervals_icu
+
+Disconnect intervals.icu and remove stored credentials. If any `user_config.preferences` entry pointed to `intervals_icu`, falls back to the next available connected source with priority: `stryd > garmin > strava` (activities / thresholds) and `oura > garmin` (recovery).
+
+**Response:**
+```json
+{ "status": "disconnected", "platform": "intervals_icu" }
+```
+
+### POST /api/sync/intervals_icu
+
+Trigger sync for intervals.icu. Runs in background; status observable via `GET /api/sync/status`.
+
+**Request body (optional):**
+```json
+{ "from_date": "2025-01-01" }
+```
+
+**Response:**
+```json
+{ "status": "queued" }
+```
+
+Background scheduler syncs intervals.icu on the same 6/12/24-hour user-configured interval as other platforms.
+
 ## Science
 
 ### GET /api/science

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -137,3 +137,13 @@ All per-source sync errors surface at `logger.warning` or above, not `debug`. De
 - Splits: warning when ≥ max(3, total/2) activities fail.
 - Recovery parse: warning when ≥ max(3, total/2) days fail.
 - HRV / sleep endpoints: circuit-break + warning after 5 consecutive failures.
+
+## intervals.icu
+
+- **Cadence is single-leg.** `sync/intervals_icu_sync.py::_parse_activity` multiplies running cadence by 2 to match Praxys' double-leg spm convention. Changing this silently will double-count steps and wreck form-score calculations.
+- **Splits come from `icu_intervals`, not raw device laps.** intervals.icu's API exposes its own post-processed intervals (types: WORK/RECOVERY/etc.) via `GET /api/v1/activity/{id}?intervals=true`. Manual lap-button presses on the athlete's watch are **not** reflected in this field. Per-interval elevation is also not exposed — `activity_splits.elevation_change_m` stays NULL for this source.
+- **`threshold_pace` is meters per second.** intervals.icu's sportSettings return `threshold_pace` in m/s (SI unit), not sec/km. `_parse_thresholds` converts: `sec_per_km = 1000 / m_per_s`. A bare 4.08 m/s value stored unconverted would be interpreted as near-sprint pace — easy to get wrong silently.
+- **No deep/REM sleep split.** `recovery_data.deep_sleep_sec` and `rem_sleep_sec` are always NULL for intervals.icu rows.
+- **Activity IDs are prefixed with `icu_`.** Prevents collisions with Garmin/Strava numeric IDs.
+- **HTTP Basic auth uses literal username `"API_KEY"`** with the PAT as password. Using `athlete_id:PAT` instead returns 403. The `athlete_id` only appears in URL path segments.
+- **Threshold metric_type names follow Praxys canonicals**, not intervals.icu names: `cp_estimate` (from intervals.icu `ftp`), `lthr_bpm` (from `lthr`), `lt_pace_sec_km` (from converted `threshold_pace`), `max_hr_bpm` (from `max_hr`). See `_parse_thresholds`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -101,3 +101,16 @@ Swappable training theories backed by published research. Each theory is a YAML 
 | Garmin Connect | Activities, splits, daily metrics (VO2max, RHR), lactate threshold |
 | Stryd | Power data, running dynamics, CP estimates, training plan |
 | Oura Ring | Sleep scores/stages, readiness, HRV, resting HR |
+| intervals.icu | Activities with intervals, wellness (sleep/HRV/RHR), thresholds from aggregated device data |
+
+### intervals.icu
+
+intervals.icu is a training analytics platform that aggregates data from many devices and apps (Wahoo, Coros, Polar, Garmin, Apple Watch, and more). For users whose primary device isn't supported directly by Praxys, intervals.icu is the recommended data source.
+
+Praxys syncs from intervals.icu:
+
+- **Activities** with post-processed intervals (`icu_intervals`) mapped to Praxys `activity_splits`. intervals.icu's intervals are WORK/RECOVERY classifications, not raw device laps — manual watch lap presses are not reflected.
+- **Wellness** (sleep duration, sleep score, HRV, resting HR, readiness) written to `recovery_data`.
+- **Thresholds** from the athlete's Run sportSettings (FTP → CP estimate, LTHR, threshold pace converted from m/s → sec/km, max HR) written to `fitness_data`.
+
+Connect in Settings → intervals.icu with your Athlete ID and API key.

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -197,3 +197,50 @@ def _parse_activity(activity: dict) -> dict:
         "avg_cadence": _round_or_empty(avg_cadence_spm),
         "source": "intervals_icu",
     }
+
+
+def _parse_laps(
+    prefixed_activity_id: str,
+    activity_detail: dict,
+    *,
+    activity_type: str,
+) -> list[dict]:
+    """Convert intervals.icu `icu_intervals` field to Praxys canonical split rows.
+
+    Per V3 verification (2026-04-22): intervals.icu exposes post-processed
+    intervals (WORK / RECOVERY / etc.) via the `icu_intervals` field when the
+    activity detail is fetched with `?intervals=true`. These are NOT raw
+    device laps. Per-interval elevation is not exposed, so
+    `elevation_change_m` stays empty.
+
+    Preserves array order (do not re-segment).
+    """
+    rows: list[dict] = []
+    for idx, lap in enumerate(activity_detail.get("icu_intervals") or [], start=1):
+        distance_m = float(lap.get("distance") or 0)
+        moving_time = float(lap.get("moving_time") or 0)
+        distance_km = round(distance_m / 1000, 3) if distance_m > 0 else 0.0
+        avg_pace_sec_km = (
+            round(moving_time / distance_km, 1)
+            if distance_km > 0 and moving_time > 0
+            else None
+        )
+        raw_cadence = lap.get("average_cadence")
+        avg_cadence_spm = (
+            float(raw_cadence) * 2 if raw_cadence not in (None, "") and activity_type == "running"
+            else raw_cadence
+        )
+
+        rows.append({
+            "activity_id": prefixed_activity_id,
+            "split_num": str(idx),
+            "distance_km": str(distance_km) if distance_km > 0 else "",
+            "duration_sec": str(moving_time) if moving_time > 0 else "",
+            "avg_power": _round_or_empty(lap.get("average_watts")),
+            "avg_hr": _round_or_empty(lap.get("average_heartrate")),
+            "max_hr": _round_or_empty(lap.get("max_heartrate")),
+            "avg_cadence": _round_or_empty(avg_cadence_spm),
+            "avg_pace_sec_km": _round_or_empty(avg_pace_sec_km),
+            "elevation_change_m": "",
+        })
+    return rows

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -244,3 +244,69 @@ def _parse_laps(
             "elevation_change_m": "",
         })
     return rows
+
+
+def _parse_wellness(wellness_rows: list[dict]) -> list[dict]:
+    """Convert intervals.icu wellness rows to Praxys recovery_data rows."""
+    rows: list[dict] = []
+    for w in wellness_rows:
+        rows.append({
+            "date": str(w.get("id") or "")[:10],
+            "readiness_score": _round_or_empty(w.get("readiness")),
+            "hrv_avg": _round_or_empty(w.get("hrv"), decimals=2),
+            "resting_hr": _round_or_empty(w.get("restingHR")),
+            "sleep_score": _round_or_empty(w.get("sleepScore")),
+            "total_sleep_sec": _round_or_empty(w.get("sleepSecs"), decimals=0),
+            "deep_sleep_sec": "",
+            "rem_sleep_sec": "",
+            "body_temp_delta": "",
+            "source": "intervals_icu",
+        })
+    return rows
+
+
+def _parse_thresholds(profile: dict, today: date) -> list[dict]:
+    """Extract running thresholds from athlete profile sportSettings.
+
+    V2 verified (2026-04-22): intervals.icu sportSettings for a Run-typed
+    entry exposes `ftp`, `lthr`, `max_hr`, `threshold_pace`. The
+    `threshold_pace` value is in meters per second — Praxys stores pace
+    as seconds per km, so convert: sec_per_km = 1000 / m_per_s.
+
+    Maps to Praxys fitness_data metric_type values:
+      ftp            -> running_ftp
+      lthr           -> lthr
+      threshold_pace -> threshold_pace_sec_km  (unit-converted)
+      max_hr         -> max_hr
+    """
+    rows: list[dict] = []
+    today_str = today.strftime("%Y-%m-%d")
+    for setting in profile.get("sportSettings") or []:
+        types = setting.get("types") or []
+        if "Run" not in types and "TrailRun" not in types:
+            continue
+
+        pace_mps = setting.get("threshold_pace")
+        pace_sec_km = (
+            round(1000 / float(pace_mps), 2)
+            if pace_mps not in (None, "", 0, 0.0)
+            else None
+        )
+
+        metric_map = {
+            "running_ftp": setting.get("ftp"),
+            "lthr": setting.get("lthr"),
+            "threshold_pace_sec_km": pace_sec_km,
+            "max_hr": setting.get("max_hr"),
+        }
+        for metric_type, value in metric_map.items():
+            if value in (None, ""):
+                continue
+            rows.append({
+                "date": today_str,
+                "metric_type": metric_type,
+                "value": _round_or_empty(value, decimals=2),
+                "source": "intervals_icu",
+            })
+        break  # first Run-containing entry wins
+    return rows

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -13,6 +13,7 @@ Endpoints:
 from __future__ import annotations
 
 import logging
+import time
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -33,3 +34,78 @@ def _build_auth(credentials: dict) -> tuple[str, str]:
     intervals.icu requires username=literal 'API_KEY', password=<PAT>.
     """
     return ("API_KEY", credentials["api_key"])
+
+
+class IntervalsIcuError(Exception):
+    """Base exception for intervals.icu sync errors."""
+
+
+class IntervalsIcuUnauthorized(IntervalsIcuError):
+    """401 — credentials invalid or revoked. Caller should mark status='expired'."""
+
+
+class IntervalsIcuRateLimited(IntervalsIcuError):
+    """429 — rate limited after MAX_RETRIES backoff attempts."""
+
+
+class IntervalsIcuServerError(IntervalsIcuError):
+    """5xx after retries."""
+
+
+def _request(
+    path: str,
+    *,
+    credentials: dict,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """GET a JSON endpoint with Basic auth, 15s timeout, and retry.
+
+    Retry policy:
+    - 401 -> raise IntervalsIcuUnauthorized (no retry)
+    - 429 -> exponential backoff 1s -> 2s -> 4s -> 8s, MAX_RETRIES attempts total
+    - 5xx -> same backoff, same retry budget
+    - Network timeout -> treat as 5xx
+    """
+    url = f"{INTERVALS_BASE_URL}{path}"
+    auth = _build_auth(credentials)
+    headers = {"User-Agent": USER_AGENT}
+    backoff = INITIAL_BACKOFF_SEC
+    last_error: Exception | None = None
+
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = requests.get(
+                url,
+                params=params,
+                auth=auth,
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT_SEC,
+            )
+        except requests.Timeout as exc:
+            last_error = exc
+            logger.warning("intervals.icu timeout on %s attempt=%d", path, attempt + 1)
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(backoff)
+                backoff *= 2
+            continue
+
+        if resp.status_code == 401:
+            raise IntervalsIcuUnauthorized(f"401 from {path}")
+
+        if resp.status_code == 429 or resp.status_code >= 500:
+            last_error = requests.HTTPError(f"{resp.status_code} from {path}")
+            logger.warning(
+                "intervals.icu %d on %s attempt=%d; backoff=%.1fs",
+                resp.status_code, path, attempt + 1, backoff,
+            )
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(backoff)
+                backoff *= 2
+            continue
+
+        resp.raise_for_status()
+        return resp.json()
+
+    if isinstance(last_error, requests.HTTPError) and "429" in str(last_error):
+        raise IntervalsIcuRateLimited(str(last_error))
+    raise IntervalsIcuServerError(str(last_error) if last_error else "unknown")

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -109,3 +109,91 @@ def _request(
     if isinstance(last_error, requests.HTTPError) and "429" in str(last_error):
         raise IntervalsIcuRateLimited(str(last_error))
     raise IntervalsIcuServerError(str(last_error) if last_error else "unknown")
+
+
+# Normalize intervals.icu sport types to Praxys canonical types.
+# V4 verified (2026-04-22): athlete i302653 returned Run, VirtualRun, TrailRun,
+# Ride, VirtualRide, VirtualRow, Hike, Walk. Include additional common types.
+_SPORT_TYPE_MAP = {
+    "run": "running",
+    "virtualrun": "running",
+    "trailrun": "trail_running",
+    "walk": "walking",
+    "hike": "hiking",
+    "ride": "cycling",
+    "virtualride": "cycling",
+    "ebikeride": "cycling",
+    "virtualrow": "rowing",
+    "row": "rowing",
+    "swim": "swimming",
+    "openwaterswim": "swimming",
+    "workout": "strength",
+    "weighttraining": "strength",
+}
+
+
+def _round_or_empty(val: Any, decimals: int = 1) -> str:
+    """Round numeric -> str, or return empty string for missing values."""
+    if val is None or val == "":
+        return ""
+    try:
+        return str(round(float(val), decimals))
+    except (TypeError, ValueError):
+        return ""
+
+
+def _map_activity_type(raw_type: str) -> str:
+    key = str(raw_type).replace(" ", "").replace("_", "").lower()
+    return _SPORT_TYPE_MAP.get(key, "other")
+
+
+def _parse_activity(activity: dict) -> dict:
+    """Convert one intervals.icu activity summary to Praxys canonical row shape.
+
+    Key transformations:
+    - id prefixed with 'icu_' to avoid cross-source ID collision
+    - distance m -> km
+    - cadence single-leg -> double-leg (x 2) for running
+    - icu_average_watts preferred over average_watts (Stryd-style running power)
+    - training_load, training_effect intentionally left null — Praxys recomputes
+    """
+    raw_id = str(activity.get("id") or "")
+    start_local = str(activity.get("start_date_local") or "")
+    sport_type = str(activity.get("type") or "")
+    activity_type = _map_activity_type(sport_type)
+
+    distance_m = float(activity.get("distance") or 0)
+    moving_time = float(activity.get("moving_time") or 0)
+    distance_km = round(distance_m / 1000, 3) if distance_m > 0 else 0.0
+    avg_pace_sec_km = (
+        round(moving_time / distance_km, 1)
+        if distance_km > 0 and moving_time > 0
+        else None
+    )
+
+    avg_power = activity.get("icu_average_watts")
+    if avg_power in (None, ""):
+        avg_power = activity.get("average_watts")
+
+    raw_cadence = activity.get("average_cadence")
+    avg_cadence_spm = (
+        float(raw_cadence) * 2 if raw_cadence not in (None, "") and activity_type == "running"
+        else raw_cadence
+    )
+
+    return {
+        "activity_id": f"icu_{raw_id}",
+        "date": start_local[:10],
+        "start_time": start_local,
+        "activity_type": activity_type,
+        "distance_km": str(distance_km) if distance_km > 0 else "",
+        "duration_sec": str(moving_time) if moving_time > 0 else "",
+        "avg_power": _round_or_empty(avg_power),
+        "max_power": _round_or_empty(activity.get("max_watts")),
+        "avg_hr": _round_or_empty(activity.get("average_heartrate")),
+        "max_hr": _round_or_empty(activity.get("max_heartrate")),
+        "avg_pace_sec_km": _round_or_empty(avg_pace_sec_km),
+        "elevation_gain_m": _round_or_empty(activity.get("total_elevation_gain")),
+        "avg_cadence": _round_or_empty(avg_cadence_spm),
+        "source": "intervals_icu",
+    }

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -274,10 +274,10 @@ def _parse_thresholds(profile: dict, today: date) -> list[dict]:
     as seconds per km, so convert: sec_per_km = 1000 / m_per_s.
 
     Maps to Praxys fitness_data metric_type values:
-      ftp            -> running_ftp
-      lthr           -> lthr
-      threshold_pace -> threshold_pace_sec_km  (unit-converted)
-      max_hr         -> max_hr
+      ftp            -> cp_estimate
+      lthr           -> lthr_bpm
+      threshold_pace -> lt_pace_sec_km  (unit-converted)
+      max_hr         -> max_hr_bpm
     """
     rows: list[dict] = []
     today_str = today.strftime("%Y-%m-%d")
@@ -294,10 +294,10 @@ def _parse_thresholds(profile: dict, today: date) -> list[dict]:
         )
 
         metric_map = {
-            "running_ftp": setting.get("ftp"),
-            "lthr": setting.get("lthr"),
-            "threshold_pace_sec_km": pace_sec_km,
-            "max_hr": setting.get("max_hr"),
+            "cp_estimate": setting.get("ftp"),
+            "lthr_bpm": setting.get("lthr"),
+            "lt_pace_sec_km": pace_sec_km,
+            "max_hr_bpm": setting.get("max_hr"),
         }
         for metric_type, value in metric_map.items():
             if value in (None, ""):

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -381,3 +381,69 @@ def fetch_wellness_api(
         params=params,
     ) or []
     return _parse_wellness(raw)
+
+
+from dataclasses import dataclass
+from datetime import date as _date
+
+
+@dataclass
+class SyncResult:
+    activities_written: int = 0
+    splits_written: int = 0
+    wellness_written: int = 0
+    thresholds_written: int = 0
+
+
+def sync_all(
+    *,
+    user_id: str,
+    credentials: dict,
+    db,
+    since: _date,
+    today: _date | None = None,
+) -> SyncResult:
+    """Orchestrate all intervals.icu sync work for one user.
+
+    Fetches activities in the date window, then per-activity intervals,
+    then wellness, then athlete profile thresholds. Writes everything
+    through db.sync_writer helpers. Returns per-table counts.
+    """
+    from db.sync_writer import (
+        write_activities,
+        write_fitness,
+        write_recovery_rows,
+        write_splits_replace,
+    )
+
+    today = today or _date.today()
+    from_str = since.isoformat()
+    to_str = today.isoformat()
+
+    result = SyncResult()
+
+    activity_rows, raw_activities = fetch_activities_api(credentials, from_str, to_str)
+    result.activities_written = write_activities(user_id, activity_rows, db)
+
+    all_split_rows: list[dict] = []
+    for raw in raw_activities:
+        raw_id = str(raw.get("id") or "")
+        if not raw_id:
+            continue
+        activity_type = _map_activity_type(str(raw.get("type") or ""))
+        try:
+            split_rows = fetch_activity_laps(raw_id, credentials, activity_type=activity_type)
+        except IntervalsIcuError as exc:
+            logger.warning("intervals.icu laps fetch failed for %s: %s", raw_id, exc)
+            continue
+        all_split_rows.extend(split_rows)
+    result.splits_written = write_splits_replace(user_id, all_split_rows, db)
+
+    wellness_rows = fetch_wellness_api(credentials, from_str, to_str)
+    result.wellness_written = write_recovery_rows(user_id, wellness_rows, "intervals_icu", db)
+
+    profile = fetch_athlete_profile_api(credentials)
+    threshold_rows = _parse_thresholds(profile, today)
+    result.thresholds_written = write_fitness(user_id, threshold_rows, "intervals_icu", db)
+
+    return result

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -9,6 +9,13 @@ Endpoints:
 - GET  /api/v1/athlete/{id}/activities              — activity list (date-windowed)
 - GET  /api/v1/activity/{id}?intervals=true         — activity detail + icu_intervals
 - GET  /api/v1/athlete/{id}/wellness                — wellness rows (date-windowed)
+
+Retry policy (exception hierarchy):
+- IntervalsIcuUnauthorized  — 401, no retry
+- IntervalsIcuClientError   — 4xx other than 401/429, no retry
+- IntervalsIcuRateLimited   — 429 after MAX_RETRIES backoff attempts
+- IntervalsIcuServerError   — 5xx after MAX_RETRIES backoff attempts
+- Network timeout treated as 5xx for retry purposes
 """
 from __future__ import annotations
 
@@ -52,6 +59,10 @@ class IntervalsIcuServerError(IntervalsIcuError):
     """5xx after retries."""
 
 
+class IntervalsIcuClientError(IntervalsIcuError):
+    """Non-retryable client error: 4xx other than 401/429."""
+
+
 def _request(
     path: str,
     *,
@@ -62,6 +73,7 @@ def _request(
 
     Retry policy:
     - 401 -> raise IntervalsIcuUnauthorized (no retry)
+    - 4xx other than 401/429 -> raise IntervalsIcuClientError (no retry)
     - 429 -> exponential backoff 1s -> 2s -> 4s -> 8s, MAX_RETRIES attempts total
     - 5xx -> same backoff, same retry budget
     - Network timeout -> treat as 5xx
@@ -102,6 +114,12 @@ def _request(
                 time.sleep(backoff)
                 backoff *= 2
             continue
+
+        if 400 <= resp.status_code < 500:
+            # 401 and 429 are handled above; anything else 4xx is a hard error.
+            raise IntervalsIcuClientError(
+                f"{resp.status_code} from {path}: {resp.text[:200]}"
+            )
 
         resp.raise_for_status()
         return resp.json()

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -1,0 +1,35 @@
+"""intervals.icu sync — HTTP layer and canonical row parsers.
+
+intervals.icu uses HTTP Basic Auth. Per V1 verification (2026-04-22),
+username is the literal string "API_KEY" and password is the user's PAT.
+The athlete_id is used only for URL path segments, not auth.
+
+Endpoints:
+- GET  /api/v1/athlete/{id}                         — profile (sportSettings)
+- GET  /api/v1/athlete/{id}/activities              — activity list (date-windowed)
+- GET  /api/v1/activity/{id}?intervals=true         — activity detail + icu_intervals
+- GET  /api/v1/athlete/{id}/wellness                — wellness rows (date-windowed)
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+INTERVALS_BASE_URL = "https://intervals.icu/api/v1"
+DEFAULT_TIMEOUT_SEC = 15
+MAX_RETRIES = 4
+INITIAL_BACKOFF_SEC = 1.0
+USER_AGENT = "praxys/intervals-icu-sync"
+
+
+def _build_auth(credentials: dict) -> tuple[str, str]:
+    """Return the (username, password) tuple for HTTP Basic Auth.
+
+    intervals.icu requires username=literal 'API_KEY', password=<PAT>.
+    """
+    return ("API_KEY", credentials["api_key"])

--- a/sync/intervals_icu_sync.py
+++ b/sync/intervals_icu_sync.py
@@ -310,3 +310,74 @@ def _parse_thresholds(profile: dict, today: date) -> list[dict]:
             })
         break  # first Run-containing entry wins
     return rows
+
+
+def fetch_athlete_profile_api(credentials: dict) -> dict:
+    """GET /athlete/{id}. Returns the profile payload."""
+    athlete_id = credentials["athlete_id"]
+    return _request(f"/athlete/{athlete_id}", credentials=credentials)
+
+
+def fetch_activities_api(
+    credentials: dict,
+    from_date: str,
+    to_date: str | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """GET /athlete/{id}/activities?oldest&newest.
+
+    Returns (canonical_rows, raw_activity_dicts). Raw is kept so the caller
+    can use it to decide which activity details to fetch for laps.
+    """
+    athlete_id = credentials["athlete_id"]
+    if to_date is None:
+        to_date = datetime.utcnow().date().isoformat()
+    params = {"oldest": from_date, "newest": to_date}
+    raw_activities = _request(
+        f"/athlete/{athlete_id}/activities",
+        credentials=credentials,
+        params=params,
+    ) or []
+    parsed = [_parse_activity(a) for a in raw_activities]
+    return parsed, raw_activities
+
+
+def fetch_activity_laps(
+    activity_id: str,
+    credentials: dict,
+    *,
+    activity_type: str,
+) -> list[dict]:
+    """GET /activity/{id}?intervals=true. Returns Praxys canonical split rows.
+
+    V3 verified (2026-04-22): the param is `intervals=true` (not
+    `include_laps=true`); per-interval data is in the response's
+    `icu_intervals` field. These are post-processed intervals
+    (WORK/RECOVERY/etc.), not raw device laps.
+
+    `activity_id` is the raw intervals.icu id (no 'icu_' prefix). The prefix
+    is added by _parse_laps().
+    """
+    detail = _request(
+        f"/activity/{activity_id}",
+        credentials=credentials,
+        params={"intervals": "true"},
+    )
+    return _parse_laps(f"icu_{activity_id}", detail, activity_type=activity_type)
+
+
+def fetch_wellness_api(
+    credentials: dict,
+    from_date: str,
+    to_date: str | None = None,
+) -> list[dict]:
+    """GET /athlete/{id}/wellness?oldest&newest. Returns canonical recovery rows."""
+    athlete_id = credentials["athlete_id"]
+    if to_date is None:
+        to_date = datetime.utcnow().date().isoformat()
+    params = {"oldest": from_date, "newest": to_date}
+    raw = _request(
+        f"/athlete/{athlete_id}/wellness",
+        credentials=credentials,
+        params=params,
+    ) or []
+    return _parse_wellness(raw)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -111,3 +111,85 @@ def test_match_activities():
     assert row1["avg_power"] == 245.0
     row2 = merged[merged["activity_id"] == "2"].iloc[0]
     assert pd.isna(row2["avg_power"])
+
+
+def test_load_data_from_db_filters_recovery_by_preference(tmp_path):
+    """When preferences.recovery is set, load_data_from_db filters
+    recovery_data to only that source."""
+    from datetime import date as D
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from analysis.data_loader import load_data_from_db
+    from db.models import Base, RecoveryData, User, UserConfig
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with SASession(engine) as db:
+        db.add(User(id="u1", email="t@e.com", hashed_password="x"))
+        db.add(UserConfig(
+            user_id="u1",
+            preferences={"recovery": "intervals_icu"},
+        ))
+        # Same date, two sources — preference should pick intervals_icu
+        db.add(RecoveryData(user_id="u1", date=D(2026, 4, 20),
+                            readiness_score=75, source="oura"))
+        db.add(RecoveryData(user_id="u1", date=D(2026, 4, 20),
+                            readiness_score=82, source="intervals_icu"))
+        db.commit()
+
+        result = load_data_from_db("u1", db)
+
+    rec = result["recovery"]
+    assert not rec.empty
+    assert list(rec["source"]) == ["intervals_icu"]
+    assert float(rec.iloc[0]["readiness_score"]) == 82
+
+
+def test_load_data_from_db_returns_all_recovery_when_no_preference(tmp_path):
+    """When preferences.recovery is unset, return all recovery rows
+    (backward-compatible behavior)."""
+    from datetime import date as D
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from analysis.data_loader import load_data_from_db
+    from db.models import Base, RecoveryData, User, UserConfig
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with SASession(engine) as db:
+        db.add(User(id="u2", email="t2@e.com", hashed_password="x"))
+        db.add(UserConfig(user_id="u2", preferences={}))
+        db.add(RecoveryData(user_id="u2", date=D(2026, 4, 20),
+                            readiness_score=75, source="oura"))
+        db.add(RecoveryData(user_id="u2", date=D(2026, 4, 20),
+                            readiness_score=82, source="intervals_icu"))
+        db.commit()
+
+        result = load_data_from_db("u2", db)
+
+    rec = result["recovery"]
+    assert len(rec) == 2
+
+
+def test_load_data_from_db_returns_all_recovery_when_no_config():
+    """If UserConfig row is absent entirely, don't crash — return all rows."""
+    from datetime import date as D
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from analysis.data_loader import load_data_from_db
+    from db.models import Base, RecoveryData, User
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with SASession(engine) as db:
+        db.add(User(id="u3", email="t3@e.com", hashed_password="x"))
+        db.add(RecoveryData(user_id="u3", date=D(2026, 4, 20),
+                            readiness_score=75, source="oura"))
+        db.commit()
+
+        result = load_data_from_db("u3", db)
+
+    assert len(result["recovery"]) == 1

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -193,3 +193,122 @@ def test_load_data_from_db_returns_all_recovery_when_no_config():
         result = load_data_from_db("u3", db)
 
     assert len(result["recovery"]) == 1
+
+
+def test_multi_source_coexistence_garmin_and_intervals_icu():
+    """End-to-end: a user with both Garmin and intervals.icu connected gets
+    the right rows based on preferences.
+
+    - Activities: both sources come through (source column preserved); filtering
+      happens in api/deps.py (not exercised here — this test checks the loader
+      passes all rows through with correct source attribution).
+    - Recovery: preference filters to intervals_icu only.
+    - Fitness: both sources come through as rows; selector disambiguates downstream.
+    """
+    from datetime import date as D
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from analysis.data_loader import load_data_from_db
+    from db.models import (
+        Activity, Base, FitnessData, RecoveryData, User, UserConfig,
+    )
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with SASession(engine) as db:
+        db.add(User(id="u1", email="t@ex.com", hashed_password="x"))
+        db.add(UserConfig(
+            user_id="u1",
+            preferences={
+                "activities": "intervals_icu",
+                "recovery": "intervals_icu",
+                "threshold_sources": {"cp_estimate": "intervals_icu"},
+            },
+        ))
+        # Two activities same date, different sources — loader returns both,
+        # deps.py filters to the preferred source.
+        db.add(Activity(
+            user_id="u1", activity_id="g_12345", date=D(2026, 4, 20),
+            distance_km=10.0, duration_sec=3000, source="garmin",
+        ))
+        db.add(Activity(
+            user_id="u1", activity_id="icu_i9000001", date=D(2026, 4, 20),
+            distance_km=10.05, duration_sec=3120, source="intervals_icu",
+        ))
+        # Two recovery rows same date: Task 13 filter should keep only intervals_icu.
+        db.add(RecoveryData(
+            user_id="u1", date=D(2026, 4, 20),
+            readiness_score=70, source="oura",
+        ))
+        db.add(RecoveryData(
+            user_id="u1", date=D(2026, 4, 20),
+            readiness_score=85, source="intervals_icu",
+        ))
+        # Fitness: cp_estimate from two sources. Loader returns both rows
+        # (selector in deps.py resolves the pick).
+        db.add(FitnessData(
+            user_id="u1", date=D(2026, 4, 18),
+            metric_type="cp_estimate", value=265.0, source="stryd",
+        ))
+        db.add(FitnessData(
+            user_id="u1", date=D(2026, 4, 20),
+            metric_type="cp_estimate", value=270.0, source="intervals_icu",
+        ))
+        db.commit()
+
+        result = load_data_from_db("u1", db)
+
+    # Activities: loader returns all rows; filtering is downstream.
+    assert "source" in result["activities"].columns
+    assert set(result["activities"]["source"]) == {"garmin", "intervals_icu"}
+    assert len(result["activities"]) == 2
+
+    # Recovery IS filtered at loader level per preferences.recovery (Task 13).
+    assert len(result["recovery"]) == 1
+    assert list(result["recovery"]["source"]) == ["intervals_icu"]
+    assert float(result["recovery"].iloc[0]["readiness_score"]) == 85
+
+    # Fitness: both rows come through to be pivoted/selected downstream.
+    # fitness is pivoted wide in load_data_from_db — confirm the wide column exists.
+    assert not result["fitness"].empty
+    assert "cp_estimate" in result["fitness"].columns
+
+
+def test_multi_source_coexistence_verifies_threshold_selector_picks_preferred():
+    """Paired with the loader test above — confirm the downstream threshold
+    selector picks intervals_icu when pinned, even if Stryd has a more
+    recent row."""
+    from datetime import date as D
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+
+    from api.deps import _resolve_thresholds
+    from db.models import Base, FitnessData, User
+
+    # Build a minimal config-like object the selector expects.
+    class _Cfg:
+        preferences = {"threshold_sources": {"cp_estimate": "intervals_icu"}}
+        thresholds = {}
+        connections = []
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with SASession(engine) as db:
+        db.add(User(id="u1", email="t@ex.com", hashed_password="x"))
+        # Stryd row is MORE RECENT (date-wise) than intervals_icu. Without the
+        # preference pin, the latest-by-date fallback would pick Stryd.
+        db.add(FitnessData(
+            user_id="u1", date=D(2026, 4, 22),
+            metric_type="cp_estimate", value=265.0, source="stryd",
+        ))
+        db.add(FitnessData(
+            user_id="u1", date=D(2026, 4, 20),
+            metric_type="cp_estimate", value=270.0, source="intervals_icu",
+        ))
+        db.commit()
+
+        estimate = _resolve_thresholds(_Cfg(), user_id="u1", db=db)
+
+    # The preference pin overrides latest-by-date.
+    assert estimate.cp_watts == 270.0

--- a/tests/test_deps_thresholds.py
+++ b/tests/test_deps_thresholds.py
@@ -278,6 +278,53 @@ def test_write_profile_thresholds_upserts_existing_same_day(db_with_user):
     assert result.rest_hr_bpm == 48.0
 
 
+def test_intervals_icu_cp_estimate_is_picked_when_pinned(db_with_user):
+    """With preferences.threshold_sources['cp_estimate']='intervals_icu',
+    the selector returns the intervals.icu row's value — even if another
+    source has a newer row.
+    """
+    from db.models import FitnessData
+    from api.deps import _resolve_thresholds
+
+    db, user_id = db_with_user
+    today = date.today()
+    # Stryd has the newer row; intervals.icu is older.
+    db.add(FitnessData(
+        user_id=user_id, date=today, metric_type="cp_estimate",
+        value=265.0, source="stryd",
+    ))
+    db.add(FitnessData(
+        user_id=user_id, date=today - timedelta(days=2), metric_type="cp_estimate",
+        value=270.0, source="intervals_icu",
+    ))
+    db.commit()
+
+    cfg = _fake_config(threshold_sources={"cp_estimate": "intervals_icu"})
+    result = _resolve_thresholds(cfg, user_id=user_id, db=db)
+    assert result.cp_watts == 270.0, (
+        "explicit intervals_icu pin must win over latest-by-date Stryd row"
+    )
+
+
+def test_intervals_icu_lthr_is_picked_when_pinned(db_with_user):
+    """Same check for lthr_bpm: the pinned intervals.icu row must be
+    selected by the resolver.
+    """
+    from db.models import FitnessData
+    from api.deps import _resolve_thresholds
+
+    db, user_id = db_with_user
+    db.add(FitnessData(
+        user_id=user_id, date=date.today(), metric_type="lthr_bpm",
+        value=168.0, source="intervals_icu",
+    ))
+    db.commit()
+
+    cfg = _fake_config(threshold_sources={"lthr_bpm": "intervals_icu"})
+    result = _resolve_thresholds(cfg, user_id=user_id, db=db)
+    assert result.lthr_bpm == 168.0
+
+
 def test_hr_base_daily_load_non_zero_via_trimp_fallback(db_with_user):
     """End-to-end regression: an HR-base user with max_hr_bpm and activities
     but no lthr_bpm (the Garmin CN shape) must still get non-zero daily load.

--- a/tests/test_intervals_icu_integration.py
+++ b/tests/test_intervals_icu_integration.py
@@ -1,0 +1,107 @@
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from db.models import Activity, ActivitySplit, Base, FitnessData, RecoveryData, User
+
+FIXTURE_DIR = Path(__file__).parent.parent / "data" / "sample" / "intervals_icu"
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        user = User(id="u-test", email="t@example.com", hashed_password="x")
+        session.add(user)
+        session.commit()
+        yield session
+
+
+def _load(name):
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+@patch("sync.intervals_icu_sync.fetch_athlete_profile_api")
+@patch("sync.intervals_icu_sync.fetch_wellness_api")
+@patch("sync.intervals_icu_sync.fetch_activity_laps")
+@patch("sync.intervals_icu_sync.fetch_activities_api")
+def test_sync_all_writes_all_tables(
+    mock_activities, mock_laps, mock_wellness, mock_profile, db
+):
+    from sync.intervals_icu_sync import (
+        _parse_activity, _parse_laps, _parse_wellness, sync_all,
+    )
+
+    acts = _load("activities.json")
+    mock_activities.return_value = ([_parse_activity(a) for a in acts], acts)
+    mock_laps.side_effect = lambda aid, *a, **kw: _parse_laps(
+        f"icu_{aid}", _load(f"activity_{aid}_intervals.json"), activity_type="running",
+    )
+    mock_wellness.return_value = _parse_wellness(_load("wellness.json"))
+    mock_profile.return_value = _load("athlete_profile.json")
+
+    credentials = {"athlete_id": "i123456", "api_key": "k"}
+    result = sync_all(
+        user_id="u-test",
+        credentials=credentials,
+        db=db,
+        since=date(2026, 4, 1),
+        today=date(2026, 4, 22),
+    )
+
+    assert result.activities_written == 2
+    assert result.splits_written == 4  # 3 + 1
+    assert result.wellness_written == 5
+    assert result.thresholds_written == 4
+
+    activities = db.query(Activity).filter_by(user_id="u-test").all()
+    assert {a.activity_id for a in activities} == {"icu_i9000001", "icu_i9000002"}
+    assert all(a.source == "intervals_icu" for a in activities)
+
+    splits = db.query(ActivitySplit).filter_by(user_id="u-test").all()
+    assert len(splits) == 4
+
+    recovery = db.query(RecoveryData).filter_by(user_id="u-test").all()
+    assert len(recovery) == 5
+    assert all(r.source == "intervals_icu" for r in recovery)
+
+    fitness = db.query(FitnessData).filter_by(user_id="u-test").all()
+    assert {f.metric_type for f in fitness} == {
+        "running_ftp", "lthr", "threshold_pace_sec_km", "max_hr",
+    }
+    assert all(f.source == "intervals_icu" for f in fitness)
+
+
+@patch("sync.intervals_icu_sync.fetch_athlete_profile_api")
+@patch("sync.intervals_icu_sync.fetch_wellness_api")
+@patch("sync.intervals_icu_sync.fetch_activity_laps")
+@patch("sync.intervals_icu_sync.fetch_activities_api")
+def test_sync_all_is_idempotent(
+    mock_activities, mock_laps, mock_wellness, mock_profile, db
+):
+    from sync.intervals_icu_sync import _parse_activity, _parse_laps, _parse_wellness, sync_all
+
+    acts = _load("activities.json")
+    mock_activities.return_value = ([_parse_activity(a) for a in acts], acts)
+    mock_laps.side_effect = lambda aid, *a, **kw: _parse_laps(
+        f"icu_{aid}", _load(f"activity_{aid}_intervals.json"), activity_type="running",
+    )
+    mock_wellness.return_value = _parse_wellness(_load("wellness.json"))
+    mock_profile.return_value = _load("athlete_profile.json")
+
+    credentials = {"athlete_id": "i123456", "api_key": "k"}
+    for _ in range(2):
+        sync_all(
+            user_id="u-test", credentials=credentials, db=db,
+            since=date(2026, 4, 1), today=date(2026, 4, 22),
+        )
+
+    assert db.query(Activity).filter_by(user_id="u-test").count() == 2
+    assert db.query(ActivitySplit).filter_by(user_id="u-test").count() == 4
+    assert db.query(RecoveryData).filter_by(user_id="u-test").count() == 5

--- a/tests/test_intervals_icu_integration.py
+++ b/tests/test_intervals_icu_integration.py
@@ -73,7 +73,7 @@ def test_sync_all_writes_all_tables(
 
     fitness = db.query(FitnessData).filter_by(user_id="u-test").all()
     assert {f.metric_type for f in fitness} == {
-        "running_ftp", "lthr", "threshold_pace_sec_km", "max_hr",
+        "cp_estimate", "lthr_bpm", "lt_pace_sec_km", "max_hr_bpm",
     }
     assert all(f.source == "intervals_icu" for f in fitness)
 

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -164,3 +164,57 @@ def test_parse_activity_maps_virtual_run_to_running():
     }
     row = _parse_activity(activity)
     assert row["activity_type"] == "running"
+
+
+def test_parse_laps_reads_from_icu_intervals_field():
+    from sync.intervals_icu_sync import _parse_laps
+    detail = _load_fixture("activity_i9000001_intervals.json")
+    rows = _parse_laps("icu_i9000001", detail, activity_type="running")
+    assert len(rows) == 3
+
+
+def test_parse_laps_preserves_array_order():
+    from sync.intervals_icu_sync import _parse_laps
+    detail = _load_fixture("activity_i9000001_intervals.json")
+    rows = _parse_laps("icu_i9000001", detail, activity_type="running")
+    assert [r["split_num"] for r in rows] == ["1", "2", "3"]
+    assert float(rows[1]["distance_km"]) == pytest.approx(5.0, abs=0.001)
+
+
+def test_parse_laps_attaches_prefixed_activity_id():
+    from sync.intervals_icu_sync import _parse_laps
+    detail = _load_fixture("activity_i9000001_intervals.json")
+    rows = _parse_laps("icu_i9000001", detail, activity_type="running")
+    for row in rows:
+        assert row["activity_id"] == "icu_i9000001"
+
+
+def test_parse_laps_doubles_cadence_for_run():
+    from sync.intervals_icu_sync import _parse_laps
+    detail = _load_fixture("activity_i9000001_intervals.json")
+    rows = _parse_laps("icu_i9000001", detail, activity_type="running")
+    # interval 1 cadence=86.0 single-leg -> 172 double-leg spm
+    assert float(rows[0]["avg_cadence"]) == pytest.approx(172.0, abs=0.1)
+
+
+def test_parse_laps_leaves_elevation_change_empty():
+    """icu_intervals has no per-interval elevation fields — leave empty."""
+    from sync.intervals_icu_sync import _parse_laps
+    detail = _load_fixture("activity_i9000001_intervals.json")
+    rows = _parse_laps("icu_i9000001", detail, activity_type="running")
+    for row in rows:
+        assert row["elevation_change_m"] in (None, "")
+
+
+def test_parse_laps_handles_single_interval_null_power():
+    from sync.intervals_icu_sync import _parse_laps
+    detail = _load_fixture("activity_i9000002_intervals.json")
+    rows = _parse_laps("icu_i9000002", detail, activity_type="running")
+    assert len(rows) == 1
+    assert rows[0]["avg_power"] in (None, "")
+
+
+def test_parse_laps_returns_empty_when_no_intervals():
+    from sync.intervals_icu_sync import _parse_laps
+    assert _parse_laps("icu_zzz", {"id": "zzz"}, activity_type="running") == []
+    assert _parse_laps("icu_zzz", {"icu_intervals": []}, activity_type="running") == []

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sync.intervals_icu_sync import INTERVALS_BASE_URL, _build_auth
+
+
+def test_build_auth_uses_api_key_username_form():
+    """HTTP Basic auth: username is literal 'API_KEY', password is user PAT.
+
+    Verified V1 against live API on 2026-04-22. The alternate form
+    (username=athlete_id) returned 403.
+    """
+    auth = _build_auth({"athlete_id": "i123456", "api_key": "secret-pat"})
+    assert auth == ("API_KEY", "secret-pat")

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -50,6 +50,22 @@ def test_request_401_raises_unauthorized(mock_get):
         _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
 
 
+@patch("sync.intervals_icu_sync.requests.get")
+def test_request_403_raises_client_error(mock_get):
+    from sync.intervals_icu_sync import IntervalsIcuClientError
+    mock_get.return_value = _mock_response(403)
+    with pytest.raises(IntervalsIcuClientError):
+        _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
+
+
+@patch("sync.intervals_icu_sync.requests.get")
+def test_request_404_raises_client_error(mock_get):
+    from sync.intervals_icu_sync import IntervalsIcuClientError
+    mock_get.return_value = _mock_response(404)
+    with pytest.raises(IntervalsIcuClientError):
+        _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
+
+
 @patch("sync.intervals_icu_sync.time.sleep")
 @patch("sync.intervals_icu_sync.requests.get")
 def test_request_429_retries_with_backoff(mock_get, mock_sleep):

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -300,3 +300,65 @@ def test_parse_thresholds_ignores_sport_settings_without_run():
     }
     rows = _parse_thresholds(profile, date(2026, 4, 22))
     assert rows == []
+
+
+@patch("sync.intervals_icu_sync._request")
+def test_fetch_activities_api_uses_date_window_params(mock_req):
+    from sync.intervals_icu_sync import fetch_activities_api
+    mock_req.return_value = []
+    creds = {"athlete_id": "i123456", "api_key": "k"}
+    fetch_activities_api(creds, from_date="2026-04-01", to_date="2026-04-22")
+    path = mock_req.call_args.args[0]
+    params = mock_req.call_args.kwargs["params"]
+    assert path == "/athlete/i123456/activities"
+    assert params["oldest"] == "2026-04-01"
+    assert params["newest"] == "2026-04-22"
+
+
+@patch("sync.intervals_icu_sync._request")
+def test_fetch_activities_api_returns_parsed_rows(mock_req):
+    from sync.intervals_icu_sync import fetch_activities_api
+    mock_req.return_value = _load_fixture("activities.json")
+    creds = {"athlete_id": "i123456", "api_key": "k"}
+    rows, raw = fetch_activities_api(creds, from_date="2026-04-01")
+    assert len(rows) == 2
+    assert rows[0]["activity_id"] == "icu_i9000001"
+    assert len(raw) == 2
+    assert raw[0]["id"] == "i9000001"
+
+
+@patch("sync.intervals_icu_sync._request")
+def test_fetch_activity_laps_uses_intervals_param(mock_req):
+    """V3 verified: lap data via ?intervals=true, response field icu_intervals."""
+    from sync.intervals_icu_sync import fetch_activity_laps
+    mock_req.return_value = _load_fixture("activity_i9000001_intervals.json")
+    creds = {"athlete_id": "i123456", "api_key": "k"}
+    rows = fetch_activity_laps("i9000001", creds, activity_type="running")
+    path = mock_req.call_args.args[0]
+    params = mock_req.call_args.kwargs["params"]
+    assert path == "/activity/i9000001"
+    assert params == {"intervals": "true"}
+    assert len(rows) == 3
+
+
+@patch("sync.intervals_icu_sync._request")
+def test_fetch_wellness_api(mock_req):
+    from sync.intervals_icu_sync import fetch_wellness_api
+    mock_req.return_value = _load_fixture("wellness.json")
+    creds = {"athlete_id": "i123456", "api_key": "k"}
+    rows = fetch_wellness_api(creds, from_date="2026-04-16", to_date="2026-04-20")
+    path = mock_req.call_args.args[0]
+    assert path == "/athlete/i123456/wellness"
+    assert len(rows) == 5
+
+
+@patch("sync.intervals_icu_sync._request")
+def test_fetch_athlete_profile_api(mock_req):
+    from sync.intervals_icu_sync import fetch_athlete_profile_api
+    mock_req.return_value = _load_fixture("athlete_profile.json")
+    creds = {"athlete_id": "i123456", "api_key": "k"}
+    profile = fetch_athlete_profile_api(creds)
+    path = mock_req.call_args.args[0]
+    assert path == "/athlete/i123456"
+    assert profile["id"] == "i123456"
+    assert len(profile["sportSettings"]) == 2

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -218,3 +219,84 @@ def test_parse_laps_returns_empty_when_no_intervals():
     from sync.intervals_icu_sync import _parse_laps
     assert _parse_laps("icu_zzz", {"id": "zzz"}, activity_type="running") == []
     assert _parse_laps("icu_zzz", {"icu_intervals": []}, activity_type="running") == []
+
+
+def test_parse_wellness_maps_date_and_fields():
+    from sync.intervals_icu_sync import _parse_wellness
+    wellness = _load_fixture("wellness.json")
+    rows = _parse_wellness(wellness)
+    assert len(rows) == 5
+    first = rows[0]
+    assert first["date"] == "2026-04-16"
+    assert float(first["readiness_score"]) == 82
+    assert float(first["hrv_avg"]) == 64.2
+    assert float(first["resting_hr"]) == 48
+    assert float(first["sleep_score"]) == 85
+    assert float(first["total_sleep_sec"]) == 27900
+    # intervals.icu does not expose these
+    assert first.get("deep_sleep_sec") in (None, "")
+    assert first.get("rem_sleep_sec") in (None, "")
+    assert first.get("body_temp_delta") in (None, "")
+    assert first["source"] == "intervals_icu"
+
+
+def test_parse_thresholds_extracts_run_sport_settings():
+    from sync.intervals_icu_sync import _parse_thresholds
+    profile = _load_fixture("athlete_profile.json")
+    today = date(2026, 4, 22)
+    rows = _parse_thresholds(profile, today)
+    metrics = {r["metric_type"]: r for r in rows}
+    assert "running_ftp" in metrics
+    assert float(metrics["running_ftp"]["value"]) == 270
+    assert "lthr" in metrics
+    assert float(metrics["lthr"]["value"]) == 168
+    # threshold_pace in m/s (V2 verified). Fixture 4.08163 m/s -> ~245.0 sec/km.
+    assert "threshold_pace_sec_km" in metrics
+    assert float(metrics["threshold_pace_sec_km"]["value"]) == pytest.approx(245.0, abs=0.5)
+    assert "max_hr" in metrics
+    assert float(metrics["max_hr"]["value"]) == 192
+    for row in rows:
+        assert row["date"] == "2026-04-22"
+        assert row["source"] == "intervals_icu"
+
+
+def test_parse_thresholds_converts_threshold_pace_from_mps():
+    """intervals.icu returns threshold_pace in m/s; Praxys stores sec/km."""
+    from sync.intervals_icu_sync import _parse_thresholds
+    profile = {
+        "sportSettings": [{
+            "types": ["Run"],
+            "ftp": 270, "lthr": 168, "max_hr": 192,
+            "threshold_pace": 4.2918453,  # m/s -> 1000/4.29 ~= 233.0 sec/km
+        }],
+    }
+    rows = _parse_thresholds(profile, date(2026, 4, 22))
+    metric = {r["metric_type"]: r for r in rows}
+    assert float(metric["threshold_pace_sec_km"]["value"]) == pytest.approx(233.0, abs=0.5)
+
+
+def test_parse_thresholds_skips_null_ftp():
+    """When sportSettings has ftp=None, do not emit a running_ftp row."""
+    from sync.intervals_icu_sync import _parse_thresholds
+    profile = {
+        "sportSettings": [{
+            "types": ["Run"],
+            "ftp": None, "lthr": 168, "max_hr": 192,
+            "threshold_pace": 4.08,
+        }],
+    }
+    rows = _parse_thresholds(profile, date(2026, 4, 22))
+    metric_types = {r["metric_type"] for r in rows}
+    assert "running_ftp" not in metric_types
+    assert "lthr" in metric_types
+
+
+def test_parse_thresholds_ignores_sport_settings_without_run():
+    """If only Ride sportSettings exist, no threshold rows are emitted."""
+    from sync.intervals_icu_sync import _parse_thresholds
+    profile = {
+        "id": "i123456",
+        "sportSettings": [{"types": ["Ride"], "ftp": 290, "lthr": 170}],
+    }
+    rows = _parse_thresholds(profile, date(2026, 4, 22))
+    assert rows == []

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from sync.intervals_icu_sync import INTERVALS_BASE_URL, _build_auth
+from sync.intervals_icu_sync import INTERVALS_BASE_URL, _build_auth, _request
 
 
 def test_build_auth_uses_api_key_username_form():
@@ -13,3 +13,62 @@ def test_build_auth_uses_api_key_username_form():
     """
     auth = _build_auth({"athlete_id": "i123456", "api_key": "secret-pat"})
     assert auth == ("API_KEY", "secret-pat")
+
+
+def _mock_response(status_code: int = 200, json_payload=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload or {}
+    if status_code >= 400:
+        def _raise():
+            from requests import HTTPError
+            raise HTTPError(response=resp)
+        resp.raise_for_status.side_effect = _raise
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+@patch("sync.intervals_icu_sync.requests.get")
+def test_request_returns_json_on_200(mock_get):
+    mock_get.return_value = _mock_response(200, {"ok": True})
+    result = _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
+    assert result == {"ok": True}
+    mock_get.assert_called_once()
+    call_kwargs = mock_get.call_args.kwargs
+    assert call_kwargs["auth"] == ("API_KEY", "k")
+    assert call_kwargs["timeout"] == 15
+    assert "praxys" in call_kwargs["headers"]["User-Agent"]
+
+
+@patch("sync.intervals_icu_sync.requests.get")
+def test_request_401_raises_unauthorized(mock_get):
+    from sync.intervals_icu_sync import IntervalsIcuUnauthorized
+    mock_get.return_value = _mock_response(401)
+    with pytest.raises(IntervalsIcuUnauthorized):
+        _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
+
+
+@patch("sync.intervals_icu_sync.time.sleep")
+@patch("sync.intervals_icu_sync.requests.get")
+def test_request_429_retries_with_backoff(mock_get, mock_sleep):
+    mock_get.side_effect = [
+        _mock_response(429),
+        _mock_response(429),
+        _mock_response(200, {"ok": True}),
+    ]
+    result = _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
+    assert result == {"ok": True}
+    assert mock_get.call_count == 3
+    assert mock_sleep.call_args_list[0].args[0] == 1.0
+    assert mock_sleep.call_args_list[1].args[0] == 2.0
+
+
+@patch("sync.intervals_icu_sync.time.sleep")
+@patch("sync.intervals_icu_sync.requests.get")
+def test_request_429_exhausts_retries(mock_get, mock_sleep):
+    from sync.intervals_icu_sync import IntervalsIcuRateLimited
+    mock_get.return_value = _mock_response(429)
+    with pytest.raises(IntervalsIcuRateLimited):
+        _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
+    assert mock_get.call_count == 4  # MAX_RETRIES

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -246,15 +246,15 @@ def test_parse_thresholds_extracts_run_sport_settings():
     today = date(2026, 4, 22)
     rows = _parse_thresholds(profile, today)
     metrics = {r["metric_type"]: r for r in rows}
-    assert "running_ftp" in metrics
-    assert float(metrics["running_ftp"]["value"]) == 270
-    assert "lthr" in metrics
-    assert float(metrics["lthr"]["value"]) == 168
+    assert "cp_estimate" in metrics
+    assert float(metrics["cp_estimate"]["value"]) == 270
+    assert "lthr_bpm" in metrics
+    assert float(metrics["lthr_bpm"]["value"]) == 168
     # threshold_pace in m/s (V2 verified). Fixture 4.08163 m/s -> ~245.0 sec/km.
-    assert "threshold_pace_sec_km" in metrics
-    assert float(metrics["threshold_pace_sec_km"]["value"]) == pytest.approx(245.0, abs=0.5)
-    assert "max_hr" in metrics
-    assert float(metrics["max_hr"]["value"]) == 192
+    assert "lt_pace_sec_km" in metrics
+    assert float(metrics["lt_pace_sec_km"]["value"]) == pytest.approx(245.0, abs=0.5)
+    assert "max_hr_bpm" in metrics
+    assert float(metrics["max_hr_bpm"]["value"]) == 192
     for row in rows:
         assert row["date"] == "2026-04-22"
         assert row["source"] == "intervals_icu"
@@ -272,11 +272,11 @@ def test_parse_thresholds_converts_threshold_pace_from_mps():
     }
     rows = _parse_thresholds(profile, date(2026, 4, 22))
     metric = {r["metric_type"]: r for r in rows}
-    assert float(metric["threshold_pace_sec_km"]["value"]) == pytest.approx(233.0, abs=0.5)
+    assert float(metric["lt_pace_sec_km"]["value"]) == pytest.approx(233.0, abs=0.5)
 
 
 def test_parse_thresholds_skips_null_ftp():
-    """When sportSettings has ftp=None, do not emit a running_ftp row."""
+    """When sportSettings has ftp=None, do not emit a cp_estimate row."""
     from sync.intervals_icu_sync import _parse_thresholds
     profile = {
         "sportSettings": [{
@@ -287,8 +287,8 @@ def test_parse_thresholds_skips_null_ftp():
     }
     rows = _parse_thresholds(profile, date(2026, 4, 22))
     metric_types = {r["metric_type"] for r in rows}
-    assert "running_ftp" not in metric_types
-    assert "lthr" in metric_types
+    assert "cp_estimate" not in metric_types
+    assert "lthr_bpm" in metric_types
 
 
 def test_parse_thresholds_ignores_sport_settings_without_run():

--- a/tests/test_intervals_icu_sync.py
+++ b/tests/test_intervals_icu_sync.py
@@ -72,3 +72,95 @@ def test_request_429_exhausts_retries(mock_get, mock_sleep):
     with pytest.raises(IntervalsIcuRateLimited):
         _request("/athlete/i1", credentials={"athlete_id": "i1", "api_key": "k"})
     assert mock_get.call_count == 4  # MAX_RETRIES
+
+
+import json
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).parent.parent / "data" / "sample" / "intervals_icu"
+
+
+def _load_fixture(name: str):
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+def test_parse_activity_applies_icu_prefix_to_id():
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0]
+    row = _parse_activity(activity)
+    assert row["activity_id"] == "icu_i9000001"
+    assert row["source"] == "intervals_icu"
+
+
+def test_parse_activity_uses_local_date_prefix_only():
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0]
+    row = _parse_activity(activity)
+    assert row["date"] == "2026-04-18"
+
+
+def test_parse_activity_maps_run_to_running():
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0]
+    row = _parse_activity(activity)
+    assert row["activity_type"] == "running"
+
+
+def test_parse_activity_converts_meters_and_computes_pace():
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0]
+    row = _parse_activity(activity)
+    # 10050m = 10.05km
+    assert float(row["distance_km"]) == pytest.approx(10.05, abs=0.001)
+    # 3120s / 10.05km ~ 310.4 sec/km
+    assert float(row["avg_pace_sec_km"]) == pytest.approx(310.4, abs=0.5)
+
+
+def test_parse_activity_prefers_icu_average_watts_over_average_watts():
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0].copy()
+    activity["icu_average_watts"] = 280
+    activity["average_watts"] = 220
+    row = _parse_activity(activity)
+    assert float(row["avg_power"]) == 280
+
+
+def test_parse_activity_doubles_cadence_for_run():
+    """intervals.icu reports single-leg cadence; Praxys stores double-leg spm."""
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0]
+    # fixture has average_cadence=87.5 single-leg -> 175 spm
+    row = _parse_activity(activity)
+    assert float(row["avg_cadence"]) == pytest.approx(175.0, abs=0.1)
+
+
+def test_parse_activity_leaves_derived_load_metrics_null():
+    """Per scientific-rigor principle, Praxys computes RSS/TRIMP itself."""
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[0]
+    row = _parse_activity(activity)
+    assert row.get("rss") in (None, "")
+    assert row.get("trimp") in (None, "")
+    assert row.get("training_effect") in (None, "")
+
+
+def test_parse_activity_with_null_power_yields_empty_strings():
+    from sync.intervals_icu_sync import _parse_activity
+    activity = _load_fixture("activities.json")[1]  # the null-power run
+    row = _parse_activity(activity)
+    assert row["avg_power"] in (None, "")
+    assert row["max_power"] in (None, "")
+
+
+def test_parse_activity_maps_virtual_run_to_running():
+    """V4 verified: VirtualRun activity type maps to running."""
+    from sync.intervals_icu_sync import _parse_activity
+    activity = {
+        "id": "i9900001",
+        "start_date_local": "2026-04-19T08:00:00",
+        "type": "VirtualRun",
+        "distance": 5000.0,
+        "moving_time": 1800,
+    }
+    row = _parse_activity(activity)
+    assert row["activity_type"] == "running"

--- a/tests/test_intervals_icu_sync_route.py
+++ b/tests/test_intervals_icu_sync_route.py
@@ -1,0 +1,107 @@
+"""API route + scheduler integration for intervals.icu."""
+from unittest.mock import patch
+
+import pytest
+
+
+def test_intervals_icu_is_in_default_sources():
+    from api.routes.sync import _DEFAULT_SOURCES
+    assert "intervals_icu" in _DEFAULT_SOURCES
+
+
+def test_sync_intervals_icu_handler_exists():
+    """The internal handler used by both scheduler and manual sync must exist
+    under the name the scheduler imports (_sync_intervals_icu)."""
+    from api.routes.sync import _sync_intervals_icu
+    assert callable(_sync_intervals_icu)
+
+
+@patch("api.routes.sync.intervals_icu_sync")
+def test_sync_intervals_icu_handler_invokes_sync_all(mock_mod):
+    """_sync_intervals_icu must call sync_all with correct kwargs and
+    return a counts dict derived from SyncResult."""
+    from api.routes.sync import _sync_intervals_icu
+    from sync.intervals_icu_sync import SyncResult
+
+    mock_mod.sync_all.return_value = SyncResult(
+        activities_written=5, splits_written=12,
+        wellness_written=7, thresholds_written=4,
+    )
+    creds = {"athlete_id": "i1", "api_key": "k"}
+
+    counts = _sync_intervals_icu("u1", creds, None, db=None)
+
+    mock_mod.sync_all.assert_called_once()
+    call = mock_mod.sync_all.call_args
+    assert call.kwargs["user_id"] == "u1"
+    assert call.kwargs["credentials"] == creds
+    assert "since" in call.kwargs
+
+    # Counts dict exposes each field from SyncResult.
+    assert counts["activities"] == 5
+    assert counts["splits"] == 12
+    assert counts["recovery"] == 7
+    assert counts["fitness"] == 4
+
+
+@patch("api.routes.sync.intervals_icu_sync")
+def test_sync_intervals_icu_honors_from_date(mock_mod):
+    """When from_date is supplied, it overrides the default 180-day window."""
+    from datetime import date
+    from api.routes.sync import _sync_intervals_icu
+    from sync.intervals_icu_sync import SyncResult
+
+    mock_mod.sync_all.return_value = SyncResult()
+    _sync_intervals_icu("u1", {"athlete_id":"i1","api_key":"k"}, "2025-01-15", db=None)
+
+    call = mock_mod.sync_all.call_args
+    assert call.kwargs["since"] == date(2025, 1, 15)
+
+
+def test_scheduler_handles_intervals_icu_platform():
+    """Confirm the scheduler's dispatch doesn't choke on platform=intervals_icu
+    — it should route to _sync_connection which dispatches to intervals_icu_sync."""
+    # Not a behavior test on the scheduler's elif branch per se (that's
+    # unit-tested via test_scheduler_dispatches_intervals_icu below), just
+    # confirms the imports wire correctly.
+    from db.sync_scheduler import _sync_connection
+    assert callable(_sync_connection)
+
+
+@patch("sync.intervals_icu_sync.sync_all")
+def test_scheduler_dispatches_intervals_icu(mock_sync_all):
+    """_sync_connection with platform='intervals_icu' calls sync_all via the
+    api.routes.sync._sync_intervals_icu handler."""
+    from datetime import date
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as SASession
+    from db.models import Base, User, UserConnection
+    from db.crypto import get_vault
+    from sync.intervals_icu_sync import SyncResult
+
+    # Build a minimal in-memory DB with a user + connection.
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with SASession(engine) as db:
+        db.add(User(id="u1", email="t@e.com", hashed_password="x"))
+        db.commit()
+
+        vault = get_vault()
+        import json
+        encrypted, wrapped = vault.encrypt(json.dumps({"athlete_id": "i1", "api_key": "k"}))
+        db.add(UserConnection(
+            user_id="u1", platform="intervals_icu",
+            encrypted_credentials=encrypted, wrapped_dek=wrapped,
+            status="connected",
+        ))
+        db.commit()
+
+        mock_sync_all.return_value = SyncResult(activities_written=3)
+
+        from db.sync_scheduler import _sync_connection
+        _sync_connection("u1", "intervals_icu", db)
+
+        mock_sync_all.assert_called_once()
+        call = mock_sync_all.call_args
+        assert call.kwargs["user_id"] == "u1"
+        assert call.kwargs["credentials"] == {"athlete_id": "i1", "api_key": "k"}

--- a/tests/test_settings_intervals_icu_api.py
+++ b/tests/test_settings_intervals_icu_api.py
@@ -126,3 +126,70 @@ def test_post_does_not_override_existing_preferences(api_client, user_id, db):
     db.expire_all()
     db.refresh(cfg)
     assert cfg.preferences["activities"] == "garmin"
+
+
+def test_delete_intervals_icu_falls_back_to_next_available_source(api_client, db):
+    """When Garmin is connected and preferences point to intervals.icu,
+    DELETE should rewrite preferences to garmin (for activities + thresholds)
+    and to the next recovery source (garmin, since oura absent)."""
+    client, user_id = api_client
+    from db.models import UserConfig, UserConnection
+    db.add(UserConnection(
+        user_id=user_id, platform="garmin", status="connected",
+    ))
+    db.add(UserConnection(
+        user_id=user_id, platform="intervals_icu", status="connected",
+    ))
+    cfg = db.query(UserConfig).filter_by(user_id=user_id).one()
+    cfg.preferences = {
+        "activities": "intervals_icu",
+        "recovery": "intervals_icu",
+        "threshold_sources": {"cp_estimate": "intervals_icu"},
+    }
+    db.commit()
+
+    resp = client.delete("/api/settings/connections/intervals_icu")
+    assert resp.status_code == 200
+    db.refresh(cfg)
+    assert cfg.preferences["activities"] == "garmin"
+    # Recovery fallback priority: oura > garmin. No oura -> garmin.
+    assert cfg.preferences["recovery"] == "garmin"
+    # Threshold fallback priority: stryd > garmin > strava. No stryd -> garmin.
+    assert cfg.preferences["threshold_sources"]["cp_estimate"] == "garmin"
+
+
+def test_delete_intervals_icu_unsets_preference_when_no_fallback(api_client, db):
+    """No other source connected -> preference key is removed entirely."""
+    client, user_id = api_client
+    from db.models import UserConfig, UserConnection
+    db.add(UserConnection(
+        user_id=user_id, platform="intervals_icu", status="connected",
+    ))
+    cfg = db.query(UserConfig).filter_by(user_id=user_id).one()
+    cfg.preferences = {
+        "activities": "intervals_icu",
+        "recovery": "intervals_icu",
+    }
+    db.commit()
+
+    client.delete("/api/settings/connections/intervals_icu")
+    db.refresh(cfg)
+    assert "activities" not in cfg.preferences or cfg.preferences["activities"] is None
+    assert "recovery" not in cfg.preferences or cfg.preferences["recovery"] is None
+
+
+def test_delete_intervals_icu_leaves_unrelated_preferences_alone(api_client, db):
+    """If activities is pinned to garmin (not intervals_icu), DELETE must not
+    touch it."""
+    client, user_id = api_client
+    from db.models import UserConfig, UserConnection
+    db.add(UserConnection(
+        user_id=user_id, platform="intervals_icu", status="connected",
+    ))
+    cfg = db.query(UserConfig).filter_by(user_id=user_id).one()
+    cfg.preferences = {"activities": "garmin", "recovery": "intervals_icu"}
+    db.commit()
+
+    client.delete("/api/settings/connections/intervals_icu")
+    db.refresh(cfg)
+    assert cfg.preferences["activities"] == "garmin"  # unchanged

--- a/tests/test_settings_intervals_icu_api.py
+++ b/tests/test_settings_intervals_icu_api.py
@@ -1,0 +1,128 @@
+"""Settings API for intervals.icu connection."""
+from unittest.mock import patch
+
+import pytest
+
+from tests.test_settings_api import api_client as _api_client_fixture  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def reset_vault():
+    from db import crypto
+
+    crypto._vault = None
+    try:
+        yield
+    finally:
+        crypto._vault = None
+
+
+@pytest.fixture
+def api_client(monkeypatch, _api_client_fixture):  # noqa: F811
+    """Unpack the (client, user_id) tuple from the shared fixture."""
+    return _api_client_fixture
+
+
+@pytest.fixture
+def user_id(api_client):
+    _, uid = api_client
+    return uid
+
+
+@pytest.fixture
+def db(user_id):
+    """Yield an open DB session (same engine as the test client) and seed UserConfig."""
+    from db import session as db_session
+    from db.models import UserConfig
+
+    session = db_session.SessionLocal()
+    try:
+        # Ensure a UserConfig row exists for the test user so auto-populate tests work.
+        if not session.query(UserConfig).filter_by(user_id=user_id).first():
+            session.add(UserConfig(user_id=user_id, preferences={}))
+            session.commit()
+        yield session
+    finally:
+        session.close()
+
+
+def test_post_connects_intervals_icu_on_valid_credentials(api_client, user_id):
+    """Validate credentials against fetch_athlete_profile_api, then persist."""
+    client, _ = api_client
+    with patch("sync.intervals_icu_sync.fetch_athlete_profile_api") as mock:
+        mock.return_value = {"id": "i123456", "sportSettings": []}
+        resp = client.post(
+            "/api/settings/connections/intervals_icu",
+            json={"athlete_id": "i123456", "api_key": "pat"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "connected"
+
+
+def test_post_rejects_invalid_intervals_icu_credentials(api_client, user_id):
+    """Handler returns 200 with status=error (consistent with all other platforms)."""
+    client, _ = api_client
+    from sync.intervals_icu_sync import IntervalsIcuUnauthorized
+
+    with patch(
+        "sync.intervals_icu_sync.fetch_athlete_profile_api",
+        side_effect=IntervalsIcuUnauthorized("401"),
+    ):
+        resp = client.post(
+            "/api/settings/connections/intervals_icu",
+            json={"athlete_id": "i123456", "api_key": "bad"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "invalid" in body["message"].lower() or "credentials" in body["message"].lower()
+
+
+def test_post_requires_athlete_id_and_api_key(api_client, user_id):
+    """Missing api_key -> 200 with status=error (Pydantic allows None; handler validates)."""
+    client, _ = api_client
+    resp = client.post(
+        "/api/settings/connections/intervals_icu",
+        json={"athlete_id": "i123456"},
+    )
+    # api_key is None -> handler returns {"status": "error", "message": "...required"}
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "error"
+
+
+def test_post_auto_populates_preferences_when_no_other_source(api_client, user_id, db):
+    """First connect with no other platforms -> preferences auto-set to intervals_icu."""
+    client, _ = api_client
+    from db.models import UserConfig
+
+    with patch("sync.intervals_icu_sync.fetch_athlete_profile_api") as mock:
+        mock.return_value = {"id": "i123456", "sportSettings": []}
+        resp = client.post(
+            "/api/settings/connections/intervals_icu",
+            json={"athlete_id": "i123456", "api_key": "pat"},
+        )
+    assert resp.status_code == 200, resp.text
+    db.expire_all()
+    cfg = db.query(UserConfig).filter_by(user_id=user_id).one()
+    assert cfg.preferences.get("activities") == "intervals_icu"
+    assert cfg.preferences.get("recovery") == "intervals_icu"
+
+
+def test_post_does_not_override_existing_preferences(api_client, user_id, db):
+    """If the user already has Garmin preferred, keep that selection."""
+    client, _ = api_client
+    from db.models import UserConfig
+
+    cfg = db.query(UserConfig).filter_by(user_id=user_id).one()
+    cfg.preferences = {"activities": "garmin"}
+    db.commit()
+
+    with patch("sync.intervals_icu_sync.fetch_athlete_profile_api") as mock:
+        mock.return_value = {"id": "i123456", "sportSettings": []}
+        client.post(
+            "/api/settings/connections/intervals_icu",
+            json={"athlete_id": "i123456", "api_key": "pat"},
+        )
+    db.expire_all()
+    db.refresh(cfg)
+    assert cfg.preferences["activities"] == "garmin"

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -92,6 +92,17 @@ const PLATFORM_META: Record<string, { label: string; color: string; icon: React.
       </svg>
     ),
   },
+  intervals_icu: {
+    label: 'intervals.icu',
+    color: '#ff6600',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-6 h-6">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M3 10h18M8 2v4M16 2v4" strokeLinecap="round" />
+        <path d="M7 14l2 2 3-3M13 16h5" strokeLinecap="round" strokeWidth="1.25" />
+      </svg>
+    ),
+  },
 };
 
 const CAPABILITY_LABELS: Record<string, MessageDescriptor> = {
@@ -159,7 +170,7 @@ function useThresholdSourceLabel() {
   };
 }
 
-const CONNECTABLE_PLATFORMS = ['garmin', 'strava', 'stryd', 'oura'] as const;
+const CONNECTABLE_PLATFORMS = ['garmin', 'strava', 'stryd', 'oura', 'intervals_icu'] as const;
 const SYNC_INTERVAL_OPTIONS = [
   { hours: 6,  recommended: true },
   { hours: 12, recommended: false },
@@ -191,6 +202,13 @@ const PLATFORM_CRED_FIELDS: Record<string, { fields: { key: string; label: strin
       { key: 'token', label: 'Personal Access Token', type: 'password' },
     ],
     help: 'Generate a token at cloud.ouraring.com/personal-access-tokens.',
+  },
+  intervals_icu: {
+    fields: [
+      { key: 'athlete_id', label: 'Athlete ID', type: 'text' },
+      { key: 'api_key', label: 'API Key', type: 'password' },
+    ],
+    help: 'Find your Athlete ID on intervals.icu (the "iNNN" in your profile URL). Generate an API key at intervals.icu → Settings → Developer Settings. Recommended for users without Garmin / Stryd / Strava accounts.',
   },
 };
 

--- a/web/src/pages/Setup.tsx
+++ b/web/src/pages/Setup.tsx
@@ -115,9 +115,20 @@ const PLATFORM_META: Record<string, {
     ],
     help: 'Generate a token at cloud.ouraring.com/personal-access-tokens.',
   },
+  intervals_icu: {
+    label: 'intervals.icu',
+    wordmark: <span className="font-semibold text-lg">intervals.icu</span>,
+    categories: ['Activities', 'Recovery', 'Fitness'],
+    detail: 'Recommended when you don\'t have Garmin, Stryd, or Strava — aggregates from Wahoo, Coros, Polar, Apple Watch, and more',
+    credFields: [
+      { key: 'athlete_id', label: 'Athlete ID', type: 'text' },
+      { key: 'api_key', label: 'API Key', type: 'password' },
+    ],
+    help: 'Find your Athlete ID on your intervals.icu profile (the "iNNN" in the URL). Generate an API key at intervals.icu → Settings → Developer Settings.',
+  },
 };
 
-const CONNECTABLE_PLATFORMS = ['garmin', 'strava', 'stryd', 'oura'] as const;
+const CONNECTABLE_PLATFORMS = ['garmin', 'strava', 'stryd', 'oura', 'intervals_icu'] as const;
 
 
 // Training-base keys used by `BASE_CONFIG` below. Display labels come from

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -36,7 +36,7 @@ export interface ScienceResponse {
   label_sets: { id: string; name: string }[];
   recommendations: PillarRecommendation[];
 }
-export type PlatformName = 'garmin' | 'strava' | 'stryd' | 'oura' | 'coros';
+export type PlatformName = 'garmin' | 'strava' | 'stryd' | 'oura' | 'coros' | 'intervals_icu';
 export type PlanSourceName = PlatformName | 'ai';
 export type DataCategory = 'activities' | 'recovery' | 'fitness' | 'plan';
 


### PR DESCRIPTION
## Summary

  Adds intervals.icu as a fourth connectable data source alongside Garmin, Stryd,
  and Oura. Users can connect with an athlete ID + API key and sync activities,
  splits, wellness, and threshold history into the same canonical schema the rest of
   the app consumes.

  The integration is positioned as a **recommended fallback**: for athletes who
  already sync Garmin/Stryd/Oura → intervals.icu, this lets them pull a single
  unified feed from intervals.icu instead of connecting each upstream platform
  directly.

  ## What's included

  **Sync pipeline** (`sync/intervals_icu_sync.py`)
  - Basic-auth HTTP client with retry + typed exceptions
  - Paginated fetchers for activities, icu_intervals (splits), wellness, and
  threshold history
  - `sync_all()` orchestrator + DB writers that emit the same canonical rows as
  existing providers

  **Backend wiring**
  - `/api/sync/intervals_icu` route + background scheduler dispatch
  (`db/sync_scheduler.py`)
  - `/api/settings/connections/intervals_icu`:
    - `POST` validates credentials against the intervals.icu API before saving, and
  auto-populates `preferences.*` when no other source is selected
    - `DELETE` falls back to the next available source for each preference (or
  unsets if none)
  - Canonical `fitness_data.metric_type` names so downstream metrics consume
  intervals.icu data transparently
  - Provider stub in `analysis/providers/` for registry parity
  - `recovery_data` reads now filter by `preferences.recovery` so multi-source users
   get a deterministic pick

  **Frontend**
  - `PlatformName` type union extended with `'intervals_icu'`
  - Settings connection card (generic handler reuse — no bespoke UI branch)
  - Setup checklist entry positioned as recommended fallback source

  **Docs**
  - README, `docs/dev/features.md`, `docs/dev/gotchas.md`,
  `docs/dev/api-reference.md` updated

  ## Testing

  4 new test files, 49 new tests, all passing:
  - `tests/test_intervals_icu_sync.py` — API client, parsers, fetchers
  - `tests/test_intervals_icu_integration.py` — `sync_all` end-to-end + idempotency
  - `tests/test_intervals_icu_sync_route.py` — route + scheduler dispatch
  - `tests/test_settings_intervals_icu_api.py` — connect/delete + preference
  auto-population and fallback
  - Plus a multi-source coexistence test ensuring intervals.icu doesn't conflict
  with Garmin/Stryd/Oura when all four are connected

  Full suite: **452 passed, 1 skipped**.