### PR TITLE
Phase 2 #4 (F2): Fold /api/plan/stryd-status into /api/plan

### DIFF
--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -26,10 +26,9 @@ _STRYD_PUSH_STATUS_DIR = os.path.join(_DATA_DIR, "ai", "stryd_push_status")
 def _stryd_push_status_path(user_id: str) -> str:
     """Per-user push-status path.
 
-    Must be per-user: a shared file would let any caller of
-    ``GET /api/plan/stryd-status`` see every other user's workout IDs and
-    push timestamps. UUID user_ids keep filenames collision-free and
-    filesystem-safe.
+    Must be per-user: a shared file would let the GET /plan response
+    include every other user's workout IDs and push timestamps.
+    UUID user_ids keep filenames collision-free and filesystem-safe.
 
     A legacy single-file layout at ``data/ai/stryd_push_status.json`` may
     still exist on older deployments — this code does not read or migrate
@@ -45,13 +44,22 @@ def get_plan(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ) -> dict:
-    """Return all upcoming planned workouts (today onwards)."""
+    """Return all upcoming planned workouts plus the caller's Stryd push status.
+
+    The push-status field used to be its own endpoint (GET /plan/stryd-status)
+    but every UI surface that asked for /plan also needed it, so each
+    Training-page cold load paid an extra cross-GFW round-trip. Folding it
+    into this response saves one request without measurably changing the
+    cost of /plan itself — _load_push_status is a single small JSON read.
+    """
     data = get_dashboard_data(user_id=user_id, db=db)
     plan_df: pd.DataFrame = data.get("plan", pd.DataFrame())
     today = date.today()
 
+    stryd_status = _load_push_status(user_id)
+
     if plan_df.empty:
-        return {"workouts": [], "cp_current": None}
+        return {"workouts": [], "cp_current": None, "stryd_status": stryd_status}
 
     # Filter for today onwards — return all (frontend handles pagination)
     upcoming = plan_df[plan_df["date"] >= today].sort_values("date")
@@ -82,7 +90,7 @@ def get_plan(
         if isinstance(plan, dict) and plan.get("power_max"):
             cp_current = plan.get("power_max")
 
-    return {"workouts": workouts, "cp_current": cp_current}
+    return {"workouts": workouts, "cp_current": cp_current, "stryd_status": stryd_status}
 
 
 def _load_push_status(user_id: str) -> dict:
@@ -136,14 +144,6 @@ def _save_push_status(user_id: str, status: dict) -> None:
         except OSError:
             pass
         raise
-
-
-@router.get("/plan/stryd-status")
-def get_stryd_push_status(
-    user_id: str = Depends(get_data_user_id),
-) -> dict:
-    """Return push status for all workouts synced to Stryd."""
-    return _load_push_status(user_id)
 
 
 class PushStrydRequest(BaseModel):

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -353,7 +353,11 @@ Paginated activity history.
 
 ### GET /api/plan
 
-Upcoming planned workouts (next 14 days).
+Upcoming planned workouts plus the caller's Stryd push history.
+
+The `stryd_status` field used to be its own `GET /api/plan/stryd-status`
+endpoint; it was folded into this response so the Training page only pays
+one cross-region round-trip on cold load.
 
 **Response:**
 ```json
@@ -369,7 +373,10 @@ Upcoming planned workouts (next 14 days).
       "description": "WU 10min, 2x20min @235-255W..."
     }
   ],
-  "cp_current": 247.8
+  "cp_current": 247.8,
+  "stryd_status": {
+    "2026-04-11": { "workout_id": "stryd_123", "pushed_at": "...", "status": "pushed" }
+  }
 }
 ```
 
@@ -390,10 +397,6 @@ Push AI plan workouts to Stryd calendar.
   ]
 }
 ```
-
-### GET /api/plan/stryd-status
-
-Push status for all workouts.
 
 ### DELETE /api/plan/stryd-workout/{workout_id}
 

--- a/miniapp/src/types/api.ts
+++ b/miniapp/src/types/api.ts
@@ -141,7 +141,7 @@ export interface PlanResponse {
   workouts: PlannedWorkout[];
   /** Server emits the key on every response with `null` when CP is unknown. */
   cp_current: number | null;
-  /** Stryd push history, folded into /api/plan in PR-N (ex-/api/plan/stryd-status). */
+  /** Stryd push history. Used to be served by GET /api/plan/stryd-status. */
   stryd_status: StrydPushStatus;
 }
 

--- a/miniapp/src/types/api.ts
+++ b/miniapp/src/types/api.ts
@@ -139,7 +139,10 @@ export interface PlannedWorkout {
 
 export interface PlanResponse {
   workouts: PlannedWorkout[];
-  cp_current?: number;
+  /** Server emits the key on every response with `null` when CP is unknown. */
+  cp_current: number | null;
+  /** Stryd push history, folded into /api/plan in PR-N (ex-/api/plan/stryd-status). */
+  stryd_status: StrydPushStatus;
 }
 
 export type StrydPushResult =

--- a/tests/test_stryd_push_status_endpoints.py
+++ b/tests/test_stryd_push_status_endpoints.py
@@ -83,13 +83,10 @@ def api_client(monkeypatch, tmp_path):
 
 
 def test_plan_stryd_status_returns_only_current_users_data(api_client, monkeypatch):
-    """The original regression — preserved across the endpoint merge.
-
-    Push-status used to be its own GET /plan/stryd-status route. PR-N folded
-    it into the /plan response as the `stryd_status` field. The isolation
-    invariant must survive the merge: user B's /plan GET must not surface
-    user A's writes via the embedded field, same as it never returned them
-    via the dedicated route.
+    """User B's /plan GET must not surface user A's push status writes via
+    the embedded `stryd_status` field. (This used to be its own
+    /plan/stryd-status route; the isolation invariant must survive the
+    merge into /plan.)
     """
     from api.routes.plan import _save_push_status
 

--- a/tests/test_stryd_push_status_endpoints.py
+++ b/tests/test_stryd_push_status_endpoints.py
@@ -82,21 +82,36 @@ def api_client(monkeypatch, tmp_path):
         tmpdir.cleanup()
 
 
-def test_get_status_returns_only_current_users_data(api_client):
-    """The original regression: user B's GET must not surface user A's writes."""
+def test_plan_stryd_status_returns_only_current_users_data(api_client, monkeypatch):
+    """The original regression — preserved across the endpoint merge.
+
+    Push-status used to be its own GET /plan/stryd-status route. PR-N folded
+    it into the /plan response as the `stryd_status` field. The isolation
+    invariant must survive the merge: user B's /plan GET must not surface
+    user A's writes via the embedded field, same as it never returned them
+    via the dedicated route.
+    """
     from api.routes.plan import _save_push_status
 
     _save_push_status("alice", {"2026-05-01": {"workout_id": "alice-only"}})
     _save_push_status("bob", {"2026-06-15": {"workout_id": "bob-only"}})
 
+    # /plan invokes get_dashboard_data which would otherwise touch DB tables
+    # this test isn't populating. Stub it to return an empty plan so we can
+    # exercise stryd_status isolation in isolation.
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {"plan": pd.DataFrame(), "signal": {}},
+    )
+
     api_client["current"]["value"] = "bob"
-    res = api_client["client"].get("/api/plan/stryd-status")
-    assert res.status_code == 200
-    assert res.json() == {"2026-06-15": {"workout_id": "bob-only"}}
+    res = api_client["client"].get("/api/plan")
+    assert res.status_code == 200, res.text
+    assert res.json()["stryd_status"] == {"2026-06-15": {"workout_id": "bob-only"}}
 
     api_client["current"]["value"] = "alice"
-    res = api_client["client"].get("/api/plan/stryd-status")
-    assert res.json() == {"2026-05-01": {"workout_id": "alice-only"}}
+    res = api_client["client"].get("/api/plan")
+    assert res.json()["stryd_status"] == {"2026-05-01": {"workout_id": "alice-only"}}
 
 
 def test_push_endpoint_persists_under_calling_user(api_client, monkeypatch):

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -335,10 +335,9 @@ export default function UpcomingPlanCard() {
   const { config: settings } = useSettings();
   const hasStryd = Boolean(settings?.connections?.includes('stryd'));
 
-  // Stryd push history is folded into /api/plan (was a dedicated
-  // /api/plan/stryd-status fetch before PR-N). Mirror it into local state so
-  // push/delete handlers can apply optimistic updates without waiting for a
-  // refetch; the next /api/plan response resyncs us to the server view.
+  // Mirror server stryd_status into local state so push/delete handlers can
+  // apply optimistic updates without waiting for a refetch; the next /api/plan
+  // response resyncs us to the server view.
   useEffect(() => {
     if (data?.stryd_status) {
       setPushStatus(data.stryd_status);

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -331,22 +331,19 @@ export default function UpcomingPlanCard() {
   const [pushingDates, setPushingDates] = useState<Set<string>>(new Set());
 
   // Stryd connection status — read from SettingsContext rather than firing
-  // a second /api/settings request. SettingsContext has already fetched
-  // this data; the old fetch here duplicated the request for every
-  // Training-page cold load.
+  // a second /api/settings request.
   const { config: settings } = useSettings();
   const hasStryd = Boolean(settings?.connections?.includes('stryd'));
 
-  // Load push status
+  // Stryd push history is folded into /api/plan (was a dedicated
+  // /api/plan/stryd-status fetch before PR-N). Mirror it into local state so
+  // push/delete handlers can apply optimistic updates without waiting for a
+  // refetch; the next /api/plan response resyncs us to the server view.
   useEffect(() => {
-    fetch(`${API_BASE}/api/plan/stryd-status`, { headers: getAuthHeaders() })
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((status) => setPushStatus(status))
-      .catch((err) => console.error('Failed to load Stryd push status:', err));
-  }, []);
+    if (data?.stryd_status) {
+      setPushStatus(data.stryd_status);
+    }
+  }, [data?.stryd_status]);
 
   const getPushState = useCallback(
     (date: string): PushState => {

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -32,7 +32,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:508
+#: src/components/UpcomingPlanCard.tsx:507
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -739,7 +739,7 @@ msgstr "Failed to load settings"
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:484
+#: src/components/UpcomingPlanCard.tsx:483
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -1361,7 +1361,7 @@ msgstr "Promote to Admin"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "Pull your latest activities, power data, and recovery metrics"
 
-#: src/components/UpcomingPlanCard.tsx:531
+#: src/components/UpcomingPlanCard.tsx:530
 msgid "Push All"
 msgstr "Push All"
 
@@ -1374,7 +1374,7 @@ msgstr "Push failed"
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
-#: src/components/UpcomingPlanCard.tsx:521
+#: src/components/UpcomingPlanCard.tsx:520
 msgid "Pushing..."
 msgstr "Pushing..."
 
@@ -1518,7 +1518,7 @@ msgstr "REST"
 msgid "Resting HR"
 msgstr "Resting HR"
 
-#: src/components/UpcomingPlanCard.tsx:487
+#: src/components/UpcomingPlanCard.tsx:486
 #: src/pages/Goal.tsx:487
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:336
@@ -1743,7 +1743,7 @@ msgstr "Sync history"
 msgid "Sync your data"
 msgstr "Sync your data"
 
-#: src/components/UpcomingPlanCard.tsx:526
+#: src/components/UpcomingPlanCard.tsx:525
 #: src/pages/Settings.tsx:820
 msgid "Synced"
 msgstr "Synced"
@@ -1875,7 +1875,7 @@ msgstr "Ultra distance power fractions (50K+) are estimates with limited researc
 msgid "Units"
 msgstr "Units"
 
-#: src/components/UpcomingPlanCard.tsx:504
+#: src/components/UpcomingPlanCard.tsx:503
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -32,7 +32,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:511
+#: src/components/UpcomingPlanCard.tsx:508
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -739,7 +739,7 @@ msgstr "Failed to load settings"
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:487
+#: src/components/UpcomingPlanCard.tsx:484
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -1361,7 +1361,7 @@ msgstr "Promote to Admin"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "Pull your latest activities, power data, and recovery metrics"
 
-#: src/components/UpcomingPlanCard.tsx:534
+#: src/components/UpcomingPlanCard.tsx:531
 msgid "Push All"
 msgstr "Push All"
 
@@ -1374,7 +1374,7 @@ msgstr "Push failed"
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
-#: src/components/UpcomingPlanCard.tsx:524
+#: src/components/UpcomingPlanCard.tsx:521
 msgid "Pushing..."
 msgstr "Pushing..."
 
@@ -1518,7 +1518,7 @@ msgstr "REST"
 msgid "Resting HR"
 msgstr "Resting HR"
 
-#: src/components/UpcomingPlanCard.tsx:490
+#: src/components/UpcomingPlanCard.tsx:487
 #: src/pages/Goal.tsx:487
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:336
@@ -1743,7 +1743,7 @@ msgstr "Sync history"
 msgid "Sync your data"
 msgstr "Sync your data"
 
-#: src/components/UpcomingPlanCard.tsx:529
+#: src/components/UpcomingPlanCard.tsx:526
 #: src/pages/Settings.tsx:820
 msgid "Synced"
 msgstr "Synced"
@@ -1875,7 +1875,7 @@ msgstr "Ultra distance power fractions (50K+) are estimates with limited researc
 msgid "Units"
 msgstr "Units"
 
-#: src/components/UpcomingPlanCard.tsx:507
+#: src/components/UpcomingPlanCard.tsx:504
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -32,7 +32,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:508
+#: src/components/UpcomingPlanCard.tsx:507
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -739,7 +739,7 @@ msgstr "加载设置失败"
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:484
+#: src/components/UpcomingPlanCard.tsx:483
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -1361,7 +1361,7 @@ msgstr "提升为管理员"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "拉取您最近的活动、功率数据和恢复指标"
 
-#: src/components/UpcomingPlanCard.tsx:531
+#: src/components/UpcomingPlanCard.tsx:530
 msgid "Push All"
 msgstr "全部推送"
 
@@ -1374,7 +1374,7 @@ msgstr "推送失败"
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
-#: src/components/UpcomingPlanCard.tsx:521
+#: src/components/UpcomingPlanCard.tsx:520
 msgid "Pushing..."
 msgstr "正在推送..."
 
@@ -1518,7 +1518,7 @@ msgstr "休息"
 msgid "Resting HR"
 msgstr "静息心率"
 
-#: src/components/UpcomingPlanCard.tsx:487
+#: src/components/UpcomingPlanCard.tsx:486
 #: src/pages/Goal.tsx:487
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:336
@@ -1743,7 +1743,7 @@ msgstr "同步历史"
 msgid "Sync your data"
 msgstr "同步数据"
 
-#: src/components/UpcomingPlanCard.tsx:526
+#: src/components/UpcomingPlanCard.tsx:525
 #: src/pages/Settings.tsx:820
 msgid "Synced"
 msgstr "已同步"
@@ -1875,7 +1875,7 @@ msgstr "超长距离功率分数（50K+）为估算值，研究支持有限。Ri
 msgid "Units"
 msgstr "单位"
 
-#: src/components/UpcomingPlanCard.tsx:504
+#: src/components/UpcomingPlanCard.tsx:503
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -32,7 +32,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:511
+#: src/components/UpcomingPlanCard.tsx:508
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -739,7 +739,7 @@ msgstr "加载设置失败"
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:487
+#: src/components/UpcomingPlanCard.tsx:484
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -1361,7 +1361,7 @@ msgstr "提升为管理员"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "拉取您最近的活动、功率数据和恢复指标"
 
-#: src/components/UpcomingPlanCard.tsx:534
+#: src/components/UpcomingPlanCard.tsx:531
 msgid "Push All"
 msgstr "全部推送"
 
@@ -1374,7 +1374,7 @@ msgstr "推送失败"
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
-#: src/components/UpcomingPlanCard.tsx:524
+#: src/components/UpcomingPlanCard.tsx:521
 msgid "Pushing..."
 msgstr "正在推送..."
 
@@ -1518,7 +1518,7 @@ msgstr "休息"
 msgid "Resting HR"
 msgstr "静息心率"
 
-#: src/components/UpcomingPlanCard.tsx:490
+#: src/components/UpcomingPlanCard.tsx:487
 #: src/pages/Goal.tsx:487
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:336
@@ -1743,7 +1743,7 @@ msgstr "同步历史"
 msgid "Sync your data"
 msgstr "同步数据"
 
-#: src/components/UpcomingPlanCard.tsx:529
+#: src/components/UpcomingPlanCard.tsx:526
 #: src/pages/Settings.tsx:820
 msgid "Synced"
 msgstr "已同步"
@@ -1875,7 +1875,7 @@ msgstr "超长距离功率分数（50K+）为估算值，研究支持有限。Ri
 msgid "Units"
 msgstr "单位"
 
-#: src/components/UpcomingPlanCard.tsx:507
+#: src/components/UpcomingPlanCard.tsx:504
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -175,6 +175,8 @@ export interface PlannedWorkout {
 export interface PlanResponse {
   workouts: PlannedWorkout[];
   cp_current?: number;
+  /** Stryd push history, folded into /api/plan in PR-N (ex-/api/plan/stryd-status). */
+  stryd_status: StrydPushStatus;
 }
 
 export type StrydPushResult =

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -176,7 +176,7 @@ export interface PlanResponse {
   workouts: PlannedWorkout[];
   /** Server emits the key on every response with `null` when CP is unknown. */
   cp_current: number | null;
-  /** Stryd push history, folded into /api/plan in PR-N (ex-/api/plan/stryd-status). */
+  /** Stryd push history. Used to be served by GET /api/plan/stryd-status. */
   stryd_status: StrydPushStatus;
 }
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -174,7 +174,8 @@ export interface PlannedWorkout {
 
 export interface PlanResponse {
   workouts: PlannedWorkout[];
-  cp_current?: number;
+  /** Server emits the key on every response with `null` when CP is unknown. */
+  cp_current: number | null;
   /** Stryd push history, folded into /api/plan in PR-N (ex-/api/plan/stryd-status). */
   stryd_status: StrydPushStatus;
 }


### PR DESCRIPTION
## Summary

- Training-page cold load used to issue two sequential, login-gated GETs (`/api/plan` and `/api/plan/stryd-status`). Push-status is small JSON, but the extra GFW-traversing round-trip costs a full RTT for ~1 KB.
- This PR folds `stryd_status` into the `/api/plan` response and deletes the dedicated route. One fewer round-trip per Training cold load; no measurable change to `/api/plan` cost (`_load_push_status` is a single small JSON read).
- **Narrowed scope**: only push-status is merged. `/api/insights/training_review` stays separate because issue #103 plans an LLM transition for that endpoint, and inlining it would force every `/api/plan` response to wait for an LLM call. Decoupling preserves the option to make AI insights async / streaming / cached.

## What changed

| Layer | File | Change |
|---|---|---|
| Backend | `api/routes/plan.py` | `GET /plan` embeds `stryd_status`. `/plan/stryd-status` route removed. |
| Types | `web/src/types/api.ts` | `PlanResponse.stryd_status: StrydPushStatus` added. |
| UI | `web/src/components/UpcomingPlanCard.tsx` | Drop second `useApi('/api/plan/stryd-status')`. Mirror `data.stryd_status` into local state via `useEffect` so optimistic push/delete updates still work between refetches. |
| Tests | `tests/test_stryd_push_status_endpoints.py` | Per-user isolation regression now exercises `GET /api/plan`. Helper-level isolation tests in `test_stryd_push_status_isolation.py` are unchanged — they prove `_load_push_status` / `_save_push_status` scope correctly; the endpoint tests prove the route handlers thread `user_id` into them. |
| Docs | `docs/dev/api-reference.md` | `GET /api/plan` documents the new shape; separate `stryd-status` section removed. |

## Anchor baseline

`docs/perf-baselines/2026-04-25-d37484b` (commit `1718aba`) was captured precisely so we can attribute any move in S2's `# API` / `API p95` to this change.

Predicted move on S2 (Today → Training transition):
- `# API` drops by 1 (one fewer endpoint).
- `API p95` may drop modestly — one fewer chance for a slow tail.

## Test plan

- [x] `pytest tests/` → **396 passed, 1 skipped**
- [x] `pytest tests/test_stryd_push_status_endpoints.py tests/test_stryd_push_status_isolation.py -v` → 9/9 pass (3 endpoint regressions + 6 helper isolation invariants)
- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint src/components/UpcomingPlanCard.tsx` clean
- [x] `npm run build` succeeds (PWA precache regenerated)
- [ ] Post-merge: rerun S2 baseline against the new commit and diff against `2026-04-25-d37484b` to confirm `# API` dropped by 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)