### PR TITLE
Today card: skip workout-structure bar for rest days (#129)

### DIFF
--- a/web/src/lib/workout-parser.ts
+++ b/web/src/lib/workout-parser.ts
@@ -169,8 +169,10 @@ function typeTemplate(workoutType: string, totalMin: number): WorkoutPhase[] {
 export function parseWorkoutStructure(plan: PlanData): WorkoutPhase[] {
   // Rest days have no structure to render — falling through to the default
   // duration template would synthesize a fake 33-min "main set" and mislead
-  // the user (#129).
-  if (plan.workout_type?.toLowerCase() === 'rest') return [];
+  // the user (#129). The backend treats both "rest" and "off" as rest types
+  // (api/routes/plan.py, api/ai.py), so match the same set here.
+  const wt = plan.workout_type?.toLowerCase();
+  if (wt === 'rest' || wt === 'off') return [];
   if (plan.duration_min === 0) return [];
 
   // If duration is missing, only render structure when the description has

--- a/web/src/lib/workout-parser.ts
+++ b/web/src/lib/workout-parser.ts
@@ -167,7 +167,23 @@ function typeTemplate(workoutType: string, totalMin: number): WorkoutPhase[] {
 }
 
 export function parseWorkoutStructure(plan: PlanData): WorkoutPhase[] {
-  const totalMin = plan.duration_min ?? 45;
+  // Rest days have no structure to render — falling through to the default
+  // duration template would synthesize a fake 33-min "main set" and mislead
+  // the user (#129).
+  if (plan.workout_type?.toLowerCase() === 'rest') return [];
+  if (plan.duration_min === 0) return [];
+
+  // If duration is missing, only render structure when the description has
+  // explicit phase durations to parse — never synthesize from a default.
+  if (plan.duration_min == null) {
+    if (plan.description) {
+      const parsed = parseDescription(plan.description, 0);
+      if (parsed && parsed.length > 0) return parsed;
+    }
+    return [];
+  }
+
+  const totalMin = plan.duration_min;
 
   if (plan.description) {
     const parsed = parseDescription(plan.description, totalMin);


### PR DESCRIPTION
## Summary
- A rest day was rendering as a structured workout — title \"Rest\", a 33-min \"main set\" bar, and a 0–45 min axis. Two short-circuits in `parseWorkoutStructure` fix it: skip rendering for `workout_type === 'rest'`, and skip when duration is missing and the description has no parsable phase durations (don't synthesize structure from a default).

Closes #129.

## Why this happened
1. The plan stores `planned_duration_min=0` for rest days.
2. `analysis/metrics.py` builds `signal.plan` with `if planned_detail.get(\"planned_duration_min\"):` — falsy for 0, so the field is dropped.
3. The frontend's `parseWorkoutStructure` did `plan.duration_min ?? 45`, then ran `'rest'` through the catch-all branch of `typeTemplate`, which produced warmup/main/cooldown phases sized off 45 min (≈ 7/33/5).

The metrics.py drop-on-zero behavior is intentional (keeps the card from showing \"0 min · 0 W\" details). The right fix is on the renderer side: rest days don't have a structure to render.

## Test plan
- [x] `npx eslint src/lib/workout-parser.ts src/components/WorkoutCard.tsx` — clean
- [x] `npx tsc -b` — clean
- [x] Manual code-trace: today's plan (`workout_type='rest'`, no `duration_min`) → `parseWorkoutStructure` returns `[]` → `WorkoutCard` already gates the timeline on `phases.length > 0`, so the bar disappears
- [x] Confirmed `UpcomingPlanCard` is a separate code path (flat list) and already handles rest via its own `isRest` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)