### PR TITLE
F1: S1/S2/S3 login-scripted scenarios for the local runner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.md text eol=lf
 *.css text eol=lf
 *.sh text eol=lf
+*.js text eol=lf

--- a/scripts/pc-setup.md
+++ b/scripts/pc-setup.md
@@ -62,7 +62,30 @@ Prints markdown table sections per scenario. Paste them into that baseline's `RE
 
 **`fonts.googleapis.com` row missing in analyzer output** → That means the Google Fonts request either never fired (good news, maybe it's blocked before the request leaves your machine) or the HAR entry timed out. Check the browsertime.har manually; the cell's `Font CSS TTFB` shows `timeout` in that case.
 
+## Login-required scenarios (S1, S2, S3)
+
+The runner now supports the three logged-in scenarios in addition to S4:
+- **S1** — Cold Today via login
+- **S2** — Cold Training via login
+- **S3** — Warm Today repeat visit (after login + warm-up)
+
+```bash
+# All four scenarios on both form factors
+bash scripts/sitespeed_runner.sh --probe cn-pc --scenario all --device both
+
+# Just the login-required ones
+bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s1,s2,s3 --device both
+```
+
+Login defaults to the public demo account (`demo@trainsight.dev` / `demo`, the same defaults `Landing.tsx`'s "Try the demo" button uses). Override via env vars if you need a different account:
+
+```bash
+PRAXYS_PERF_USER=other@example.com PRAXYS_PERF_PASSWORD=secret \
+  bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s1 --device desktop
+```
+
+`PRAXYS_PERF_BASE_URL` overrides the host (defaults to `https://www.praxys.run`); useful for testing against a staging deploy.
+
 ## What this PR doesn't yet cover
 
-- **S1 / S2 / S3** (logged-in scenarios) need a scripted login flow. That's a follow-up PR — we need to decide on a perf-test user account and stash its credentials in a shell env var (never in the repo).
-- **Multi-region** runs from Azure land in PR-F (the CI workflow), which will reuse this same runner script inside ACI containers.
+- **S1 / S2 / S3 in CI (ACI workflow)** — the login scripts work locally; pushing them through the ACI workflow needs the YAML deployment file pattern (the current `--command-line` argv parser shreds compound args). Tracked separately.

--- a/scripts/sitespeed_runner.sh
+++ b/scripts/sitespeed_runner.sh
@@ -5,15 +5,23 @@
 #
 # Works on git bash (Windows + Docker Desktop), macOS, and Linux.
 #
-# Example — anchor baseline on the user's PC before Phase 1 optimizations:
-#   scripts/sitespeed_runner.sh --probe cn-pc --scenario s4 --device both
+# Example — full Tier 1 from a PC probe:
+#   scripts/sitespeed_runner.sh --probe cn-pc --scenario all --device both
 #
 # Cells emit artifacts into:
 #   docs/perf-baselines/<YYYY-MM-DD>-<short-sha>/s<N>-<probe>-<device>/
 #
-# This PR only implements S4 (anonymous Landing). S1-S3 (login-required
-# flows) come in a follow-up — they need scripted flows and test creds,
-# which deserve their own PR.
+# Scenarios:
+#   s4 — Anonymous Landing (no login)
+#   s1 — Cold Today via login
+#   s2 — Cold Training via login
+#   s3 — Warm Today repeat visit (after login + warm-up)
+#
+# For s1/s2/s3, the runner injects credentials into the container as env
+# vars. Defaults to the public demo account (demo@trainsight.dev / demo,
+# the same defaults Landing.tsx uses for the "Try the demo" button).
+# Override via PRAXYS_PERF_USER + PRAXYS_PERF_PASSWORD if you need a
+# different account. PRAXYS_PERF_BASE_URL also overrides the target host.
 
 set -euo pipefail
 
@@ -38,13 +46,20 @@ Required:
 
 Optional:
   --scenario <ids>     Comma-separated: s1,s2,s3,s4,all. Default: s4.
-                       (PR-E: only s4 is implemented.)
+                       s1=Cold Today via login, s2=Cold Training via login,
+                       s3=Warm Today repeat visit, s4=Anonymous Landing.
   --device <dev>       desktop | mobile | both. Default: both.
-  --url <url>          Target URL. Default: https://www.praxys.run/
+  --url <url>          Target URL for s4. Default: https://www.praxys.run/
+                       (Login scenarios use PRAXYS_PERF_BASE_URL — see env.)
   --runs <N>           Sitespeed iterations per cell. Default: 3.
   --outdir <path>      Output root. Default: docs/perf-baselines/<date>-<sha>/
   --sha <sha>          Override the sha suffix in the default outdir.
   -h, --help           Show this help.
+
+Env (login scenarios only):
+  PRAXYS_PERF_USER      default: demo@trainsight.dev (public demo account)
+  PRAXYS_PERF_PASSWORD  default: demo
+  PRAXYS_PERF_BASE_URL  default: https://www.praxys.run (no trailing slash)
 EOF
 }
 
@@ -100,17 +115,29 @@ else
   ABS_OUTDIR="$(cd "$OUTDIR" && pwd)"
 fi
 
+# Path to the bundled browsertime preScripts that drive S1/S2/S3. Computed
+# once and bind-mounted into the container at /sitespeed.io/scripts.
+SCRIPTS_DIR_UNIX="$(dirname "$0")/sitespeed_scripts"
+if command -v cygpath >/dev/null 2>&1; then
+  SCRIPTS_DIR_HOST="$(cygpath -aw "$SCRIPTS_DIR_UNIX")"
+else
+  SCRIPTS_DIR_HOST="$(cd "$SCRIPTS_DIR_UNIX" && pwd)"
+fi
+
+# Public demo defaults — these match the values Landing.tsx ships in its
+# "Try the demo" CTA, so they're not secret. Override via PRAXYS_PERF_USER
+# / PRAXYS_PERF_PASSWORD if testing against a non-demo account.
+: "${PRAXYS_PERF_USER:=demo@trainsight.dev}"
+: "${PRAXYS_PERF_PASSWORD:=demo}"
+: "${PRAXYS_PERF_BASE_URL:=${URL%/}}"
+
 run_cell() {
   local scenario="$1"
   local device="$2"
   local cell="${scenario}-${PROBE}-${device}"
 
   case "$scenario" in
-    s4) : ;;  # anonymous Landing — supported
-    s1|s2|s3)
-      echo "  → ${cell}: SKIPPED (login-required scenarios land in a follow-up PR)" >&2
-      return 0
-      ;;
+    s1|s2|s3|s4) : ;;
     *) echo "Error: unknown scenario '$scenario'" >&2; return 1 ;;
   esac
 
@@ -127,7 +154,7 @@ run_cell() {
   fi
 
   echo ">>> ${cell}"
-  echo "    url     : $URL"
+  echo "    base    : $PRAXYS_PERF_BASE_URL"
   echo "    outdir  : $cell_mount"
   echo "    runs    : $RUNS"
   echo "    device  : $device"
@@ -146,24 +173,39 @@ run_cell() {
     # presets — the preset list drifts per Chrome version (146.x doesn't
     # recognize "iPhone 14 Pro" as of this writing, for example), which
     # breaks CI runs silently. Viewport matches iPhone 14 Pro (CSS px),
-    # UA is recent iOS Safari. For S4 Landing this is enough — we're
-    # measuring render-path, not touch interactions.
+    # UA is recent iOS Safari. Adequate for render-path measurement.
     args+=(
       --browsertime.viewPort "390x844"
       --browsertime.userAgent "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
     )
   fi
 
+  # Build the trailing positional args. S4 = plain URL test. S1/S2/S3 use
+  # --multi mode where a JS file drives the browser through the login
+  # flow + measured navigation.
+  local -a tail_args
+  local -a script_mount=()
+  if [[ "$scenario" == "s4" ]]; then
+    tail_args=("$PRAXYS_PERF_BASE_URL/")
+  else
+    tail_args=(--multi "/sitespeed.io/scripts/${scenario}.js")
+    script_mount=(-v "${SCRIPTS_DIR_HOST}:/sitespeed.io/scripts:ro")
+  fi
+
   # --shm-size=1g avoids Chrome's /dev/shm crashes on larger pages
   # (sitespeed.io's documented floor). MSYS_NO_PATHCONV keeps git bash
-  # from converting the container-side /sitespeed.io/out argument, while
-  # cell_mount is already a Windows-style path so Docker Desktop accepts
-  # it as a bind-mount to the real filesystem.
+  # from converting container-side /sitespeed.io/* paths, while the
+  # mount sources are already Windows-style absolute via cygpath -aw so
+  # Docker Desktop accepts them as bind-mounts.
   MSYS_NO_PATHCONV=1 docker run --rm --shm-size=1g \
     -v "${cell_mount}:/sitespeed.io/out" \
+    "${script_mount[@]}" \
+    -e "PRAXYS_PERF_USER=${PRAXYS_PERF_USER}" \
+    -e "PRAXYS_PERF_PASSWORD=${PRAXYS_PERF_PASSWORD}" \
+    -e "PRAXYS_PERF_BASE_URL=${PRAXYS_PERF_BASE_URL}" \
     "$IMAGE" \
     "${args[@]}" \
-    "$URL"
+    "${tail_args[@]}"
 }
 
 echo "Baseline run starting"

--- a/scripts/sitespeed_scripts/s1.js
+++ b/scripts/sitespeed_scripts/s1.js
@@ -1,0 +1,52 @@
+/**
+ * S1 — Cold first load of Today page (via login).
+ *
+ * Drives Chrome through:
+ *   1. Navigate to /login (cold profile, no cache)
+ *   2. Fill email + password from PRAXYS_PERF_USER / PRAXYS_PERF_PASSWORD
+ *      env vars (defaults to the public demo account)
+ *   3. Submit, wait for the SPA to redirect to /today
+ *   4. Measure the navigation that lands on /today
+ *
+ * The login submit triggers the SPA's auth flow, which navigates to /today
+ * on success. We wrap that with measure.start/stop so the resulting metrics
+ * (FCP, LCP, TTI, etc.) describe "how long from login click to Today
+ * paint" — i.e. what a real new user actually feels.
+ *
+ * Used by sitespeed.io's --multi mode:
+ *   sitespeed.io --multi scripts/sitespeed_scripts/s1.js -n 3 \
+ *     --outputFolder /sitespeed.io/out/s1-<probe>-<device>
+ *
+ * Reads PRAXYS_PERF_BASE_URL (defaults to https://www.praxys.run).
+ */
+
+module.exports = async function (context, commands) {
+  const baseUrl = process.env.PRAXYS_PERF_BASE_URL || 'https://www.praxys.run';
+  const user = process.env.PRAXYS_PERF_USER || 'demo@trainsight.dev';
+  const password = process.env.PRAXYS_PERF_PASSWORD || 'demo';
+
+  // Step 1 — get to the login form (not measured).
+  await commands.navigate(`${baseUrl}/login`);
+  await commands.wait.byId('login-email', 10000);
+
+  // Step 2 — fill credentials. Form is empty on a fresh navigation; no
+  // need to clear. Browser autofill is disabled in headless Chrome that
+  // sitespeed.io ships, so this stays clean.
+  await commands.click.byId('login-email');
+  await commands.addText.byId(user, 'login-email');
+
+  await commands.click.byId('login-password');
+  await commands.addText.byId(password, 'login-password');
+
+  // Step 3 — measure the click → /today navigation.
+  await commands.measure.start('s1-today-via-login');
+  await commands.click.bySelector('button[type="submit"]');
+  // Wait until the SPA has actually transitioned to /today.
+  await commands.wait.byCondition(
+    'document.location.pathname === "/today"',
+    30000,
+  );
+  // Give the rendered Today page a moment to settle so LCP fires.
+  await commands.wait.byPageToComplete(15000);
+  await commands.measure.stop();
+};

--- a/scripts/sitespeed_scripts/s2.js
+++ b/scripts/sitespeed_scripts/s2.js
@@ -1,0 +1,38 @@
+/**
+ * S2 — Cold first load of Training page (via login).
+ *
+ * Same login flow as S1, but the measured navigation lands on /training
+ * instead of /today. Training is the page with the worst pre-Phase-2-#4
+ * waterfall (multiple parallel /api/* calls) so this scenario is where
+ * Phase 1 #3 (FastAPI GZip) and Phase 2 #4 (Training collapse) become
+ * measurable.
+ */
+
+module.exports = async function (context, commands) {
+  const baseUrl = process.env.PRAXYS_PERF_BASE_URL || 'https://www.praxys.run';
+  const user = process.env.PRAXYS_PERF_USER || 'demo@trainsight.dev';
+  const password = process.env.PRAXYS_PERF_PASSWORD || 'demo';
+
+  // Step 1 — log in (not measured).
+  await commands.navigate(`${baseUrl}/login`);
+  await commands.wait.byId('login-email', 10000);
+
+  await commands.click.byId('login-email');
+  await commands.addText.byId(user, 'login-email');
+
+  await commands.click.byId('login-password');
+  await commands.addText.byId(password, 'login-password');
+
+  await commands.click.bySelector('button[type="submit"]');
+  await commands.wait.byCondition(
+    'document.location.pathname === "/today"',
+    30000,
+  );
+  await commands.wait.byPageToComplete(15000);
+
+  // Step 2 — now navigate to /training and measure that.
+  await commands.measure.start('s2-training');
+  await commands.navigate(`${baseUrl}/training`);
+  await commands.wait.byPageToComplete(20000);
+  await commands.measure.stop();
+};

--- a/scripts/sitespeed_scripts/s3.js
+++ b/scripts/sitespeed_scripts/s3.js
@@ -1,0 +1,52 @@
+/**
+ * S3 — Warm repeat visit to Today (after login).
+ *
+ * Drives Chrome through:
+ *   1. Login flow (not measured)
+ *   2. Settle on /today (warm-up — populates SW cache, react-query cache)
+ *   3. Navigate AWAY (about:blank) to clear current page state
+ *   4. Re-navigate to /today and MEASURE that
+ *
+ * Step 3 is the trick: simply re-navigating to the same URL would no-op or
+ * use bfcache. Bouncing through about:blank forces a real navigation, but
+ * the SW + HTTP cache from step 2 still apply, so we measure "what does
+ * /today feel like for a returning user whose service worker already has
+ * the shell cached?"
+ *
+ * Phase 2 #7 (PWA precaching) is exactly the change that makes this
+ * scenario fast — without the SW, S3 is a normal cold load minus the
+ * login.
+ */
+
+module.exports = async function (context, commands) {
+  const baseUrl = process.env.PRAXYS_PERF_BASE_URL || 'https://www.praxys.run';
+  const user = process.env.PRAXYS_PERF_USER || 'demo@trainsight.dev';
+  const password = process.env.PRAXYS_PERF_PASSWORD || 'demo';
+
+  // Step 1 — log in.
+  await commands.navigate(`${baseUrl}/login`);
+  await commands.wait.byId('login-email', 10000);
+
+  await commands.click.byId('login-email');
+  await commands.addText.byId(user, 'login-email');
+
+  await commands.click.byId('login-password');
+  await commands.addText.byId(password, 'login-password');
+
+  await commands.click.bySelector('button[type="submit"]');
+  await commands.wait.byCondition(
+    'document.location.pathname === "/today"',
+    30000,
+  );
+  await commands.wait.byPageToComplete(15000);
+
+  // Step 2 — bounce off about:blank to force a real next navigation.
+  await commands.navigate('about:blank');
+  await commands.wait.byTime(500);
+
+  // Step 3 — measured warm revisit to /today.
+  await commands.measure.start('s3-today-warm');
+  await commands.navigate(`${baseUrl}/today`);
+  await commands.wait.byPageToComplete(15000);
+  await commands.measure.stop();
+};


### PR DESCRIPTION
## Summary

Closes the "S1-S3 not yet implemented" gap left in PR-E. Adds three browsertime preScripts that drive Chrome through the login flow + the measured post-auth navigation:

- `s1.js` — login → /today (Cold first load via login)
- `s2.js` — login → /training (Cold first load via login)
- `s3.js` — login → /today (warm-up) → about:blank → /today (measured warm revisit)

The runner switches to sitespeed.io's `--multi` mode when scenario is s1/s2/s3, mounts `scripts/sitespeed_scripts/` into the container at `/sitespeed.io/scripts`, and passes `PRAXYS_PERF_USER` / `PRAXYS_PERF_PASSWORD` / `PRAXYS_PERF_BASE_URL` as env vars that the scripts read at runtime.

## Credential handling

Defaults to the public demo account (`demo@trainsight.dev` / `demo`) — these are the **same defaults `web/src/pages/Landing.tsx` ships in its "Try the demo" button**, so they're already on every browser bundle. Not secret. Operators override via env vars if testing against a different account:

```bash
PRAXYS_PERF_USER=other@example.com PRAXYS_PERF_PASSWORD=secret \
  bash scripts/sitespeed_runner.sh --probe cn-pc --scenario s1
```

`PRAXYS_PERF_BASE_URL` overrides the host (defaults to `https://www.praxys.run`); useful for staging tests.

## Smoke test (passing)

```bash
bash scripts/sitespeed_runner.sh --probe smoketest --scenario s1 --device desktop --runs 1
```

Result — login form filled, submitted, `/today` painted, full HAR captured. Analyzer extracts:

| Probe | Device | FCP | LCP | TTI | HTML TTFB | Static KB | API KB | # reqs | # API | API p50 | **API p95** |
|---|---|---|---|---|---|---|---|---|---|---|---|
| smoketest | Desktop | 2804 | 2804 | 989 | 971 | 681 | 14.9 | 34 | 18 | 274 | **4106** |

**That API p95 of 4106 ms is informative** — it's the slowest API call during /today's first paint, an expected fat-tail finding that F2 (Training waterfall collapse) is meant to address. Now that S1/S2 are runnable we have the measurement signal F2 needs to attribute against.

## What's NOT in this PR

- **CI workflow support for s1/s2/s3.** ACI's `--command-line` argv parser shreds compound shell args (we hit this earlier with the mobile UA). Threading scripts + env vars through ACI needs the YAML-deployment-file pattern, which is a separate refactor. F1 unblocks PC-side baseline measurement; ACI workflow extension is tracked as a follow-up.

## Files

- `scripts/sitespeed_scripts/s1.js`, `s2.js`, `s3.js` — the preScripts
- `scripts/sitespeed_runner.sh` — `run_cell` now branches on scenario type and selects URL-mode vs `--multi` mode + adds the script bind-mount + env vars
- `scripts/pc-setup.md` — login-scenario docs + credential override examples
- `.gitattributes` — `*.js text eol=lf` so the scripts ship to Linux containers clean

## Test plan

- [x] `bash -n` syntax check on the runner
- [x] `node -c` syntax check on each preScript
- [x] **End-to-end smoke**: `--scenario s1 --device desktop --runs 1` against prod with public demo creds → real metrics extracted
- [ ] Operator manual: `--scenario all --device both --runs 3` once back at the PC, including S2 and S3 which weren't smoke-tested but follow the same pattern