### PR TITLE
Phase 1 #2: Route-level code splitting + vendor chunks

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { TooltipProvider } from './components/ui/tooltip';
 import { AuthProvider, useAuth } from './hooks/useAuth';
@@ -6,16 +7,22 @@ import { ScienceProvider } from './contexts/ScienceContext';
 import { LocaleProvider } from './contexts/LocaleContext';
 import LocaleSync from './contexts/LocaleSync';
 import Layout from './components/Layout';
-import Today from './pages/Today';
-import Training from './pages/Training';
-import Goal from './pages/Goal';
-import History from './pages/History';
-import Science from './pages/Science';
-import Settings from './pages/Settings';
-import Setup from './pages/Setup';
-import Admin from './pages/Admin';
-import Login from './pages/Login';
+// Eagerly imported: Landing is the anonymous first-impression, Login is
+// the auth entry point, Today is where every logged-in user lands. All
+// three must be in the initial bundle for fastest cold-load.
 import Landing from './pages/Landing';
+import Login from './pages/Login';
+import Today from './pages/Today';
+import Setup from './pages/Setup';
+// Lazy-loaded: secondary routes the user navigates to after landing on
+// Today. Chunks load on first visit to each route; cached immutably
+// thereafter (see staticwebapp.config.json cache headers).
+const Training = lazy(() => import('./pages/Training'));
+const Goal = lazy(() => import('./pages/Goal'));
+const History = lazy(() => import('./pages/History'));
+const Science = lazy(() => import('./pages/Science'));
+const SettingsPage = lazy(() => import('./pages/Settings'));
+const Admin = lazy(() => import('./pages/Admin'));
 import { useSetupStatus } from './hooks/useSetupStatus';
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
@@ -57,12 +64,12 @@ export default function App() {
               >
                 <Route path="today" element={<TodayOrSetup />} />
                 <Route path="setup" element={<Setup />} />
-                <Route path="training" element={<Training />} />
-                <Route path="goal" element={<Goal />} />
-                <Route path="history" element={<History />} />
-                <Route path="science" element={<Science />} />
-                <Route path="settings" element={<Settings />} />
-                <Route path="admin" element={<Admin />} />
+                <Route path="training" element={<Suspense fallback={null}><Training /></Suspense>} />
+                <Route path="goal" element={<Suspense fallback={null}><Goal /></Suspense>} />
+                <Route path="history" element={<Suspense fallback={null}><History /></Suspense>} />
+                <Route path="science" element={<Suspense fallback={null}><Science /></Suspense>} />
+                <Route path="settings" element={<Suspense fallback={null}><SettingsPage /></Suspense>} />
+                <Route path="admin" element={<Suspense fallback={null}><Admin /></Suspense>} />
               </Route>
             </Routes>
           </BrowserRouter>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -22,4 +22,23 @@ export default defineConfig({
       '/api': 'http://localhost:8000',
     },
   },
+  build: {
+    // Vendor chunks that get their own cacheable file. Splitting helps
+    // returning visitors: the app-code chunk changes every deploy (its
+    // hash rotates) but recharts / react-markdown / @tanstack/react-query
+    // rarely change, so their hashed filenames stay stable across
+    // deploys and the browser keeps them cached.
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (/node_modules[\\/](react-router-dom|react-dom|react)[\\/]/.test(id)) return 'react-vendor'
+          if (/node_modules[\\/]recharts[\\/]/.test(id)) return 'recharts'
+          if (/node_modules[\\/](react-markdown|remark-gfm)[\\/]/.test(id)) return 'markdown'
+          if (/node_modules[\\/]@tanstack[\\/]react-query[\\/]/.test(id)) return 'query'
+          return undefined
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

Split the monolithic 1.27 MB / 377 KB gzipped bundle into targeted chunks that map better to user navigation patterns and cache lifecycles.

## The split

**Eager (in the initial bundle):** Landing, Login, Today, Setup — first-paint-critical for anonymous and freshly-authed users.

**Lazy via React.lazy + Suspense:** Training, Goal, History, Science, Settings, Admin — users pay the chunk-download cost only when they navigate there.

**Vendor chunks via `manualChunks`:** `react-vendor` / `recharts` / `markdown` / `query`.

## Bundle delta (production build, verified locally)

| | Before | After (initial load hitting Today) |
|---|---|---|
| Monolithic JS | **1,270 KB / 377 KB gz** | — |
| Split — `index.js` (app code) | — | 232 KB / 73 KB |
| Split — `react-vendor` | — | 182 KB / 57 KB |
| Split — `recharts` | — | 397 KB / 113 KB |
| Split — `query` | — | 22 KB / 7 KB |
| Split — `markdown` | — | **not loaded** (only Science page needs it, which is lazy) |
| **Initial JS total** | **377 KB gz** | **~250 KB gz** |

Net: **−127 KB gzipped on cold first-load today**, and better still on repeat visits where vendor chunks have stable filenames across deploys → browser keeps them cached. Compounds with Phase 1 #4's `immutable` cache headers.

Lazy routes (Training/Goal/History/Science/Settings/Admin): 5–71 KB each, fetched only when navigated to.

## One TS note

Had to use the function form of `manualChunks`. The newer Rolldown-based Vite tightens the object-form type at compile time to reject unknown chunk-name keys. Function form is the documented path going forward.

## Where this shows up in measurement

- **S4 cold load (anchor baseline)**: modest improvement — Today's critical path still needs react-vendor + recharts + query, so the savings are mostly the non-Today route code that's no longer shipped.
- **S3 warm revisit** (when we run it): larger improvement — vendor chunks stay cached across deploys.
- **Users who never visit Training/Settings/etc.**: never download those bundles at all.

## Test plan

- [x] `tsc -b` → clean
- [x] `npm run build` → green, bundle breakdown as documented above
- [x] Bundle actually contains the lazy chunks (verified: Training-*.js, Goal-*.js etc. present in dist/assets)
- [ ] Post-deploy smoke: open prod site, navigate to /training, DevTools Network should show a new chunk request for Training-*.js
- [ ] Post-deploy smoke: refresh on /today, confirm no Training-*.js in initial waterfall