### PR TITLE
Today recovery: surface staleness when today hasn't synced (#130)

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -1075,6 +1075,15 @@ def _compute_recovery_analysis(recovery: pd.DataFrame) -> tuple[dict, float | No
     """Extract recovery time series and run analyze_recovery().
 
     Returns (recovery_analysis, today_hrv, today_sleep, today_rhr).
+
+    The returned analysis dict is augmented with two staleness fields used
+    by the frontend (#130):
+      - ``latest_date`` (ISO date or None): when the "today" reading was
+        actually recorded. The latest available row may be from yesterday
+        if Oura/Garmin haven't synced yet.
+      - ``is_stale`` (bool): True iff ``latest_date`` is before today. The
+        UI uses this to label the data instead of silently rendering a
+        prior day's reading as "today".
     """
     recovery_sorted = recovery.sort_values("date") if not recovery.empty else recovery
     hrv_series: list[float] = []
@@ -1082,6 +1091,7 @@ def _compute_recovery_analysis(recovery: pd.DataFrame) -> tuple[dict, float | No
     today_hrv = None
     today_sleep = None
     today_rhr = None
+    latest_date: date | None = None
 
     if not recovery_sorted.empty:
         if "hrv_avg" in recovery_sorted.columns:
@@ -1092,6 +1102,12 @@ def _compute_recovery_analysis(recovery: pd.DataFrame) -> tuple[dict, float | No
             rhr_series = [float(v) for v in rhr_vals.dropna() if v > 0]
 
         latest_row = recovery_sorted.iloc[-1]
+        latest_date_val = latest_row.get("date")
+        if hasattr(latest_date_val, "date"):
+            latest_date = latest_date_val.date()
+        elif isinstance(latest_date_val, date):
+            latest_date = latest_date_val
+
         hrv_val = pd.to_numeric(
             pd.Series([latest_row.get("hrv_avg")]), errors="coerce"
         ).iloc[0]
@@ -1114,7 +1130,14 @@ def _compute_recovery_analysis(recovery: pd.DataFrame) -> tuple[dict, float | No
         today_rhr=today_rhr,
         rhr_series=rhr_series if rhr_series else None,
     )
-    return analysis, today_hrv, today_sleep, today_rhr
+
+    is_stale = latest_date is not None and latest_date < date.today()
+    augmented = {
+        **analysis,
+        "latest_date": latest_date.isoformat() if latest_date else None,
+        "is_stale": is_stale,
+    }
+    return augmented, today_hrv, today_sleep, today_rhr
 
 
 def _build_threshold_trend_chart(

--- a/api/deps.py
+++ b/api/deps.py
@@ -1103,10 +1103,15 @@ def _compute_recovery_analysis(recovery: pd.DataFrame) -> tuple[dict, float | No
 
         latest_row = recovery_sorted.iloc[-1]
         latest_date_val = latest_row.get("date")
-        if hasattr(latest_date_val, "date"):
-            latest_date = latest_date_val.date()
-        elif isinstance(latest_date_val, date):
-            latest_date = latest_date_val
+        if pd.notna(latest_date_val):
+            # Order matters: pd.Timestamp inherits from datetime.date, so the
+            # isinstance branch alone would assign a Timestamp and break the
+            # later comparison against datetime.date(). Try .date() first to
+            # normalize Timestamp/datetime to a plain date.
+            if hasattr(latest_date_val, "date") and callable(getattr(latest_date_val, "date", None)):
+                latest_date = latest_date_val.date()
+            elif isinstance(latest_date_val, date):
+                latest_date = latest_date_val
 
         hrv_val = pd.to_numeric(
             pd.Series([latest_row.get("hrv_avg")]), errors="coerce"

--- a/tests/test_recovery_freshness.py
+++ b/tests/test_recovery_freshness.py
@@ -1,0 +1,81 @@
+"""Tests for the recovery-data staleness signal added in #130.
+
+Guards the contract that `_compute_recovery_analysis` exposes the date of
+the latest available reading and an `is_stale` flag — so the Today page UI
+no longer renders yesterday's HRV/sleep/RHR as if they were today's.
+"""
+from datetime import date, timedelta
+
+import pandas as pd
+
+from api.deps import _compute_recovery_analysis
+
+
+def _build_recovery_df(rows: list[tuple[date, float]]) -> pd.DataFrame:
+    """Build a recovery dataframe from (date, hrv_avg) rows."""
+    return pd.DataFrame([
+        {"date": pd.Timestamp(d), "hrv_avg": h, "resting_hr": 55.0, "sleep_score": 75.0}
+        for d, h in rows
+    ])
+
+
+def test_fresh_data_is_not_stale():
+    """When the latest row is today, is_stale is False and latest_date is today."""
+    today = date.today()
+    rows = [(today - timedelta(days=i), 45.0) for i in range(10, 0, -1)]
+    rows.append((today, 50.0))
+    df = _build_recovery_df(rows)
+
+    analysis, _, _, _ = _compute_recovery_analysis(df)
+
+    assert analysis["is_stale"] is False
+    assert analysis["latest_date"] == today.isoformat()
+
+
+def test_yesterday_only_is_stale():
+    """When latest row is yesterday, is_stale is True and latest_date is yesterday.
+
+    This is the bug from #130: the Today page used to render yesterday's
+    reading as if it were today's. Now the analysis exposes the actual date
+    so the UI can label it.
+    """
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    rows = [(today - timedelta(days=i), 45.0) for i in range(10, 1, -1)]
+    rows.append((yesterday, 50.0))
+    df = _build_recovery_df(rows)
+
+    analysis, _, _, _ = _compute_recovery_analysis(df)
+
+    assert analysis["is_stale"] is True
+    assert analysis["latest_date"] == yesterday.isoformat()
+
+
+def test_no_recovery_data_returns_none_latest_date():
+    """Empty dataframe → latest_date is None and is_stale is False."""
+    analysis, _, _, _ = _compute_recovery_analysis(pd.DataFrame())
+
+    assert analysis["latest_date"] is None
+    assert analysis["is_stale"] is False
+    assert analysis["status"] == "insufficient_data"
+
+
+def test_stale_data_still_classifies_status():
+    """Stale data still drives the status field — the UI just labels it.
+
+    Behavior change scope: this PR surfaces staleness; it doesn't suppress
+    the signal. Yesterday's "fatigued" reading still classifies as fatigued
+    until today's data syncs (#130 acceptance criteria).
+    """
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    # 30 days of high HRV → low yesterday → fatigued classification
+    rows = [(today - timedelta(days=i), 60.0) for i in range(30, 1, -1)]
+    rows.append((yesterday, 30.0))  # well below baseline
+    df = _build_recovery_df(rows)
+
+    analysis, _, _, _ = _compute_recovery_analysis(df)
+
+    assert analysis["is_stale"] is True
+    assert analysis["latest_date"] == yesterday.isoformat()
+    assert analysis["status"] == "fatigued"

--- a/web/src/components/RecoveryPanel.tsx
+++ b/web/src/components/RecoveryPanel.tsx
@@ -6,6 +6,7 @@ import ScienceNote from '@/components/ScienceNote';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { msg } from '@lingui/core/macro';
 import type { MessageDescriptor } from '@lingui/core';
+import { useLocale } from '@/contexts/LocaleContext';
 
 interface Props {
   recovery: RecoveryData;
@@ -33,6 +34,13 @@ const RHR_LABELS: Record<string, { label: MessageDescriptor; class: string }> = 
   low: { label: msg`Low`, class: 'text-primary' },
 };
 
+function formatLatestDate(dateStr: string, locale: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', {
+    month: 'short', day: 'numeric',
+  });
+}
+
 export default function RecoveryPanel({ recovery, theoryMeta, analysis }: Props) {
   const { tsbZones } = useScience();
   const { i18n, t } = useLingui();
@@ -47,6 +55,10 @@ export default function RecoveryPanel({ recovery, theoryMeta, analysis }: Props)
   const hrv = analysis?.hrv;
   const recoveryUnavailable = status === 'insufficient_data';
   const trendCfg = hrv ? (TREND_LABELS[hrv.trend] ?? TREND_LABELS.stable) : null;
+  const isStale = analysis?.is_stale === true;
+  const latestDate = analysis?.latest_date;
+  const { locale } = useLocale();
+  const latestDateLabel = latestDate ? formatLatestDate(latestDate, locale) : null;
 
   return (
     <Card>
@@ -56,6 +68,16 @@ export default function RecoveryPanel({ recovery, theoryMeta, analysis }: Props)
         </CardTitle>
       </CardHeader>
       <CardContent>
+        {isStale && latestDateLabel && (
+          <div className="rounded-lg border border-dashed border-accent-amber/40 bg-accent-amber/5 p-3 mb-3">
+            <p className="text-xs text-accent-amber">
+              <Trans>
+                Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}.
+              </Trans>
+            </p>
+          </div>
+        )}
+
         {/* Status — categorical output from Kiviniemi/Plews protocols */}
         <div className="rounded-xl bg-muted p-4 mb-3">
           <div className="flex items-center justify-between mb-1">
@@ -85,9 +107,11 @@ export default function RecoveryPanel({ recovery, theoryMeta, analysis }: Props)
               <span className="text-muted-foreground/50 font-normal ml-1">(ln RMSSD)</span>
             </p>
             <div className="grid grid-cols-3 gap-2">
-              {/* Today's value */}
-              <div className="rounded-lg bg-muted p-3">
-                <p className="text-[9px] uppercase tracking-wider text-muted-foreground mb-1"><Trans>Today</Trans></p>
+              {/* Today's value (or latest available, if today not synced) */}
+              <div className={`rounded-lg bg-muted p-3 ${isStale ? 'opacity-70' : ''}`}>
+                <p className="text-[9px] uppercase tracking-wider text-muted-foreground mb-1">
+                  {isStale && latestDateLabel ? latestDateLabel : <Trans>Today</Trans>}
+                </p>
                 <span className={`text-lg font-bold font-data ${statusCfg.class}`}>
                   {hrv.today_ln.toFixed(2)}
                 </span>

--- a/web/src/components/RecoveryPanel.tsx
+++ b/web/src/components/RecoveryPanel.tsx
@@ -35,7 +35,12 @@ const RHR_LABELS: Record<string, { label: MessageDescriptor; class: string }> = 
 };
 
 function formatLatestDate(dateStr: string, locale: string): string {
-  const d = new Date(dateStr);
+  // Parse the ISO date-only string as a local calendar date. `new Date("YYYY-MM-DD")`
+  // would be parsed as UTC midnight and shift backward in negative-offset locales
+  // (e.g. en-US users see "Apr 24" for an ISO "2026-04-25").
+  const [y, m, day] = dateStr.split('-').map(Number);
+  if (!y || !m || !day) return dateStr;
+  const d = new Date(y, m - 1, day);
   return d.toLocaleDateString(locale === 'zh' ? 'zh-CN' : 'en-US', {
     month: 'short', day: 'numeric',
   });

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -235,6 +235,10 @@ export interface RecoveryAnalysis {
   sleep_score: number | null;
   resting_hr: number | null;
   rhr_trend: 'stable' | 'elevated' | 'low' | null;
+  /** ISO date of the most recent recovery reading, or null when no data exists. */
+  latest_date: string | null;
+  /** True when latest_date is before today — UI should label the data instead of rendering it as "today's". */
+  is_stale: boolean;
 }
 
 export interface LastActivity {


### PR DESCRIPTION
## Summary
- The Today page was rendering yesterday's HRV / sleep / RHR as if they belonged to today whenever Oura/Garmin hadn't synced yet — silently lying about autonomic state. Now `_compute_recovery_analysis` returns `latest_date` + `is_stale`, and the RecoveryPanel labels stale data instead of presenting it as today's.
- Backend: pure metric computation unchanged (still in `analysis/metrics.py`); the staleness fact is added at the data-layer boundary in `api/deps.py`.
- Frontend: dashed-amber banner ("Today's recovery hasn't synced yet. Showing the latest reading from Apr 24.") + the HRV cell's "Today" label is replaced with the actual date and opacity-70 treatment.

Closes #130.

## Scope (deliberate)
This PR surfaces staleness; it does NOT change which value drives the recommendation. The training signal still comes from `analyze_recovery` on the most recent row — same behavior as before, just honestly labeled. A follow-up could decide whether stale data should suppress strong recommendations entirely (would change behavior in a way that's worth a separate discussion).

## Test plan
- [x] `pytest tests/test_recovery_freshness.py` — 4 new tests cover fresh / stale / empty / status-still-classified
- [x] Full pytest suite — 411 passed, 1 skipped
- [x] `eslint` + `tsc -b` clean
- [x] Trace: today's recovery row missing → `latest_date='2026-04-24'`, `is_stale=true` → banner renders + cell label shows "Apr 24" with opacity-70

🤖 Generated with [Claude Code](https://claude.com/claude-code)