### PR TITLE
Phase 2 #4a: Drop duplicate /api/settings fetch in UpcomingPlanCard

### DIFF
--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Trans, useLingui, Plural } from '@lingui/react/macro';
 import { useLocale } from '@/contexts/LocaleContext';
+import { useSettings } from '@/contexts/SettingsContext';
 
 const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
   easy:       { bg: 'bg-primary/15', text: 'text-primary' },
@@ -328,20 +329,13 @@ export default function UpcomingPlanCard() {
   const [pushErrors, setPushErrors] = useState<Record<string, string>>({});
   const [pushing, setPushing] = useState(false);
   const [pushingDates, setPushingDates] = useState<Set<string>>(new Set());
-  const [hasStryd, setHasStryd] = useState(false);
 
-  // Check if Stryd is connected
-  useEffect(() => {
-    fetch(`${API_BASE}/api/settings`, { headers: getAuthHeaders() })
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((config) => {
-        if (config?.config?.connections?.includes('stryd')) setHasStryd(true);
-      })
-      .catch((err) => console.error('Failed to load settings:', err));
-  }, []);
+  // Stryd connection status — read from SettingsContext rather than firing
+  // a second /api/settings request. SettingsContext has already fetched
+  // this data; the old fetch here duplicated the request for every
+  // Training-page cold load.
+  const { config: settings } = useSettings();
+  const hasStryd = Boolean(settings?.connections?.includes('stryd'));
 
   // Load push status
   useEffect(() => {

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -32,7 +32,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:517
+#: src/components/UpcomingPlanCard.tsx:511
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -371,7 +371,7 @@ msgstr "Clear"
 msgid "Click to copy"
 msgstr "Click to copy"
 
-#: src/components/UpcomingPlanCard.tsx:125
+#: src/components/UpcomingPlanCard.tsx:126
 msgid "click to retry"
 msgstr "click to retry"
 
@@ -739,7 +739,7 @@ msgstr "Failed to load settings"
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:493
+#: src/components/UpcomingPlanCard.tsx:487
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -1361,20 +1361,20 @@ msgstr "Promote to Admin"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "Pull your latest activities, power data, and recovery metrics"
 
-#: src/components/UpcomingPlanCard.tsx:540
+#: src/components/UpcomingPlanCard.tsx:534
 msgid "Push All"
 msgstr "Push All"
 
-#: src/components/UpcomingPlanCard.tsx:125
+#: src/components/UpcomingPlanCard.tsx:126
 msgid "Push failed"
 msgstr "Push failed"
 
-#: src/components/UpcomingPlanCard.tsx:168
-#: src/components/UpcomingPlanCard.tsx:176
+#: src/components/UpcomingPlanCard.tsx:169
+#: src/components/UpcomingPlanCard.tsx:177
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
-#: src/components/UpcomingPlanCard.tsx:530
+#: src/components/UpcomingPlanCard.tsx:524
 msgid "Pushing..."
 msgstr "Pushing..."
 
@@ -1414,8 +1414,8 @@ msgstr "Race Prediction"
 msgid "Range"
 msgstr "Range"
 
-#: src/components/UpcomingPlanCard.tsx:142
-#: src/components/UpcomingPlanCard.tsx:151
+#: src/components/UpcomingPlanCard.tsx:143
+#: src/components/UpcomingPlanCard.tsx:152
 msgid "Re-push to Stryd"
 msgstr "Re-push to Stryd"
 
@@ -1518,7 +1518,7 @@ msgstr "REST"
 msgid "Resting HR"
 msgstr "Resting HR"
 
-#: src/components/UpcomingPlanCard.tsx:496
+#: src/components/UpcomingPlanCard.tsx:490
 #: src/pages/Goal.tsx:487
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:336
@@ -1527,7 +1527,7 @@ msgstr "Resting HR"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/UpcomingPlanCard.tsx:117
+#: src/components/UpcomingPlanCard.tsx:118
 msgid "Retry push to Stryd"
 msgstr "Retry push to Stryd"
 
@@ -1608,11 +1608,11 @@ msgid "Setup"
 msgstr "Setup"
 
 #. placeholder {0}: workouts.length - INITIAL_COUNT
-#: src/components/UpcomingPlanCard.tsx:318
+#: src/components/UpcomingPlanCard.tsx:319
 msgid "Show {0} more workouts"
 msgstr "Show {0} more workouts"
 
-#: src/components/UpcomingPlanCard.tsx:317
+#: src/components/UpcomingPlanCard.tsx:318
 msgid "Show less"
 msgstr "Show less"
 
@@ -1743,7 +1743,7 @@ msgstr "Sync history"
 msgid "Sync your data"
 msgstr "Sync your data"
 
-#: src/components/UpcomingPlanCard.tsx:535
+#: src/components/UpcomingPlanCard.tsx:529
 #: src/pages/Settings.tsx:820
 msgid "Synced"
 msgstr "Synced"
@@ -1823,7 +1823,7 @@ msgstr "Thresholds"
 msgid "Today"
 msgstr "Today"
 
-#: src/components/UpcomingPlanCard.tsx:221
+#: src/components/UpcomingPlanCard.tsx:222
 msgid "TODAY"
 msgstr "TODAY"
 
@@ -1875,7 +1875,7 @@ msgstr "Ultra distance power fractions (50K+) are estimates with limited researc
 msgid "Units"
 msgstr "Units"
 
-#: src/components/UpcomingPlanCard.tsx:513
+#: src/components/UpcomingPlanCard.tsx:507
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -32,7 +32,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:517
+#: src/components/UpcomingPlanCard.tsx:511
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -371,7 +371,7 @@ msgstr "清除"
 msgid "Click to copy"
 msgstr "点击复制"
 
-#: src/components/UpcomingPlanCard.tsx:125
+#: src/components/UpcomingPlanCard.tsx:126
 msgid "click to retry"
 msgstr "点击重试"
 
@@ -739,7 +739,7 @@ msgstr "加载设置失败"
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:493
+#: src/components/UpcomingPlanCard.tsx:487
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -1361,20 +1361,20 @@ msgstr "提升为管理员"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "拉取您最近的活动、功率数据和恢复指标"
 
-#: src/components/UpcomingPlanCard.tsx:540
+#: src/components/UpcomingPlanCard.tsx:534
 msgid "Push All"
 msgstr "全部推送"
 
-#: src/components/UpcomingPlanCard.tsx:125
+#: src/components/UpcomingPlanCard.tsx:126
 msgid "Push failed"
 msgstr "推送失败"
 
-#: src/components/UpcomingPlanCard.tsx:168
-#: src/components/UpcomingPlanCard.tsx:176
+#: src/components/UpcomingPlanCard.tsx:169
+#: src/components/UpcomingPlanCard.tsx:177
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
-#: src/components/UpcomingPlanCard.tsx:530
+#: src/components/UpcomingPlanCard.tsx:524
 msgid "Pushing..."
 msgstr "正在推送..."
 
@@ -1414,8 +1414,8 @@ msgstr "比赛预测"
 msgid "Range"
 msgstr "范围"
 
-#: src/components/UpcomingPlanCard.tsx:142
-#: src/components/UpcomingPlanCard.tsx:151
+#: src/components/UpcomingPlanCard.tsx:143
+#: src/components/UpcomingPlanCard.tsx:152
 msgid "Re-push to Stryd"
 msgstr "重新推送到 Stryd"
 
@@ -1518,7 +1518,7 @@ msgstr "休息"
 msgid "Resting HR"
 msgstr "静息心率"
 
-#: src/components/UpcomingPlanCard.tsx:496
+#: src/components/UpcomingPlanCard.tsx:490
 #: src/pages/Goal.tsx:487
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:336
@@ -1527,7 +1527,7 @@ msgstr "静息心率"
 msgid "Retry"
 msgstr "重试"
 
-#: src/components/UpcomingPlanCard.tsx:117
+#: src/components/UpcomingPlanCard.tsx:118
 msgid "Retry push to Stryd"
 msgstr "重试推送到 Stryd"
 
@@ -1608,11 +1608,11 @@ msgid "Setup"
 msgstr "设置向导"
 
 #. placeholder {0}: workouts.length - INITIAL_COUNT
-#: src/components/UpcomingPlanCard.tsx:318
+#: src/components/UpcomingPlanCard.tsx:319
 msgid "Show {0} more workouts"
 msgstr "显示另外 {0} 项训练"
 
-#: src/components/UpcomingPlanCard.tsx:317
+#: src/components/UpcomingPlanCard.tsx:318
 msgid "Show less"
 msgstr "显示更少"
 
@@ -1743,7 +1743,7 @@ msgstr "同步历史"
 msgid "Sync your data"
 msgstr "同步数据"
 
-#: src/components/UpcomingPlanCard.tsx:535
+#: src/components/UpcomingPlanCard.tsx:529
 #: src/pages/Settings.tsx:820
 msgid "Synced"
 msgstr "已同步"
@@ -1823,7 +1823,7 @@ msgstr "阈值"
 msgid "Today"
 msgstr "今日"
 
-#: src/components/UpcomingPlanCard.tsx:221
+#: src/components/UpcomingPlanCard.tsx:222
 msgid "TODAY"
 msgstr "今日"
 
@@ -1875,7 +1875,7 @@ msgstr "超长距离功率分数（50K+）为估算值，研究支持有限。Ri
 msgid "Units"
 msgstr "单位"
 
-#: src/components/UpcomingPlanCard.tsx:513
+#: src/components/UpcomingPlanCard.tsx:507
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 


### PR DESCRIPTION
## Summary

One step of the Training-page waterfall collapse (7 endpoints → 6). UpcomingPlanCard was firing its own `fetch('/api/settings')` via useEffect to check a single field (`config.connections.includes('stryd')`), duplicating a request that `SettingsContext` had already made and cached. Replaced with `useSettings()` — instant in-memory read.

## Why it was duplicating

The UpcomingPlanCard fetch was raw `fetch()`, not `useApi<T>`. React Query's request deduplication only covers queries keyed through the same hook/URL pair; raw fetches bypass it entirely.

## Before / after

Training cold load endpoints (post-auth, parallel):

| | Before (7 unique) | After (6 unique) |
|---|---|---|
| `/api/settings` (context) | ✓ | ✓ |
| `/api/science` (context) | ✓ | ✓ |
| `/api/training` (page) | ✓ | ✓ |
| `/api/insights/training_review` (card) | ✓ | ✓ |
| `/api/plan` (card) | ✓ | ✓ |
| `/api/settings` (DUPLICATE) | ✓ | **gone** |
| `/api/plan/stryd-status` (card) | ✓ | ✓ |

One cross-GFW round-trip saved on every cold Training-page load.

## What's not in this PR

Two more endpoints can still be folded:
- **`/api/plan/stryd-status` → `/api/plan`** (add a `stryd_status` field to PlanResponse, populate server-side)
- **`/api/insights/training_review` → `/api/training`** (add insight field, AI computation already runs server-side)

Both need backend route + Pydantic model + TypeScript interface + test updates — larger scope, deferred to follow-up PRs per the "small PRs ship faster" rhythm we've been using.

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean
- [x] `vite build` green (no bundle size change — the fetch was runtime, not compile-time)
- [ ] Post-deploy: Training page DevTools → Network → filter `/api/settings` → expect exactly one request, from SettingsContext on auth