### PR TITLE
perf: synthetic load validator + PR-139 validation report

### DIFF
--- a/docs/perf-baselines/2026-04-25-c73e4a1-backend-perf/README.md
+++ b/docs/perf-baselines/2026-04-25-c73e4a1-backend-perf/README.md
@@ -1,0 +1,97 @@
+# Backend perf validation: 2026-04-25 — `c73e4a1` (PR-139)
+
+**Purpose:** validate that the SQLite WAL pragmas + per-DEK unwrap cache
+shipped in PR-139 actually moved server-side latency on the live App
+Service — without waiting for organic traffic (~3 `/api/today` calls/day
+is too sparse for stable percentiles).
+
+**Method:** synthetic burst from PC against the App Service origin
+(`trainsight-app.azurewebsites.net`, bypassing the SWA proxy on
+`www.praxys.run` which doesn't forward POST). 30 sequential requests per
+endpoint, 200ms apart, signed in as the read-only demo account (which
+proxies reads to the admin's data via `users.demo_of`, so the queries
+hit the same SQLite tables and row counts a real user would). After the
+burst, a 2-minute wait for App Insights ingestion, then KQL.
+
+The deploy completed at **12:07 UTC**. The synthetic burst ran
+**12:22:52–12:27:42 UTC** — well clear of the deploy window.
+
+Reproduce: `python scripts/perf_synthetic_load_check.py`
+
+## Server-side latency (App Insights `AppRequests.DurationMs`)
+
+| Endpoint | Pre p50 | **Post p50** | Δ p50 | Pre p95 | **Post p95** | Δ p95 |
+|---|---|---|---|---|---|---|
+| `GET /api/today` | 5194 ms | **1839 ms** | **−65 %** | 11887 ms | **3998 ms** | **−66 %** |
+| `GET /api/training` | 4127 ms | **1954 ms** | **−53 %** | 15938 ms | **4391 ms** | **−72 %** |
+| `GET /api/science` | 4404 ms | **2067 ms** | **−53 %** | 15549 ms | **6566 ms** | **−58 %** |
+
+- Pre = real production traffic, last 7 days before the deploy
+  (n = 3-21 per endpoint, low confidence on the tails but the medians
+  are credible).
+- Post = synthetic burst, n = 30 per endpoint.
+
+## Key Vault unwrap_key cliff (`AppDependencies`)
+
+5-minute bins straddling the deploy boundary at 12:07 UTC:
+
+| 5-min bin (UTC) | unwrap_key calls |
+|---|---|
+| 11:35 | 4 |
+| 11:45 | 4 |
+| 11:55 | 1 |
+| 12:00 | 4 |
+| 12:05 | 3 |
+| 12:15 | 4  ← first post-deploy sync tick, cache cold-fill |
+| 12:20+ | **0** (no rows emitted = bin had no calls) |
+
+Pre-deploy steady-state ~3-4 calls per 5-min bin from the sync scheduler
+decrypting platform credentials each tick. Post-deploy the first tick at
+12:15 populates the cache (4 calls — one per credential), then 0 calls
+for the rest of the observation window. Exactly the cliff the cache was
+designed to produce.
+
+## Client-side timings (sanity check)
+
+From PC via passwall2 → App Service East Asia, includes network RTT:
+
+| Endpoint | n | p50 | p95 | mean |
+|---|---|---|---|---|
+| `/api/today` | 30 | 2578 ms | 4267 ms | 2877 ms |
+| `/api/training` | 30 | 2547 ms | 4289 ms | 2788 ms |
+| `/api/science` | 30 | 2680 ms | 7269 ms | 3414 ms |
+
+Client p50 sits ~600-700 ms above server p50, which matches a typical
+HK round-trip (cold TLS adds more on the first call). Plausible.
+
+## Interpretation
+
+The forecast in PR-139's description was 30-60 % p50 drop. We landed at
+53-65 % across the slow trio, with even sharper p95 drops (58-72 %). The
+unwrap_key cliff is binary and clean — no ambiguity that the cache works.
+
+This is enough evidence to call backend perf "good for now" at the
+B1 / SQLite-on-/home tier and move on to F4 (frontend off SWA-Amsterdam).
+A future DB migration to Azure SQL Serverless / Postgres remains the
+right move when traffic grows or when we want sub-second p50, but it's
+no longer urgent.
+
+## Caveats
+
+- Synthetic burst is sequential, single-client. Real concurrent load on
+  B1 (1 worker, 1.75 GB RAM) would saturate differently — both pre and
+  post — but that's not our regime today.
+- Pre-baseline n is small (3-21 calls per endpoint over 7 days). Medians
+  are stable but the published p95s have wide CIs. The post-PR p95
+  drops we measured are large enough that they're not in the
+  pre-baseline noise.
+- The B1 worker had been warm before the burst (kept alive by the
+  webtest pinging `/api/health` every 5 min), so this measures the
+  warm steady-state, not cold start. That's the regime real users
+  experience the great majority of the time.
+
+## Raw artifacts
+
+- `synthetic-burst-output.txt` — script stdout including per-call
+  client timings.
+- KQL queries are inlined in `scripts/perf_synthetic_load_check.py`.

--- a/scripts/perf_synthetic_load_check.py
+++ b/scripts/perf_synthetic_load_check.py
@@ -158,15 +158,18 @@ def _server_window_summary(start: datetime, end: datetime) -> list[dict]:
     return _run_kql(query)
 
 
-def _server_baseline_summary(days: int) -> list[dict]:
-    """Server-side baseline over the last N days, EXCLUDING our synthetic
-    burst window — since we just ran load, recent calls are the synthetic
-    ones, not a clean baseline. Cap the range to (now-Ndays .. now-30min)
-    to drop any of our burst that already ingested.
+def _server_baseline_summary(days: int, burst_start: datetime) -> list[dict]:
+    """Server-side baseline over the last N days, ending strictly before
+    this run's burst. Earlier versions used ``< ago(30m)`` for the upper
+    bound, but a burst takes <1 min plus ingestion lag — re-running this
+    script within 30 min of a previous run would let the prior burst
+    contaminate the "before" baseline and silently understate the delta.
+    Anchoring on ``burst_start`` instead is exact.
     """
     query = f"""
         AppRequests
-        | where TimeGenerated > ago({days}d) and TimeGenerated < ago(30m)
+        | where TimeGenerated > ago({days}d)
+              and TimeGenerated < datetime({burst_start.isoformat()})
         | where Name in ("GET /api/today", "GET /api/training", "GET /api/science")
         | summarize n=count(),
                     p50=percentile(DurationMs, 50),
@@ -213,20 +216,21 @@ def main() -> int:
 
     print("\n[3/4] Client-side timings (includes network from this PC):")
     cs = _client_summary(samples)
-    print(f"  {'endpoint':<22} {'n':>4} {'p50':>8} {'p95':>8} {'mean':>8}")
-    print(f"  {'-'*22} {'-'*4} {'-'*8} {'-'*8} {'-'*8}")
+    print(f"  {'endpoint':<22} {'n':>4} {'p50':>8} {'p95':>8} {'p99':>8} {'mean':>8}")
+    print(f"  {'-'*22} {'-'*4} {'-'*8} {'-'*8} {'-'*8} {'-'*8}")
     for ep, s in cs.items():
         if s.get("n", 0) == 0:
             print(f"  {ep:<22} (none)")
             continue
-        print(f"  {ep:<22} {s['n']:>4} {s['p50']:>7.0f}ms {s['p95']:>7.0f}ms {s['mean']:>7.0f}ms")
+        print(f"  {ep:<22} {s['n']:>4} {s['p50']:>7.0f}ms {s['p95']:>7.0f}ms "
+              f"{s['p99']:>7.0f}ms {s['mean']:>7.0f}ms")
 
     print(f"\n[4/4] Waiting {ingest_s}s for App Insights ingestion...")
     time.sleep(ingest_s)
 
-    print(f"\nServer-side BEFORE (last {baseline_days} days, excluding last 30 min):")
+    print(f"\nServer-side BEFORE (last {baseline_days} days, ending at {start.isoformat()}):")
     try:
-        before = _server_baseline_summary(baseline_days)
+        before = _server_baseline_summary(baseline_days, start)
         _print_table(f"baseline ({baseline_days}d)", before)
     except Exception as e:
         print(f"  baseline query failed: {e}")
@@ -249,7 +253,7 @@ def main() -> int:
             a = after_by_name.get(name)
             if not (b and a):
                 continue
-            for stat in ("p50", "p95"):
+            for stat in ("p50", "p95", "p99"):
                 bv = float(b[stat])
                 av = float(a[stat])
                 pct = (av - bv) / bv * 100 if bv else float("nan")

--- a/scripts/perf_synthetic_load_check.py
+++ b/scripts/perf_synthetic_load_check.py
@@ -1,0 +1,262 @@
+"""Drive synthetic API load and report before/after server-side latency.
+
+Why this exists: the Praxys app has very low organic traffic (~3
+``/api/today`` calls per day), so percentile-based latency moves can take
+days to surface in App Insights after a perf change. This script
+generates a controlled burst of read-only requests against the live app
+using the public demo account, waits for telemetry ingestion, then runs
+the same KQL the pre-change profile used and prints a side-by-side
+comparison.
+
+Usage::
+
+    .venv/Scripts/python.exe scripts/perf_synthetic_load_check.py
+
+Optional env vars (all have safe defaults):
+
+    PRAXYS_PERF_BASE_URL   default: https://trainsight-app.azurewebsites.net
+                                    (the App Service origin — bypasses
+                                    the SWA proxy on www.praxys.run,
+                                    which doesn't forward POSTs)
+    PRAXYS_PERF_USER       default: demo@trainsight.dev
+    PRAXYS_PERF_PASSWORD   default: demo
+    PRAXYS_PERF_N          default: 30  (calls per endpoint)
+    PRAXYS_PERF_PAUSE_MS   default: 200  (between requests)
+    PRAXYS_PERF_INGEST_S   default: 120  (App Insights ingestion lag)
+    PRAXYS_PERF_BASELINE_DAYS   default: 7  (lookback window for "before")
+
+Reads the workspace customer-id and tenant via the local az CLI cache,
+so no secrets in env vars. The demo account is read-only and (per
+api/auth.py:62) proxies to the admin's data, so the queries hit the
+same SQLite tables and row counts a real user request would.
+"""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import requests
+
+
+WORKSPACE_GUID = "cc14473b-35d9-44f0-b8a7-7d4e9a06917a"  # log-trainsight
+ENDPOINTS = ["/api/today", "/api/training", "/api/science"]
+
+
+@dataclass
+class ClientSample:
+    endpoint: str
+    duration_ms: float
+    status: int
+
+
+def _login(base_url: str, email: str, password: str) -> str:
+    r = requests.post(
+        f"{base_url}/api/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+def _drive_load(base_url: str, token: str, n: int, pause_ms: int) -> list[ClientSample]:
+    headers = {"Authorization": f"Bearer {token}"}
+    samples: list[ClientSample] = []
+    total = n * len(ENDPOINTS)
+    done = 0
+    for endpoint in ENDPOINTS:
+        for _ in range(n):
+            t0 = time.monotonic()
+            try:
+                r = requests.get(f"{base_url}{endpoint}", headers=headers, timeout=60)
+                samples.append(ClientSample(
+                    endpoint=endpoint,
+                    duration_ms=(time.monotonic() - t0) * 1000,
+                    status=r.status_code,
+                ))
+            except requests.RequestException as e:
+                samples.append(ClientSample(endpoint=endpoint, duration_ms=-1, status=0))
+                print(f"  request failed: {e}", file=sys.stderr)
+            done += 1
+            print(f"  {done}/{total}  {endpoint}  {samples[-1].duration_ms:.0f}ms", flush=True)
+            time.sleep(pause_ms / 1000)
+    return samples
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    k = (len(s) - 1) * (pct / 100)
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def _client_summary(samples: list[ClientSample]) -> dict[str, dict[str, float]]:
+    out: dict[str, dict[str, float]] = {}
+    for ep in ENDPOINTS:
+        ds = [s.duration_ms for s in samples if s.endpoint == ep and s.status == 200]
+        if not ds:
+            out[ep] = {"n": 0}
+            continue
+        out[ep] = {
+            "n": len(ds),
+            "p50": _percentile(ds, 50),
+            "p95": _percentile(ds, 95),
+            "p99": _percentile(ds, 99),
+            "mean": statistics.mean(ds),
+        }
+    return out
+
+
+def _run_kql(query: str) -> list[dict]:
+    """Run a KQL query against log-trainsight and return rows.
+
+    Uses ``shell=True`` because ``az`` is a ``.cmd`` shim on Windows that
+    Python's subprocess won't resolve through PATHEXT without it. On Linux
+    / mac this is also fine — the shell just locates the binary.
+    """
+    cmd_str = (
+        f'az monitor log-analytics query '
+        f'--workspace {WORKSPACE_GUID} '
+        f'--analytics-query "{query.replace(chr(34), chr(92) + chr(34))}" '
+        f'--timespan P14D -o json'
+    )
+    env = {**os.environ, "MSYS_NO_PATHCONV": "1"}
+    result = subprocess.run(
+        cmd_str, capture_output=True, text=True, env=env, timeout=60, shell=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"az query failed: {result.stderr}")
+    return json.loads(result.stdout)
+
+
+def _server_window_summary(start: datetime, end: datetime) -> list[dict]:
+    """Server-side p50/p95/p99 from App Insights for the synthetic-load window."""
+    start_iso = start.isoformat()
+    end_iso = end.isoformat()
+    query = f"""
+        AppRequests
+        | where TimeGenerated between (datetime({start_iso}) .. datetime({end_iso}))
+        | where Name in ("GET /api/today", "GET /api/training", "GET /api/science")
+        | summarize n=count(),
+                    p50=percentile(DurationMs, 50),
+                    p95=percentile(DurationMs, 95),
+                    p99=percentile(DurationMs, 99),
+                    maxMs=max(DurationMs)
+                  by Name
+        | order by Name asc
+    """
+    return _run_kql(query)
+
+
+def _server_baseline_summary(days: int) -> list[dict]:
+    """Server-side baseline over the last N days, EXCLUDING our synthetic
+    burst window — since we just ran load, recent calls are the synthetic
+    ones, not a clean baseline. Cap the range to (now-Ndays .. now-30min)
+    to drop any of our burst that already ingested.
+    """
+    query = f"""
+        AppRequests
+        | where TimeGenerated > ago({days}d) and TimeGenerated < ago(30m)
+        | where Name in ("GET /api/today", "GET /api/training", "GET /api/science")
+        | summarize n=count(),
+                    p50=percentile(DurationMs, 50),
+                    p95=percentile(DurationMs, 95),
+                    p99=percentile(DurationMs, 99),
+                    maxMs=max(DurationMs)
+                  by Name
+        | order by Name asc
+    """
+    return _run_kql(query)
+
+
+def _print_table(title: str, rows: list[dict]) -> None:
+    print(f"\n{title}")
+    print(f"  {'endpoint':<22} {'n':>4} {'p50':>8} {'p95':>8} {'p99':>8} {'max':>8}")
+    print(f"  {'-'*22} {'-'*4} {'-'*8} {'-'*8} {'-'*8} {'-'*8}")
+    for r in rows:
+        print(f"  {r['Name']:<22} {int(float(r['n'])):>4} "
+              f"{float(r['p50']):>7.0f}ms {float(r['p95']):>7.0f}ms "
+              f"{float(r['p99']):>7.0f}ms {float(r['maxMs']):>7.0f}ms")
+
+
+def main() -> int:
+    base = os.environ.get("PRAXYS_PERF_BASE_URL", "https://trainsight-app.azurewebsites.net")
+    user = os.environ.get("PRAXYS_PERF_USER", "demo@trainsight.dev")
+    pwd = os.environ.get("PRAXYS_PERF_PASSWORD", "demo")
+    n = int(os.environ.get("PRAXYS_PERF_N", "30"))
+    pause_ms = int(os.environ.get("PRAXYS_PERF_PAUSE_MS", "200"))
+    ingest_s = int(os.environ.get("PRAXYS_PERF_INGEST_S", "120"))
+    baseline_days = int(os.environ.get("PRAXYS_PERF_BASELINE_DAYS", "7"))
+
+    print(f"Target: {base}")
+    print(f"Plan: {n} requests x {len(ENDPOINTS)} endpoints = "
+          f"{n * len(ENDPOINTS)} calls, {pause_ms}ms apart")
+
+    print("\n[1/4] Logging in...")
+    token = _login(base, user, pwd)
+
+    print(f"\n[2/4] Driving synthetic load...")
+    start = datetime.now(timezone.utc)
+    samples = _drive_load(base, token, n, pause_ms)
+    end = datetime.now(timezone.utc)
+    print(f"\nClient wall-clock window: {start.isoformat()} .. {end.isoformat()}")
+
+    print("\n[3/4] Client-side timings (includes network from this PC):")
+    cs = _client_summary(samples)
+    print(f"  {'endpoint':<22} {'n':>4} {'p50':>8} {'p95':>8} {'mean':>8}")
+    print(f"  {'-'*22} {'-'*4} {'-'*8} {'-'*8} {'-'*8}")
+    for ep, s in cs.items():
+        if s.get("n", 0) == 0:
+            print(f"  {ep:<22} (none)")
+            continue
+        print(f"  {ep:<22} {s['n']:>4} {s['p50']:>7.0f}ms {s['p95']:>7.0f}ms {s['mean']:>7.0f}ms")
+
+    print(f"\n[4/4] Waiting {ingest_s}s for App Insights ingestion...")
+    time.sleep(ingest_s)
+
+    print(f"\nServer-side BEFORE (last {baseline_days} days, excluding last 30 min):")
+    try:
+        before = _server_baseline_summary(baseline_days)
+        _print_table(f"baseline ({baseline_days}d)", before)
+    except Exception as e:
+        print(f"  baseline query failed: {e}")
+        before = []
+
+    print(f"\nServer-side AFTER (synthetic burst, server-side timings via AppRequests):")
+    try:
+        after = _server_window_summary(start, end)
+        _print_table("burst", after)
+    except Exception as e:
+        print(f"  burst query failed: {e}")
+        after = []
+
+    if before and after:
+        print("\nDelta (negative = faster):")
+        before_by_name = {r["Name"]: r for r in before}
+        after_by_name = {r["Name"]: r for r in after}
+        for name in sorted(set(before_by_name) | set(after_by_name)):
+            b = before_by_name.get(name)
+            a = after_by_name.get(name)
+            if not (b and a):
+                continue
+            for stat in ("p50", "p95"):
+                bv = float(b[stat])
+                av = float(a[stat])
+                pct = (av - bv) / bv * 100 if bv else float("nan")
+                print(f"  {name:<22} {stat}: {bv:>7.0f}ms -> {av:>7.0f}ms "
+                      f"({pct:+.1f}%)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

You asked: *how do we know if the SQLite WAL + DEK cache fixes actually helped, without waiting days for organic traffic to accumulate?*

This PR ships the answer: a small Python script that drives a controlled burst of read-only requests against the live App Service, waits for App Insights ingestion, then re-runs the same KQL the pre-change profile used and prints a side-by-side comparison.

## Validation result for PR-139 (already merged on `main` as `c73e4a1`)

**Server-side `AppRequests.DurationMs` — pre vs. post:**

| Endpoint | Pre p50 | **Post p50** | Δ p50 | Pre p95 | **Post p95** | Δ p95 |
|---|---|---|---|---|---|---|
| `GET /api/today` | 5194 ms | **1839 ms** | **−65 %** | 11887 ms | **3998 ms** | **−66 %** |
| `GET /api/training` | 4127 ms | **1954 ms** | **−53 %** | 15938 ms | **4391 ms** | **−72 %** |
| `GET /api/science` | 4404 ms | **2067 ms** | **−53 %** | 15549 ms | **6566 ms** | **−58 %** |

PR-139's forecast was 30-60 % p50 drop. We landed at **53-65 %** across the slow trio, with even sharper p95 drops (58-72 %).

**Key Vault `unwrap_key` cliff (binary signal):**

5-min bins straddling the 12:07 UTC deploy:

| 5-min bin | unwrap_key calls |
|---|---|
| 11:35–12:05 (pre-deploy) | 3-4 / bin (sync scheduler ticks) |
| 12:15 (first post-deploy tick) | 4 (cache cold-fill — one per credential) |
| 12:20+ | **0** |

Exactly the cliff the per-DEK cache was designed to produce.

## How the script works

- POST `/api/auth/login` as the public demo account (`demo@trainsight.dev` / `demo`). The demo account proxies reads to the admin's data via `users.demo_of` (api/auth.py:62), so the queries hit the same SQLite tables and row counts a real user request would.
- 30 sequential GETs per endpoint × 3 endpoints (`/api/today`, `/api/training`, `/api/science`), 200ms apart.
- Records start/end timestamps. Sleeps 120s for App Insights ingestion lag.
- Runs two KQL queries via `az monitor log-analytics query`: one for the burst window (post), one for the last 7 days excluding the last 30 min (baseline).
- Prints per-endpoint p50/p95/p99 + delta.

Hits the App Service origin `trainsight-app.azurewebsites.net` directly — the SWA proxy on `www.praxys.run` returns 405 on POST (the frontend bypasses SWA for API calls via `VITE_API_URL`).

All knobs are env-var configurable: `PRAXYS_PERF_BASE_URL`, `PRAXYS_PERF_USER`, `PRAXYS_PERF_PASSWORD`, `PRAXYS_PERF_N`, `PRAXYS_PERF_PAUSE_MS`, `PRAXYS_PERF_INGEST_S`, `PRAXYS_PERF_BASELINE_DAYS`.

## What this isn't

- Not a load test — single-client sequential, no concurrency. B1 has 1 worker / 1.75 GB; concurrent load would saturate differently. That's not our regime today.
- Not a replacement for the sitespeed.io baselines (S1/S2/S3) — those measure end-to-end browser perf with real assets, fonts, render. This isolates the API tier.

## Test plan

- [x] Ran end-to-end against prod at 2026-04-25 12:22-12:27 UTC. Got the numbers above. Full report at `docs/perf-baselines/2026-04-25-c73e4a1-backend-perf/README.md`.
- [ ] Re-run after F4 (frontend off SWA-Amsterdam) to confirm no regression on the API tier.
- [ ] Re-run after any future backend perf change (DB migration, etc.) — that's the script's whole purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)