### PR TITLE
perf-baseline workflow: invoke /start.sh, drop mobile UA

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -89,16 +89,28 @@ jobs:
       - name: Build sitespeed.io command-line
         id: cmd
         run: |
+          # The image's ENTRYPOINT is /start.sh which prepares Chrome and
+          # then execs sitespeed.io. ACI's --command-line *overrides* the
+          # entrypoint, so passing "sitespeed.io ..." fails with
+          # "executable not found in PATH" — sitespeed.io lives in
+          # /usr/src/app/bin/, only added to PATH inside /start.sh.
+          # Calling /start.sh directly with the same args restores the
+          # image's intended startup flow.
           BASE_ARGS="--outputFolder /sitespeed.io/out/${CELL} -n 3"
           if [ "${{ matrix.device }}" = "mobile" ]; then
-            # Same explicit viewport + UA approach the local runner uses,
-            # stable across Chrome versions inside the official
-            # sitespeedio/sitespeed.io image.
-            DEVICE_ARGS='--browsertime.viewPort 390x844 --browsertime.userAgent "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"'
+            # Viewport only — no UA override. The local runner sets a UA
+            # too but ACI's --command-line argv parser splits on
+            # whitespace and doesn't honour quoted strings, so a UA value
+            # like "Mozilla/5.0 (iPhone; CPU...)" gets shredded into many
+            # tokens. For S4 cold-load FCP the UA doesn't change the
+            # measurement (Chrome's default mobile UA renders the same
+            # CSS path); analytics-driven UA differences are out of scope
+            # for synthetic baselines.
+            DEVICE_ARGS="--browsertime.viewPort 390x844"
           else
             DEVICE_ARGS=""
           fi
-          echo "args=sitespeed.io '${{ inputs.target_url }}' ${BASE_ARGS} ${DEVICE_ARGS}" >> "$GITHUB_OUTPUT"
+          echo "args=/start.sh ${{ inputs.target_url }} ${BASE_ARGS} ${DEVICE_ARGS}" >> "$GITHUB_OUTPUT"
 
       - name: Create ACI + wait for completion
         run: |


### PR DESCRIPTION
## Summary

Second iteration on the ACI command-line for the perf-baseline workflow. First retry (run 24921405942) failed with:

```
exec: "sitespeed.io": executable file not found in $PATH
```

## Root cause

The `sitespeedio/sitespeed.io` image's `ENTRYPOINT ["/start.sh"]` is what makes `sitespeed.io` runnable — it's a wrapper that prepares Chrome and exec's `/usr/src/app/bin/sitespeed.io` after augmenting PATH. ACI's `--command-line` **overrides** the entrypoint entirely and tries to exec the first token directly. Without `/start.sh`'s PATH augmentation, `sitespeed.io` isn't in the default `$PATH`.

Fix: call `/start.sh` directly with the same args. The image's wrapper handles the rest.

## Side fix: dropping the mobile UA override

ACI's `--command-line` argv parser splits on whitespace with no quoted-string handling, so a value like `"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)..."` shreds into 10+ separate tokens that sitespeed.io rejects. Keeping `--browsertime.viewPort 390x844` for the mobile cell (same as the local runner) but accepting Chrome's default mobile UA. For S4 anonymous-landing FCP measurement this is irrelevant — same CSS branches render either way.

For F1 (login-scripted scenarios), the UA + script-flag complexity will force us to use an ACI YAML deployment file with explicit `command + args` arrays. That's the right time to bring back UA control. For now the simpler `--command-line` path keeps the workflow YAML compact.

## Test plan

- [x] YAML still parses
- [ ] Re-trigger after merge: `gh workflow run perf-baseline.yml -f reason="retry after entrypoint fix" -f probe=eastasia -f device=both`