### PR TITLE
PR-F: Multi-region perf baseline workflow (ACI + workflow_dispatch)

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -1,0 +1,217 @@
+name: Perf Baseline (sitespeed.io via ACI)
+
+# Manual-trigger-only. Runs sitespeed.io inside an Azure Container Instance
+# in the chosen region, captures HAR + sitespeed output to an Azure Files
+# share, downloads back to the runner, uploads as a GH Action artifact.
+#
+# One-time prerequisites (see docs/perf-baselines/ci-setup.md):
+#   - Storage account `stperftrainsight` in rg-trainsight (already created)
+#   - File share `perfbaselines` (already created)
+#   - GitHub repo secret STORAGE_ACCOUNT_KEY set to that account's access key
+#   - AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID already
+#     used by deploy-backend.yml (SP has Contributor on rg-trainsight)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why running this baseline (e.g. "anchor before phase 2" or "after self-host fonts")'
+        required: true
+        type: string
+      probe:
+        description: 'Azure region the ACI runs in'
+        required: false
+        type: choice
+        default: 'eastasia'
+        options:
+          - 'eastasia'
+          - 'westus'
+          - 'northeurope'
+          - 'eastus'
+      target_url:
+        description: 'URL to measure'
+        required: false
+        type: string
+        default: 'https://www.praxys.run/'
+      device:
+        description: 'Device emulation'
+        required: false
+        type: choice
+        default: 'both'
+        options:
+          - 'desktop'
+          - 'mobile'
+          - 'both'
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AZ_SUBSCRIPTION: 3ff02750-211c-4579-94a6-8c9af4e6d891
+  AZ_RG: rg-trainsight
+  STORAGE_ACCOUNT: stperftrainsight
+  FILE_SHARE: perfbaselines
+
+jobs:
+  resolve-devices:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - id: build
+        run: |
+          if [ "${{ inputs.device }}" = "both" ]; then
+            echo 'matrix=["desktop","mobile"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix=["${{ inputs.device }}"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  baseline:
+    needs: resolve-devices
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJson(needs.resolve-devices.outputs.matrix) }}
+    env:
+      CELL: s4-${{ inputs.probe }}-${{ matrix.device }}
+      CONTAINER_NAME: sitespeed-s4-${{ inputs.probe }}-${{ matrix.device }}-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build sitespeed.io command-line
+        id: cmd
+        run: |
+          BASE_ARGS="--outputFolder /sitespeed.io/out/${CELL} -n 3"
+          if [ "${{ matrix.device }}" = "mobile" ]; then
+            # Same explicit viewport + UA approach the local runner uses,
+            # stable across Chrome versions inside the official
+            # sitespeedio/sitespeed.io image.
+            DEVICE_ARGS='--browsertime.viewPort 390x844 --browsertime.userAgent "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"'
+          else
+            DEVICE_ARGS=""
+          fi
+          echo "args=sitespeed.io '${{ inputs.target_url }}' ${BASE_ARGS} ${DEVICE_ARGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Create ACI + wait for completion
+        run: |
+          set -euo pipefail
+
+          az container create \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --resource-group "$AZ_RG" \
+            --name "$CONTAINER_NAME" \
+            --image sitespeedio/sitespeed.io:latest \
+            --location "${{ inputs.probe }}" \
+            --cpu 2 --memory 4 \
+            --restart-policy Never \
+            --azure-file-volume-account-name "$STORAGE_ACCOUNT" \
+            --azure-file-volume-account-key "${{ secrets.STORAGE_ACCOUNT_KEY }}" \
+            --azure-file-volume-share-name "$FILE_SHARE" \
+            --azure-file-volume-mount-path /sitespeed.io/out \
+            --command-line "${{ steps.cmd.outputs.args }}" \
+            --no-wait
+
+          # Poll until the container exits. ACI's single-run model surfaces
+          # state as "Terminated" with an exitCode once the process finishes.
+          while true; do
+            STATE=$(az container show \
+              --subscription "$AZ_SUBSCRIPTION" \
+              --resource-group "$AZ_RG" \
+              --name "$CONTAINER_NAME" \
+              --query "containers[0].instanceView.currentState.state" -o tsv 2>/dev/null || true)
+            echo "[$(date -u +%T)] container state: ${STATE:-pending}"
+            if [ "$STATE" = "Terminated" ]; then break; fi
+            sleep 20
+          done
+
+          EXIT_CODE=$(az container show \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --resource-group "$AZ_RG" \
+            --name "$CONTAINER_NAME" \
+            --query "containers[0].instanceView.currentState.exitCode" -o tsv)
+          echo "container exit code: $EXIT_CODE"
+
+          echo "---- container logs (tail) ----"
+          az container logs \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --resource-group "$AZ_RG" \
+            --name "$CONTAINER_NAME" | tail -80
+
+          exit "$EXIT_CODE"
+
+      - name: Download HARs + strip heavy binaries
+        run: |
+          set -euo pipefail
+          mkdir -p baseline-output
+          az storage file download-batch \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --account-name "$STORAGE_ACCOUNT" \
+            --account-key "${{ secrets.STORAGE_ACCOUNT_KEY }}" \
+            --source "$FILE_SHARE" \
+            --pattern "${CELL}/*" \
+            --destination ./baseline-output/
+
+          # Match the .gitignore pattern in docs/perf-baselines/: keep HAR +
+          # light reports, drop videos/filmstrip/screenshots bundles.
+          find baseline-output -type d \( -name video -o -name filmstrip -o -name screenshots \) \
+            -exec rm -rf {} + 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: baseline-${{ env.CELL }}-${{ github.run_id }}
+          path: baseline-output/
+          retention-days: 30
+
+      - name: Delete ACI
+        if: always()
+        run: |
+          az container delete \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --resource-group "$AZ_RG" \
+            --name "$CONTAINER_NAME" \
+            --yes || true
+
+      - name: Delete downloaded results from Azure Files
+        if: always()
+        run: |
+          # Avoid share filling up; GH artifact is the durable copy.
+          az storage file delete-batch \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --account-name "$STORAGE_ACCOUNT" \
+            --account-key "${{ secrets.STORAGE_ACCOUNT_KEY }}" \
+            --source "$FILE_SHARE" \
+            --pattern "${CELL}/*" || true
+
+  summary:
+    needs: baseline
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: baseline-collected
+          pattern: baseline-*-${{ github.run_id }}
+          merge-multiple: true
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Run analyzer across all cells
+        run: |
+          mkdir -p baseline-combined
+          cp -r baseline-collected/* baseline-combined/
+          python scripts/analyze_baseline.py --baseline-dir baseline-combined || true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: baseline-combined-${{ github.run_id }}
+          path: baseline-combined/
+          retention-days: 30

--- a/docs/perf-baselines/ci-setup.md
+++ b/docs/perf-baselines/ci-setup.md
@@ -1,0 +1,92 @@
+# Perf-baseline CI — one-time setup
+
+This documents the Azure resources + GitHub config that back `.github/workflows/perf-baseline.yml`. Everything here is **already provisioned on the `dddtc2005/praxys` repo** — this doc exists so a future operator (or a forked repo) knows how to reproduce it.
+
+## What the workflow does
+
+Trigger: **manual** (`workflow_dispatch`) only. Inputs: `reason`, `probe` (Azure region), `target_url`, `device`.
+
+1. Uses OIDC to log in to Azure with the same service principal `deploy-backend.yml` uses.
+2. Spins up an Azure Container Instance in the chosen region running `sitespeedio/sitespeed.io:latest`.
+3. ACI mounts an Azure Files share at `/sitespeed.io/out` so the HAR + browsertime output lands somewhere durable.
+4. Polls until the container exits, dumps its stdout log, then downloads the HARs from the share back to the GH runner.
+5. Uploads a GH Actions artifact per cell (one per probe × device pair in the matrix).
+6. Deletes the container + wipes the share path so nothing accumulates.
+7. A final summary job runs `scripts/analyze_baseline.py` across all cells and uploads the populated markdown table as its own artifact.
+
+## Azure resources
+
+All in `rg-trainsight`, subscription `3ff02750-211c-4579-94a6-8c9af4e6d891`.
+
+| Resource | Name | Created via |
+|---|---|---|
+| Storage account | `stperftrainsight` (StorageV2, Standard_LRS, eastasia) | `az storage account create` |
+| File share | `perfbaselines` (5 GB quota) | `az storage share-rm create` |
+
+Cost: ~$0.05/month for the share at idle + $0.30/baseline in ACI compute at our cadence. Roughly **$1–3/month** total.
+
+## Azure RBAC / auth
+
+The workflow reuses the existing OIDC service principal that ships backend deploys (secrets `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`). That SP already holds **Contributor on `rg-trainsight`**, which is sufficient for:
+- `Microsoft.ContainerInstance/containerGroups/write` (create ACI)
+- `Microsoft.Storage/storageAccounts/fileServices/shares/files/write` (mount share)
+- `Microsoft.ContainerInstance/containerGroups/delete` (teardown)
+
+No extra role assignments needed.
+
+## GitHub secret
+
+The workflow needs one additional secret beyond the OIDC trio:
+
+- **`STORAGE_ACCOUNT_KEY`** — `key1` of `stperftrainsight`. Used to mount the Azure File share into the ACI container, and also to download/delete files from the runner.
+  - Already set on `dddtc2005/praxys`.
+  - To rotate: `az storage account keys renew --account-name stperftrainsight --key key1` then `gh secret set STORAGE_ACCOUNT_KEY --repo dddtc2005/praxys` with the new value.
+
+## Reproducing from scratch
+
+If you fork the repo or rebuild the environment:
+
+```bash
+# 1. Create the storage account + share
+az storage account create \
+  --subscription <sub> --resource-group <rg> \
+  --name <account> --location eastasia \
+  --sku Standard_LRS --kind StorageV2
+
+az storage share-rm create \
+  --subscription <sub> --resource-group <rg> \
+  --storage-account <account> --name perfbaselines --quota 5
+
+# 2. Get the key
+KEY=$(az storage account keys list \
+  --subscription <sub> --resource-group <rg> \
+  --account-name <account> --query "[0].value" -o tsv)
+
+# 3. Set the GH secret
+echo "$KEY" | gh secret set STORAGE_ACCOUNT_KEY --repo <owner>/<repo>
+
+# 4. Update the `env:` block at the top of
+#    .github/workflows/perf-baseline.yml with your sub ID, RG name,
+#    storage account name if different.
+```
+
+## Triggering a run
+
+GitHub UI → Actions → "Perf Baseline (sitespeed.io via ACI)" → **Run workflow** → fill inputs → Run.
+
+Or via CLI:
+
+```bash
+gh workflow run perf-baseline.yml --repo dddtc2005/praxys \
+  -f reason="after phase 1 #1 (self-host fonts)" \
+  -f probe=eastasia \
+  -f device=both
+```
+
+Outputs land as GH Actions artifacts named `baseline-s4-<probe>-<device>-<run-id>/`. Download + merge into a `docs/perf-baselines/<YYYY-MM-DD>-<sha>/` directory per the `README.md` / `TEMPLATE.md` convention.
+
+## Known limitations
+
+- **No mainland-China POPs.** Azure has none in the public cloud; closest is `eastasia` (Hong Kong). For CN-from-inside-the-GFW numbers keep using `scripts/sitespeed_runner.sh` on an operator PC.
+- **Single scenario.** Only S4 (Anonymous Landing) is implemented today. S1-S3 (login-scripted scenarios) need a perf-test account + credential handling first.
+- **Cost scales with cadence.** At a baseline-per-week cadence, ~$3/month. More frequent runs scale linearly on ACI compute.


### PR DESCRIPTION
## Summary

Phase 2 of the PC-first → CI/CD architecture (paired with PR-E that landed the local runner). Adds a manual-trigger GH Actions workflow that runs sitespeed.io inside an Azure Container Instance in any chosen Azure region, captures HAR + browsertime output to an Azure Files share, downloads back to the runner, and uploads as a GH Action artifact. Plus a summary job that runs the analyzer across all cells.

## What's provisioned (already, as part of this PR)

All in `rg-trainsight`, subscription `3ff02750-...`:

| Resource | Name | Cost |
|---|---|---|
| Storage account | `stperftrainsight` (StorageV2, Standard_LRS, eastasia) | ~$0.05/mo idle |
| File share | `perfbaselines` (5 GB quota) | included |
| GH secret | `STORAGE_ACCOUNT_KEY` (key1 of the account) | — |

Reuses OIDC auth already wired for `deploy-backend.yml` (`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`). The SP has Contributor on the RG, which covers ACI create/delete + share mount.

Nothing more for you to do to enable the workflow — everything's live on the `dddtc2005/praxys` repo.

## How to use

GitHub UI → **Actions** → "Perf Baseline (sitespeed.io via ACI)" → **Run workflow** → fill inputs → Run.

Or via CLI:
```bash
gh workflow run perf-baseline.yml --repo dddtc2005/praxys \
  -f reason="after phase 1 #1 (self-host fonts)" \
  -f probe=eastasia \
  -f device=both
```

Inputs:
- **reason** — required, free text
- **probe** — Azure region (choice: eastasia / westus / northeurope / eastus, default eastasia)
- **target_url** — defaults to `https://www.praxys.run/`
- **device** — desktop / mobile / both (default)

Outputs are GH Actions artifacts named `baseline-s4-<probe>-<device>-<run-id>/` plus a combined `baseline-combined-<run-id>/` with the analyzer-generated markdown table ready to paste into a new `docs/perf-baselines/<date>-<sha>/README.md`.

## Jobs

1. **resolve-devices** — tiny job that fans out the matrix based on the `device` input (one entry or two)
2. **baseline (matrix)** — creates ACI, polls until Terminated, dumps container logs, downloads files from the share, deletes the container, wipes the share path
3. **summary** — downloads all cell artifacts, runs `scripts/analyze_baseline.py`, uploads the combined output

## Scope of this drop

- **Single probe per run.** The matrix runs two devices (desktop + mobile) against the same region. Multi-region is a deliberate follow-up: just trigger the workflow twice with different probes.
- **Only scenario S4.** S1-S3 (login-required) need a perf-test account + credential stash before the workflow can execute them. Follow-up PR.
- **HAR is the committed artifact.** Videos / filmstrips / screenshots get dropped from the upload, matching the `.gitignore` rule on the repo baseline directories.

## Cost

At a baseline-per-week cadence: ~$3/month. Storage idle $0.05/mo, ACI compute ~$0.30 per baseline, GH Actions minutes on free tier. Linear scale with frequency.

## Test plan

- [x] YAML syntax-validated locally
- [x] Azure resources live + GH secret set
- [ ] **First real run**: trigger manually, expect 2 artifacts (desktop + mobile) plus 1 combined summary. If the container OOMs on full Noto-SC subsets (unlikely — 4 GB should be plenty) we'll bump to `--memory 8`.

## Companion docs

- `docs/perf-baselines/ci-setup.md` — resource map + reproduction steps for future operators / forks