### PR TITLE
perf-baseline workflow: add --os-type Linux + tolerant summary

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -109,6 +109,7 @@ jobs:
             --resource-group "$AZ_RG" \
             --name "$CONTAINER_NAME" \
             --image sitespeedio/sitespeed.io:latest \
+            --os-type Linux \
             --location "${{ inputs.probe }}" \
             --cpu 2 --memory 4 \
             --restart-policy Never \
@@ -208,8 +209,12 @@ jobs:
       - name: Run analyzer across all cells
         run: |
           mkdir -p baseline-combined
-          cp -r baseline-collected/* baseline-combined/
-          python scripts/analyze_baseline.py --baseline-dir baseline-combined || true
+          if [ -d baseline-collected ] && [ -n "$(ls -A baseline-collected 2>/dev/null)" ]; then
+            cp -r baseline-collected/. baseline-combined/
+            python scripts/analyze_baseline.py --baseline-dir baseline-combined || true
+          else
+            echo "No baseline cells produced — earlier jobs failed. Skipping analyzer." >&2
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: baseline-combined-${{ github.run_id }}


### PR DESCRIPTION
## Summary

First trigger of the perf-baseline workflow (run 24921340505) failed both matrix jobs with:

```
ERROR: (InvalidOsType) The 'osType' for container group '<null>' is invalid.
The value must be one of 'Windows,Linux'.
```

`az container create` doesn't infer osType from the Docker image manifest in the current ARM API version — must be passed explicitly. Adding `--os-type Linux` (sitespeed.io's image is Linux-only).

Bonus fix in the summary job: the `cp -r baseline-collected/*` line errored with "cannot stat" when the matrix jobs all failed and produced no artifacts. Now conditional on the directory being non-empty, so a partial-failure run doesn't pile a misleading second red box.

## Test plan

- [x] YAML still parses
- [ ] Re-trigger the workflow with `gh workflow run perf-baseline.yml -f reason="retry after os-type fix" -f probe=eastasia -f device=both` after merge — expected: both ACI containers spin up, ~5-10 min total, three artifacts produced