### PR TITLE
Phase 1 #4: Explicit cache-control headers in SWA config

### DIFF
--- a/web/staticwebapp.config.json
+++ b/web/staticwebapp.config.json
@@ -12,6 +12,24 @@
     {
       "route": "/api/*",
       "allowedRoles": ["anonymous"]
+    },
+    {
+      "route": "/assets/*",
+      "headers": {
+        "cache-control": "public, max-age=31536000, immutable"
+      }
+    },
+    {
+      "route": "/index.html",
+      "headers": {
+        "cache-control": "no-cache"
+      }
+    },
+    {
+      "route": "/favicon.svg",
+      "headers": {
+        "cache-control": "public, max-age=86400"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

JSON-only change to `web/staticwebapp.config.json`. Adds per-route cache-control for `/assets/*`, `/index.html`, and `/favicon.svg` so every revisit from a cached browser skips the RTT-expensive revalidation step.

## Why this matters on CN

Content-hashed assets like `index-Cy-yKpdm.js` never change once deployed — the hash IS the version. Browsers that cache them with `max-age=31536000, immutable` skip the validation round-trip entirely. For a CN user behind GFW, that's the entire RTT per asset saved on every repeat visit.

## The change

```json
{ "route": "/assets/*",     "headers": { "cache-control": "public, max-age=31536000, immutable" } },
{ "route": "/index.html",   "headers": { "cache-control": "no-cache" } },
{ "route": "/favicon.svg",  "headers": { "cache-control": "public, max-age=86400" } }
```

- **`/assets/*`** — all Vite build output lives here (JS bundles, CSS bundle, WOFF2 subsets, chart icons). All content-hashed by Vite. Safe to cache forever.
- **`/index.html`** — `no-cache` forces revalidation so new deploys are seen immediately. Without it, a browser could serve stale HTML that references JS hashes no longer on the server. `no-cache` ≠ `no-store`: bytes still cached, just validated first.
- **`/favicon.svg`** — not content-hashed. One-day cache is a reasonable compromise.

No change to `/api/*` route — API responses are dynamic; FastAPI decides.

## Measurable where?

- **S3 (warm revisit)** when we run it — fewer-or-no revalidation requests should show up in the HAR.
- Not measurable on S4 cold loads (first visit, cache is empty anyway).
- Pairs naturally with Phase 2 #7 (PWA), which needs predictable cache semantics for its service-worker shell cache.

## Test plan

- [x] `python -c 'json.load(...)'` → valid
- [ ] Post-deploy smoke: `curl -sI https://www.praxys.run/assets/<some-file>.js | grep -i cache-control` should return `public, max-age=31536000, immutable`
- [ ] Post-deploy smoke: `curl -sI https://www.praxys.run/index.html | grep -i cache-control` should return `no-cache`