### PR TITLE
Harden auth surface and add legal disclosures for public release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,16 @@ PRAXYS_LOCAL_ENCRYPTION_KEY=
 # and is always granted admin privileges. Not needed if you're the first user.
 # PRAXYS_ADMIN_EMAIL=
 
+# Optional: Authentication rate limiter (api/auth_rate_limit.py).
+#   Caps per-IP attempts on /api/auth/login, /api/auth/register, and the
+#   /api/auth/wechat/* endpoints. Enabled by default in any deployment.
+#   Set to "true" to disable for tests / local development. Adjust
+#   PRAXYS_TRUSTED_PROXY_HOPS when you have multiple reverse proxies in
+#   front of the app (default 1 = trust the rightmost X-Forwarded-For
+#   entry, which is correct for a vanilla Azure App Service deployment).
+# PRAXYS_AUTH_RATE_LIMIT_DISABLED=false
+# PRAXYS_TRUSTED_PROXY_HOPS=1
+
 # Optional: Strava OAuth app credentials for browser-based Strava connect.
 # Activities-only sync uses these to exchange and refresh tokens.
 # Register the callback URL shown below in your Strava app settings.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,21 @@ For sample data without API credentials: `python scripts/seed_sample_data.py`
 - [API Reference](docs/dev/api-reference.md)
 - [Contributing](docs/dev/contributing.md)
 - [Webhook Feasibility (Oura + Garmin)](docs/studies/webhook-feasibility.md)
+
+## Legal
+
+### License
+
+Praxys is released under the [MIT License](LICENSE).
+
+### Trademarks
+
+Garmin, Stryd, Oura, and WeChat are trademarks of their respective owners. Praxys is not affiliated with, endorsed by, or sponsored by any of these companies. Logos and names are used solely to identify the data sources the app can sync from.
+
+### Third-party data sources
+
+- **Garmin Connect** — synced via the unofficial [`garminconnect`](https://github.com/cyberjunky/python-garminconnect) Python library. There is no official Garmin partnership; the integration depends on Garmin's consumer web endpoints continuing to work. Garmin's [Terms of Use](https://www.garmin.com/en-US/legal/general-terms-of-use/) restrict automated access — use at your own risk.
+- **Stryd** — synced via the same email/password endpoints the Stryd web app uses. There is no official partner API for individual users. Same risk class as Garmin.
+- **Oura Ring** — synced via the [official Oura API v2](https://cloud.ouraring.com/v2/docs) using a Personal Access Token. This is a supported integration path.
+
+You retain full ownership of your data. Praxys stores it on your own database (local for local development, your own Azure deployment for cloud).

--- a/api/auth_rate_limit.py
+++ b/api/auth_rate_limit.py
@@ -18,10 +18,10 @@ Endpoints covered
 
 Implementation notes
 --------------------
-- In-memory sliding window per (path, client_ip), backed by a ``deque``
-  of timestamps. ``OrderedDict`` of buckets is LRU-bounded so a malicious
-  enumerator cannot OOM the worker.
-- On Azure App Service with N gunicorn workers the effective ceiling is
+- In-memory sliding window per ``(path, client_ip)``, backed by a deque
+  of monotonic timestamps. The bucket ``OrderedDict`` is LRU-bounded so a
+  malicious enumerator cannot OOM the worker.
+- Per-process state. With N gunicorn workers the effective ceiling is
   N × the configured value — acceptable as defense against unsophisticated
   brute force, not a sophisticated DoS. Move to a Redis-backed limiter
   if cross-worker enforcement matters.
@@ -36,26 +36,39 @@ Implementation notes
 """
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import logging
 import os
 import threading
 import time
 from collections import OrderedDict, deque
-from typing import Mapping
+from types import MappingProxyType
+from typing import Any, Awaitable, Callable, Mapping, MutableMapping
 
 logger = logging.getLogger(__name__)
 
-# (path, (max_requests, window_seconds)). The limits are tuned for a
-# small user base: tight enough that brute force is infeasible, loose
-# enough that a real user accidentally hammering "login" doesn't get
-# locked out for the day.
-DEFAULT_LIMITS: dict[str, tuple[int, int]] = {
+# ASGI-style aliases so this file doesn't pull starlette.types into a
+# hot path. Matches the shapes Starlette/uvicorn pass through.
+Scope = MutableMapping[str, Any]
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+ASGIApp = Callable[..., Awaitable[None]]
+
+# (max_requests, window_seconds) per path. Tuned for a small user base:
+# tight enough that brute force is infeasible, loose enough that a real
+# user fat-fingering "login" doesn't get locked out for the day. Wrapped
+# in MappingProxyType so a stray import-time mutation can't silently
+# weaken the limiter.
+_DEFAULT_LIMITS_RAW: dict[str, tuple[int, int]] = {
     "/api/auth/login":                       (10, 5 * 60),
     "/api/auth/register":                    (5, 60 * 60),
     "/api/auth/wechat/login":                (30, 5 * 60),
     "/api/auth/wechat/link-with-password":   (10, 15 * 60),
     "/api/auth/wechat/register":             (5, 60 * 60),
 }
+DEFAULT_LIMITS: Mapping[str, tuple[int, int]] = MappingProxyType(
+    _DEFAULT_LIMITS_RAW
+)
 
 _DEFAULT_MAX_TRACKED_CLIENTS = 10_000
 
@@ -66,6 +79,12 @@ class _SlidingWindow:
     __slots__ = ("limit", "window_secs", "_buckets", "_lock", "_max_clients")
 
     def __init__(self, limit: int, window_secs: int, max_clients: int):
+        if limit < 1 or window_secs < 1 or max_clients < 1:
+            raise ValueError(
+                "_SlidingWindow requires limit>=1, window_secs>=1, "
+                f"max_clients>=1; got limit={limit}, "
+                f"window_secs={window_secs}, max_clients={max_clients}"
+            )
         self.limit = limit
         self.window_secs = window_secs
         self._buckets: OrderedDict[str, deque[float]] = OrderedDict()
@@ -100,7 +119,38 @@ class _SlidingWindow:
         return True, 0
 
 
-def _client_ip(scope) -> str:
+def _parse_xff_entry(raw: str) -> str | None:
+    """Extract a normalized IP from a single X-Forwarded-For entry.
+
+    Handles four shapes seen in the wild:
+        "1.2.3.4"             — bare IPv4
+        "1.2.3.4:443"         — IPv4 with port
+        "2001:db8::1"         — bare IPv6
+        "[2001:db8::1]:443"   — bracketed IPv6 with port (RFC 7239)
+
+    Returns ``None`` for unparseable input so the caller can choose a
+    safe fallback (the ASGI socket peer) instead of conflating every
+    bad-XFF caller into a single bucket.
+    """
+    e = raw.strip()
+    if not e:
+        return None
+    if e.startswith("["):
+        end = e.find("]")
+        if end > 0:
+            e = e[1:end]
+        else:
+            return None
+    elif e.count(":") == 1:
+        e = e.split(":", 1)[0]
+    try:
+        ipaddress.ip_address(e)
+    except ValueError:
+        return None
+    return e
+
+
+def _client_ip(scope: Scope) -> str:
     """Best-effort client IP for rate-limit bucketing.
 
     Trusts the rightmost X-Forwarded-For entry — that's what the immediate
@@ -108,30 +158,55 @@ def _client_ip(scope) -> str:
     (single proxy hop). Leftmost entries are client-controlled and
     forgeable. Tune ``PRAXYS_TRUSTED_PROXY_HOPS`` to walk further left when
     the proxy chain is fixed and longer.
+
+    Falls back to the ASGI socket peer if XFF is absent, malformed, or
+    parses to an invalid IP. We deliberately do *not* fall back to a
+    shared sentinel like ``"unknown"`` — that would conflate every
+    bad-XFF caller into a single bucket and let one misbehaving upstream
+    lock out every legitimate client.
     """
+    raw_hops = os.environ.get("PRAXYS_TRUSTED_PROXY_HOPS", "1")
     try:
-        hops = max(0, int(os.environ.get("PRAXYS_TRUSTED_PROXY_HOPS", "1")))
+        hops = max(0, int(raw_hops))
     except ValueError:
+        logger.warning(
+            "PRAXYS_TRUSTED_PROXY_HOPS=%r is not an int; defaulting to 1",
+            raw_hops,
+        )
         hops = 1
 
     if hops > 0:
         for name, value in scope.get("headers", ()):
             if name == b"x-forwarded-for":
                 entries = [
-                    e.strip().split(":")[0]
-                    for e in value.decode("latin-1").split(",")
-                    if e.strip()
+                    e for e in (
+                        s.strip() for s in value.decode("latin-1").split(",")
+                    )
+                    if e
                 ]
                 if entries:
                     idx = max(0, len(entries) - hops)
-                    return entries[idx] or "unknown"
+                    parsed = _parse_xff_entry(entries[idx])
+                    if parsed:
+                        return parsed
+                    logger.warning(
+                        "rate-limit: unparseable XFF entry %r; "
+                        "falling back to ASGI socket peer",
+                        entries[idx],
+                    )
                 break
 
     client = scope.get("client")
     return client[0] if client else "unknown"
 
 
-async def _send_429(send, retry_after: int) -> None:
+async def _send_429(send: Send, retry_after: int) -> None:
+    """Emit a 429 with a JSON body and Retry-After header.
+
+    Swallows the narrow set of exceptions raised when the client
+    disconnects mid-response — the throttle is already recorded; no need
+    to bubble a teardown error up through Starlette's error logger.
+    """
     body = (
         b'{"detail":"AUTH_RATE_LIMITED","retry_after":'
         + str(retry_after).encode()
@@ -142,53 +217,68 @@ async def _send_429(send, retry_after: int) -> None:
         (b"retry-after", str(retry_after).encode()),
         (b"content-length", str(len(body)).encode()),
     ]
-    await send({"type": "http.response.start", "status": 429, "headers": headers})
-    await send({"type": "http.response.body", "body": body})
+    try:
+        await send({"type": "http.response.start", "status": 429, "headers": headers})
+        await send({"type": "http.response.body", "body": body})
+    except (OSError, RuntimeError, asyncio.CancelledError) as exc:
+        logger.debug("client disconnected before 429 sent: %s", exc)
+
+
+def _normalize_path(path: str) -> str:
+    """Strip a single trailing slash so ``/api/auth/login`` and
+    ``/api/auth/login/`` map to the same window. The root ``/`` is kept
+    as-is so we don't collapse it to an empty string."""
+    return path.rstrip("/") or path
 
 
 class AuthRateLimitMiddleware:
     """ASGI middleware enforcing per-path per-IP auth rate limits.
 
-    Only HTTP requests whose path matches a configured limit are
-    inspected; all other traffic short-circuits with no overhead beyond a
+    Only HTTP requests whose (normalized) path matches a configured
+    limit are inspected; all other traffic short-circuits with a single
     dict lookup.
     """
 
     def __init__(
         self,
-        app,
+        app: ASGIApp,
         limits: Mapping[str, tuple[int, int]] | None = None,
         max_tracked_clients: int = _DEFAULT_MAX_TRACKED_CLIENTS,
     ):
         self.app = app
-        self._windows = {
-            path: _SlidingWindow(limit, window, max_tracked_clients)
-            for path, (limit, window) in (limits or DEFAULT_LIMITS).items()
+        effective = limits if limits is not None else DEFAULT_LIMITS
+        self._windows: dict[str, _SlidingWindow] = {
+            _normalize_path(path): _SlidingWindow(limit, window, max_tracked_clients)
+            for path, (limit, window) in effective.items()
         }
+        logger.info(
+            "AuthRateLimitMiddleware enabled for: %s",
+            sorted(self._windows),
+        )
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(self, scope: Scope, receive, send: Send) -> None:
         if scope.get("type") != "http":
             await self.app(scope, receive, send)
             return
-        window = self._windows.get(scope.get("path", ""))
+        path = _normalize_path(scope.get("path", ""))
+        window = self._windows.get(path)
         if window is None:
             await self.app(scope, receive, send)
             return
         ip = _client_ip(scope)
-        key = f"{scope['path']}|{ip}"
-        allowed, retry_after = window.check_and_record(key)
+        allowed, retry_after = window.check_and_record(ip)
         if allowed:
             await self.app(scope, receive, send)
             return
         logger.warning(
             "auth rate limit hit ip=%s path=%s retry_after=%ds",
-            ip, scope["path"], retry_after,
+            ip, path, retry_after,
         )
         await _send_429(send, retry_after)
 
 
 def is_rate_limit_disabled() -> bool:
     """True when ``PRAXYS_AUTH_RATE_LIMIT_DISABLED`` opts out (tests, dev)."""
-    return os.environ.get("PRAXYS_AUTH_RATE_LIMIT_DISABLED", "").lower() in {
+    return os.environ.get("PRAXYS_AUTH_RATE_LIMIT_DISABLED", "").strip().lower() in {
         "1", "true", "yes", "on",
     }

--- a/api/auth_rate_limit.py
+++ b/api/auth_rate_limit.py
@@ -1,0 +1,194 @@
+"""Per-IP sliding-window rate limiter for the authentication surface.
+
+Why this module exists
+----------------------
+Praxys is open-source on GitHub. Anyone can read api/routes/register.py,
+api/routes/wechat.py, and the FastAPI-Users login route to learn the
+exact request shapes. This middleware caps per-IP attempts on the auth
+surface so credential-stuffing and invitation-code-bruteforcing become
+infeasible, even though the endpoint contracts are public.
+
+Endpoints covered
+-----------------
+- /api/auth/login                       (FastAPI-Users JWT login)
+- /api/auth/register                    (custom invite-aware register)
+- /api/auth/wechat/login
+- /api/auth/wechat/register
+- /api/auth/wechat/link-with-password
+
+Implementation notes
+--------------------
+- In-memory sliding window per (path, client_ip), backed by a ``deque``
+  of timestamps. ``OrderedDict`` of buckets is LRU-bounded so a malicious
+  enumerator cannot OOM the worker.
+- On Azure App Service with N gunicorn workers the effective ceiling is
+  N × the configured value — acceptable as defense against unsophisticated
+  brute force, not a sophisticated DoS. Move to a Redis-backed limiter
+  if cross-worker enforcement matters.
+- Client-IP resolution trusts the *rightmost* X-Forwarded-For entry. The
+  leftmost is client-controlled (forgeable); the rightmost is what the
+  immediate upstream proxy observed and is therefore safe on a single-hop
+  Azure App Service deployment. ``PRAXYS_TRUSTED_PROXY_HOPS`` lets an
+  operator walk further left when the proxy chain is longer (e.g.
+  Front Door → App Service).
+- Disable entirely with ``PRAXYS_AUTH_RATE_LIMIT_DISABLED=true`` for
+  tests / local dev.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict, deque
+from typing import Mapping
+
+logger = logging.getLogger(__name__)
+
+# (path, (max_requests, window_seconds)). The limits are tuned for a
+# small user base: tight enough that brute force is infeasible, loose
+# enough that a real user accidentally hammering "login" doesn't get
+# locked out for the day.
+DEFAULT_LIMITS: dict[str, tuple[int, int]] = {
+    "/api/auth/login":                       (10, 5 * 60),
+    "/api/auth/register":                    (5, 60 * 60),
+    "/api/auth/wechat/login":                (30, 5 * 60),
+    "/api/auth/wechat/link-with-password":   (10, 15 * 60),
+    "/api/auth/wechat/register":             (5, 60 * 60),
+}
+
+_DEFAULT_MAX_TRACKED_CLIENTS = 10_000
+
+
+class _SlidingWindow:
+    """Per-key bounded deque of recent request timestamps."""
+
+    __slots__ = ("limit", "window_secs", "_buckets", "_lock", "_max_clients")
+
+    def __init__(self, limit: int, window_secs: int, max_clients: int):
+        self.limit = limit
+        self.window_secs = window_secs
+        self._buckets: OrderedDict[str, deque[float]] = OrderedDict()
+        self._lock = threading.Lock()
+        self._max_clients = max_clients
+
+    def check_and_record(self, key: str) -> tuple[bool, int]:
+        """Return ``(allowed, retry_after_seconds)``.
+
+        ``retry_after_seconds`` is 0 when the call is allowed, and the
+        smallest integer wait for the oldest in-window entry to expire
+        when blocked.
+        """
+        now = time.monotonic()
+        cutoff = now - self.window_secs
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = deque()
+                self._buckets[key] = bucket
+            else:
+                self._buckets.move_to_end(key)
+            while bucket and bucket[0] < cutoff:
+                bucket.popleft()
+            if len(bucket) >= self.limit:
+                oldest = bucket[0]
+                retry = int(oldest + self.window_secs - now) + 1
+                return False, max(1, retry)
+            bucket.append(now)
+            while len(self._buckets) > self._max_clients:
+                self._buckets.popitem(last=False)
+        return True, 0
+
+
+def _client_ip(scope) -> str:
+    """Best-effort client IP for rate-limit bucketing.
+
+    Trusts the rightmost X-Forwarded-For entry — that's what the immediate
+    upstream proxy observed and is the safe choice on Azure App Service
+    (single proxy hop). Leftmost entries are client-controlled and
+    forgeable. Tune ``PRAXYS_TRUSTED_PROXY_HOPS`` to walk further left when
+    the proxy chain is fixed and longer.
+    """
+    try:
+        hops = max(0, int(os.environ.get("PRAXYS_TRUSTED_PROXY_HOPS", "1")))
+    except ValueError:
+        hops = 1
+
+    if hops > 0:
+        for name, value in scope.get("headers", ()):
+            if name == b"x-forwarded-for":
+                entries = [
+                    e.strip().split(":")[0]
+                    for e in value.decode("latin-1").split(",")
+                    if e.strip()
+                ]
+                if entries:
+                    idx = max(0, len(entries) - hops)
+                    return entries[idx] or "unknown"
+                break
+
+    client = scope.get("client")
+    return client[0] if client else "unknown"
+
+
+async def _send_429(send, retry_after: int) -> None:
+    body = (
+        b'{"detail":"AUTH_RATE_LIMITED","retry_after":'
+        + str(retry_after).encode()
+        + b"}"
+    )
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"retry-after", str(retry_after).encode()),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    await send({"type": "http.response.start", "status": 429, "headers": headers})
+    await send({"type": "http.response.body", "body": body})
+
+
+class AuthRateLimitMiddleware:
+    """ASGI middleware enforcing per-path per-IP auth rate limits.
+
+    Only HTTP requests whose path matches a configured limit are
+    inspected; all other traffic short-circuits with no overhead beyond a
+    dict lookup.
+    """
+
+    def __init__(
+        self,
+        app,
+        limits: Mapping[str, tuple[int, int]] | None = None,
+        max_tracked_clients: int = _DEFAULT_MAX_TRACKED_CLIENTS,
+    ):
+        self.app = app
+        self._windows = {
+            path: _SlidingWindow(limit, window, max_tracked_clients)
+            for path, (limit, window) in (limits or DEFAULT_LIMITS).items()
+        }
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        window = self._windows.get(scope.get("path", ""))
+        if window is None:
+            await self.app(scope, receive, send)
+            return
+        ip = _client_ip(scope)
+        key = f"{scope['path']}|{ip}"
+        allowed, retry_after = window.check_and_record(key)
+        if allowed:
+            await self.app(scope, receive, send)
+            return
+        logger.warning(
+            "auth rate limit hit ip=%s path=%s retry_after=%ds",
+            ip, scope["path"], retry_after,
+        )
+        await _send_429(send, retry_after)
+
+
+def is_rate_limit_disabled() -> bool:
+    """True when ``PRAXYS_AUTH_RATE_LIMIT_DISABLED`` opts out (tests, dev)."""
+    return os.environ.get("PRAXYS_AUTH_RATE_LIMIT_DISABLED", "").lower() in {
+        "1", "true", "yes", "on",
+    }

--- a/api/main.py
+++ b/api/main.py
@@ -117,6 +117,12 @@ if not os.environ.get("WEBSITE_SITE_NAME"):
         allow_headers=["*"],
     )
 
+# Per-IP rate limit on the auth surface — see api/auth_rate_limit.py for the
+# threat model. Skipped only when explicitly disabled (tests / local dev).
+from api.auth_rate_limit import AuthRateLimitMiddleware, is_rate_limit_disabled
+if not is_rate_limit_disabled():
+    app.add_middleware(AuthRateLimitMiddleware)
+
 # Auth routes
 from api.users import fastapi_users, auth_backend
 

--- a/api/main.py
+++ b/api/main.py
@@ -120,7 +120,12 @@ if not os.environ.get("WEBSITE_SITE_NAME"):
 # Per-IP rate limit on the auth surface — see api/auth_rate_limit.py for the
 # threat model. Skipped only when explicitly disabled (tests / local dev).
 from api.auth_rate_limit import AuthRateLimitMiddleware, is_rate_limit_disabled
-if not is_rate_limit_disabled():
+if is_rate_limit_disabled():
+    logging.getLogger(__name__).warning(
+        "Auth rate limit disabled by PRAXYS_AUTH_RATE_LIMIT_DISABLED — "
+        "/api/auth/* endpoints accept unlimited attempts per IP."
+    )
+else:
     app.add_middleware(AuthRateLimitMiddleware)
 
 # Auth routes

--- a/tests/test_auth_rate_limit.py
+++ b/tests/test_auth_rate_limit.py
@@ -17,8 +17,11 @@ from fastapi.testclient import TestClient
 
 from api.auth_rate_limit import (
     AuthRateLimitMiddleware,
+    DEFAULT_LIMITS,
     _SlidingWindow,
     _client_ip,
+    _normalize_path,
+    _parse_xff_entry,
     is_rate_limit_disabled,
 )
 
@@ -36,14 +39,16 @@ def test_sliding_window_allows_under_limit():
         assert retry == 0
 
 
-def test_sliding_window_blocks_at_limit_with_retry_after():
+def test_sliding_window_blocks_at_limit_with_bounded_retry_after():
     win = _SlidingWindow(limit=2, window_secs=60, max_clients=10)
     win.check_and_record("ip-a")
     win.check_and_record("ip-a")
     allowed, retry = win.check_and_record("ip-a")
     assert allowed is False
-    # Retry-After is bounded by the window length.
-    assert 1 <= retry <= 60
+    # Retry-After is bounded above by the window length plus a 1-second
+    # rounding margin; below by 1 (we never advise the client to retry
+    # immediately when blocked).
+    assert 1 <= retry <= 61
 
 
 def test_sliding_window_separates_keys():
@@ -67,21 +72,75 @@ def test_sliding_window_evicts_old_entries(monkeypatch):
     assert win.check_and_record("ip-a") == (True, 0)
 
 
-def test_sliding_window_lru_caps_tracked_clients():
+def test_sliding_window_lru_evicts_least_recent_and_tracks_recency():
+    """Inserting beyond ``max_clients`` removes the least-recently-used
+    bucket; touching an existing key promotes it via ``move_to_end`` so
+    a different key gets evicted on the next overflow."""
     win = _SlidingWindow(limit=10, window_secs=60, max_clients=2)
     win.check_and_record("ip-a")
     win.check_and_record("ip-b")
-    win.check_and_record("ip-c")  # forces eviction of ip-a (oldest)
-    # Re-recording ip-a creates a new bucket; previous count is gone.
-    # If LRU did not evict, ip-a would still count as 1 here, but with
-    # eviction we observe it as fresh.
-    bucket_a_size_after = len(win._buckets["ip-a"]) if "ip-a" in win._buckets else 0
-    assert bucket_a_size_after == 0 or "ip-a" not in win._buckets
+    win.check_and_record("ip-c")  # forces eviction of the LRU (ip-a)
+    assert "ip-a" not in win._buckets
+    assert list(win._buckets.keys()) == ["ip-b", "ip-c"]
+
+    # Touching ip-b promotes it; ip-c is now the LRU and must be evicted
+    # when ip-d arrives.
+    win.check_and_record("ip-b")
+    assert list(win._buckets.keys()) == ["ip-c", "ip-b"]
+    win.check_and_record("ip-d")
+    assert list(win._buckets.keys()) == ["ip-b", "ip-d"]
+
+
+@pytest.mark.parametrize(
+    "limit,window,max_clients",
+    [
+        (0, 60, 10),
+        (1, 0, 10),
+        (1, 60, 0),
+        (-1, 60, 10),
+    ],
+)
+def test_sliding_window_rejects_nonpositive_args(limit, window, max_clients):
+    """A misconfigured window would fail silently (limit=0 → always block;
+    max_clients=0 → every bucket evicted on insert). Better to refuse to
+    construct it at all."""
+    with pytest.raises(ValueError):
+        _SlidingWindow(limit=limit, window_secs=window, max_clients=max_clients)
 
 
 # ---------------------------------------------------------------------------
-# _client_ip unit tests
+# _parse_xff_entry / _client_ip unit tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1.2.3.4", "1.2.3.4"),
+        ("1.2.3.4:443", "1.2.3.4"),
+        ("2001:db8::1", "2001:db8::1"),
+        ("[2001:db8::1]:443", "2001:db8::1"),
+        ("[::1]", "::1"),
+        ("  2001:db8::1  ", "2001:db8::1"),
+    ],
+)
+def test_parse_xff_entry_accepts_valid_forms(raw, expected):
+    assert _parse_xff_entry(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "not-an-ip",
+        "real-1.2.3.4",
+        "1.2.3.4.5",
+        "[2001:db8::1",  # missing closing bracket
+        ":::",
+    ],
+)
+def test_parse_xff_entry_rejects_invalid(raw):
+    assert _parse_xff_entry(raw) is None
 
 
 def _scope_with_xff(xff_value: bytes) -> dict:
@@ -94,14 +153,36 @@ def _scope_with_xff(xff_value: bytes) -> dict:
 
 def test_client_ip_trusts_rightmost_by_default(monkeypatch):
     monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
-    scope = _scope_with_xff(b"forged-leftmost, real-1.2.3.4")
-    assert _client_ip(scope) == "real-1.2.3.4"
+    scope = _scope_with_xff(b"203.0.113.7, 198.51.100.42")
+    assert _client_ip(scope) == "198.51.100.42"
 
 
-def test_client_ip_strips_port_suffix(monkeypatch):
+def test_client_ip_strips_ipv4_port_suffix(monkeypatch):
     monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
-    scope = _scope_with_xff(b"5.6.7.8:443")
-    assert _client_ip(scope) == "5.6.7.8"
+    assert _client_ip(_scope_with_xff(b"5.6.7.8:443")) == "5.6.7.8"
+
+
+def test_client_ip_handles_bare_ipv6(monkeypatch):
+    """Bare IPv6 must NOT be split on the first colon — that bug would
+    collapse every IPv6 client into a single "2001" bucket."""
+    monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
+    assert _client_ip(_scope_with_xff(b"2001:db8::1")) == "2001:db8::1"
+
+
+def test_client_ip_handles_bracketed_ipv6_with_port(monkeypatch):
+    monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
+    assert _client_ip(_scope_with_xff(b"[2001:db8::1]:443")) == "2001:db8::1"
+
+
+def test_client_ip_falls_back_to_scope_client_when_xff_invalid(monkeypatch, caplog):
+    monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
+    scope = _scope_with_xff(b"garbage-not-an-ip")
+    scope["client"] = ("9.9.9.9", 1)
+    with caplog.at_level("WARNING", logger="api.auth_rate_limit"):
+        assert _client_ip(scope) == "9.9.9.9"
+    assert any(
+        "unparseable XFF entry" in r.message for r in caplog.records
+    )
 
 
 def test_client_ip_falls_back_to_scope_client_when_xff_absent():
@@ -111,16 +192,59 @@ def test_client_ip_falls_back_to_scope_client_when_xff_absent():
 
 def test_client_ip_respects_proxy_hops(monkeypatch):
     monkeypatch.setenv("PRAXYS_TRUSTED_PROXY_HOPS", "2")
-    scope = _scope_with_xff(b"orig, hop1, hop2")
+    scope = _scope_with_xff(b"203.0.113.7, 198.51.100.42, 192.0.2.5")
     # With 2 trusted hops we walk one entry left of the rightmost.
-    assert _client_ip(scope) == "hop1"
+    assert _client_ip(scope) == "198.51.100.42"
 
 
 def test_client_ip_zero_hops_ignores_xff(monkeypatch):
     monkeypatch.setenv("PRAXYS_TRUSTED_PROXY_HOPS", "0")
-    scope = _scope_with_xff(b"forged, also-forged")
+    scope = _scope_with_xff(b"1.2.3.4, 5.6.7.8")
     scope["client"] = ("9.9.9.9", 1)
     assert _client_ip(scope) == "9.9.9.9"
+
+
+def test_client_ip_logs_warning_on_malformed_hops(monkeypatch, caplog):
+    monkeypatch.setenv("PRAXYS_TRUSTED_PROXY_HOPS", "two")
+    scope = _scope_with_xff(b"203.0.113.7, 198.51.100.42")
+    with caplog.at_level("WARNING", logger="api.auth_rate_limit"):
+        # Falls back to hops=1 → rightmost entry.
+        assert _client_ip(scope) == "198.51.100.42"
+    assert any(
+        "PRAXYS_TRUSTED_PROXY_HOPS" in r.message for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# _normalize_path unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/api/auth/login", "/api/auth/login"),
+        ("/api/auth/login/", "/api/auth/login"),
+        ("/api/auth/login///", "/api/auth/login"),
+        ("/", "/"),
+        ("", ""),
+    ],
+)
+def test_normalize_path(raw, expected):
+    assert _normalize_path(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_LIMITS immutability
+# ---------------------------------------------------------------------------
+
+
+def test_default_limits_is_immutable():
+    """A stray import-time mutation of the module-level limits dict
+    would silently weaken every subsequently-instantiated middleware.
+    The MappingProxyType wrapper closes that hole."""
+    with pytest.raises(TypeError):
+        DEFAULT_LIMITS["/api/auth/login"] = (10000, 1)  # type: ignore[index]
 
 
 # ---------------------------------------------------------------------------
@@ -165,18 +289,18 @@ def _xff(ip: str) -> dict:
 
 def test_middleware_allows_under_limit(rl_client):
     for _ in range(3):
-        r = rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+        r = rl_client.post("/api/auth/login", headers=_xff("198.51.100.1"))
         assert r.status_code == 200, r.text
 
 
 def test_middleware_blocks_with_retry_after(rl_client):
     for _ in range(3):
-        rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
-    blocked = rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+        rl_client.post("/api/auth/login", headers=_xff("198.51.100.1"))
+    blocked = rl_client.post("/api/auth/login", headers=_xff("198.51.100.1"))
     assert blocked.status_code == 429
     payload = blocked.json()
     assert payload["detail"] == "AUTH_RATE_LIMITED"
-    assert payload["retry_after"] >= 1
+    assert 1 <= payload["retry_after"] <= 61
     assert int(blocked.headers["retry-after"]) >= 1
     assert blocked.headers["content-type"].startswith("application/json")
 
@@ -184,25 +308,46 @@ def test_middleware_blocks_with_retry_after(rl_client):
 def test_middleware_separates_ips(rl_client):
     """Different X-Forwarded-For values get independent buckets."""
     for _ in range(3):
-        rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
-    # 1.1.1.1 is now blocked, but 2.2.2.2 should still pass.
-    assert rl_client.post("/api/auth/login", headers=_xff("1.1.1.1")).status_code == 429
-    assert rl_client.post("/api/auth/login", headers=_xff("2.2.2.2")).status_code == 200
+        rl_client.post("/api/auth/login", headers=_xff("198.51.100.1"))
+    assert rl_client.post("/api/auth/login", headers=_xff("198.51.100.1")).status_code == 429
+    assert rl_client.post("/api/auth/login", headers=_xff("203.0.113.2")).status_code == 200
 
 
 def test_middleware_separates_paths(rl_client):
     """A login bucket exhaustion does not block a register attempt."""
     for _ in range(3):
-        rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
-    assert rl_client.post("/api/auth/login", headers=_xff("1.1.1.1")).status_code == 429
+        rl_client.post("/api/auth/login", headers=_xff("198.51.100.1"))
+    assert rl_client.post("/api/auth/login", headers=_xff("198.51.100.1")).status_code == 429
     # Register has its own bucket and limit (2).
-    assert rl_client.post("/api/auth/register", headers=_xff("1.1.1.1")).status_code == 200
+    assert rl_client.post("/api/auth/register", headers=_xff("198.51.100.1")).status_code == 200
+
+
+def test_middleware_normalizes_trailing_slash(rl_client):
+    """`/api/auth/login` and `/api/auth/login/` share one bucket so an
+    attacker can't bypass the limiter by appending a slash."""
+    for _ in range(3):
+        rl_client.post("/api/auth/login/", headers=_xff("198.51.100.1"))
+    blocked = rl_client.post("/api/auth/login", headers=_xff("198.51.100.1"))
+    assert blocked.status_code == 429
+
+
+def test_middleware_separates_ipv6_from_ipv4(rl_client):
+    """The IPv6 parser fix is load-bearing: without it `2001:db8::1`
+    would be truncated to `2001` and bucket alongside everyone else's
+    truncated IPv6."""
+    for _ in range(3):
+        rl_client.post("/api/auth/login", headers=_xff("2001:db8::1"))
+    # IPv4 client must still be able to log in.
+    assert rl_client.post("/api/auth/login", headers=_xff("198.51.100.1")).status_code == 200
+    # And a *different* IPv6 client must too — they parsed to a distinct
+    # bucket, which would not have been the case under the old split-on-":".
+    assert rl_client.post("/api/auth/login", headers=_xff("2001:db8::2")).status_code == 200
 
 
 def test_middleware_ignores_unconfigured_paths(rl_client):
     """Health is not in the limits dict; never rate-limited."""
     for _ in range(20):
-        r = rl_client.get("/api/health", headers=_xff("1.1.1.1"))
+        r = rl_client.get("/api/health", headers=_xff("198.51.100.1"))
         assert r.status_code == 200
 
 
@@ -211,7 +356,7 @@ def test_middleware_ignores_unconfigured_paths(rl_client):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on", "  true  "])
 def test_disable_flag_recognizes_truthy_values(monkeypatch, value):
     monkeypatch.setenv("PRAXYS_AUTH_RATE_LIMIT_DISABLED", value)
     assert is_rate_limit_disabled() is True

--- a/tests/test_auth_rate_limit.py
+++ b/tests/test_auth_rate_limit.py
@@ -1,0 +1,223 @@
+"""Tests for the auth-endpoint rate limiter (api/auth_rate_limit.py).
+
+Two layers of coverage:
+
+- ``_SlidingWindow`` is exercised directly with a stubbed clock so the
+  window-rollover and LRU-eviction paths run without real sleeps.
+- The full ASGI middleware is exercised through a tiny FastAPI app
+  (mirrors api/main.py wiring without depending on the auth machinery)
+  to verify per-path bucketing, per-IP bucketing via X-Forwarded-For,
+  the 429 body, and the Retry-After header.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.auth_rate_limit import (
+    AuthRateLimitMiddleware,
+    _SlidingWindow,
+    _client_ip,
+    is_rate_limit_disabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# _SlidingWindow unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_sliding_window_allows_under_limit():
+    win = _SlidingWindow(limit=3, window_secs=60, max_clients=10)
+    for _ in range(3):
+        allowed, retry = win.check_and_record("ip-a")
+        assert allowed is True
+        assert retry == 0
+
+
+def test_sliding_window_blocks_at_limit_with_retry_after():
+    win = _SlidingWindow(limit=2, window_secs=60, max_clients=10)
+    win.check_and_record("ip-a")
+    win.check_and_record("ip-a")
+    allowed, retry = win.check_and_record("ip-a")
+    assert allowed is False
+    # Retry-After is bounded by the window length.
+    assert 1 <= retry <= 60
+
+
+def test_sliding_window_separates_keys():
+    win = _SlidingWindow(limit=1, window_secs=60, max_clients=10)
+    assert win.check_and_record("ip-a") == (True, 0)
+    assert win.check_and_record("ip-b") == (True, 0)
+    assert win.check_and_record("ip-a")[0] is False
+
+
+def test_sliding_window_evicts_old_entries(monkeypatch):
+    """Once timestamps fall outside the window, capacity is restored."""
+    fake_now = [1000.0]
+    monkeypatch.setattr(
+        "api.auth_rate_limit.time.monotonic", lambda: fake_now[0]
+    )
+    win = _SlidingWindow(limit=2, window_secs=10, max_clients=10)
+    win.check_and_record("ip-a")
+    win.check_and_record("ip-a")
+    assert win.check_and_record("ip-a")[0] is False
+    fake_now[0] += 11  # roll past the window
+    assert win.check_and_record("ip-a") == (True, 0)
+
+
+def test_sliding_window_lru_caps_tracked_clients():
+    win = _SlidingWindow(limit=10, window_secs=60, max_clients=2)
+    win.check_and_record("ip-a")
+    win.check_and_record("ip-b")
+    win.check_and_record("ip-c")  # forces eviction of ip-a (oldest)
+    # Re-recording ip-a creates a new bucket; previous count is gone.
+    # If LRU did not evict, ip-a would still count as 1 here, but with
+    # eviction we observe it as fresh.
+    bucket_a_size_after = len(win._buckets["ip-a"]) if "ip-a" in win._buckets else 0
+    assert bucket_a_size_after == 0 or "ip-a" not in win._buckets
+
+
+# ---------------------------------------------------------------------------
+# _client_ip unit tests
+# ---------------------------------------------------------------------------
+
+
+def _scope_with_xff(xff_value: bytes) -> dict:
+    return {
+        "type": "http",
+        "headers": [(b"x-forwarded-for", xff_value)],
+        "client": ("127.0.0.1", 50000),
+    }
+
+
+def test_client_ip_trusts_rightmost_by_default(monkeypatch):
+    monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
+    scope = _scope_with_xff(b"forged-leftmost, real-1.2.3.4")
+    assert _client_ip(scope) == "real-1.2.3.4"
+
+
+def test_client_ip_strips_port_suffix(monkeypatch):
+    monkeypatch.delenv("PRAXYS_TRUSTED_PROXY_HOPS", raising=False)
+    scope = _scope_with_xff(b"5.6.7.8:443")
+    assert _client_ip(scope) == "5.6.7.8"
+
+
+def test_client_ip_falls_back_to_scope_client_when_xff_absent():
+    scope = {"type": "http", "headers": [], "client": ("9.9.9.9", 50000)}
+    assert _client_ip(scope) == "9.9.9.9"
+
+
+def test_client_ip_respects_proxy_hops(monkeypatch):
+    monkeypatch.setenv("PRAXYS_TRUSTED_PROXY_HOPS", "2")
+    scope = _scope_with_xff(b"orig, hop1, hop2")
+    # With 2 trusted hops we walk one entry left of the rightmost.
+    assert _client_ip(scope) == "hop1"
+
+
+def test_client_ip_zero_hops_ignores_xff(monkeypatch):
+    monkeypatch.setenv("PRAXYS_TRUSTED_PROXY_HOPS", "0")
+    scope = _scope_with_xff(b"forged, also-forged")
+    scope["client"] = ("9.9.9.9", 1)
+    assert _client_ip(scope) == "9.9.9.9"
+
+
+# ---------------------------------------------------------------------------
+# Middleware integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rl_client():
+    """Tiny FastAPI app that mirrors api/main.py wiring of the limiter.
+
+    The handlers are stubs so the test isolates the middleware's behavior
+    from real auth, DB, or WeChat code paths.
+    """
+    app = FastAPI()
+    app.add_middleware(
+        AuthRateLimitMiddleware,
+        limits={
+            "/api/auth/login": (3, 60),
+            "/api/auth/register": (2, 60),
+        },
+    )
+
+    @app.post("/api/auth/login")
+    async def _login_stub():
+        return {"ok": True}
+
+    @app.post("/api/auth/register")
+    async def _register_stub():
+        return {"ok": True}
+
+    @app.get("/api/health")
+    async def _health_stub():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def _xff(ip: str) -> dict:
+    return {"X-Forwarded-For": ip}
+
+
+def test_middleware_allows_under_limit(rl_client):
+    for _ in range(3):
+        r = rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+        assert r.status_code == 200, r.text
+
+
+def test_middleware_blocks_with_retry_after(rl_client):
+    for _ in range(3):
+        rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+    blocked = rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+    assert blocked.status_code == 429
+    payload = blocked.json()
+    assert payload["detail"] == "AUTH_RATE_LIMITED"
+    assert payload["retry_after"] >= 1
+    assert int(blocked.headers["retry-after"]) >= 1
+    assert blocked.headers["content-type"].startswith("application/json")
+
+
+def test_middleware_separates_ips(rl_client):
+    """Different X-Forwarded-For values get independent buckets."""
+    for _ in range(3):
+        rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+    # 1.1.1.1 is now blocked, but 2.2.2.2 should still pass.
+    assert rl_client.post("/api/auth/login", headers=_xff("1.1.1.1")).status_code == 429
+    assert rl_client.post("/api/auth/login", headers=_xff("2.2.2.2")).status_code == 200
+
+
+def test_middleware_separates_paths(rl_client):
+    """A login bucket exhaustion does not block a register attempt."""
+    for _ in range(3):
+        rl_client.post("/api/auth/login", headers=_xff("1.1.1.1"))
+    assert rl_client.post("/api/auth/login", headers=_xff("1.1.1.1")).status_code == 429
+    # Register has its own bucket and limit (2).
+    assert rl_client.post("/api/auth/register", headers=_xff("1.1.1.1")).status_code == 200
+
+
+def test_middleware_ignores_unconfigured_paths(rl_client):
+    """Health is not in the limits dict; never rate-limited."""
+    for _ in range(20):
+        r = rl_client.get("/api/health", headers=_xff("1.1.1.1"))
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Disable flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+def test_disable_flag_recognizes_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("PRAXYS_AUTH_RATE_LIMIT_DISABLED", value)
+    assert is_rate_limit_disabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "false", "0", "no"])
+def test_disable_flag_recognizes_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("PRAXYS_AUTH_RATE_LIMIT_DISABLED", value)
+    assert is_rate_limit_disabled() is False

--- a/tests/test_wechat_auth.py
+++ b/tests/test_wechat_auth.py
@@ -39,6 +39,12 @@ def wechat_client(monkeypatch):
     monkeypatch.setenv("WECHAT_MINIAPP_APPID", "test-appid")
     monkeypatch.setenv("WECHAT_MINIAPP_SECRET", "test-secret")
     monkeypatch.setenv("TRAINSIGHT_ADMIN_EMAIL", "")
+    # The auth rate limiter (api/auth_rate_limit.py) caps wechat/register
+    # at 5/hour per IP. TestClient pins client.host to "testclient", so a
+    # single test that calls register more than five times would otherwise
+    # bleed into 429s. Tests for the limiter itself live in
+    # tests/test_auth_rate_limit.py and re-enable it explicitly.
+    monkeypatch.setenv("PRAXYS_AUTH_RATE_LIMIT_DISABLED", "true")
 
     from db import session as db_session
     db_session.engine = None


### PR DESCRIPTION
## Summary

Two follow-ups to making the repo public on GitHub: defend the auth endpoints against the brute-force / credential-stuffing risk that source disclosure makes cheaper, and add the legal disclosures (license, trademarks, unofficial-integration warning) that public-facing OSS expects.

## Changes

- **`api/auth_rate_limit.py` (new)** — per-IP sliding-window ASGI middleware. Caps:
  - `/api/auth/login` — 10 / 5min
  - `/api/auth/register` — 5 / hr
  - `/api/auth/wechat/login` — 30 / 5min
  - `/api/auth/wechat/link-with-password` — 10 / 15min
  - `/api/auth/wechat/register` — 5 / hr
  - LRU-bounded bucket dict (10k entries default) so enumeration can't OOM the worker.
  - Trusts the **rightmost** `X-Forwarded-For` entry (forgery-resistant on a single-hop Azure App Service deployment). `PRAXYS_TRUSTED_PROXY_HOPS` walks further left when the proxy chain is longer.
  - Disable with `PRAXYS_AUTH_RATE_LIMIT_DISABLED=true` (tests/dev only).
- **`api/main.py`** — wired the middleware (skipped only when explicitly disabled).
- **`README.md`** — Legal section: MIT license, trademark disclaimer for Garmin / Stryd / Oura / WeChat, "Third-party data sources" note distinguishing the unofficial Garmin/Stryd integrations from Oura's official API v2.
- **`tests/test_auth_rate_limit.py` (new, 24 tests)** — sliding-window unit tests, `_client_ip` under spoofed XFF, middleware integration (per-path / per-IP isolation, 429 + Retry-After), disable-flag parsing.
- **`tests/test_wechat_auth.py`** — fixture sets `PRAXYS_AUTH_RATE_LIMIT_DISABLED=true` so the heaviest single test (3 wechat/registers) doesn't trip the new 5/hr ceiling.
- **`.env.example`** — documented the two new env vars.

## Why these limits

Tight enough that brute force is infeasible (5 register/hr/IP eats only 120 invitation codes/day even from a /24, and a real human registers once); loose enough that an actual user fat-fingering their password 3-4 times doesn't get locked out for the day. WeChat login is hot (mini program re-logs on each app open) so it gets a higher 30 / 5min ceiling.

In-memory only — with N gunicorn workers the effective ceiling is N × the configured value. Acceptable as a first defense; switch to Redis-backed enforcement if the threat model demands cross-worker accuracy.

## Test plan

- [x] `python -m pytest tests/` — 459 passed, 1 skipped.
- [x] `python -m pytest tests/test_auth_rate_limit.py -v` — 24 / 24 pass.
- [x] `python -m pytest tests/test_wechat_auth.py tests/test_jwt_secret_wiring.py -v` — 15 / 15 pass (no regressions in existing auth surface).
- [ ] After merge, manually `curl -X POST .../api/auth/login` 11× from one IP → expect a 429 with a numeric `Retry-After` on the 11th, not unlimited 401s.
- [ ] Verify GitHub renders the README "License" + "Trademarks" sections cleanly and the right-rail picks up MIT.

## Operational follow-ups (not in this PR)

1. Verify `PRAXYS_JWT_SECRET` and `KEY_VAULT_URL` are set in App Service config.
2. Restrict OIDC trust on `AZURE_CLIENT_ID` to `dddtc2005/praxys` repo + `main` branch only.
3. Investigate the 4 Dependabot alerts (3 high, 1 moderate) GitHub flagged on push; not in scope here.