### PR TITLE
Phase 2 #8: Disable refetchOnWindowFocus

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -20,7 +20,13 @@ const queryClient = new QueryClient({
       staleTime: 2 * 60 * 1000,
       gcTime: 5 * 60 * 1000,
       retry: 2,
-      refetchOnWindowFocus: true,
+      // Disabled because CN users on spotty mobile network were burning
+      // seconds of round-trips every time they tabbed back from WeChat
+      // or another app. Stale data is refetched lazily via staleTime
+      // expiration + manual refetch() calls already wired where it matters
+      // (sync status polling, etc.). Leaving this on made the app feel
+      // like it "reloaded for no reason" after an app switch.
+      refetchOnWindowFocus: false,
     },
   },
 })


### PR DESCRIPTION
## Summary

Trivial react-query default flip: `refetchOnWindowFocus: true` → `false`. Stops every tab-switch from triggering a full requery of the current page.

## Why it matters on CN

The reality for mainland-China mobile users: they tap a WeChat link to share a workout to a friend, WeChat backgrounds the browser, they come back a minute later — every `useApi` / react-query on the page fires again. Each of those is an API round-trip across the GFW. A single tab-switch on the Training page costs 4–7 wasted network calls.

The data was already correct. The user sees a brief loading state and identical bytes replace identical bytes.

## What doesn't break

Places that need real-time freshness use their own mechanisms:
- Sync-status pages → explicit `refetchInterval` on the relevant query
- Plan editor post-save → explicit `refetch()` call after mutation

Stale data after window-focus still refreshes on the next user interaction via the existing 2-minute `staleTime`.

## Measurable

- **RUM** (App Insights): fewer dependency spans per tab-switch event. Visible in `AppDependencies` queries filtered by country=CN.
- **S3** (warm revisit) once we run it: request-count column drops on this specific flow.
- Not visible on S1/S2/S4 (cold load).

## Test plan

- [x] eslint clean
- [ ] Post-deploy manual sanity: open prod on a mobile browser, tab out to another app, come back; DevTools network should NOT show a burst of `/api/*` calls