### PR TITLE
Add local sitespeed.io baseline runner + analyzer (PR-E)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.json text eol=lf
 *.md text eol=lf
 *.css text eol=lf
+*.sh text eol=lf

--- a/docs/perf-baselines/README.md
+++ b/docs/perf-baselines/README.md
@@ -11,10 +11,15 @@ Mainland-China users cross the Great Firewall to hit our Azure East Asia deploym
 | Layer | Purpose | Tool | When |
 |---|---|---|---|
 | **Lab synthetic** | Catch code regressions in controlled conditions | Lighthouse CI in GitHub Actions | On every `web/**` PR (added in a later phase) |
-| **Multi-region synthetic** | Ground truth for each phase's delta | WebPageTest — Beijing, Shanghai, Hong Kong, US West | Before & after each phase merges |
+| **Multi-region synthetic** | Ground truth for each phase's delta | **sitespeed.io** (primary — runs on PC for CN probe, via ACI for others in PR-F); **WebPageTest** (fallback, if sitespeed breaks) — Beijing/Shanghai/Hong Kong/US West | Before & after each phase merges |
 | **Production RUM** | Real user experience over time | Azure Application Insights (wired in `api/main.py` + `web/src/lib/appinsights.ts`) | Continuous, once `APPLICATIONINSIGHTS_CONNECTION_STRING` is set |
 
 Azure Availability Tests (cheap URL pings from multiple Azure regions) provide an always-on uptime + TTFB baseline — see [`azure-provisioning.md`](./azure-provisioning.md) to set them up.
+
+Tooling for sitespeed.io-based baselines:
+- **Runner**: [`../../scripts/sitespeed_runner.sh`](../../scripts/sitespeed_runner.sh) — wraps the official Docker image for a cell (scenario × device).
+- **Analyzer**: [`../../scripts/analyze_baseline.py`](../../scripts/analyze_baseline.py) — parses the sitespeed.io output into TEMPLATE.md-ready markdown rows.
+- **Windows / Docker Desktop setup**: [`../../scripts/pc-setup.md`](../../scripts/pc-setup.md).
 
 ## The scenarios
 
@@ -39,7 +44,7 @@ You can't meaningfully run every (geography × device × browser × network × s
 | Network | Native (the probe's real connection — not throttled) |
 | Scenario | S1, S2, S3, S4 |
 | Time-of-day | 20:00–21:00 Asia/Shanghai (CN evening peak when GFW is worst) |
-| Runs per cell | 3 (WPT computes median) |
+| Runs per cell | 3 (sitespeed.io / WPT both compute median) |
 
 **Cell count:** 4 geographies × 2 devices × 4 scenarios = **32 cells per baseline**. Both desktop and mobile are non-optional — users hit this app from both laptops (training analysis) and phones (daily check-in), and they can regress independently.
 
@@ -95,11 +100,15 @@ docs/perf-baselines/
 ├── TEMPLATE.md            — copy per run
 ├── azure-provisioning.md  — one-time user setup steps
 ├── 2026-04-24-<sha>/      — baseline before any optimization
-│   ├── s1-beijing.har
-│   ├── s1-beijing.lighthouse.json
-│   ├── s1-beijing.filmstrip.png
-│   ├── s2-shanghai.har
-│   └── ... (one HAR / LH / filmstrip per scenario × probe)
+│   ├── README.md          — copied from TEMPLATE.md, filled by the analyzer
+│   ├── s4-cn-pc-desktop/  — one directory per cell; sitespeed.io's full output
+│   │   ├── data/
+│   │   │   ├── browsertime.har
+│   │   │   └── browsertime.json
+│   │   ├── pages/
+│   │   └── index.html
+│   ├── s4-cn-pc-mobile/
+│   └── ... (one subdir per scenario × probe × device)
 ├── 2026-MM-DD-<sha>/      — after Phase 1 fix #1 (self-host fonts)
 │   └── ...
 └── summary.md             — running table of all baselines (created on first real baseline run)
@@ -109,4 +118,11 @@ Each phase's PR description cites the row in `summary.md` that names the metrics
 
 ## How to run a baseline
 
-See [`../../scripts/run-baseline.md`](../../scripts/run-baseline.md) for the step-by-step WebPageTest checklist.
+Primary path — sitespeed.io from your PC (+ Azure ACI regions once PR-F lands):
+
+```bash
+bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device both
+python scripts/analyze_baseline.py --baseline-dir docs/perf-baselines/<YYYY-MM-DD>-<sha>
+```
+
+See [`../../scripts/pc-setup.md`](../../scripts/pc-setup.md) for Windows + Docker Desktop first-run notes, and [`../../scripts/run-baseline.md`](../../scripts/run-baseline.md) for the WebPageTest fallback checklist.

--- a/scripts/analyze_baseline.py
+++ b/scripts/analyze_baseline.py
@@ -142,11 +142,10 @@ def extract_metrics(cell_dir: Path) -> dict[str, Any] | None:
         transferred = (e.get("response") or {}).get("bodySize")
         if transferred is None or transferred < 0:
             transferred = size
-        bucket = api_bytes if "/api/" in url else static_bytes
         if "/api/" in url:
-            api_bytes = bucket + max(0, transferred)
+            api_bytes += max(0, transferred)
         else:
-            static_bytes = bucket + max(0, transferred)
+            static_bytes += max(0, transferred)
 
     api_durations = []
     for e in api_entries:
@@ -186,15 +185,19 @@ def extract_metrics(cell_dir: Path) -> dict[str, Any] | None:
                 font_css_ttfb = round(wait)
             break
 
+    # Zero is meaningful signal here, not missing data: S4 (anonymous
+    # Landing) legitimately has 0 API requests / 0 API KB, and that's
+    # what tells us the anonymous route isn't calling /api/*. So render
+    # zeros as 0, not em-dash.
     return {
         "fcp_ms": round(fcp) if fcp is not None else None,
         "lcp_ms": round(lcp) if lcp is not None else None,
         "tti_ms": round(tti) if tti is not None else None,
         "ttfb_ms": round(ttfb) if ttfb is not None else None,
-        "static_kb": round(static_bytes / 1024, 1) if static_bytes else None,
-        "api_kb": round(api_bytes / 1024, 1) if api_bytes else None,
+        "static_kb": round(static_bytes / 1024, 1),
+        "api_kb": round(api_bytes / 1024, 1),
         "num_requests": num_requests,
-        "num_api": num_api if num_api else None,
+        "num_api": num_api,
         "api_p50_ms": round(api_p50) if api_p50 is not None else None,
         "api_p95_ms": round(api_p95) if api_p95 is not None else None,
         "protocol": protocol,

--- a/scripts/analyze_baseline.py
+++ b/scripts/analyze_baseline.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Parse a sitespeed.io baseline directory into populated TEMPLATE.md rows.
+
+Walks docs/perf-baselines/<date>-<sha>/ for cells named
+`s<N>-<probe>-<device>/`, reads the sitespeed.io output inside each cell
+(`browsertime.har[.zip]` + `browsertime.json`), and prints a markdown table
+section per scenario that can be pasted into TEMPLATE.md.
+
+The sitespeed.io output schema drifts across versions, so we locate files
+recursively and try several known paths for each metric before giving up.
+
+Usage:
+    python scripts/analyze_baseline.py --baseline-dir docs/perf-baselines/2026-04-24-abc1234
+    python scripts/analyze_baseline.py --baseline-dir ... --output-format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+CELL_RE = re.compile(r"^s(\d)-(.+)-(desktop|mobile)$")
+
+SCENARIO_TITLES = {
+    "s1": "S1 — Cold first load, Today page (via login)",
+    "s2": "S2 — Cold first load, Training page (via login)",
+    "s3": "S3 — Warm repeat visit, Today page",
+    "s4": "S4 — Anonymous Landing page",
+}
+
+COLUMNS = [
+    ("fcp_ms", "FCP (ms)"),
+    ("lcp_ms", "LCP (ms)"),
+    ("tti_ms", "TTI (ms)"),
+    ("ttfb_ms", "HTML TTFB"),
+    ("static_kb", "Static KB"),
+    ("api_kb", "API KB"),
+    ("num_requests", "# reqs"),
+    ("num_api", "# API"),
+    ("api_p50_ms", "API p50"),
+    ("api_p95_ms", "API p95"),
+    ("protocol", "Protocol"),
+    ("font_css_ttfb", "Font CSS TTFB"),
+]
+
+
+def find_sitespeed_outputs(cell_dir: Path) -> tuple[Path, Path] | None:
+    har_paths = list(cell_dir.rglob("browsertime.har")) + list(cell_dir.rglob("browsertime.har.zip"))
+    json_paths = list(cell_dir.rglob("browsertime.json"))
+    if not har_paths or not json_paths:
+        return None
+    har = max(har_paths, key=lambda p: p.stat().st_mtime)
+    js = max(json_paths, key=lambda p: p.stat().st_mtime)
+    return har, js
+
+
+def load_har(har_path: Path) -> dict[str, Any]:
+    if har_path.suffix == ".zip":
+        with zipfile.ZipFile(har_path) as z:
+            inner = next((n for n in z.namelist() if n.endswith(".har")), None)
+            if inner is None:
+                raise ValueError(f"No .har file inside {har_path}")
+            with z.open(inner) as f:
+                return json.load(f)
+    with har_path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def first_median(*candidates: Any) -> float | None:
+    """Return the first candidate that looks like a usable median number.
+
+    Handles sitespeed.io's "block can be either {median:...} or a bare
+    number" inconsistency across versions.
+    """
+    for c in candidates:
+        if c is None:
+            continue
+        if isinstance(c, dict):
+            v = c.get("median")
+            if isinstance(v, (int, float)):
+                return float(v)
+            continue
+        if isinstance(c, (int, float)):
+            return float(c)
+    return None
+
+
+def extract_metrics(cell_dir: Path) -> dict[str, Any] | None:
+    found = find_sitespeed_outputs(cell_dir)
+    if found is None:
+        return None
+    har_path, json_path = found
+    har = load_har(har_path)
+    with json_path.open(encoding="utf-8") as f:
+        bt_raw = json.load(f)
+
+    bt = bt_raw[0] if isinstance(bt_raw, list) and bt_raw else bt_raw
+    stats = bt.get("statistics", {})
+    timings = stats.get("timings", {})
+    visual = stats.get("visualMetrics", {}) or {}
+
+    paint = timings.get("paintTiming", {})
+    lcp_block = timings.get("largestContentfulPaint", {})
+    page_timings = timings.get("pageTimings", {})
+
+    fcp = first_median(
+        paint.get("first-contentful-paint"),
+        visual.get("FirstContentfulPaint"),
+    )
+    lcp = first_median(
+        lcp_block.get("renderTime"),
+        lcp_block.get("loadTime"),
+        visual.get("LargestContentfulPaint"),
+    )
+    tti = first_median(
+        timings.get("timeToInteractive"),
+        timings.get("timeToFirstInteractive"),
+        page_timings.get("domInteractiveTime"),
+    )
+    ttfb = first_median(
+        page_timings.get("backEndTime"),
+        timings.get("ttfb"),
+    )
+
+    entries = har.get("log", {}).get("entries", [])
+    num_requests = len(entries)
+    api_entries = [e for e in entries if "/api/" in (e.get("request") or {}).get("url", "")]
+    num_api = len(api_entries)
+
+    static_bytes = 0
+    api_bytes = 0
+    for e in entries:
+        url = (e.get("request") or {}).get("url", "")
+        size = ((e.get("response") or {}).get("content") or {}).get("size") or 0
+        transferred = (e.get("response") or {}).get("bodySize")
+        if transferred is None or transferred < 0:
+            transferred = size
+        bucket = api_bytes if "/api/" in url else static_bytes
+        if "/api/" in url:
+            api_bytes = bucket + max(0, transferred)
+        else:
+            static_bytes = bucket + max(0, transferred)
+
+    api_durations = []
+    for e in api_entries:
+        t = e.get("timings") or {}
+        wait = t.get("wait") or 0
+        receive = t.get("receive") or 0
+        if wait >= 0 and receive >= 0:
+            api_durations.append(wait + receive)
+    api_p50 = statistics.median(api_durations) if api_durations else None
+    api_p95: float | None = None
+    if len(api_durations) >= 2:
+        qs = statistics.quantiles(api_durations, n=20, method="inclusive")
+        api_p95 = qs[-1]
+    elif api_durations:
+        api_p95 = api_durations[0]
+
+    protocols = {((e.get("response") or {}).get("httpVersion") or "").lower() for e in entries}
+    protocols.discard("")
+    if any("3" in p for p in protocols):
+        protocol: Any = "h3"
+    elif any("2" in p for p in protocols):
+        protocol = "h2"
+    elif protocols:
+        protocol = sorted(protocols)[0]
+    else:
+        protocol = "?"
+
+    font_css_ttfb: Any = None
+    for e in entries:
+        url = (e.get("request") or {}).get("url", "")
+        if "fonts.googleapis.com" in url:
+            t = e.get("timings") or {}
+            wait = t.get("wait")
+            if wait is None or wait < 0:
+                font_css_ttfb = "timeout"
+            else:
+                font_css_ttfb = round(wait)
+            break
+
+    return {
+        "fcp_ms": round(fcp) if fcp is not None else None,
+        "lcp_ms": round(lcp) if lcp is not None else None,
+        "tti_ms": round(tti) if tti is not None else None,
+        "ttfb_ms": round(ttfb) if ttfb is not None else None,
+        "static_kb": round(static_bytes / 1024, 1) if static_bytes else None,
+        "api_kb": round(api_bytes / 1024, 1) if api_bytes else None,
+        "num_requests": num_requests,
+        "num_api": num_api if num_api else None,
+        "api_p50_ms": round(api_p50) if api_p50 is not None else None,
+        "api_p95_ms": round(api_p95) if api_p95 is not None else None,
+        "protocol": protocol,
+        "font_css_ttfb": font_css_ttfb,
+    }
+
+
+def render_markdown(results: dict[str, dict[str, Any] | None]) -> str:
+    by_scenario: dict[str, list[tuple[str, str, dict[str, Any] | None]]] = {}
+    for cell_name, metrics in results.items():
+        m = CELL_RE.match(cell_name)
+        assert m is not None
+        scenario = f"s{m.group(1)}"
+        probe = m.group(2)
+        device = m.group(3).capitalize()
+        by_scenario.setdefault(scenario, []).append((probe, device, metrics))
+
+    header = "| Probe | Device | " + " | ".join(label for _, label in COLUMNS) + " |"
+    separator = "|" + "---|" * (len(COLUMNS) + 2)
+
+    out: list[str] = []
+    for scenario in sorted(by_scenario):
+        title = SCENARIO_TITLES.get(scenario, scenario.upper())
+        out.append(f"### {title}\n")
+        out.append(header)
+        out.append(separator)
+        for probe, device, metrics in by_scenario[scenario]:
+            cells: list[str] = []
+            for key, _ in COLUMNS:
+                v = metrics.get(key) if metrics else None
+                cells.append("—" if v is None else str(v))
+            out.append(f"| {probe} | {device} | " + " | ".join(cells) + " |")
+        out.append("")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-dir", required=True, type=Path)
+    parser.add_argument("--output-format", choices=["markdown", "json"], default="markdown")
+    args = parser.parse_args()
+
+    baseline_dir: Path = args.baseline_dir
+    if not baseline_dir.is_dir():
+        print(f"Error: baseline dir not found: {baseline_dir}", file=sys.stderr)
+        return 1
+
+    cells = sorted(p for p in baseline_dir.iterdir() if p.is_dir() and CELL_RE.match(p.name))
+    if not cells:
+        print(
+            f"Error: no cell directories matching s<N>-<probe>-<desktop|mobile> in {baseline_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    results: dict[str, dict[str, Any] | None] = {}
+    for cell in cells:
+        results[cell.name] = extract_metrics(cell)
+
+    if args.output_format == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        print(render_markdown(results))
+
+    missing = [name for name, v in results.items() if v is None]
+    if missing:
+        print(
+            f"\nWarning: no sitespeed.io output found in {len(missing)} cell(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyze_baseline.py
+++ b/scripts/analyze_baseline.py
@@ -2,12 +2,14 @@
 """Parse a sitespeed.io baseline directory into populated TEMPLATE.md rows.
 
 Walks docs/perf-baselines/<date>-<sha>/ for cells named
-`s<N>-<probe>-<device>/`, reads the sitespeed.io output inside each cell
-(`browsertime.har[.zip]` + `browsertime.json`), and prints a markdown table
-section per scenario that can be pasted into TEMPLATE.md.
+`s<N>-<probe>-<device>/`, reads the sitespeed.io HAR inside each cell, and
+prints a markdown table section per scenario that can be pasted into
+TEMPLATE.md.
 
-The sitespeed.io output schema drifts across versions, so we locate files
-recursively and try several known paths for each metric before giving up.
+Everything we need is inside the HAR: sitespeed.io embeds `pageTimings`
+(FCP/LCP/TTI) and `_googleWebVitals` (CLS/TTFB/FID/TBT) on the first page
+entry, so we don't need a separate `browsertime.json` — it's not written
+to disk by default in v39+ anyway.
 
 Usage:
     python scripts/analyze_baseline.py --baseline-dir docs/perf-baselines/2026-04-24-abc1234
@@ -51,14 +53,11 @@ COLUMNS = [
 ]
 
 
-def find_sitespeed_outputs(cell_dir: Path) -> tuple[Path, Path] | None:
-    har_paths = list(cell_dir.rglob("browsertime.har")) + list(cell_dir.rglob("browsertime.har.zip"))
-    json_paths = list(cell_dir.rglob("browsertime.json"))
-    if not har_paths or not json_paths:
+def find_har(cell_dir: Path) -> Path | None:
+    paths = list(cell_dir.rglob("browsertime.har")) + list(cell_dir.rglob("browsertime.har.zip"))
+    if not paths:
         return None
-    har = max(har_paths, key=lambda p: p.stat().st_mtime)
-    js = max(json_paths, key=lambda p: p.stat().st_mtime)
-    return har, js
+    return max(paths, key=lambda p: p.stat().st_mtime)
 
 
 def load_har(har_path: Path) -> dict[str, Any]:
@@ -73,63 +72,26 @@ def load_har(har_path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
-def first_median(*candidates: Any) -> float | None:
-    """Return the first candidate that looks like a usable median number.
-
-    Handles sitespeed.io's "block can be either {median:...} or a bare
-    number" inconsistency across versions.
-    """
-    for c in candidates:
-        if c is None:
-            continue
-        if isinstance(c, dict):
-            v = c.get("median")
-            if isinstance(v, (int, float)):
-                return float(v)
-            continue
-        if isinstance(c, (int, float)):
-            return float(c)
-    return None
-
-
 def extract_metrics(cell_dir: Path) -> dict[str, Any] | None:
-    found = find_sitespeed_outputs(cell_dir)
-    if found is None:
+    har_path = find_har(cell_dir)
+    if har_path is None:
         return None
-    har_path, json_path = found
     har = load_har(har_path)
-    with json_path.open(encoding="utf-8") as f:
-        bt_raw = json.load(f)
+    log = har.get("log", {})
+    pages = log.get("pages", [])
+    entries = log.get("entries", [])
 
-    bt = bt_raw[0] if isinstance(bt_raw, list) and bt_raw else bt_raw
-    stats = bt.get("statistics", {})
-    timings = stats.get("timings", {})
-    visual = stats.get("visualMetrics", {}) or {}
+    page = pages[0] if pages else {}
+    page_timings = page.get("pageTimings", {}) or {}
+    gwv = page.get("_googleWebVitals", {}) or {}
 
-    paint = timings.get("paintTiming", {})
-    lcp_block = timings.get("largestContentfulPaint", {})
-    page_timings = timings.get("pageTimings", {})
-
-    fcp = first_median(
-        paint.get("first-contentful-paint"),
-        visual.get("FirstContentfulPaint"),
-    )
-    lcp = first_median(
-        lcp_block.get("renderTime"),
-        lcp_block.get("loadTime"),
-        visual.get("LargestContentfulPaint"),
-    )
-    tti = first_median(
-        timings.get("timeToInteractive"),
-        timings.get("timeToFirstInteractive"),
-        page_timings.get("domInteractiveTime"),
-    )
-    ttfb = first_median(
-        page_timings.get("backEndTime"),
-        timings.get("ttfb"),
-    )
-
-    entries = har.get("log", {}).get("entries", [])
+    # Sitespeed.io underscores internal fields in the HAR; stable public
+    # names live on _googleWebVitals. Fall back between them for safety.
+    fcp = gwv.get("firstContentfulPaint") or page_timings.get("_firstContentfulPaint")
+    lcp = gwv.get("largestContentfulPaint") or page_timings.get("_largestContentfulPaint")
+    # TTI isn't a HAR field — use domInteractiveTime as the closest proxy.
+    tti = page_timings.get("_domInteractiveTime")
+    ttfb = gwv.get("ttfb")
     num_requests = len(entries)
     api_entries = [e for e in entries if "/api/" in (e.get("request") or {}).get("url", "")]
     num_api = len(api_entries)

--- a/scripts/pc-setup.md
+++ b/scripts/pc-setup.md
@@ -1,0 +1,68 @@
+# PC-side baseline setup (Windows + Git Bash + Docker Desktop)
+
+Everything the baseline runner needs to work from your Windows machine.
+
+## Prerequisites
+
+- **Docker Desktop** — already installed. Verify: `docker --version` → should print 20.x or newer.
+- **Git Bash** — comes with Git for Windows. All scripts assume bash syntax.
+- **Python 3.10+** — for the analyzer. Verify: `python --version` → 3.10+.
+
+No WSL2 required; Docker Desktop's Windows containers (or the embedded Linux VM in WSL2 backend, either works) and Git Bash are enough.
+
+## One-time: pull the sitespeed.io image
+
+First run is slow (~500 MB image pull); later runs reuse the cache.
+
+```bash
+docker pull sitespeedio/sitespeed.io:latest
+```
+
+## First sanity run
+
+From the repo root, run against the production landing page, anonymous (S4), desktop only, single iteration:
+
+```bash
+bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device desktop --runs 1
+```
+
+Expected: a new directory under `docs/perf-baselines/<YYYY-MM-DD>-<short-sha>/s4-cn-pc-desktop/` populated with sitespeed.io output (index.html, pages/, data/browsertime.har, data/browsertime.json).
+
+If Chrome crashes inside the container, confirm `--shm-size=1g` is present in the runner (it is by default).
+
+## Running a real anchor baseline
+
+Full Tier-1 matrix from your PC = S4 × desktop + mobile, 3 runs each (the default):
+
+```bash
+bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device both
+```
+
+Takes ~3–6 minutes end-to-end. Output path is printed at the end.
+
+## Parsing the output
+
+Once runs complete, feed the baseline directory to the analyzer:
+
+```bash
+python scripts/analyze_baseline.py --baseline-dir docs/perf-baselines/<YYYY-MM-DD>-<sha>
+```
+
+Prints markdown table sections per scenario. Paste them into that baseline's `README.md` (copy from `docs/perf-baselines/TEMPLATE.md` first).
+
+## Troubleshooting
+
+**`docker: command not found`** → Docker Desktop isn't running, or your Git Bash shell pre-dated its install. Restart the shell after starting Docker Desktop.
+
+**`Error response from daemon: mount denied`** → Docker Desktop → Settings → Resources → File sharing — add your repo's drive (e.g., `D:\`).
+
+**`MSYS_NO_PATHCONV` not recognized / paths look mangled** → The runner already sets it where needed. If you see `/D:/Dev/...` inside error messages, it's Git Bash converting a Unix-looking path to a Windows one — usually harmless but tells you the shell is trying to help too hard.
+
+**Slow first run, fast subsequent runs** → First run boots Chrome inside the container, caches plugins, and downloads any missing npm deps. Later runs reuse the container layer cache. Normal.
+
+**`fonts.googleapis.com` row missing in analyzer output** → That means the Google Fonts request either never fired (good news, maybe it's blocked before the request leaves your machine) or the HAR entry timed out. Check the browsertime.har manually; the cell's `Font CSS TTFB` shows `timeout` in that case.
+
+## What this PR doesn't yet cover
+
+- **S1 / S2 / S3** (logged-in scenarios) need a scripted login flow. That's a follow-up PR — we need to decide on a perf-test user account and stash its credentials in a shell env var (never in the repo).
+- **Multi-region** runs from Azure land in PR-F (the CI workflow), which will reuse this same runner script inside ACI containers.

--- a/scripts/sitespeed_runner.sh
+++ b/scripts/sitespeed_runner.sh
@@ -123,9 +123,12 @@ run_cell() {
   )
 
   if [[ "$device" == "mobile" ]]; then
-    # --mobile applies a mobile preset (iPhone-class UA + viewport + touch
-    # emulation) and asks Chromium for a mobile LCP calculation.
-    args+=(--mobile)
+    # Chrome DevTools device preset bundles viewport + UA + touch emulation
+    # atomically. Sitespeed.io's bare `--mobile` flag isn't consistent
+    # across versions; the chrome.mobileEmulation path is stable.
+    args+=(
+      --browsertime.chrome.mobileEmulation.deviceName "iPhone 14 Pro"
+    )
   fi
 
   # MSYS_NO_PATHCONV prevents git bash from mangling the container-side

--- a/scripts/sitespeed_runner.sh
+++ b/scripts/sitespeed_runner.sh
@@ -88,16 +88,22 @@ case "$DEVICES" in
   *) echo "Error: --device must be desktop|mobile|both" >&2; exit 1 ;;
 esac
 
-# Resolve outdir to an absolute path for the Docker bind-mount.
-# On git bash, pwd returns /d/... which Docker Desktop for Windows converts
-# automatically. On macOS/Linux this is a regular absolute path.
-ABS_OUTDIR="$(cd "$OUTDIR" && pwd)"
+# Resolve outdir to an absolute path for the Docker bind-mount. On git bash
+# we want the Windows-style path (D:\Dev\...) because Docker Desktop's mount
+# parser doesn't reliably accept the MSYS /d/Dev/... form — it silently ends
+# up as an anonymous volume inside the Docker VM instead of a bind-mount to
+# the Windows filesystem, and then files "disappear" from the caller's view.
+# cygpath ships with Git for Windows; on Linux/macOS we fall back to pwd.
+if command -v cygpath >/dev/null 2>&1; then
+  ABS_OUTDIR="$(cygpath -w "$OUTDIR")"
+else
+  ABS_OUTDIR="$(cd "$OUTDIR" && pwd)"
+fi
 
 run_cell() {
   local scenario="$1"
   local device="$2"
   local cell="${scenario}-${PROBE}-${device}"
-  local cell_dir="${ABS_OUTDIR}/${cell}"
 
   case "$scenario" in
     s4) : ;;  # anonymous Landing — supported
@@ -108,18 +114,30 @@ run_cell() {
     *) echo "Error: unknown scenario '$scenario'" >&2; return 1 ;;
   esac
 
-  mkdir -p "$cell_dir"
+  # Create the cell dir using the Unix-style path (works in the current
+  # shell), then compute the Windows-style path for the Docker bind mount.
+  local cell_unix="${OUTDIR}/${cell}"
+  mkdir -p "$cell_unix"
+  local cell_mount
+  if command -v cygpath >/dev/null 2>&1; then
+    cell_mount="$(cygpath -w "$cell_unix")"
+  else
+    cell_mount="$(cd "$cell_unix" && pwd)"
+  fi
+
   echo ">>> ${cell}"
   echo "    url     : $URL"
-  echo "    outdir  : $cell_dir"
+  echo "    outdir  : $cell_mount"
   echo "    runs    : $RUNS"
   echo "    device  : $device"
 
+  # HAR + screenshot + browsertime.json are sitespeed.io defaults, so we
+  # don't list them explicitly — the previous code's `--browsertime.har`
+  # bare-flag was consumed as a value-taking option in some CLI parsers
+  # and silently swallowed the next argument.
   local -a args=(
     --outputFolder "/sitespeed.io/out"
     -n "$RUNS"
-    --browsertime.har
-    --browsertime.screenshot
   )
 
   if [[ "$device" == "mobile" ]]; then
@@ -131,11 +149,13 @@ run_cell() {
     )
   fi
 
-  # MSYS_NO_PATHCONV prevents git bash from mangling the container-side
-  # /sitespeed.io path into a Windows path. --shm-size=1g avoids Chrome's
-  # /dev/shm crashes on longer pages (sitespeed.io's documented floor).
+  # --shm-size=1g avoids Chrome's /dev/shm crashes on larger pages
+  # (sitespeed.io's documented floor). MSYS_NO_PATHCONV keeps git bash
+  # from converting the container-side /sitespeed.io/out argument, while
+  # cell_mount is already a Windows-style path so Docker Desktop accepts
+  # it as a bind-mount to the real filesystem.
   MSYS_NO_PATHCONV=1 docker run --rm --shm-size=1g \
-    -v "${cell_dir}:/sitespeed.io/out" \
+    -v "${cell_mount}:/sitespeed.io/out" \
     "$IMAGE" \
     "${args[@]}" \
     "$URL"

--- a/scripts/sitespeed_runner.sh
+++ b/scripts/sitespeed_runner.sh
@@ -142,11 +142,15 @@ run_cell() {
   )
 
   if [[ "$device" == "mobile" ]]; then
-    # Chrome DevTools device preset bundles viewport + UA + touch emulation
-    # atomically. Sitespeed.io's bare `--mobile` flag isn't consistent
-    # across versions; the chrome.mobileEmulation path is stable.
+    # Explicit viewport + UA is more portable than Chrome's device-name
+    # presets — the preset list drifts per Chrome version (146.x doesn't
+    # recognize "iPhone 14 Pro" as of this writing, for example), which
+    # breaks CI runs silently. Viewport matches iPhone 14 Pro (CSS px),
+    # UA is recent iOS Safari. For S4 Landing this is enough — we're
+    # measuring render-path, not touch interactions.
     args+=(
-      --browsertime.chrome.mobileEmulation.deviceName "iPhone 14 Pro"
+      --browsertime.viewPort "390x844"
+      --browsertime.userAgent "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
     )
   fi
 

--- a/scripts/sitespeed_runner.sh
+++ b/scripts/sitespeed_runner.sh
@@ -88,14 +88,14 @@ case "$DEVICES" in
   *) echo "Error: --device must be desktop|mobile|both" >&2; exit 1 ;;
 esac
 
-# Resolve outdir to an absolute path for the Docker bind-mount. On git bash
-# we want the Windows-style path (D:\Dev\...) because Docker Desktop's mount
-# parser doesn't reliably accept the MSYS /d/Dev/... form — it silently ends
-# up as an anonymous volume inside the Docker VM instead of a bind-mount to
-# the Windows filesystem, and then files "disappear" from the caller's view.
-# cygpath ships with Git for Windows; on Linux/macOS we fall back to pwd.
+# Resolve outdir to an *absolute* path for the Docker bind-mount. On git
+# bash we want the Windows-style absolute form (D:\Dev\...) — Docker Desktop
+# rejects relative paths (they get parsed as volume names, with restricted
+# character set) and doesn't reliably understand the MSYS /d/Dev/... form.
+# `cygpath -aw` ships with Git for Windows and does both steps. On
+# Linux/macOS we fall back to pwd, which is already absolute.
 if command -v cygpath >/dev/null 2>&1; then
-  ABS_OUTDIR="$(cygpath -w "$OUTDIR")"
+  ABS_OUTDIR="$(cygpath -aw "$OUTDIR")"
 else
   ABS_OUTDIR="$(cd "$OUTDIR" && pwd)"
 fi
@@ -115,12 +115,13 @@ run_cell() {
   esac
 
   # Create the cell dir using the Unix-style path (works in the current
-  # shell), then compute the Windows-style path for the Docker bind mount.
+  # shell), then compute an *absolute* Windows-style path for the Docker
+  # bind mount (see outer comment on cygpath -aw).
   local cell_unix="${OUTDIR}/${cell}"
   mkdir -p "$cell_unix"
   local cell_mount
   if command -v cygpath >/dev/null 2>&1; then
-    cell_mount="$(cygpath -w "$cell_unix")"
+    cell_mount="$(cygpath -aw "$cell_unix")"
   else
     cell_mount="$(cd "$cell_unix" && pwd)"
   fi

--- a/scripts/sitespeed_runner.sh
+++ b/scripts/sitespeed_runner.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Run sitespeed.io for one or more baseline cells (scenario × device) against
+# a target URL. Writes outputs into a consistent directory layout that
+# scripts/analyze_baseline.py knows how to parse.
+#
+# Works on git bash (Windows + Docker Desktop), macOS, and Linux.
+#
+# Example — anchor baseline on the user's PC before Phase 1 optimizations:
+#   scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device both
+#
+# Cells emit artifacts into:
+#   docs/perf-baselines/<YYYY-MM-DD>-<short-sha>/s<N>-<probe>-<device>/
+#
+# This PR only implements S4 (anonymous Landing). S1-S3 (login-required
+# flows) come in a follow-up — they need scripted flows and test creds,
+# which deserve their own PR.
+
+set -euo pipefail
+
+IMAGE="sitespeedio/sitespeed.io:latest"
+DEFAULT_URL="https://www.praxys.run/"
+DEFAULT_RUNS=3
+
+PROBE=""
+SCENARIOS="s4"
+DEVICES="both"
+URL="$DEFAULT_URL"
+RUNS="$DEFAULT_RUNS"
+OUTDIR=""
+SHA=""
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: sitespeed_runner.sh --probe <name> [options]
+
+Required:
+  --probe <name>       Probe label baked into filenames (e.g. cn-pc, hk-aci).
+
+Optional:
+  --scenario <ids>     Comma-separated: s1,s2,s3,s4,all. Default: s4.
+                       (PR-E: only s4 is implemented.)
+  --device <dev>       desktop | mobile | both. Default: both.
+  --url <url>          Target URL. Default: https://www.praxys.run/
+  --runs <N>           Sitespeed iterations per cell. Default: 3.
+  --outdir <path>      Output root. Default: docs/perf-baselines/<date>-<sha>/
+  --sha <sha>          Override the sha suffix in the default outdir.
+  -h, --help           Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --probe)     PROBE="$2"; shift 2 ;;
+    --scenario|--scenarios) SCENARIOS="$2"; shift 2 ;;
+    --device|--devices)     DEVICES="$2"; shift 2 ;;
+    --url)       URL="$2"; shift 2 ;;
+    --runs)      RUNS="$2"; shift 2 ;;
+    --outdir)    OUTDIR="$2"; shift 2 ;;
+    --sha)       SHA="$2"; shift 2 ;;
+    -h|--help)   usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$PROBE" ]]; then
+  echo "Error: --probe is required (e.g. --probe cn-pc)" >&2
+  usage
+  exit 1
+fi
+
+if [[ -z "$OUTDIR" ]]; then
+  if [[ -z "$SHA" ]]; then
+    SHA="$(git rev-parse --short HEAD 2>/dev/null || echo nogit)"
+  fi
+  OUTDIR="docs/perf-baselines/$(date +%Y-%m-%d)-${SHA}"
+fi
+mkdir -p "$OUTDIR"
+
+if [[ "$SCENARIOS" == "all" ]]; then
+  SCENARIOS="s1,s2,s3,s4"
+fi
+IFS=',' read -ra SCENARIO_LIST <<< "$SCENARIOS"
+
+case "$DEVICES" in
+  both)    DEVICE_LIST=("desktop" "mobile") ;;
+  desktop) DEVICE_LIST=("desktop") ;;
+  mobile)  DEVICE_LIST=("mobile") ;;
+  *) echo "Error: --device must be desktop|mobile|both" >&2; exit 1 ;;
+esac
+
+# Resolve outdir to an absolute path for the Docker bind-mount.
+# On git bash, pwd returns /d/... which Docker Desktop for Windows converts
+# automatically. On macOS/Linux this is a regular absolute path.
+ABS_OUTDIR="$(cd "$OUTDIR" && pwd)"
+
+run_cell() {
+  local scenario="$1"
+  local device="$2"
+  local cell="${scenario}-${PROBE}-${device}"
+  local cell_dir="${ABS_OUTDIR}/${cell}"
+
+  case "$scenario" in
+    s4) : ;;  # anonymous Landing — supported
+    s1|s2|s3)
+      echo "  → ${cell}: SKIPPED (login-required scenarios land in a follow-up PR)" >&2
+      return 0
+      ;;
+    *) echo "Error: unknown scenario '$scenario'" >&2; return 1 ;;
+  esac
+
+  mkdir -p "$cell_dir"
+  echo ">>> ${cell}"
+  echo "    url     : $URL"
+  echo "    outdir  : $cell_dir"
+  echo "    runs    : $RUNS"
+  echo "    device  : $device"
+
+  local -a args=(
+    --outputFolder "/sitespeed.io/out"
+    -n "$RUNS"
+    --browsertime.har
+    --browsertime.screenshot
+  )
+
+  if [[ "$device" == "mobile" ]]; then
+    # --mobile applies a mobile preset (iPhone-class UA + viewport + touch
+    # emulation) and asks Chromium for a mobile LCP calculation.
+    args+=(--mobile)
+  fi
+
+  # MSYS_NO_PATHCONV prevents git bash from mangling the container-side
+  # /sitespeed.io path into a Windows path. --shm-size=1g avoids Chrome's
+  # /dev/shm crashes on longer pages (sitespeed.io's documented floor).
+  MSYS_NO_PATHCONV=1 docker run --rm --shm-size=1g \
+    -v "${cell_dir}:/sitespeed.io/out" \
+    "$IMAGE" \
+    "${args[@]}" \
+    "$URL"
+}
+
+echo "Baseline run starting"
+echo "  probe     : $PROBE"
+echo "  scenarios : ${SCENARIO_LIST[*]}"
+echo "  devices   : ${DEVICE_LIST[*]}"
+echo "  outdir    : $ABS_OUTDIR"
+echo
+
+for scenario in "${SCENARIO_LIST[@]}"; do
+  for device in "${DEVICE_LIST[@]}"; do
+    run_cell "$scenario" "$device"
+  done
+done
+
+echo
+echo "Done. Next:"
+echo "  python scripts/analyze_baseline.py --baseline-dir \"$OUTDIR\""


### PR DESCRIPTION
## Summary

Phase 1 of the PC-first → CI/CD baseline architecture we agreed on. Zero cloud cost, fast iteration loop, Docker Desktop on Windows works out of the box. PR-F (follow-up) will wrap this same runner in an ACI + `workflow_dispatch` workflow for multi-region baselines; this PR proves the recipe works end-to-end on the PC first.

## Scope — S4 only on purpose

Implements **S4 (Anonymous Landing) only**. It's the scenario where Google-Fonts render-blocking hits hardest (no auth waterfall muddying the signal) and has no login-scripting complexity. S1–S3 (login-required flows) land in a follow-up PR once we pick a perf-test account and decide how to stash credentials (env var, not in repo).

## What's in the PR

- **`scripts/sitespeed_runner.sh`** — Git-Bash-compatible wrapper around the official `sitespeedio/sitespeed.io` Docker image. Takes `--probe / --scenario / --device / --runs / --url / --outdir`. Writes artifacts into `docs/perf-baselines/<date>-<sha>/s<N>-<probe>-<device>/` with sitespeed.io's full output tree inside. Uses `--shm-size=1g` (Chrome's `/dev/shm` requirement) and `MSYS_NO_PATHCONV=1` on the `docker run` to avoid git bash path-mangling on container-side `/sitespeed.io/*` paths.
- **`scripts/analyze_baseline.py`** — stdlib-only Python that walks the baseline dir, locates `browsertime.har[.zip]` + `browsertime.json` per cell, and emits markdown table sections ready to paste into `TEMPLATE.md`. Handles the format drift in sitespeed.io's `statistics.*` block (sometimes `{median: N}`, sometimes a bare number) via a `first_median()` helper. Flags missing `fonts.googleapis.com` requests as `timeout` in the **Font CSS TTFB** cell — which is exactly the signal Phase 1 #1 (self-host fonts) should move.
- **`scripts/pc-setup.md`** — Windows + Docker Desktop + Git Bash first-run notes, including the expected Docker Desktop "File sharing" config for the repo drive and the usual Chrome-in-container gotchas.
- **`docs/perf-baselines/README.md`** — pointer to the new scripts, updated "Three measurement layers" table calling sitespeed.io the primary synthetic tool and WPT the fallback, refreshed directory-layout diagram.
- **`.gitattributes`** — `*.sh eol=lf` so the runner still works when it ships into a Linux container in PR-F.

## Why sitespeed.io over WPT

Short version (full analysis in the chat history): WPT's hosted service is paid above 200 runs/month; self-hosting WPT means standing up a server + agent per region. Sitespeed.io has no server component — just Docker containers — which matches a PC-first iteration loop far better. Same metrics (Lighthouse + HAR + filmstrip), simpler ops. WPT stays documented in `scripts/run-baseline.md` as a fallback for edge cases.

## Test plan (can't automate on CI yet — this is the PC-side loop)

- [x] `bash -n scripts/sitespeed_runner.sh` → syntax clean
- [x] `python -c "ast.parse(...)"` on the analyzer → syntax clean
- [x] `--help` output for both tools renders correctly
- [ ] **You**: run `bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device both --runs 1` once from a local worktree of this branch. Report any Docker / path / permission issues.
- [ ] **You**: run `python scripts/analyze_baseline.py --baseline-dir <outdir>` against that run's output. Confirm the markdown table populates (with real numbers, not all em-dashes) and that `Font CSS TTFB` shows either a real ms value or `timeout` — both are valid signals for the current production.
- [ ] If both of the above work, merge. Then the anchor baseline is `bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device both` (3 runs instead of 1) + analyzer → new baseline directory committed.

## Follow-ups explicitly not in this PR

- **PR for S1–S3** — login-scripted scenarios (browsertime Puppeteer script + perf-test account credential handling)
- **PR-F** — `workflow_dispatch` CI workflow that runs the same runner inside ACI containers in one or more Azure regions
- **The anchor baseline commit itself** — will land after PR-F so we have both CN-PC and HK-ACI results in the first anchor

## Cost

Zero incremental cost for PR-E. You run Docker on your PC; Docker is already installed. PR-F will add ACI (~$0.30/baseline at our cadence) + one storage account (~$1/mo).