### PR TITLE
Perf-baseline workflow: matrix sweep + polling-bug fix

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -1,8 +1,13 @@
 name: Perf Baseline (sitespeed.io via ACI)
 
-# Manual-trigger-only. Runs sitespeed.io inside an Azure Container Instance
-# in the chosen region, captures HAR + sitespeed output to an Azure Files
-# share, downloads back to the runner, uploads as a GH Action artifact.
+# Manual-trigger-only. Runs sitespeed.io inside Azure Container Instances
+# in the chosen regions, captures HAR + sitespeed output to an Azure Files
+# share, downloads back to the runner, uploads as GH Action artifacts.
+#
+# Matrix-driven: each input axis (scenario, probe, device) accepts 'all' or
+# a specific value. With defaults (scenario=all, probe=all, device=both)
+# one click produces the full sweep — 4 scenarios × 3 regions × 2 devices
+# = 24 cells, all running in parallel as separate matrix jobs.
 #
 # One-time prerequisites (see docs/perf-baselines/ci-setup.md):
 #   - Storage account `stperftrainsight` in rg-trainsight (already created)
@@ -15,42 +20,44 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Why running this baseline (e.g. "anchor before phase 2" or "after self-host fonts")'
+        description: 'Why running this baseline (e.g. "anchor before phase 2" or "after L1 refactor")'
         required: true
         type: string
       probe:
-        description: 'Azure region the ACI runs in — three macro-regions matching real audience: APAC/CN, US-West, EU'
+        description: 'Azure region — three macro-regions matching audience: APAC/CN, US-West, EU; or all'
         required: false
         type: choice
-        default: 'eastasia'
+        default: 'all'
         options:
+          - 'all'
           - 'eastasia'
           - 'westus'
           - 'northeurope'
-      target_url:
-        description: 'URL or base URL — for S4 the page to load; for S1/S2/S3 the host without trailing slash (login flow appends /login etc.)'
-        required: false
-        type: string
-        default: 'https://www.praxys.run/'
       scenario:
-        description: 'Test scenario — S4=anonymous landing, S1=login→Today, S2=Today→Training, S3=warm-Today repeat'
+        description: 'Test scenario — S4=anonymous landing, S1=login→Today, S2=Today→Training, S3=warm-Today; or all'
         required: false
         type: choice
-        default: 's4'
+        default: 'all'
         options:
-          - 's4'
+          - 'all'
           - 's1'
           - 's2'
           - 's3'
+          - 's4'
       device:
         description: 'Device emulation'
         required: false
         type: choice
         default: 'both'
         options:
+          - 'both'
           - 'desktop'
           - 'mobile'
-          - 'both'
+      target_url:
+        description: 'URL or base URL — for S4 the page to load; for S1/S2/S3 the host (login flow appends /login etc.)'
+        required: false
+        type: string
+        default: 'https://www.praxys.run/'
 
 permissions:
   contents: read
@@ -63,32 +70,52 @@ env:
   FILE_SHARE: perfbaselines
 
 jobs:
-  resolve-devices:
+  resolve-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.build.outputs.matrix }}
+      scenarios: ${{ steps.build.outputs.scenarios }}
+      probes: ${{ steps.build.outputs.probes }}
+      devices: ${{ steps.build.outputs.devices }}
     steps:
       - id: build
         run: |
-          if [ "${{ inputs.device }}" = "both" ]; then
-            echo 'matrix=["desktop","mobile"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix=["${{ inputs.device }}"]' >> "$GITHUB_OUTPUT"
-          fi
+          # Each axis accepts 'all' (expand to all known options) or a
+          # specific value (single-element list). Three nested matrix
+          # axes give us scenario × probe × device — the full sweep with
+          # 'all/all/both' = 24 cells.
+          case "${{ inputs.scenario }}" in
+            all) SCENARIOS='["s1","s2","s3","s4"]' ;;
+            *)   SCENARIOS='["${{ inputs.scenario }}"]' ;;
+          esac
+          case "${{ inputs.probe }}" in
+            all) PROBES='["eastasia","westus","northeurope"]' ;;
+            *)   PROBES='["${{ inputs.probe }}"]' ;;
+          esac
+          case "${{ inputs.device }}" in
+            both) DEVICES='["desktop","mobile"]' ;;
+            *)    DEVICES='["${{ inputs.device }}"]' ;;
+          esac
+          echo "scenarios=$SCENARIOS" >> "$GITHUB_OUTPUT"
+          echo "probes=$PROBES"      >> "$GITHUB_OUTPUT"
+          echo "devices=$DEVICES"    >> "$GITHUB_OUTPUT"
+          echo "Resolved matrix: scenarios=$SCENARIOS probes=$PROBES devices=$DEVICES"
 
   baseline:
-    needs: resolve-devices
+    needs: resolve-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Cap parallelism so we don't hammer Azure quotas with 24 simultaneous
+      # ACI creates. Default GH limit is 256 jobs, but ACI per-region quotas
+      # are much tighter. 8 in parallel finishes a full sweep in ~3 waves.
+      max-parallel: 8
       matrix:
-        device: ${{ fromJson(needs.resolve-devices.outputs.matrix) }}
+        scenario: ${{ fromJSON(needs.resolve-matrix.outputs.scenarios) }}
+        probe: ${{ fromJSON(needs.resolve-matrix.outputs.probes) }}
+        device: ${{ fromJSON(needs.resolve-matrix.outputs.devices) }}
     env:
-      CELL: ${{ inputs.scenario }}-${{ inputs.probe }}-${{ matrix.device }}
-      CONTAINER_NAME: sitespeed-${{ inputs.scenario }}-${{ inputs.probe }}-${{ matrix.device }}-${{ github.run_id }}-${{ github.run_attempt }}
-      # Strip trailing slash so preScripts can do `${baseUrl}/login` etc.
-      # without doubling it. target_url's default has a trailing slash for
-      # S4 (sitespeed.io accepts it as URL); S1/S2/S3 want the bare host.
+      CELL: ${{ matrix.scenario }}-${{ matrix.probe }}-${{ matrix.device }}
+      CONTAINER_NAME: sitespeed-${{ matrix.scenario }}-${{ matrix.probe }}-${{ matrix.device }}-${{ github.run_id }}-${{ github.run_attempt }}
       PRAXYS_PERF_BASE_URL: ${{ inputs.target_url }}
     steps:
       - uses: actions/checkout@v6
@@ -100,7 +127,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Upload preScripts (S1/S2/S3 only)
-        if: inputs.scenario != 's4'
+        if: matrix.scenario != 's4'
         run: |
           # The preScripts (s1.js etc.) drive Chrome through the login flow.
           # ACI mounts the perfbaselines file share at /sitespeed.io/out, so
@@ -145,24 +172,17 @@ jobs:
           # navigation. preScripts read PRAXYS_PERF_BASE_URL +
           # PRAXYS_PERF_USER + PRAXYS_PERF_PASSWORD env vars (set on the
           # ACI below), defaulting to the public demo account.
-          if [ "${{ inputs.scenario }}" = "s4" ]; then
+          if [ "${{ matrix.scenario }}" = "s4" ]; then
             TAIL_ARGS="${{ inputs.target_url }}"
           else
-            TAIL_ARGS="--multi /sitespeed.io/out/scripts/${{ inputs.scenario }}.js"
+            TAIL_ARGS="--multi /sitespeed.io/out/scripts/${{ matrix.scenario }}.js"
           fi
           echo "args=/start.sh ${TAIL_ARGS} ${BASE_ARGS} ${DEVICE_ARGS}" >> "$GITHUB_OUTPUT"
 
-      - name: Create ACI + wait for completion
+      - name: Create ACI
         run: |
           set -euo pipefail
-
-          # Strip trailing slash from base URL so preScripts can do
-          # ${baseUrl}/login without doubling the slash.
           BASE_URL="${PRAXYS_PERF_BASE_URL%/}"
-          # Public demo account — same defaults Landing.tsx ships in its
-          # "Try the demo" CTA; not secret. Override via repository secrets
-          # PRAXYS_PERF_USER / PRAXYS_PERF_PASSWORD if testing against a
-          # non-demo account.
           PERF_USER="${{ secrets.PRAXYS_PERF_USER || 'demo@trainsight.dev' }}"
           PERF_PASS="${{ secrets.PRAXYS_PERF_PASSWORD || 'demo' }}"
 
@@ -172,7 +192,7 @@ jobs:
             --name "$CONTAINER_NAME" \
             --image sitespeedio/sitespeed.io:latest \
             --os-type Linux \
-            --location "${{ inputs.probe }}" \
+            --location "${{ matrix.probe }}" \
             --cpu 2 --memory 4 \
             --restart-policy Never \
             --azure-file-volume-account-name "$STORAGE_ACCOUNT" \
@@ -186,37 +206,58 @@ jobs:
             --command-line "${{ steps.cmd.outputs.args }}" \
             --no-wait
 
-          # Poll until the container exits. ACI's single-run model surfaces
-          # state as "Terminated" with an exitCode once the process finishes.
-          while true; do
+      - name: Wait for container to terminate
+        id: wait
+        run: |
+          # Poll until exit code is set OR 15-min hard timeout. We use
+          # exit-code presence as the completion signal because the
+          # `currentState.state` field is unreliable cross-region —
+          # it can stay as "Running" even after the container has
+          # actually exited (we hung 15 of 15 cross-region runs on this
+          # before the rewrite). Exit code is the canonical "done"
+          # marker that's set exactly when the process terminates.
+          DEADLINE=$(($(date +%s) + 900))   # 15 min wall clock
+          EXIT_CODE=""
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            EXIT_CODE=$(az container show \
+              --subscription "$AZ_SUBSCRIPTION" \
+              --resource-group "$AZ_RG" \
+              --name "$CONTAINER_NAME" \
+              --query "containers[0].instanceView.currentState.exitCode" -o tsv 2>/dev/null || true)
+            if [ -n "$EXIT_CODE" ] && [ "$EXIT_CODE" != "null" ]; then
+              break
+            fi
             STATE=$(az container show \
               --subscription "$AZ_SUBSCRIPTION" \
               --resource-group "$AZ_RG" \
               --name "$CONTAINER_NAME" \
               --query "containers[0].instanceView.currentState.state" -o tsv 2>/dev/null || true)
-            echo "[$(date -u +%T)] container state: ${STATE:-pending}"
-            if [ "$STATE" = "Terminated" ]; then break; fi
+            echo "[$(date -u +%T)] state=${STATE:-pending} exit_code=${EXIT_CODE:-pending}"
             sleep 20
           done
-
-          EXIT_CODE=$(az container show \
-            --subscription "$AZ_SUBSCRIPTION" \
-            --resource-group "$AZ_RG" \
-            --name "$CONTAINER_NAME" \
-            --query "containers[0].instanceView.currentState.exitCode" -o tsv)
-          echo "container exit code: $EXIT_CODE"
 
           echo "---- container logs (tail) ----"
           az container logs \
             --subscription "$AZ_SUBSCRIPTION" \
             --resource-group "$AZ_RG" \
-            --name "$CONTAINER_NAME" | tail -80
+            --name "$CONTAINER_NAME" 2>&1 | tail -80 || true
 
-          exit "$EXIT_CODE"
+          # Persist the exit code (or 'timeout') as a step output so
+          # downstream steps can decide whether to treat as success.
+          if [ -z "$EXIT_CODE" ] || [ "$EXIT_CODE" = "null" ]; then
+            echo "::warning::Polling timed out at 15 min — container exit code never appeared. Will still attempt to download whatever made it to the share."
+            echo "exit_code=timeout" >> "$GITHUB_OUTPUT"
+          else
+            echo "Container terminated with exit code: $EXIT_CODE"
+            echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download HARs + strip heavy binaries
+        if: always()
         run: |
-          set -euo pipefail
+          # Run even on polling timeout — sitespeed.io may have written
+          # output to the share before our polling lost track of it.
+          set -uo pipefail
           mkdir -p baseline-output
           az storage file download-batch \
             --subscription "$AZ_SUBSCRIPTION" \
@@ -224,18 +265,37 @@ jobs:
             --account-key "${{ secrets.STORAGE_ACCOUNT_KEY }}" \
             --source "$FILE_SHARE" \
             --pattern "${CELL}/*" \
-            --destination ./baseline-output/
+            --destination ./baseline-output/ || true
 
           # Match the .gitignore pattern in docs/perf-baselines/: keep HAR +
           # light reports, drop videos/filmstrip/screenshots bundles.
           find baseline-output -type d \( -name video -o -name filmstrip -o -name screenshots \) \
             -exec rm -rf {} + 2>/dev/null || true
 
+          # If nothing came down, surface that — but don't fail the step
+          # (the upload-artifact step will skip an empty dir gracefully).
+          if [ -z "$(find baseline-output -name 'browsertime.har' 2>/dev/null)" ]; then
+            echo "::warning::No HARs in baseline-output for cell ${CELL} — sitespeed didn't produce output, or the share write is delayed."
+          fi
+
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: baseline-${{ env.CELL }}-${{ github.run_id }}
           path: baseline-output/
           retention-days: 30
+          if-no-files-found: warn
+
+      - name: Fail step if container exit was non-zero or timed out
+        run: |
+          # Surface failure AFTER artifact upload so we still capture data
+          # from cells that ran but reported a non-zero exit.
+          EC="${{ steps.wait.outputs.exit_code }}"
+          case "$EC" in
+            0)       echo "Cell ${CELL} succeeded." ;;
+            timeout) echo "::error::Cell ${CELL} polling timed out — see preceding warnings."; exit 1 ;;
+            *)       echo "::error::Cell ${CELL} container exit code: $EC"; exit "$EC" ;;
+          esac
 
       - name: Delete ACI
         if: always()

--- a/docs/perf-baselines/2026-04-26-checkpoint.md
+++ b/docs/perf-baselines/2026-04-26-checkpoint.md
@@ -1,0 +1,95 @@
+# Perf checkpoint — 2026-04-26
+
+A snapshot of where Praxys' user-perceived performance stands after the recent four-fix arc (Phase-1 #1 self-host fonts, PWA precache, PR-139 backend pragmas + DEK cache, F4 frontend co-location). This is the **"before" reference** for the next round of work — the L1/L2/L3 backend-call optimizations targeted at Today / Training cold load.
+
+Numerical sources for every claim below are the committed baselines in `docs/perf-baselines/`. This file is just the consolidated narrative.
+
+## What's been fixed so far
+
+| Phase | What | Anchor showing the gain |
+|---|---|---|
+| Phase 1 #1 | Self-hosted fonts (eliminated Google Fonts blocking on raw CN ISP) | `2026-04-25-667dcc2/` — S4 cn-pc-2 desktop FCP **22476 ms → 2892 ms** (−87 %) |
+| Phase 2 #4 (F2) | Folded `/api/plan/stryd-status` into `/api/plan` (one fewer round-trip on Training cold load) | `2026-04-25-d37484b/` set the S1/S2/S3 anchor right before this |
+| PR-139 | SQLite WAL pragmas + 20 MB page cache + per-DEK unwrap LRU | `2026-04-25-c73e4a1-backend-perf/` — synthetic-load script measured `/api/today` p50 **5194 ms → 1839 ms** (−65 %) |
+| PR-141/142 (F4) | Frontend off SWA-Amsterdam onto App Service East Asia (`praxys-frontend`); apex `praxys.run` lives | `2026-04-26-1358017/` — see headline table below |
+
+## Headline numbers — `cn-pc-2` (passwall2 OFF, raw mainland CN ISP)
+
+This is the row that matters for friends in mainland CN without VPN — the population the recent work was designed to serve.
+
+| Scenario | Metric | Pre-arc (`2026-04-24-468ce25` or `d37484b`) | Now (`1358017`) | Δ |
+|---|---|---|---|---|
+| **S1 cold-Today desktop** | FCP | 2892 ms | **2056 ms** | −29 % |
+| | TTFB | 1039 ms | **570 ms** | −45 % |
+| | API p95 | 4112 ms | 3839 ms | −7 % (small sample) |
+| **S1 cold-Today mobile** | FCP | 2840 ms | **1680 ms** | −41 % |
+| | TTFB | 984 ms | **479 ms** | −51 % |
+| | API p95 | 3759 ms | **2520 ms** | −33 % |
+| **S2 Today→Training mobile** | LCP | 5336 ms | 5084 ms | −5 % |
+| | API p95 | 4814 ms | 4196 ms | −13 % |
+| **S3 warm-Today mobile** | LCP | 9732 ms | **5452 ms** | −44 % |
+| **S4 cold landing desktop** | FCP | 22476 ms (raw) → 2892 ms (post-Phase-1 #1) | **1636 ms** | −93 % overall, −43 % vs post-Phase-1 |
+| **S4 cold landing mobile** | FCP | 22532 ms (raw) → 2788 ms (post-Phase-1 #1) | **1504 ms** | −93 % overall, −46 % vs post-Phase-1 |
+
+### Pre-PR-139 production median (App Insights, real traffic)
+
+| Endpoint | p50 | p95 |
+|---|---|---|
+| `GET /api/today` | 5194 ms | 11887 ms |
+| `GET /api/training` | 4127 ms | 15938 ms |
+| `GET /api/science` | 4404 ms | 15549 ms |
+| `GET /api/health` | 8 ms | 47 ms |
+| `GET /api/settings` | 218 ms | 1098 ms |
+
+### Post-PR-139 synthetic-load median
+
+| Endpoint | p50 | p95 |
+|---|---|---|
+| `GET /api/today` | **1839 ms** | 3998 ms |
+| `GET /api/training` | **1954 ms** | 4391 ms |
+| `GET /api/science` | **2067 ms** | 6566 ms |
+
+### Architectural inversion confirmed
+
+Pre-F4: `cn-pc` (passwall2 ON) was always faster than `cn-pc-2` because passwall2 bypassed the GFW-throttled CN→AMS path that SWA-Amsterdam forced on us.
+
+Post-F4: `cn-pc` (passwall2 ON) is *consistently slower* than `cn-pc-2` on Praxys traffic — direct CN-ISP→HK is a shorter route than CN-ISP→overseas-tunnel→HK now that the origin lives in East Asia. Most visible: S4 desktop FCP `cn-pc` 3788 ms vs `cn-pc-2` 1636 ms.
+
+**Friends in mainland CN without VPN now get the best Praxys experience.** That's the right outcome for the audience.
+
+## What's still slow (and where we go next)
+
+The user's current subjective feel (verbatim, lightly paraphrased):
+
+- Landing (`praxys.run` / `www.praxys.run`): fast cold + warm. Done.
+- **Today + Training: slow on cold load — data and charts take many seconds; nav bar is quick.**
+- Settings, Science: feel fast.
+- Warm Today/Training: better, still not snappy.
+
+Code-read (without instrumentation) found the smoking gun: **five endpoints (`/api/today`, `/api/training`, `/api/goal`, `/api/history`, `/api/science`) all call the same kitchen-sink `get_dashboard_data()` function**, which runs ~22 distinct top-level computations on every request, then each endpoint returns ~15-40 % of the result. The other 60-85 % of work is wasted. The four production endpoints clustering near the same 1.8-2 s p50 (post-PR-139) is the data-side fingerprint of this — they're literally doing the same work.
+
+This is what the next three optimization layers target. Each is a separate piece of work with its own measurement gate before moving on:
+
+| Layer | Issue | Mechanism | Expected Today p50 after |
+|---|---|---|---|
+| **L1** | (TBD — open after PR-145 lands) | Refactor `get_dashboard_data` into per-endpoint slim functions; routes call only what they need | ~400 ms (4-5× drop) |
+| **L2** | (TBD) | ETag/304 keyed on `(user, latest_sync_timestamp)` — saves bandwidth on warm visits | minimal compute change; cuts the JSON-body re-send cost |
+| **L3** | (TBD) | Materialize per-section caches at sync_writer commit; reads become SELECTs | ~50 ms (≈ instant) |
+
+**L1 is required before L2 and L3 make sense** — without splitting the kitchen-sink, neither caching strategy has a sane invalidation surface. Once L1 lands, L2 is additive and L3 stays in the toolbox until the warm-visit speed of L1 stops feeling adequate.
+
+## Tooling state
+
+- **Local sitespeed runner** (`scripts/sitespeed_runner.sh`) — works against any URL, supports S1/S2/S3/S4 × desktop/mobile. The cn-pc-2 anchor numbers above all came from this. Gold standard for "what does the operator (and CN audience) actually feel."
+- **Cloud sitespeed runner** (`.github/workflows/perf-baseline.yml`) — currently being rewritten in PR-145: matrix-driven (`scenario × probe × device` = up to 24 cells per dispatch), polling-bug fixed (was hanging cross-region runs by relying on an unreliable state field). Once PR-145 lands, we have reliable Azure-internal probes for eastasia/westus/northeurope to triangulate audience experience without needing the operator's PC.
+- **Synthetic-load validator** (`scripts/perf_synthetic_load_check.py`) — drives 30-call bursts against a deployed environment, queries App Insights for server-side p50/p95 vs a baseline window. This is what produced the PR-139 −65 % p50 measurement that synthetic browser baselines couldn't capture cleanly because of small-sample p95 noise. Reusable for every backend perf change.
+- **Azure Monitor alert** — `praxys-today-latency-regression` fires when `/api/today` mean exceeds 3000 ms over a 24-h window. Catches future regressions on real traffic without us having to remember to look.
+
+## How this checkpoint will be used
+
+The next set of PRs (L1, L2, L3 in order) will each be measured against the numbers in this file. The acceptance gate for each layer is "Today / Training p50 reduces by at least the expected amount, no S4 / Settings / Science regression, security headers still present, suite still green." If a layer doesn't move the number, that's a signal to stop and re-diagnose rather than ship.
+
+Anchors-of-anchors:
+- Source-of-truth pre-arc: `2026-04-24-468ce25/`
+- Last anchor before this checkpoint: `2026-04-26-1358017/`
+- Everything below this checkpoint should compare to `1358017`'s cn-pc-2 row.

--- a/docs/perf-baselines/2026-04-26-checkpoint.md
+++ b/docs/perf-baselines/2026-04-26-checkpoint.md
@@ -2,7 +2,7 @@
 
 A snapshot of where Praxys' user-perceived performance stands after the recent four-fix arc (Phase-1 #1 self-host fonts, PWA precache, PR-139 backend pragmas + DEK cache, F4 frontend co-location). This is the **"before" reference** for the next round of work — the L1/L2/L3 backend-call optimizations targeted at Today / Training cold load.
 
-Numerical sources for every claim below are the committed baselines in `docs/perf-baselines/`. This file is just the consolidated narrative.
+Numerical sources for every claim below are the committed baselines in `docs/perf-baselines/`. This file consolidates every metric across every probe, including the ones that didn't move or that regressed — full picture, not just the wins.
 
 ## What's been fixed so far
 
@@ -11,83 +11,240 @@ Numerical sources for every claim below are the committed baselines in `docs/per
 | Phase 1 #1 | Self-hosted fonts (eliminated Google Fonts blocking on raw CN ISP) | `2026-04-25-667dcc2/` — S4 cn-pc-2 desktop FCP **22476 ms → 2892 ms** (−87 %) |
 | Phase 2 #4 (F2) | Folded `/api/plan/stryd-status` into `/api/plan` (one fewer round-trip on Training cold load) | `2026-04-25-d37484b/` set the S1/S2/S3 anchor right before this |
 | PR-139 | SQLite WAL pragmas + 20 MB page cache + per-DEK unwrap LRU | `2026-04-25-c73e4a1-backend-perf/` — synthetic-load script measured `/api/today` p50 **5194 ms → 1839 ms** (−65 %) |
-| PR-141/142 (F4) | Frontend off SWA-Amsterdam onto App Service East Asia (`praxys-frontend`); apex `praxys.run` lives | `2026-04-26-1358017/` — see headline table below |
+| PR-141/142 (F4) | Frontend off SWA-Amsterdam onto App Service East Asia (`praxys-frontend`); apex `praxys.run` lives | `2026-04-26-1358017/` — see comprehensive tables below |
 
-## Headline numbers — `cn-pc-2` (passwall2 OFF, raw mainland CN ISP)
+## Data sources for this checkpoint
 
-This is the row that matters for friends in mainland CN without VPN — the population the recent work was designed to serve.
-
-| Scenario | Metric | Pre-arc (`2026-04-24-468ce25` or `d37484b`) | Now (`1358017`) | Δ |
-|---|---|---|---|---|
-| **S1 cold-Today desktop** | FCP | 2892 ms | **2056 ms** | −29 % |
-| | TTFB | 1039 ms | **570 ms** | −45 % |
-| | API p95 | 4112 ms | 3839 ms | −7 % (small sample) |
-| **S1 cold-Today mobile** | FCP | 2840 ms | **1680 ms** | −41 % |
-| | TTFB | 984 ms | **479 ms** | −51 % |
-| | API p95 | 3759 ms | **2520 ms** | −33 % |
-| **S2 Today→Training mobile** | LCP | 5336 ms | 5084 ms | −5 % |
-| | API p95 | 4814 ms | 4196 ms | −13 % |
-| **S3 warm-Today mobile** | LCP | 9732 ms | **5452 ms** | −44 % |
-| **S4 cold landing desktop** | FCP | 22476 ms (raw) → 2892 ms (post-Phase-1 #1) | **1636 ms** | −93 % overall, −43 % vs post-Phase-1 |
-| **S4 cold landing mobile** | FCP | 22532 ms (raw) → 2788 ms (post-Phase-1 #1) | **1504 ms** | −93 % overall, −46 % vs post-Phase-1 |
-
-### Pre-PR-139 production median (App Insights, real traffic)
-
-| Endpoint | p50 | p95 |
+| Scenario | Pre-arc anchor | "Now" anchor |
 |---|---|---|
-| `GET /api/today` | 5194 ms | 11887 ms |
-| `GET /api/training` | 4127 ms | 15938 ms |
-| `GET /api/science` | 4404 ms | 15549 ms |
-| `GET /api/health` | 8 ms | 47 ms |
-| `GET /api/settings` | 218 ms | 1098 ms |
+| S1/S2/S3 (login-gated) | `2026-04-25-d37484b/` (cn-pc-2 only) | `2026-04-26-1358017/` (cn-pc + cn-pc-2) |
+| S4 (anonymous landing) | `2026-04-24-468ce25/` (raw, cn-pc + cn-pc-2) | `2026-04-26-1358017/` (cn-pc + cn-pc-2) |
 
-### Post-PR-139 synthetic-load median
+The S4 pre-arc starts from `468ce25` (raw, before any Phase-1 work) so the delta captures the full fix arc including self-host fonts. The S1/S2/S3 pre-arc starts from `d37484b` because that's our oldest login-scripted baseline; cn-pc S1/S2/S3 has no committed pre-arc data, so those rows show only "now".
 
-| Endpoint | p50 | p95 |
+Cloud-region probes (`eastasia` / `westus` / `northeurope`) — pending; needs PR-145 (workflow rewrite) to land + a first sweep against the new origin. Will be appended to this file once we have the data.
+
+---
+
+## S1 — Cold first load, Today page (via login)
+
+### cn-pc-2 (passwall2 OFF — real mainland-CN ISP, what your friends without VPN see)
+
+| Metric | Desktop pre | Desktop now | Δ | Mobile pre | Mobile now | Δ |
+|---|---|---|---|---|---|---|
+| FCP (ms) | 2892 | **2056** | **−836 (−29 %)** | 2840 | **1680** | **−1160 (−41 %)** |
+| LCP (ms) | 2892 | **2056** | **−836 (−29 %)** | 2840 | **1680** | **−1160 (−41 %)** |
+| TTI (ms) | 1059 | **580** | **−479 (−45 %)** | 1010 | **489** | **−521 (−52 %)** |
+| HTML TTFB (ms) | 1039 | **570** | **−469 (−45 %)** | 984 | **479** | **−505 (−51 %)** |
+| Static KB | 2361.0 | 2053.4 | −307.6 (−13 %) | 1910.3 | 1010.4 | −899.9 (−47 %) |
+| API KB | 45.6 | 33.8 | −11.8 (−26 %) | 34.8 | 12.9 | −21.9 (−63 %) |
+| # reqs | 108 | 99 | −9 (−8 %) | 97 | 75 | −22 (−23 %) |
+| # API calls | 54 | 52 | −2 (−4 %) | 52 | 48 | −4 (−8 %) |
+| API p50 (ms) | 186 | 170 | −16 (−9 %) | 175 | 214 | **+39 (+22 %)** |
+| API p95 (ms) | 4112 | 3839 | −273 (−7 %) | 3759 | **2520** | **−1239 (−33 %)** |
+
+### cn-pc (passwall2 ON — overseas tunnel "control"; no pre-arc S1 baseline)
+
+| Metric | Desktop now | Mobile now | Note |
+|---|---|---|---|
+| FCP (ms) | 1684 | 1736 | comparable to cn-pc-2 now — passwall no longer "wins" |
+| LCP (ms) | 1684 | 1736 | |
+| TTI (ms) | 538 | 519 | |
+| HTML TTFB (ms) | 515 | 510 | |
+| Static KB | 1361.0 | 2399.6 | |
+| # reqs | 81 | 108 | |
+| API p50 (ms) | 201 | 169 | |
+| API p95 (ms) | 1136 | 4280 | desktop fast / mobile slow — single-iteration tail |
+
+### Observations
+
+- **The wins are all in render path.** FCP/LCP/TTI/TTFB drop 29-52 % because F4 eliminated the Amsterdam round-trip on every blocking asset.
+- **Mobile API p50 went UP +22 %** — odd against the rest of the picture. Sample is 3 iterations × 48 calls; p50 of small samples is noisy. Mobile p95 dropped 33 % so the headline-tail story holds; treat the p50 +22 % as noise unless it persists across follow-up runs.
+- **Static-KB drop on mobile is bigger than desktop** (−47 % vs −13 %). Probably a viewport-aware bundle-split kicking in correctly post-F4 — Vite emits different chunks per breakpoint and mobile got a slimmer initial bundle.
+
+---
+
+## S2 — Today loaded → click to /training
+
+### cn-pc-2 (passwall2 OFF)
+
+| Metric | Desktop pre | Desktop now | Δ | Mobile pre | Mobile now | Δ |
+|---|---|---|---|---|---|---|
+| FCP (ms) | 568 | 484 | −84 (−15 %) | 500 | 368 | −132 (−26 %) |
+| LCP (ms) | 1100 ⚠ | 4920 | **+3820 (anchor outlier)** | 5336 | 5084 | −252 (−5 %) |
+| TTI (ms) | 19 | 22 | +3 | 25 | 21 | −4 |
+| HTML TTFB (ms) | 5 | 8 | +3 | 9 | 7 | −2 |
+| Static KB | 240.8 | 621.8 | +381.0 (+158 %) | 922.4 | 501.4 | −421.0 (−46 %) |
+| API KB | 37.0 | 35.2 | −1.8 | 50.8 | 48.3 | −2.5 |
+| # reqs | 59 | 63 | +4 | 81 | 66 | −15 |
+| # API calls | 46 | 42 | −4 | 54 | 48 | −6 |
+| API p50 (ms) | 143 | 159 | +16 | 137 | 144 | +7 |
+| API p95 (ms) | 4102 | 4001 | −101 (−2 %) | 4814 | 4196 | **−618 (−13 %)** |
+
+⚠ **S2 desktop LCP 1100 ms in the pre-arc was an explicit outlier** — the d37484b README flagged it: "Mobile LCP 5336 ms vs Desktop 1100 ms is a 5× gap not network-explained… probably one bad iteration." Post-arc desktop and mobile both land around 5 s, consistent with the "chart-needs-API-to-paint" pattern observed everywhere else. The "regression" is the outlier reverting to the mean, not a real slowdown.
+
+### cn-pc (passwall2 ON; no pre-arc S2 baseline)
+
+| Metric | Desktop now | Mobile now |
 |---|---|---|
-| `GET /api/today` | **1839 ms** | 3998 ms |
-| `GET /api/training` | **1954 ms** | 4391 ms |
-| `GET /api/science` | **2067 ms** | 6566 ms |
+| FCP (ms) | 1156 | 692 |
+| LCP (ms) | 12668 | 1220 |
+| TTI (ms) | 21 | 24 |
+| HTML TTFB (ms) | 5 | 7 |
+| API p50 (ms) | 159 | 145 |
+| API p95 (ms) | 5295 | 4706 |
 
-### Architectural inversion confirmed
+### Observations
+
+- **Mobile S2 LCP −5 %, p95 −13 %.** Real wins, modest, expected — Training page is mostly chart-blocked-on-API.
+- **Static KB +158 % desktop, −46 % mobile.** Bundle-split mismatch between viewports — probably worth investigating but small absolute size impact.
+- **cn-pc desktop LCP 12668 ms** — wildly worse than cn-pc-2 desktop 4920 ms. The architectural-inversion fingerprint: passwall ON sends API calls through overseas tunnel before reaching East Asia origin, adding latency the chart paints late.
+
+---
+
+## S3 — Warm repeat visit, /today (PWA shell from cache)
+
+### cn-pc-2 (passwall2 OFF)
+
+| Metric | Desktop pre | Desktop now | Δ | Mobile pre | Mobile now | Δ |
+|---|---|---|---|---|---|---|
+| FCP (ms) | 508 | 484 | −24 (−5 %) | 440 | 364 | −76 (−17 %) |
+| LCP (ms) | 4888 | 5904 | **+1016 (+21 %)** | 9732 | **5452** | **−4280 (−44 %)** |
+| TTI (ms) | 20 | 18 | −2 | 21 | 15 | −6 |
+| HTML TTFB (ms) | 8 | 8 | 0 | 7 | 6 | −1 |
+| Static KB | 334.8 | 246.2 | −88.6 (−26 %) | 902.1 | 1.1 | **−901.0 (−100 %)** |
+| API KB | 45.6 | 33.7 | −11.9 (−26 %) | 45.6 | 44.1 | −1.5 |
+| # reqs | 64 | 60 | −4 | 75 | 57 | −18 |
+| # API calls | 48 | 46 | −2 | 48 | 48 | 0 |
+| API p50 (ms) | 145 | 161 | +16 (+11 %) | 158 | 139 | −19 (−12 %) |
+| API p95 (ms) | 4147 | 4507 | +360 (+9 %) | 4398 | 4452 | +54 (+1 %) |
+
+### cn-pc (passwall2 ON; no pre-arc S3 baseline)
+
+| Metric | Desktop now | Mobile now |
+|---|---|---|
+| FCP (ms) | 476 | 368 |
+| LCP (ms) | 4888 | 5116 |
+| TTI (ms) | 18 | 14 |
+| HTML TTFB (ms) | 7 | 6 |
+| API p50 (ms) | 147 | 171 |
+| API p95 (ms) | 4235 | 4685 |
+
+### Observations
+
+- **Mobile LCP −44 %** — biggest single move on the board. Pre-arc 9732 ms was waiting on `/api/today` (then ~4.4 s) plus chart paint; post-arc both halves of that chain are faster.
+- **Desktop LCP +21 %** — mild regression, σ-bounded at 3 iterations. Worth a follow-up if it reproduces; for now treated as noise.
+- **Mobile Static KB −100 %** (902 → 1.1 KB) — PWA precache fully active on warm visits. Pre-arc PWA wasn't yet in S3 path (PR-122 landed during the arc); now mobile reads the entire shell from disk.
+
+---
+
+## S4 — Anonymous Landing page (no login, pure static delivery)
+
+### cn-pc-2 (passwall2 OFF)
+
+| Metric | Desktop pre (raw) | Desktop now | Δ | Mobile pre (raw) | Mobile now | Δ |
+|---|---|---|---|---|---|---|
+| FCP (ms) | **22476** | **1636** | **−20840 (−93 %)** | **22532** | **1504** | **−21028 (−93 %)** |
+| LCP (ms) | 22476 | 1772 | −20704 (−92 %) | 22532 | 1504 | −21028 (−93 %) |
+| TTI (ms) | 22059 | 432 | −21627 (−98 %) | 22102 | 450 | −21652 (−98 %) |
+| HTML TTFB (ms) | 1009 | 423 | −586 (−58 %) | 1039 | 438 | −601 (−58 %) |
+| Static KB | 1473.3 | 4954.9 | +3481.6 (+236 %) | 1473.2 | 4954.9 | +3481.7 (+236 %) |
+| # reqs | 42 | 105 | +63 (+150 %) | 42 | 105 | +63 (+150 %) |
+| Font CSS TTFB (ms) | — (timeout) | — | — | — | — | — |
+
+### cn-pc (passwall2 ON)
+
+| Metric | Desktop pre (raw) | Desktop now | Δ | Mobile pre (raw) | Mobile now | Δ |
+|---|---|---|---|---|---|---|
+| FCP (ms) | 3000 | **3788** | **+788 (+26 %)** ⚠ | 3264 | 1536 | −1728 (−53 %) |
+| LCP (ms) | 3152 | 3956 | +804 (+25 %) | 3264 | 1536 | −1728 (−53 %) |
+| TTI (ms) | 1407 | 419 | −988 (−70 %) | 1214 | 406 | −808 (−67 %) |
+| HTML TTFB (ms) | 1040 | 409 | −631 (−61 %) | 957 | 396 | −561 (−59 %) |
+| Static KB | 2379.2 | 4954.9 | +2575.7 (+108 %) | 2319.6 | 4954.9 | +2635.3 (+114 %) |
+| # reqs | 52 | 108 | +56 (+108 %) | 53 | 107 | +54 (+102 %) |
+
+⚠ **cn-pc desktop FCP +26 %** is the architectural-inversion fingerprint. Pre-arc, passwall2 ON routed CN traffic through an overseas tunnel which BYPASSED the GFW-throttled CN→AMS path that SWA-Amsterdam was forcing. Post-arc with the origin in East Asia (HK), passwall2 ON now routes CN-ISP→overseas→HK — adding hops that direct CN-ISP→HK doesn't pay. This is the right outcome: friends without VPN now have the optimal path; friends with VPN pay a small tunnel cost to get an architecture that benefits the audience overall.
+
+### Observations
+
+- **The headline win for the audience-without-VPN: 22.5 s → 1.5 s FCP cold landing on raw CN ISP.** That's a 21-second cut per cold visit.
+- **Static KB up across all rows.** Self-hosted fonts (PR-G era) and the larger-but-PWA-friendly bundle are the cause. Bigger absolute payload, but it actually arrives now (pre-arc the WOFF2 fetches were timing out at TLS, never reaching the browser).
+- **Request count up.** Same reason — fonts, vendor chunks, brand assets that previously timed out now successfully fetch.
+
+---
+
+## Cross-endpoint API median (App Insights — server-side, real production traffic)
+
+### Pre-PR-139 (1 week of organic traffic before PR-139 landed)
+
+| Endpoint | Calls | p50 (ms) | p95 (ms) |
+|---|---|---|---|
+| `GET /api/today` | 21 | 5194 | 11887 |
+| `GET /api/training` | 3 | 4127 | 15938 |
+| `GET /api/science` | 11 | 4404 | 15549 |
+| `GET /api/health` | 764 | 8 | 47 |
+| `GET /api/settings` | 8 | 218 | 1098 |
+
+### Post-PR-139 (synthetic-load script, n=30 burst)
+
+| Endpoint | p50 (ms) | p95 (ms) | p50 Δ |
+|---|---|---|---|
+| `GET /api/today` | **1839** | 3998 | −3355 (−65 %) |
+| `GET /api/training` | **1954** | 4391 | −2173 (−53 %) |
+| `GET /api/science` | **2067** | 6566 | −2337 (−53 %) |
+
+The clustering of three endpoints around the same 1.8-2.1 s p50 is the data-side fingerprint of the kitchen-sink anti-pattern in `get_dashboard_data()` — they're all doing the same work. L1 (#146) targets exactly this.
+
+---
+
+## Architectural inversion confirmed
 
 Pre-F4: `cn-pc` (passwall2 ON) was always faster than `cn-pc-2` because passwall2 bypassed the GFW-throttled CN→AMS path that SWA-Amsterdam forced on us.
 
-Post-F4: `cn-pc` (passwall2 ON) is *consistently slower* than `cn-pc-2` on Praxys traffic — direct CN-ISP→HK is a shorter route than CN-ISP→overseas-tunnel→HK now that the origin lives in East Asia. Most visible: S4 desktop FCP `cn-pc` 3788 ms vs `cn-pc-2` 1636 ms.
+Post-F4: `cn-pc` is *consistently slower* on Praxys traffic — direct CN-ISP→HK is a shorter route than CN-ISP→overseas-tunnel→HK now that the origin lives in East Asia. Most visible cells:
+
+| Cell | cn-pc (passwall ON) | cn-pc-2 (passwall OFF) |
+|---|---|---|
+| S4 desktop FCP | 3788 ms | 1636 ms |
+| S2 desktop LCP | 12668 ms | 4920 ms |
+| S2 desktop API p95 | 5295 ms | 4001 ms |
+| S1 mobile API p95 | 4280 ms | 2520 ms |
 
 **Friends in mainland CN without VPN now get the best Praxys experience.** That's the right outcome for the audience.
 
+---
+
 ## What's still slow (and where we go next)
 
-The user's current subjective feel (verbatim, lightly paraphrased):
+The user's current subjective feel:
 
 - Landing (`praxys.run` / `www.praxys.run`): fast cold + warm. Done.
 - **Today + Training: slow on cold load — data and charts take many seconds; nav bar is quick.**
 - Settings, Science: feel fast.
 - Warm Today/Training: better, still not snappy.
 
-Code-read (without instrumentation) found the smoking gun: **five endpoints (`/api/today`, `/api/training`, `/api/goal`, `/api/history`, `/api/science`) all call the same kitchen-sink `get_dashboard_data()` function**, which runs ~22 distinct top-level computations on every request, then each endpoint returns ~15-40 % of the result. The other 60-85 % of work is wasted. The four production endpoints clustering near the same 1.8-2 s p50 (post-PR-139) is the data-side fingerprint of this — they're literally doing the same work.
+Code-read found the smoking gun without instrumentation: **five endpoints (`/api/today`, `/api/training`, `/api/goal`, `/api/history`, `/api/science`) all call the same kitchen-sink `get_dashboard_data()` function**, which runs ~22 distinct top-level computations on every request, then each endpoint returns 15-40 % of the result. The other 60-85 % of work is wasted. The four production endpoints clustering near the same 1.8-2 s p50 (post-PR-139) is the data-side fingerprint.
 
-This is what the next three optimization layers target. Each is a separate piece of work with its own measurement gate before moving on:
+This is what the next three optimization layers target:
 
-| Layer | Issue | Mechanism | Expected Today p50 after |
+| Layer | Issue | Mechanism | Expected `/api/today` p50 after |
 |---|---|---|---|
-| **L1** | (TBD — open after PR-145 lands) | Refactor `get_dashboard_data` into per-endpoint slim functions; routes call only what they need | ~400 ms (4-5× drop) |
-| **L2** | (TBD) | ETag/304 keyed on `(user, latest_sync_timestamp)` — saves bandwidth on warm visits | minimal compute change; cuts the JSON-body re-send cost |
-| **L3** | (TBD) | Materialize per-section caches at sync_writer commit; reads become SELECTs | ~50 ms (≈ instant) |
+| **L1** | [#146](https://github.com/dddtc2005/praxys/issues/146) | Refactor `get_dashboard_data` into per-endpoint slim functions | ~400 ms (4-5× drop) |
+| **L2** | [#147](https://github.com/dddtc2005/praxys/issues/147) | ETag/304 keyed on `(user, latest_sync_timestamp)` — saves bandwidth on warm visits | minimal compute change; cuts the JSON-body re-send cost |
+| **L3** | [#148](https://github.com/dddtc2005/praxys/issues/148) | Materialize per-section caches at sync_writer commit; reads become SELECTs | ~50 ms (≈ instant) |
 
 **L1 is required before L2 and L3 make sense** — without splitting the kitchen-sink, neither caching strategy has a sane invalidation surface. Once L1 lands, L2 is additive and L3 stays in the toolbox until the warm-visit speed of L1 stops feeling adequate.
 
 ## Tooling state
 
-- **Local sitespeed runner** (`scripts/sitespeed_runner.sh`) — works against any URL, supports S1/S2/S3/S4 × desktop/mobile. The cn-pc-2 anchor numbers above all came from this. Gold standard for "what does the operator (and CN audience) actually feel."
-- **Cloud sitespeed runner** (`.github/workflows/perf-baseline.yml`) — currently being rewritten in PR-145: matrix-driven (`scenario × probe × device` = up to 24 cells per dispatch), polling-bug fixed (was hanging cross-region runs by relying on an unreliable state field). Once PR-145 lands, we have reliable Azure-internal probes for eastasia/westus/northeurope to triangulate audience experience without needing the operator's PC.
+- **Local sitespeed runner** (`scripts/sitespeed_runner.sh`) — works against any URL, supports S1/S2/S3/S4 × desktop/mobile. The cn-pc / cn-pc-2 anchor numbers above all came from this. Gold standard for "what does the operator (and CN audience) actually feel."
+- **Cloud sitespeed runner** (`.github/workflows/perf-baseline.yml`) — being rewritten in PR-145: matrix-driven (`scenario × probe × device` = up to 24 cells per dispatch), polling-bug fixed (was hanging cross-region runs by relying on an unreliable state field). Once PR-145 lands, we have reliable Azure-internal probes for eastasia/westus/northeurope to triangulate audience experience without needing the operator's PC. **Cloud-region rows above are still TBD.**
 - **Synthetic-load validator** (`scripts/perf_synthetic_load_check.py`) — drives 30-call bursts against a deployed environment, queries App Insights for server-side p50/p95 vs a baseline window. This is what produced the PR-139 −65 % p50 measurement that synthetic browser baselines couldn't capture cleanly because of small-sample p95 noise. Reusable for every backend perf change.
 - **Azure Monitor alert** — `praxys-today-latency-regression` fires when `/api/today` mean exceeds 3000 ms over a 24-h window. Catches future regressions on real traffic without us having to remember to look.
 
 ## How this checkpoint will be used
 
-The next set of PRs (L1, L2, L3 in order) will each be measured against the numbers in this file. The acceptance gate for each layer is "Today / Training p50 reduces by at least the expected amount, no S4 / Settings / Science regression, security headers still present, suite still green." If a layer doesn't move the number, that's a signal to stop and re-diagnose rather than ship.
+The next set of PRs (L1, L2, L3 in order) will each be measured against the cn-pc-2 column above. The acceptance gate for each layer is "Today / Training p50 reduces by at least the expected amount, no S4 / Settings / Science regression, security headers still present, suite still green." If a layer doesn't move the number, that's a signal to stop and re-diagnose rather than ship.
 
 Anchors-of-anchors:
 - Source-of-truth pre-arc: `2026-04-24-468ce25/`

--- a/docs/perf-baselines/ci-setup.md
+++ b/docs/perf-baselines/ci-setup.md
@@ -4,15 +4,19 @@ This documents the Azure resources + GitHub config that back `.github/workflows/
 
 ## What the workflow does
 
-Trigger: **manual** (`workflow_dispatch`) only. Inputs: `reason`, `probe` (Azure region — `eastasia` / `westus` / `northeurope`), `target_url`, `scenario` (`s1` / `s2` / `s3` / `s4`), `device`.
+Trigger: **manual** (`workflow_dispatch`) only. Inputs: `reason`, `probe` (`all` / `eastasia` / `westus` / `northeurope`), `scenario` (`all` / `s1` / `s2` / `s3` / `s4`), `device` (`both` / `desktop` / `mobile`), `target_url`.
+
+The workflow expands those inputs into a three-axis matrix (`scenario × probe × device`). With defaults (`scenario=all probe=all device=both`) one click produces 24 cells in a single workflow run, all running in parallel via GH Actions matrix (capped at 8 concurrent for ACI quota friendliness). Single-cell runs are still possible — set the specific axis values you want.
+
+Per-cell flow:
 
 1. Uses OIDC to log in to Azure with the same service principal `deploy-backend.yml` uses.
-2. Spins up an Azure Container Instance in the chosen region running `sitespeedio/sitespeed.io:latest`.
-3. ACI mounts an Azure Files share at `/sitespeed.io/out` so the HAR + browsertime output lands somewhere durable.
-4. Polls until the container exits, dumps its stdout log, then downloads the HARs from the share back to the GH runner.
-5. Uploads a GH Actions artifact per cell (one per probe × device pair in the matrix).
-6. Deletes the container + wipes the share path so nothing accumulates.
-7. A final summary job runs `scripts/analyze_baseline.py` across all cells and uploads the populated markdown table as its own artifact.
+2. (For S1/S2/S3) Uploads `scripts/sitespeed_scripts/*.js` preScripts to a `scripts/` subfolder of the perfbaselines share.
+3. Spins up an Azure Container Instance in the cell's region running `sitespeedio/sitespeed.io:latest` with the share mounted at `/sitespeed.io/out`.
+4. Waits for the container to terminate by polling **`exitCode != null`** (not `state == "Terminated"` — that field is unreliable cross-region). 15-min hard timeout; on timeout, downloads whatever made it to the share anyway.
+5. Downloads the cell's HARs back to the runner and uploads as a GH Actions artifact (`baseline-<cell>-<run-id>`).
+6. Deletes the container + wipes the cell's path on the share (`if: always()` — runs even on cell failure).
+7. A final summary job runs `scripts/analyze_baseline.py` across all cells in the run and uploads the populated markdown table as `baseline-combined-<run-id>`.
 
 ## Azure resources
 


### PR DESCRIPTION
## Two-part rewrite of `.github/workflows/perf-baseline.yml`

### Part 1 — fix the cross-region polling hang

Yesterday all 15 cross-region cells (westus + northeurope) hung at the polling step despite the underlying ACIs all reaching `Succeeded` provisioning state. Root cause: the polling loop waited for `containers[0].instanceView.currentState.state == "Terminated"`, which is a field that's reliably set in-region but stays as `Running` cross-region long after the container has actually exited. The GH job timeout (6 h) was the only thing that eventually killed those runs.

Fix:
- **Replace the polling field with `currentState.exitCode != null`.** Exit code is the canonical "container terminated" marker — it's set exactly when the process exits, no cross-region delay.
- **Add a 15-min hard timeout** to the polling loop. On timeout, surface a warning and proceed to download whatever made it to the share — this rescues cells where the container ran but polling lost track.
- **`if: always()`** on the download/upload/cleanup steps so partial-data cells still surface artefacts and clean up resources before the cell marks itself failed.

### Part 2 — matrix sweep, fewer dispatches

Old design: 9 separate `gh workflow run` invocations for a 3 scenario × 3 region sweep, each running its own 2-device matrix internally. 9 GH UI rows to track, 9 separate Azure-login steps, 9 chances to flake at dispatch.

New design: every input axis (`scenario`, `probe`, `device`) accepts `all` or a specific value. With defaults (`scenario=all probe=all device=both`) one click produces 24 cells in a single workflow run. Single-cell runs still work the same way — just set specific values. Matrix concurrency capped at 8 to be friendly to ACI per-region quotas.

## Why both in one PR

Both touch the same workflow file, in adjacent regions, and they're complementary:
- The matrix change reduces the number of dispatch-time failure points.
- The polling fix removes the per-cell hang.
- Together they make a 24-cell sweep go from "9 separate dispatches each gambling on cross-region polling" to "one click, exit-code-based completion, 15-min timeout fallback".

## Doc updates

- `docs/perf-baselines/ci-setup.md` — reflects the matrix UX and new polling behaviour.
- `docs/perf-baselines/2026-04-26-checkpoint.md` — **new file**. Consolidated snapshot of where Praxys' user-perceived perf stands after Phase-1 #1, F2, PR-139, and F4. Acts as the explicit before-reference for the L1/L2/L3 optimization arc so each future PR has a single numerical target instead of stitching across four different baseline READMEs.

## Test plan

- [x] YAML validates (`yaml.safe_load` clean)
- [ ] Post-merge: dispatch the workflow with **all defaults** and confirm 24 cells run in parallel, finish within ~10-15 min wall clock, all upload artefacts. The polling fix is the headline; if any cell hangs >15 min that's a regression.
- [ ] Post-merge: dispatch a single-cell run (`scenario=s1 probe=westus device=desktop`) and confirm backward compatibility — same shape as today's UX, just one cell.
- [ ] If the sweep is healthy, write the next checkpoint baseline as the L1 target.

## What this PR is NOT

This doesn't add or remove any measurement scenarios. It doesn't change S1/S2/S3/S4 semantics, doesn't change preScript handling, doesn't change devices. Pure reliability + ergonomics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)