### PR TITLE
Plan API: per-day upsert/delete + mode=merge|replace (#128)

### DIFF
--- a/api/routes/ai.py
+++ b/api/routes/ai.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id, require_write_access
 from api.deps import get_dashboard_data
+from db.models import TrainingPlan
 from db.session import get_db
 
 router = APIRouter()
@@ -41,7 +42,7 @@ class PlanWorkout(BaseModel):
     workout_description: Optional[str] = None
 
 
-def _row_to_response(plan) -> dict:
+def _row_to_response(plan: TrainingPlan) -> dict:
     return {
         "id": plan.id,
         "date": plan.date.isoformat() if plan.date else None,
@@ -94,8 +95,6 @@ def upload_plan(
     are left alone. Use this when shifting or editing individual workouts
     without resending the whole plan window.
     """
-    from db.models import TrainingPlan
-
     reader = csv.DictReader(io.StringIO(payload.csv))
     rows = list(reader)
 
@@ -117,7 +116,7 @@ def upload_plan(
             TrainingPlan.user_id == user_id,
             TrainingPlan.source == "ai",
             TrainingPlan.date >= date.today(),
-        ).delete()
+        ).delete(synchronize_session=False)
     else:  # merge: clear only the dates we're about to write
         target_dates = {p.date for p in parsed_rows if p.date is not None}
         if target_dates:
@@ -148,8 +147,6 @@ def upsert_plan_day(
     e.g. shifting a single workout — instead of round-tripping the whole
     future plan via /plan/upload.
     """
-    from db.models import TrainingPlan
-
     try:
         d = datetime.strptime(plan_date, "%Y-%m-%d").date()
     except ValueError:
@@ -186,8 +183,6 @@ def delete_plan_day(
     db: Session = Depends(get_db),
 ):
     """Delete the AI plan workout(s) for the given date (YYYY-MM-DD)."""
-    from db.models import TrainingPlan
-
     try:
         d = datetime.strptime(plan_date, "%Y-%m-%d").date()
     except ValueError:

--- a/api/routes/ai.py
+++ b/api/routes/ai.py
@@ -1,9 +1,10 @@
-"""AI-related endpoints: training context and plan upload."""
+"""AI-related endpoints: training context, plan upload, per-day upsert/delete."""
 import csv
 import io
 from datetime import date, datetime
+from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -29,15 +30,69 @@ class PlanUpload(BaseModel):
     csv: str
 
 
+class PlanWorkout(BaseModel):
+    """Single-day workout payload for `PUT /api/plan/{plan_date}`."""
+
+    workout_type: str
+    planned_duration_min: Optional[float] = None
+    planned_distance_km: Optional[float] = None
+    target_power_min: Optional[float] = None
+    target_power_max: Optional[float] = None
+    workout_description: Optional[str] = None
+
+
+def _row_to_response(plan) -> dict:
+    return {
+        "id": plan.id,
+        "date": plan.date.isoformat() if plan.date else None,
+        "workout_type": plan.workout_type,
+        "planned_duration_min": plan.planned_duration_min,
+        "planned_distance_km": plan.planned_distance_km,
+        "target_power_min": plan.target_power_min,
+        "target_power_max": plan.target_power_max,
+        "workout_description": plan.workout_description,
+        "source": plan.source,
+    }
+
+
+def _parse_csv_row(row: dict, row_index: int) -> dict:
+    """Parse one CSV dict-row into TrainingPlan kwargs (without user_id)."""
+    try:
+        d_raw = row.get("date", "")
+        d = datetime.strptime(d_raw, "%Y-%m-%d").date() if d_raw else None
+        return {
+            "date": d,
+            "workout_type": row.get("workout_type", ""),
+            "planned_duration_min": float(row["planned_duration_min"])
+                if row.get("planned_duration_min") else None,
+            "planned_distance_km": float(row["planned_distance_km"])
+                if row.get("planned_distance_km") else None,
+            "target_power_min": float(row["target_power_min"])
+                if row.get("target_power_min") else None,
+            "target_power_max": float(row["target_power_max"])
+                if row.get("target_power_max") else None,
+            "workout_description": row.get("workout_description", ""),
+        }
+    except (ValueError, TypeError) as e:
+        raise HTTPException(400, f"Invalid data in row {row_index + 1}: {e}")
+
+
 @router.post("/plan/upload")
 def upload_plan(
     payload: PlanUpload,
+    mode: str = Query("replace", pattern="^(replace|merge)$"),
     user_id: str = Depends(require_write_access),
     db: Session = Depends(get_db),
 ):
     """Upload an AI-generated training plan as CSV text.
 
-    Replaces future AI plan entries for this user while preserving past ones.
+    `mode=replace` (default, backwards-compatible): delete every future AI
+    plan row for the user, then insert the payload. Past rows are preserved.
+
+    `mode=merge`: upsert by `(user, date, source='ai')` — only the dates
+    present in the payload are touched; all other AI rows (past and future)
+    are left alone. Use this when shifting or editing individual workouts
+    without resending the whole plan window.
     """
     from db.models import TrainingPlan
 
@@ -47,33 +102,101 @@ def upload_plan(
     if not rows:
         return {"status": "error", "message": "No rows in CSV"}
 
-    # Validate all rows first (before deleting existing plan)
     parsed_rows = []
     for i, row in enumerate(rows):
-        try:
-            parsed_rows.append(TrainingPlan(
-                user_id=user_id,
-                date=datetime.strptime(row.get("date", ""), "%Y-%m-%d").date() if row.get("date") else None,
-                workout_type=row.get("workout_type", ""),
-                planned_duration_min=float(row.get("planned_duration_min", 0)) if row.get("planned_duration_min") else None,
-                target_power_min=float(row.get("target_power_min", 0)) if row.get("target_power_min") else None,
-                target_power_max=float(row.get("target_power_max", 0)) if row.get("target_power_max") else None,
-                workout_description=row.get("workout_description", ""),
-                source="ai",
-                meta={"uploaded_at": datetime.utcnow().isoformat()},
-            ))
-        except (ValueError, TypeError) as e:
-            raise HTTPException(400, f"Invalid data in row {i + 1}: {e}")
+        kwargs = _parse_csv_row(row, i)
+        parsed_rows.append(TrainingPlan(
+            user_id=user_id,
+            source="ai",
+            meta={"uploaded_at": datetime.utcnow().isoformat()},
+            **kwargs,
+        ))
 
-    # Delete future AI plan entries only after validation succeeds
-    db.query(TrainingPlan).filter(
-        TrainingPlan.user_id == user_id,
-        TrainingPlan.source == "ai",
-        TrainingPlan.date >= date.today(),
-    ).delete()
+    if mode == "replace":
+        db.query(TrainingPlan).filter(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.source == "ai",
+            TrainingPlan.date >= date.today(),
+        ).delete()
+    else:  # merge: clear only the dates we're about to write
+        target_dates = {p.date for p in parsed_rows if p.date is not None}
+        if target_dates:
+            db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == user_id,
+                TrainingPlan.source == "ai",
+                TrainingPlan.date.in_(target_dates),
+            ).delete(synchronize_session=False)
 
     for plan in parsed_rows:
         db.add(plan)
 
     db.commit()
-    return {"status": "saved", "rows": len(parsed_rows)}
+    return {"status": "saved", "rows": len(parsed_rows), "mode": mode}
+
+
+@router.put("/plan/{plan_date}")
+def upsert_plan_day(
+    plan_date: str,
+    workout: PlanWorkout,
+    user_id: str = Depends(require_write_access),
+    db: Session = Depends(get_db),
+):
+    """Upsert a single AI plan workout for the given date (YYYY-MM-DD).
+
+    Replaces any existing AI rows for `(user, date)` with one new row from
+    the payload. Other dates are untouched. Use this for partial edits —
+    e.g. shifting a single workout — instead of round-tripping the whole
+    future plan via /plan/upload.
+    """
+    from db.models import TrainingPlan
+
+    try:
+        d = datetime.strptime(plan_date, "%Y-%m-%d").date()
+    except ValueError:
+        raise HTTPException(400, "date must be YYYY-MM-DD")
+
+    db.query(TrainingPlan).filter(
+        TrainingPlan.user_id == user_id,
+        TrainingPlan.source == "ai",
+        TrainingPlan.date == d,
+    ).delete(synchronize_session=False)
+
+    plan = TrainingPlan(
+        user_id=user_id,
+        date=d,
+        workout_type=workout.workout_type,
+        planned_duration_min=workout.planned_duration_min,
+        planned_distance_km=workout.planned_distance_km,
+        target_power_min=workout.target_power_min,
+        target_power_max=workout.target_power_max,
+        workout_description=workout.workout_description or "",
+        source="ai",
+        meta={"uploaded_at": datetime.utcnow().isoformat()},
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return _row_to_response(plan)
+
+
+@router.delete("/plan/{plan_date}")
+def delete_plan_day(
+    plan_date: str,
+    user_id: str = Depends(require_write_access),
+    db: Session = Depends(get_db),
+):
+    """Delete the AI plan workout(s) for the given date (YYYY-MM-DD)."""
+    from db.models import TrainingPlan
+
+    try:
+        d = datetime.strptime(plan_date, "%Y-%m-%d").date()
+    except ValueError:
+        raise HTTPException(400, "date must be YYYY-MM-DD")
+
+    deleted = db.query(TrainingPlan).filter(
+        TrainingPlan.user_id == user_id,
+        TrainingPlan.source == "ai",
+        TrainingPlan.date == d,
+    ).delete(synchronize_session=False)
+    db.commit()
+    return {"status": "deleted", "rows": deleted, "date": plan_date}

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -402,6 +402,48 @@ Push AI plan workouts to Stryd calendar.
 
 Remove a workout from Stryd calendar.
 
+### POST /api/plan/upload
+
+Upload an AI-generated training plan as CSV text. The body is `{"csv": "..."}`
+where the CSV uses the columns `date,workout_type,planned_duration_min,
+planned_distance_km,target_power_min,target_power_max,workout_description`.
+
+**Query params:**
+- `mode=replace` *(default)* — delete every future AI plan row for the user,
+  then insert the payload. Past rows survive. Used by full-plan generation
+  (the AI training-plan skill writes a 28-day window).
+- `mode=merge` — upsert by `(user, date, source='ai')`. Only the dates in the
+  payload are touched; other AI rows (past and future) are preserved. Used
+  for partial edits like shifting a single workout.
+
+**Response:** `{ "status": "saved", "rows": <int>, "mode": "replace"|"merge" }`
+
+### PUT /api/plan/{date}
+
+Upsert a single AI plan workout for the given date (`YYYY-MM-DD`). Replaces any
+existing `(user, date, source='ai')` row(s) with one new row from the body;
+other dates are untouched. Prefer this over `/plan/upload` when editing one
+day so you don't have to round-trip the whole future window.
+
+**Request body:**
+```json
+{
+  "workout_type": "easy",
+  "planned_duration_min": 45,
+  "planned_distance_km": 8.0,
+  "target_power_min": 150,
+  "target_power_max": 200,
+  "workout_description": "Easy aerobic run"
+}
+```
+
+**Response:** the upserted row (`id`, `date`, `workout_type`, …, `source`).
+
+### DELETE /api/plan/{date}
+
+Delete the AI plan workout(s) for the given date (`YYYY-MM-DD`). Idempotent —
+deleting a missing date returns `{ "status": "deleted", "rows": 0 }`.
+
 ## Settings
 
 ### GET /api/settings

--- a/plugins/praxys/mcp-server/server.py
+++ b/plugins/praxys/mcp-server/server.py
@@ -509,24 +509,181 @@ def disconnect_platform(platform: str) -> str:
 # MCP Tools — Plans & Sync
 # ---------------------------------------------------------------------------
 
+def _parse_plan_csv(plan_csv: str) -> list[dict]:
+    """Parse a plan CSV into TrainingPlan kwargs dicts. Raises ValueError on bad rows."""
+    import csv as _csv
+    import io as _io
+    from datetime import datetime as _dt
+
+    rows = []
+    reader = _csv.DictReader(_io.StringIO(plan_csv))
+    for i, raw in enumerate(reader):
+        d_raw = raw.get("date", "")
+        rows.append({
+            "date": _dt.strptime(d_raw, "%Y-%m-%d").date() if d_raw else None,
+            "workout_type": raw.get("workout_type", ""),
+            "planned_duration_min": float(raw["planned_duration_min"])
+                if raw.get("planned_duration_min") else None,
+            "planned_distance_km": float(raw["planned_distance_km"])
+                if raw.get("planned_distance_km") else None,
+            "target_power_min": float(raw["target_power_min"])
+                if raw.get("target_power_min") else None,
+            "target_power_max": float(raw["target_power_max"])
+                if raw.get("target_power_max") else None,
+            "workout_description": raw.get("workout_description", ""),
+        })
+    return rows
+
+
+def _local_push_plan(plan_csv: str, mode: str) -> dict:
+    """Local mirror of POST /api/plan/upload?mode=...."""
+    from datetime import date as _date, datetime as _dt
+    from db.models import TrainingPlan
+    db = _local_db()
+    try:
+        parsed = _parse_plan_csv(plan_csv)
+        if not parsed:
+            return {"status": "error", "message": "No rows in CSV"}
+        user_id = _local_user_id()
+        if mode == "replace":
+            db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == user_id,
+                TrainingPlan.source == "ai",
+                TrainingPlan.date >= _date.today(),
+            ).delete(synchronize_session=False)
+        else:
+            target_dates = {p["date"] for p in parsed if p["date"] is not None}
+            if target_dates:
+                db.query(TrainingPlan).filter(
+                    TrainingPlan.user_id == user_id,
+                    TrainingPlan.source == "ai",
+                    TrainingPlan.date.in_(target_dates),
+                ).delete(synchronize_session=False)
+        for kwargs in parsed:
+            db.add(TrainingPlan(
+                user_id=user_id, source="ai",
+                meta={"uploaded_at": _dt.utcnow().isoformat()},
+                **kwargs,
+            ))
+        db.commit()
+        return {"status": "saved", "rows": len(parsed), "mode": mode}
+    finally:
+        db.close()
+
+
 @mcp.tool()
-def push_training_plan(plan_csv: str) -> str:
-    """Push an AI-generated training plan. Pass the plan as CSV text (date,workout_type,planned_duration_min,target_power_min,target_power_max,workout_description)."""
+def push_training_plan(plan_csv: str, mode: str = "replace") -> str:
+    """Push an AI-generated training plan. Pass the plan as CSV text (columns: date,workout_type,planned_duration_min,planned_distance_km,target_power_min,target_power_max,workout_description).
+
+    mode='replace' (default): wipes all future AI plan entries for this user, then inserts.
+    Use this for full-window plan generation (the typical 28-day plan).
+
+    mode='merge': only the dates in the CSV are touched; other AI rows are
+    preserved. Use this when patching individual days without resending the
+    whole plan.
+    """
+    if mode not in ("replace", "merge"):
+        return json.dumps({"status": "error", "message": "mode must be 'replace' or 'merge'"})
     if IS_REMOTE:
-        data = _remote_post("/api/plan/upload", {"csv": plan_csv})
+        data = _remote_post(f"/api/plan/upload?mode={mode}", {"csv": plan_csv})
     else:
-        import csv
-        import io
-        from db import sync_writer
+        try:
+            data = _local_push_plan(plan_csv, mode)
+        except ValueError as e:
+            data = {"status": "error", "message": f"Invalid CSV: {e}"}
+    return json.dumps(data, indent=2, default=str)
+
+
+@mcp.tool()
+def update_training_day(
+    plan_date: str,
+    workout_type: str,
+    planned_duration_min: float | None = None,
+    planned_distance_km: float | None = None,
+    target_power_min: float | None = None,
+    target_power_max: float | None = None,
+    workout_description: str | None = None,
+) -> str:
+    """Upsert a single AI plan workout for the given date (YYYY-MM-DD).
+
+    Replaces any existing AI entry for that date with the new values; other
+    dates are untouched. Use this for shifts and partial edits — much safer
+    than push_training_plan when you only want to change one day.
+    """
+    payload = {
+        "workout_type": workout_type,
+        "planned_duration_min": planned_duration_min,
+        "planned_distance_km": planned_distance_km,
+        "target_power_min": target_power_min,
+        "target_power_max": target_power_max,
+        "workout_description": workout_description,
+    }
+    if IS_REMOTE:
+        data = _remote_put(f"/api/plan/{plan_date}", payload)
+    else:
+        from datetime import datetime as _dt
+        from db.models import TrainingPlan
+        try:
+            d = _dt.strptime(plan_date, "%Y-%m-%d").date()
+        except ValueError:
+            return json.dumps({"status": "error", "message": "date must be YYYY-MM-DD"})
         db = _local_db()
         try:
-            reader = csv.DictReader(io.StringIO(plan_csv))
-            rows = list(reader)
-            count = sync_writer.write_training_plan(
-                _local_user_id(), rows, "ai", db
+            user_id = _local_user_id()
+            db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == user_id,
+                TrainingPlan.source == "ai",
+                TrainingPlan.date == d,
+            ).delete(synchronize_session=False)
+            plan = TrainingPlan(
+                user_id=user_id, date=d, source="ai",
+                workout_type=workout_type,
+                planned_duration_min=planned_duration_min,
+                planned_distance_km=planned_distance_km,
+                target_power_min=target_power_min,
+                target_power_max=target_power_max,
+                workout_description=workout_description or "",
+                meta={"uploaded_at": _dt.utcnow().isoformat()},
             )
+            db.add(plan)
             db.commit()
-            data = {"status": "saved", "rows": count}
+            db.refresh(plan)
+            data = {
+                "id": plan.id, "date": plan.date.isoformat(),
+                "workout_type": plan.workout_type,
+                "planned_duration_min": plan.planned_duration_min,
+                "planned_distance_km": plan.planned_distance_km,
+                "target_power_min": plan.target_power_min,
+                "target_power_max": plan.target_power_max,
+                "workout_description": plan.workout_description,
+                "source": plan.source,
+            }
+        finally:
+            db.close()
+    return json.dumps(data, indent=2, default=str)
+
+
+@mcp.tool()
+def delete_training_day(plan_date: str) -> str:
+    """Delete the AI plan workout(s) for the given date (YYYY-MM-DD)."""
+    if IS_REMOTE:
+        data = _remote_delete(f"/api/plan/{plan_date}")
+    else:
+        from datetime import datetime as _dt
+        from db.models import TrainingPlan
+        try:
+            d = _dt.strptime(plan_date, "%Y-%m-%d").date()
+        except ValueError:
+            return json.dumps({"status": "error", "message": "date must be YYYY-MM-DD"})
+        db = _local_db()
+        try:
+            deleted = db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == _local_user_id(),
+                TrainingPlan.source == "ai",
+                TrainingPlan.date == d,
+            ).delete(synchronize_session=False)
+            db.commit()
+            data = {"status": "deleted", "rows": deleted, "date": plan_date}
         finally:
             db.close()
     return json.dumps(data, indent=2, default=str)

--- a/tests/test_plan_endpoints.py
+++ b/tests/test_plan_endpoints.py
@@ -1,0 +1,315 @@
+"""Integration tests for the AI plan endpoints in api/routes/ai.py.
+
+Covers:
+- POST /api/plan/upload — replace (default) and merge modes
+- PUT /api/plan/{date} — upsert single workout
+- DELETE /api/plan/{date} — delete single day
+
+These guard the contract change in #128 (delete-and-recreate replaced by
+explicit modes + per-day operations) so a future refactor can't quietly
+revert to "wipe everything on every push" semantics.
+"""
+import tempfile
+from datetime import date, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def api_client(monkeypatch):
+    """FastAPI TestClient with an isolated SQLite DB and a stable test user."""
+    from fastapi.testclient import TestClient
+
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_SYNC_SCHEDULER", "false")
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY", "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o="
+    )
+
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from api.main import app
+    from api.auth import require_write_access, get_data_user_id
+    from db.session import get_db
+
+    test_user_id = "test-user-plan-endpoints"
+
+    def _override_user():
+        return test_user_id
+
+    def _override_db():
+        db = db_session.SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[require_write_access] = _override_user
+    app.dependency_overrides[get_data_user_id] = _override_user
+    app.dependency_overrides[get_db] = _override_db
+
+    client = TestClient(app)
+    try:
+        yield client, test_user_id
+    finally:
+        app.dependency_overrides.clear()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _seed_plan(user_id: str, days: list[tuple[str, str, str]]):
+    """Insert (date_iso, workout_type, description) rows as source='ai'."""
+    from datetime import datetime
+    from db import session as db_session
+    from db.models import TrainingPlan
+
+    db = db_session.SessionLocal()
+    try:
+        for date_iso, wt, desc in days:
+            db.add(TrainingPlan(
+                user_id=user_id,
+                date=datetime.strptime(date_iso, "%Y-%m-%d").date(),
+                workout_type=wt,
+                workout_description=desc,
+                source="ai",
+            ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _list_plan_rows(user_id: str) -> list[dict]:
+    from db import session as db_session
+    from db.models import TrainingPlan
+
+    db = db_session.SessionLocal()
+    try:
+        rows = db.query(TrainingPlan).filter(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.source == "ai",
+        ).order_by(TrainingPlan.date).all()
+        return [
+            {
+                "date": r.date.isoformat(),
+                "workout_type": r.workout_type,
+                "workout_description": r.workout_description,
+            }
+            for r in rows
+        ]
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/plan/upload — replace mode (default, backwards-compat)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadReplaceMode:
+    def test_replace_is_default(self, api_client):
+        client, user_id = api_client
+        future = (date.today() + timedelta(days=2)).isoformat()
+        far = (date.today() + timedelta(days=20)).isoformat()
+        _seed_plan(user_id, [
+            (future, "easy", "stale entry, must be deleted"),
+            (far, "rest", "also stale"),
+        ])
+
+        new_date = (date.today() + timedelta(days=5)).isoformat()
+        res = client.post("/api/plan/upload", json={
+            "csv": "date,workout_type,workout_description\n"
+                   f"{new_date},long_run,Fresh row\n",
+        })
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "saved"
+        assert body["rows"] == 1
+        assert body["mode"] == "replace"
+
+        rows = _list_plan_rows(user_id)
+        assert len(rows) == 1, "replace mode wiped existing future rows"
+        assert rows[0]["date"] == new_date
+
+    def test_replace_preserves_past_rows(self, api_client):
+        client, user_id = api_client
+        past = (date.today() - timedelta(days=3)).isoformat()
+        future = (date.today() + timedelta(days=3)).isoformat()
+        _seed_plan(user_id, [
+            (past, "easy", "history"),
+            (future, "easy", "to be replaced"),
+        ])
+
+        new_date = (date.today() + timedelta(days=5)).isoformat()
+        res = client.post("/api/plan/upload?mode=replace", json={
+            "csv": f"date,workout_type\n{new_date},rest\n",
+        })
+        assert res.status_code == 200, res.text
+
+        rows = _list_plan_rows(user_id)
+        dates = [r["date"] for r in rows]
+        assert past in dates, "past rows must survive a replace"
+        assert future not in dates
+        assert new_date in dates
+
+
+# ---------------------------------------------------------------------------
+# POST /api/plan/upload — merge mode (the new behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadMergeMode:
+    def test_merge_only_touches_payload_dates(self, api_client):
+        client, user_id = api_client
+        d1 = (date.today() + timedelta(days=1)).isoformat()
+        d2 = (date.today() + timedelta(days=2)).isoformat()
+        d3 = (date.today() + timedelta(days=3)).isoformat()
+        _seed_plan(user_id, [
+            (d1, "easy", "keep me"),
+            (d2, "easy", "stale, will be replaced"),
+            (d3, "rest", "keep me too"),
+        ])
+
+        res = client.post("/api/plan/upload?mode=merge", json={
+            "csv": "date,workout_type,workout_description\n"
+                   f"{d2},threshold,Updated\n",
+        })
+        assert res.status_code == 200, res.text
+        assert res.json()["mode"] == "merge"
+
+        rows = {r["date"]: r for r in _list_plan_rows(user_id)}
+        assert rows[d1]["workout_description"] == "keep me"
+        assert rows[d2]["workout_type"] == "threshold"
+        assert rows[d2]["workout_description"] == "Updated"
+        assert rows[d3]["workout_description"] == "keep me too"
+
+    def test_merge_inserts_new_dates(self, api_client):
+        client, user_id = api_client
+        d_existing = (date.today() + timedelta(days=1)).isoformat()
+        _seed_plan(user_id, [(d_existing, "easy", "existing")])
+
+        d_new = (date.today() + timedelta(days=10)).isoformat()
+        res = client.post("/api/plan/upload?mode=merge", json={
+            "csv": f"date,workout_type\n{d_new},long_run\n",
+        })
+        assert res.status_code == 200, res.text
+
+        rows = _list_plan_rows(user_id)
+        assert len(rows) == 2
+        assert {r["date"] for r in rows} == {d_existing, d_new}
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/plan/{date}
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertPlanDay:
+    def test_put_inserts_new_day(self, api_client):
+        client, user_id = api_client
+        target = (date.today() + timedelta(days=4)).isoformat()
+        res = client.put(f"/api/plan/{target}", json={
+            "workout_type": "easy",
+            "planned_duration_min": 45,
+            "target_power_min": 150,
+            "target_power_max": 200,
+            "workout_description": "Easy aerobic run",
+        })
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["date"] == target
+        assert body["workout_type"] == "easy"
+        assert body["planned_duration_min"] == 45
+        assert body["source"] == "ai"
+
+    def test_put_replaces_existing_day_only(self, api_client):
+        client, user_id = api_client
+        target = (date.today() + timedelta(days=4)).isoformat()
+        other = (date.today() + timedelta(days=5)).isoformat()
+        _seed_plan(user_id, [
+            (target, "easy", "old"),
+            (other, "rest", "untouched"),
+        ])
+
+        res = client.put(f"/api/plan/{target}", json={
+            "workout_type": "threshold",
+            "workout_description": "New workout",
+        })
+        assert res.status_code == 200, res.text
+
+        rows = {r["date"]: r for r in _list_plan_rows(user_id)}
+        assert rows[target]["workout_type"] == "threshold"
+        assert rows[target]["workout_description"] == "New workout"
+        assert rows[other]["workout_description"] == "untouched"
+
+    def test_put_rejects_bad_date(self, api_client):
+        client, _ = api_client
+        res = client.put("/api/plan/not-a-date", json={"workout_type": "easy"})
+        assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/plan/{date}
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePlanDay:
+    def test_delete_removes_only_target_day(self, api_client):
+        client, user_id = api_client
+        target = (date.today() + timedelta(days=4)).isoformat()
+        other = (date.today() + timedelta(days=5)).isoformat()
+        _seed_plan(user_id, [
+            (target, "easy", "to be deleted"),
+            (other, "rest", "must survive"),
+        ])
+
+        res = client.delete(f"/api/plan/{target}")
+        assert res.status_code == 200, res.text
+        assert res.json()["rows"] == 1
+
+        rows = _list_plan_rows(user_id)
+        dates = [r["date"] for r in rows]
+        assert target not in dates
+        assert other in dates
+
+    def test_delete_missing_day_is_noop(self, api_client):
+        client, _ = api_client
+        target = (date.today() + timedelta(days=99)).isoformat()
+        res = client.delete(f"/api/plan/{target}")
+        assert res.status_code == 200, res.text
+        assert res.json()["rows"] == 0
+
+    def test_delete_rejects_bad_date(self, api_client):
+        client, _ = api_client
+        res = client.delete("/api/plan/2026-99-99")
+        assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Mode validation guard
+# ---------------------------------------------------------------------------
+
+
+def test_upload_rejects_invalid_mode(api_client):
+    client, _ = api_client
+    res = client.post("/api/plan/upload?mode=bogus", json={
+        "csv": "date,workout_type\n2026-12-31,easy\n",
+    })
+    # FastAPI returns 422 for query validation failures
+    assert res.status_code == 422


### PR DESCRIPTION
## Summary
- Adds `PUT /api/plan/{date}` and `DELETE /api/plan/{date}` for single-day edits — no need to round-trip the whole future plan window to shift one workout.
- Adds `?mode=merge` to `POST /api/plan/upload` (default stays `replace` for backwards-compat with the AI plan generator skill).
- Adds matching MCP tools `update_training_day` / `delete_training_day` and a `mode` arg on `push_training_plan`.
- Also fixes a latent `NameError`: `upload_plan` raised `HTTPException` without importing it.

Closes #128.

## Why
The current `POST /api/plan/upload` deletes every future `source='ai'` row and re-inserts the payload. A single-row CSV silently wipes everything else, so any partial edit had to resend the whole plan window. Surfaced today during a race-day reschedule (HRV came in low; shifting one workout forced a 7-row reupload of untouched dates).

## Behavior matrix
| Endpoint | Touches |
|---|---|
| `POST /plan/upload` (default `mode=replace`) | wipes all future `ai` rows, inserts payload |
| `POST /plan/upload?mode=merge` | upserts by `(user, date)`; only payload dates are touched |
| `PUT /plan/{date}` | replaces all `ai` rows for that date with one new row |
| `DELETE /plan/{date}` | removes `ai` row(s) for that date; idempotent |

All endpoints scoped to `source='ai'` (matches existing surface).

## Test plan
- [x] `pytest tests/test_plan_endpoints.py` — 11 new tests cover replace/merge/PUT/DELETE behavior, bad date → 400, bad mode → 422
- [x] Full pytest suite — 407 passed, 1 skipped
- [x] MCP server compiles cleanly
- [x] API reference doc updated with the new endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)