### PR TITLE
Phase 1 #1: Self-host fonts (forecast: CN FCP 22.5s → 3s)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,9 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#4a9e6e" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=Geist:wght@300..700&family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@300;400;500;600;700&family=Noto+Serif+SC:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>Praxys — Train like a pro. Whatever your level.</title>
 
     <meta name="description" content="Praxys turns your runs into science-grounded insights, personalized zones, and a training plan that evolves with you. For every runner — road to trail." />

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@base-ui/react": "^1.4.1",
+        "@fontsource-variable/dm-sans": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/noto-sans-sc": "^5.2.10",
         "@lingui/core": "^5.9.5",
         "@lingui/detect-locale": "^5.9.5",
         "@lingui/react": "^5.9.5",
@@ -1295,10 +1298,37 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@fontsource-variable/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fontsource-variable/geist": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
       "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans-sc": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-sc/-/noto-sans-sc-5.2.10.tgz",
+      "integrity": "sha512-zdk10i5HrDQTXI7ldD61zToX1fsgig8vDTsu7zB48SXOitWfuX0e5viZAwnkHuhwh096PU6X6i1AyAsbBCISpA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@fontsource-variable/dm-sans": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/noto-sans-sc": "^5.2.10",
     "@lingui/core": "^5.9.5",
     "@lingui/detect-locale": "^5.9.5",
     "@lingui/react": "^5.9.5",

--- a/web/src/components/charts/FitnessFatigueChart.tsx
+++ b/web/src/components/charts/FitnessFatigueChart.tsx
@@ -219,7 +219,7 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
 
             <XAxis
               dataKey="date"
-              tick={{ fill: chartColors.tick, fontSize: 10, fontFamily: 'JetBrains Mono, monospace' }}
+              tick={{ fill: chartColors.tick, fontSize: 10, fontFamily: 'JetBrains Mono Variable, monospace' }}
               tickLine={false}
               axisLine={{ stroke: chartColors.grid }}
               tickFormatter={(v: string) => {
@@ -229,7 +229,7 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
               interval={Math.max(0, Math.floor(chartData.length / 10) - 1)}
             />
             <YAxis
-              tick={{ fill: chartColors.tick, fontSize: 10, fontFamily: 'JetBrains Mono, monospace' }}
+              tick={{ fill: chartColors.tick, fontSize: 10, fontFamily: 'JetBrains Mono Variable, monospace' }}
               tickLine={false}
               axisLine={false}
               domain={[yMin, yMax]}

--- a/web/src/components/charts/FormSparkline.tsx
+++ b/web/src/components/charts/FormSparkline.tsx
@@ -166,7 +166,7 @@ export default function FormSparkline({ data, scienceNote }: Props) {
 
               <XAxis
                 dataKey="date"
-                tick={{ fontSize: 9, fill: chartColors.tick, fontFamily: 'JetBrains Mono, monospace' }}
+                tick={{ fontSize: 9, fill: chartColors.tick, fontFamily: 'JetBrains Mono Variable, monospace' }}
                 tickLine={false}
                 axisLine={false}
                 tickFormatter={(v: string) => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -147,14 +147,18 @@
   --color-accent-purple: var(--accent-purple-val);
   --color-accent-cobalt: var(--accent-cobalt-val);
 
-  --font-sans: 'DM Sans', 'Noto Sans SC', system-ui, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Noto Sans SC', ui-monospace, monospace;
+  /* @fontsource-variable packages emit font-family names with the ` Variable`
+     suffix (e.g. `DM Sans Variable`, not `DM Sans`). Without that suffix the
+     browser would download the WOFF2 files but silently fall back to system
+     fonts because no @font-face would match. */
+  --font-sans: 'DM Sans Variable', 'Noto Sans SC Variable', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono Variable', 'Noto Sans SC Variable', ui-monospace, monospace;
 }
 
 /* ── shadcn utility mappings ── */
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: 'DM Sans', 'Noto Sans SC', system-ui, sans-serif;
+  --font-sans: 'DM Sans Variable', 'Noto Sans SC Variable', system-ui, sans-serif;
 
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,3 +1,12 @@
+/* Self-hosted fonts — no render-blocking fonts.googleapis.com round-trip.
+   Vite bundles the WOFF2 subsets into dist/assets/ and rewrites @font-face
+   URLs to our origin, so every font byte is served from Azure SWA on the
+   same clean path as the HTML, dodging the GFW for mainland users. */
+@import "@fontsource-variable/dm-sans";
+@import "@fontsource-variable/geist";
+@import "@fontsource-variable/jetbrains-mono";
+@import "@fontsource-variable/noto-sans-sc";
+
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";

--- a/web/src/pages/Landing.css
+++ b/web/src/pages/Landing.css
@@ -20,9 +20,9 @@
   --l-rust: oklch(0.55 0.18 30);
   --l-grain: 0.04;
 
-  --l-font-display: 'Geist', 'DM Sans', system-ui, sans-serif;
-  --l-font-body: 'Geist', 'DM Sans', system-ui, sans-serif;
-  --l-font-data: 'JetBrains Mono', ui-monospace, monospace;
+  --l-font-display: 'Geist Variable', 'DM Sans Variable', system-ui, sans-serif;
+  --l-font-body: 'Geist Variable', 'DM Sans Variable', system-ui, sans-serif;
+  --l-font-data: 'JetBrains Mono Variable', ui-monospace, monospace;
 
   background: var(--l-paper);
   color: var(--l-ink);
@@ -35,8 +35,8 @@
 }
 
 html[lang="zh"] .landing-root {
-  --l-font-display: 'Noto Sans SC', 'Geist', sans-serif;
-  --l-font-body: 'Noto Sans SC', 'Geist', sans-serif;
+  --l-font-display: 'Noto Sans SC Variable', 'Geist Variable', sans-serif;
+  --l-font-body: 'Noto Sans SC Variable', 'Geist Variable', sans-serif;
 }
 
 .dark .landing-root {


### PR DESCRIPTION
## Summary

Biggest-leverage perf fix for mainland-China users, predicted to cut FCP by **~19.4 seconds** on real-CN connections. Attributable against the anchor baseline `e82e3cb` (docs/perf-baselines/2026-04-24-468ce25/).

## The fix in one sentence

Drop the three render-blocking `<link>` tags in `web/index.html` that preconnect to `fonts.googleapis.com` + fetch the stylesheet, replace with `@fontsource-variable/*` npm imports from `web/src/index.css` — Vite bundles WOFF2 subsets into our origin so every font byte ships from Azure SWA instead of Google.

## Why this wins by so much

From the anchor baseline:

| Probe | FCP | Static KB | # reqs | Font CSS TTFB |
|---|---|---|---|---|
| cn-pc (passwall ON, bypass) | 3000 ms | 2379 | 52 | 108 ms |
| **cn-pc-2 (passwall OFF, real CN)** | **22476 ms** | **1473** | **42** | **— (absent from HAR)** |

The 19.4-second gap between the two probes is entirely render-blocking external resources that the GFW drops. The HTML document itself arrives in ~1s on both — Azure East Asia → CN ISP is clean. Self-hosting fonts moves those bytes to the same clean path, so they arrive like the HTML does.

## Files touched

- `web/index.html` — removed 2 × `<link rel="preconnect">` + 1 × `<link href="https://fonts.googleapis.com/...">`
- `web/src/index.css` — prepended 4 × `@import "@fontsource-variable/*"`
- `web/package.json` + lock — added `@fontsource-variable/dm-sans`, `@fontsource-variable/jetbrains-mono`, `@fontsource-variable/noto-sans-sc` (`@fontsource-variable/geist` was already in deps)
- Also dropped `Noto Serif SC` from the URL — it was requested from Google but never referenced in any CSS. Dead weight.

## Bundle impact

Production build (verified via `npm run build` on this branch):

| Asset | Before | After | Delta |
|---|---|---|---|
| Main CSS | 125.43 KB (20.35 KB gz) | 239.52 KB (69.96 KB gz) | **+114 KB raw / +50 KB gz** — the inlined @font-face block |
| Main JS | 1,270 KB (377 KB gz) | 1,270 KB (377 KB gz) | no change |
| WOFF2 files in dist/assets/ | 0 | 108 files, 4.8 MB total on disk | +108 files |

**Important nuance:** the 4.8 MB WOFF2 total is the *on-disk* weight. The browser only fetches unicode-range subsets it actually renders. For an English-only Landing page (our S4 scenario), browser fetches maybe 50–80 KB of WOFF2 over the wire. For a Chinese-locale page it grows as text triggers more subsets. In either case, significantly less than the bypassed run's 906 KB of Google WOFF2.

## Forecast (from anchor baseline)

| Probe | Metric | Before | Predicted After |
|---|---|---|---|
| cn-pc-2 Desktop | FCP | 22476 ms | ~3000 ms (**-19.4s, -87%**) |
| cn-pc-2 Mobile | FCP | 22532 ms | ~3000 ms (**-19.5s, -87%**) |
| cn-pc Desktop (bypass) | FCP | 3000 ms | ~3000 ms (no change — already reaches Google OK) |
| cn-pc-2 any | Font CSS TTFB | — (absent) | — (request doesn't exist anymore) |

## Test plan

- [x] `npm run build` → green, sizes as documented above
- [x] `eslint` → clean on the modified files
- [ ] **Post-merge, operator PC**: `bash scripts/sitespeed_runner.sh --probe cn-pc-2 --scenario s4 --device both --runs 3` with passwall OFF. Commit new baseline directory. Expected row: FCP ≈ 3000 ms on both form factors, Font CSS TTFB `—` because there is no such request. If the numbers don't move that way, something's wrong with the deploy or the build didn't inline the right fonts.
- [ ] **Post-merge spot check**: open https://www.praxys.run/ in a browser, DevTools → Network tab → filter for `fonts.googleapis.com` → should be zero requests.

## Follow-ups (separate PRs)

- **Phase 1 #2** — route-level React.lazy + manualChunks for the 1.27 MB JS bundle
- **Phase 1 #3** — FastAPI `GZipMiddleware` (one line; affects API not S4, so measurable on S2 after S1/S2/S3 runner lands)
- **Phase 1 #4** — explicit cache-control headers in `staticwebapp.config.json`