### PR TITLE
Perf-baseline workflow: support S1/S2/S3 + trim regions

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -19,7 +19,7 @@ on:
         required: true
         type: string
       probe:
-        description: 'Azure region the ACI runs in'
+        description: 'Azure region the ACI runs in — three macro-regions matching real audience: APAC/CN, US-West, EU'
         required: false
         type: choice
         default: 'eastasia'
@@ -27,12 +27,21 @@ on:
           - 'eastasia'
           - 'westus'
           - 'northeurope'
-          - 'eastus'
       target_url:
-        description: 'URL to measure'
+        description: 'URL or base URL — for S4 the page to load; for S1/S2/S3 the host without trailing slash (login flow appends /login etc.)'
         required: false
         type: string
         default: 'https://www.praxys.run/'
+      scenario:
+        description: 'Test scenario — S4=anonymous landing, S1=login→Today, S2=Today→Training, S3=warm-Today repeat'
+        required: false
+        type: choice
+        default: 's4'
+        options:
+          - 's4'
+          - 's1'
+          - 's2'
+          - 's3'
       device:
         description: 'Device emulation'
         required: false
@@ -75,8 +84,12 @@ jobs:
       matrix:
         device: ${{ fromJson(needs.resolve-devices.outputs.matrix) }}
     env:
-      CELL: s4-${{ inputs.probe }}-${{ matrix.device }}
-      CONTAINER_NAME: sitespeed-s4-${{ inputs.probe }}-${{ matrix.device }}-${{ github.run_id }}-${{ github.run_attempt }}
+      CELL: ${{ inputs.scenario }}-${{ inputs.probe }}-${{ matrix.device }}
+      CONTAINER_NAME: sitespeed-${{ inputs.scenario }}-${{ inputs.probe }}-${{ matrix.device }}-${{ github.run_id }}-${{ github.run_attempt }}
+      # Strip trailing slash so preScripts can do `${baseUrl}/login` etc.
+      # without doubling it. target_url's default has a trailing slash for
+      # S4 (sitespeed.io accepts it as URL); S1/S2/S3 want the bare host.
+      PRAXYS_PERF_BASE_URL: ${{ inputs.target_url }}
     steps:
       - uses: actions/checkout@v6
 
@@ -85,6 +98,23 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Upload preScripts (S1/S2/S3 only)
+        if: inputs.scenario != 's4'
+        run: |
+          # The preScripts (s1.js etc.) drive Chrome through the login flow.
+          # ACI mounts the perfbaselines file share at /sitespeed.io/out, so
+          # we put scripts in a `scripts/` subfolder of that share — the
+          # container will then see them at /sitespeed.io/out/scripts/.
+          # Idempotent (overwrites on every run); not cleaned up between
+          # runs (tiny files, OK to leave).
+          az storage file upload-batch \
+            --subscription "$AZ_SUBSCRIPTION" \
+            --account-name "$STORAGE_ACCOUNT" \
+            --account-key "${{ secrets.STORAGE_ACCOUNT_KEY }}" \
+            --destination "$FILE_SHARE" \
+            --destination-path "scripts" \
+            --source scripts/sitespeed_scripts/
 
       - name: Build sitespeed.io command-line
         id: cmd
@@ -110,11 +140,31 @@ jobs:
           else
             DEVICE_ARGS=""
           fi
-          echo "args=/start.sh ${{ inputs.target_url }} ${BASE_ARGS} ${DEVICE_ARGS}" >> "$GITHUB_OUTPUT"
+          # S4 = plain URL test. S1/S2/S3 = --multi mode where the JS
+          # preScript drives the browser through login then measures the
+          # navigation. preScripts read PRAXYS_PERF_BASE_URL +
+          # PRAXYS_PERF_USER + PRAXYS_PERF_PASSWORD env vars (set on the
+          # ACI below), defaulting to the public demo account.
+          if [ "${{ inputs.scenario }}" = "s4" ]; then
+            TAIL_ARGS="${{ inputs.target_url }}"
+          else
+            TAIL_ARGS="--multi /sitespeed.io/out/scripts/${{ inputs.scenario }}.js"
+          fi
+          echo "args=/start.sh ${TAIL_ARGS} ${BASE_ARGS} ${DEVICE_ARGS}" >> "$GITHUB_OUTPUT"
 
       - name: Create ACI + wait for completion
         run: |
           set -euo pipefail
+
+          # Strip trailing slash from base URL so preScripts can do
+          # ${baseUrl}/login without doubling the slash.
+          BASE_URL="${PRAXYS_PERF_BASE_URL%/}"
+          # Public demo account — same defaults Landing.tsx ships in its
+          # "Try the demo" CTA; not secret. Override via repository secrets
+          # PRAXYS_PERF_USER / PRAXYS_PERF_PASSWORD if testing against a
+          # non-demo account.
+          PERF_USER="${{ secrets.PRAXYS_PERF_USER || 'demo@trainsight.dev' }}"
+          PERF_PASS="${{ secrets.PRAXYS_PERF_PASSWORD || 'demo' }}"
 
           az container create \
             --subscription "$AZ_SUBSCRIPTION" \
@@ -129,6 +179,10 @@ jobs:
             --azure-file-volume-account-key "${{ secrets.STORAGE_ACCOUNT_KEY }}" \
             --azure-file-volume-share-name "$FILE_SHARE" \
             --azure-file-volume-mount-path /sitespeed.io/out \
+            --environment-variables \
+              "PRAXYS_PERF_BASE_URL=$BASE_URL" \
+              "PRAXYS_PERF_USER=$PERF_USER" \
+              "PRAXYS_PERF_PASSWORD=$PERF_PASS" \
             --command-line "${{ steps.cmd.outputs.args }}" \
             --no-wait
 

--- a/docs/perf-baselines/ci-setup.md
+++ b/docs/perf-baselines/ci-setup.md
@@ -4,7 +4,7 @@ This documents the Azure resources + GitHub config that back `.github/workflows/
 
 ## What the workflow does
 
-Trigger: **manual** (`workflow_dispatch`) only. Inputs: `reason`, `probe` (Azure region), `target_url`, `device`.
+Trigger: **manual** (`workflow_dispatch`) only. Inputs: `reason`, `probe` (Azure region — `eastasia` / `westus` / `northeurope`), `target_url`, `scenario` (`s1` / `s2` / `s3` / `s4`), `device`.
 
 1. Uses OIDC to log in to Azure with the same service principal `deploy-backend.yml` uses.
 2. Spins up an Azure Container Instance in the chosen region running `sitespeedio/sitespeed.io:latest`.
@@ -83,10 +83,21 @@ gh workflow run perf-baseline.yml --repo dddtc2005/praxys \
   -f device=both
 ```
 
-Outputs land as GH Actions artifacts named `baseline-s4-<probe>-<device>-<run-id>/`. Download + merge into a `docs/perf-baselines/<YYYY-MM-DD>-<sha>/` directory per the `README.md` / `TEMPLATE.md` convention.
+Outputs land as GH Actions artifacts named `baseline-<scenario>-<probe>-<device>-<run-id>/`. Download + merge into a `docs/perf-baselines/<YYYY-MM-DD>-<sha>/` directory per the `README.md` / `TEMPLATE.md` convention.
+
+## Login-scripted scenarios (S1/S2/S3)
+
+When `scenario` is `s1`, `s2`, or `s3`, the workflow uploads `scripts/sitespeed_scripts/*.js` to a `scripts/` subfolder of the same `perfbaselines` Azure File share before the ACI starts. The container mounts the share at `/sitespeed.io/out`, so the preScripts appear at `/sitespeed.io/out/scripts/<scenario>.js`. Sitespeed.io is then invoked with `--multi /sitespeed.io/out/scripts/<scenario>.js` instead of a target URL.
+
+The preScripts read three env vars (passed via `az container create --environment-variables`):
+
+- `PRAXYS_PERF_BASE_URL` — derived from the workflow's `target_url` input (trailing slash stripped, e.g. `https://www.praxys.run`).
+- `PRAXYS_PERF_USER` — defaults to `demo@trainsight.dev` (public demo account, same one Landing's "Try the demo" CTA ships). Override via repo secret `PRAXYS_PERF_USER`.
+- `PRAXYS_PERF_PASSWORD` — defaults to `demo`. Override via repo secret `PRAXYS_PERF_PASSWORD`.
+
+The defaults match `scripts/sitespeed_runner.sh` so a cloud cell and a local cell of the same scenario measure the same flow against the same account.
 
 ## Known limitations
 
 - **No mainland-China POPs.** Azure has none in the public cloud; closest is `eastasia` (Hong Kong). For CN-from-inside-the-GFW numbers keep using `scripts/sitespeed_runner.sh` on an operator PC.
-- **Single scenario.** Only S4 (Anonymous Landing) is implemented today. S1-S3 (login-scripted scenarios) need a perf-test account + credential handling first.
 - **Cost scales with cadence.** At a baseline-per-week cadence, ~$3/month. More frequent runs scale linearly on ACI compute.


### PR DESCRIPTION
## Why

The cloud workflow previously ran S4 only (anonymous landing) — so the multi-region runs we did yesterday for F4 verification couldn't reach the login-gated paths where the user actually feels slowness (Today / Training cold load). This adds S1/S2/S3 support so we can measure those from Azure-internal probes (eastasia, westus, northeurope) and compare against the local cn-pc-2 numbers.

Also trims `eastus` from the region choices — redundant vs `westus` for the US audience, and we only need three triangulating macro-regions (APAC, US, EU).

## How

- New `scenario` input (s1/s2/s3/s4, default s4 for backward compat with existing muscle memory).
- For S1/S2/S3 the workflow uploads the local preScripts (`s1.js` etc. from `scripts/sitespeed_scripts/`) to the existing `perfbaselines` file share under a `scripts/` subfolder before the ACI starts. The share is already mounted at `/sitespeed.io/out` so the scripts land at `/sitespeed.io/out/scripts/` inside the container.
- For S4 the URL-based invocation stays. For S1/S2/S3 we pass `--multi /sitespeed.io/out/scripts/<scenario>.js` instead.
- ACI gets `PRAXYS_PERF_BASE_URL` / `USER` / `PASSWORD` env vars, defaulting to the public demo account (same as the local runner). Override via repo secrets `PRAXYS_PERF_USER` / `PRAXYS_PERF_PASSWORD` if you ever want to run against a non-demo account.
- `CELL` and `CONTAINER_NAME` interpolate the scenario, so the artifact layout (`s1-eastasia-desktop/`, etc.) matches the local runner's exactly — `analyze_baseline.py` picks them up identically.

## Region change

| Was | Now |
|---|---|
| eastasia, westus, northeurope, eastus | eastasia, westus, northeurope |

`eastus` was useful when we were debugging SWA-Amsterdam routing (eastus showed almost-zero AMS latency vs westus paying cross-country). Post-F4 there's no asymmetry to test — three regions triangulate the three audience macros (APAC/CN, US-West, EU). Drops one redundant cell from any "all regions" sweep.

## Test plan

- [x] YAML syntax validated locally
- [ ] Trigger S4 single-region run (eastasia) — should be no behaviour change vs old workflow
- [ ] Trigger S1 single-region run — verify preScript upload + login flow + output layout
- [ ] After PR merges, trigger 9-cell sweep: 3 scenarios × 3 regions × both devices = enough data to compare against local cn-pc-2 anchors

## What this isn't

This doesn't change the local `scripts/sitespeed_runner.sh` — that still works the same way (the cn-pc-2 anchor at `2026-04-26-1358017/` was generated with it and remains the gold standard for "what does the user actually experience").

🤖 Generated with [Claude Code](https://claude.com/claude-code)