### PR TITLE
L1: refactor get_dashboard_data into per-endpoint packs (#146)

### DIFF
--- a/api/packs.py
+++ b/api/packs.py
@@ -1,0 +1,613 @@
+"""Per-endpoint dashboard packs (issue #146).
+
+Each pack is a small, composable function returning only the data a single
+endpoint actually serves. The 5 endpoints (`/api/today`, `/api/training`,
+`/api/goal`, `/api/history`, `/api/science`) used to share a single
+`get_dashboard_data()` that did ~22 top-level computations, then each
+endpoint dropped 60-85% of the result. With packs, an endpoint pays only
+for the work it actually consumes.
+
+A `RequestContext` holds the request-scoped cache so that within a single
+HTTP request, shared inputs (config, deduplicated activities, thresholds,
+science, EWMA load series) are computed exactly once even when the route
+calls multiple packs.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from functools import cached_property
+
+import pandas as pd
+
+from analysis.config import load_config_from_db
+from analysis.data_loader import load_data_from_db
+from analysis.metrics import (
+    compute_ewma_load,
+    compute_tsb,
+    daily_training_signal,
+    get_distance_config,
+    project_tsb,
+)
+from analysis.providers.models import ThresholdEstimate
+from analysis.science import load_active_science
+from analysis.training_base import get_display_config
+from api.deps import (
+    _build_activities_list,
+    _build_compliance,
+    _build_race_countdown,
+    _build_sleep_perf,
+    _build_threshold_trend_chart,
+    _build_warnings,
+    _build_workout_flags,
+    _compute_daily_load,
+    _compute_diagnosis,
+    _compute_recovery_analysis,
+    _compute_threshold_data,
+    _ensure_env,
+    _estimate_plan_daily_loads,
+    _get_todays_plan,
+    _plan_row_duration_sec,
+    _plan_workout_load,
+    _resolve_thresholds,
+    _select_prediction_method,
+)
+from api.views import upcoming_workouts
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request-scoped cache
+# ---------------------------------------------------------------------------
+
+
+class RequestContext:
+    """Request-scoped cache for inputs shared across packs.
+
+    Each ``cached_property`` is computed at most once per ``RequestContext``
+    instance, so a route calling multiple packs in the same request pays
+    for shared work (config, deduplicated activities, thresholds, science,
+    EWMA load series) only once. Construct one ``RequestContext`` per
+    request and pass it to each pack the endpoint needs.
+    """
+
+    def __init__(self, user_id: str, db) -> None:
+        _ensure_env()
+        self.user_id = user_id
+        self.db = db
+        self.today = date.today()
+
+    # --- raw inputs --------------------------------------------------------
+
+    @cached_property
+    def config(self):
+        return load_config_from_db(self.user_id, self.db)
+
+    @cached_property
+    def _data(self) -> dict:
+        return load_data_from_db(self.user_id, self.db)
+
+    @cached_property
+    def merged_activities(self) -> pd.DataFrame:
+        """Activities deduplicated by primary-source preference.
+
+        Mirrors the dedup pass at the top of the legacy
+        ``get_dashboard_data``: when the same activity is synced by two
+        sources (Garmin + Stryd, same date, durations within 10%), keep
+        the row whose source matches ``preferences.activities``.
+        """
+        merged = self._data["activities"]
+        primary_source = self.config.preferences.get("activities")
+        if not primary_source or merged.empty or "source" not in merged.columns:
+            return merged
+        merged = merged.copy()
+        merged["_date"] = pd.to_datetime(merged["date"]).dt.date
+        merged["_dur"] = pd.to_numeric(
+            merged.get("duration_sec", 0), errors="coerce"
+        ).fillna(0)
+        merged["_is_primary"] = merged["source"] == primary_source
+
+        keep_mask = pd.Series(True, index=merged.index)
+        for _dt, group in merged.groupby("_date"):
+            if len(group) <= 1:
+                continue
+            primary = group[group["_is_primary"]]
+            others = group[~group["_is_primary"]]
+            for oidx, orow in others.iterrows():
+                for _, prow in primary.iterrows():
+                    if prow["_dur"] > 0 and orow["_dur"] > 0:
+                        ratio = abs(prow["_dur"] - orow["_dur"]) / max(
+                            prow["_dur"], orow["_dur"]
+                        )
+                        if ratio < 0.10:
+                            keep_mask[oidx] = False
+                            break
+        return (
+            merged[keep_mask]
+            .drop(columns=["_date", "_dur", "_is_primary"], errors="ignore")
+            .reset_index(drop=True)
+        )
+
+    @cached_property
+    def splits(self) -> pd.DataFrame:
+        return self._data["splits"]
+
+    @cached_property
+    def recovery(self) -> pd.DataFrame:
+        return self._data["recovery"]
+
+    @cached_property
+    def plan(self) -> pd.DataFrame:
+        return self._data["plan"]
+
+    @cached_property
+    def thresholds(self) -> ThresholdEstimate:
+        return _resolve_thresholds(
+            self.config, user_id=self.user_id, db=self.db,
+        )
+
+    @cached_property
+    def latest_cp_watts(self) -> float | None:
+        cp = self.thresholds.cp_watts
+        return cp if cp and cp > 0 else None
+
+    @cached_property
+    def science(self) -> dict:
+        locale = (
+            self.config.language
+            if self.config.language in {"en", "zh"}
+            else None
+        )
+        return load_active_science(
+            self.config.science, self.config.zone_labels, locale=locale,
+        )
+
+    @cached_property
+    def display(self) -> dict:
+        return get_display_config(self.config.training_base)
+
+    # --- derived series ----------------------------------------------------
+
+    @cached_property
+    def _load_constants(self) -> tuple[int, int]:
+        load_theory = self.science.get("load")
+        params = load_theory.params if load_theory else {}
+        return (
+            int(params.get("ctl_time_constant", 42)),
+            int(params.get("atl_time_constant", 7)),
+        )
+
+    @cached_property
+    def fitness_series(self) -> dict:
+        """Daily load + EWMA-derived CTL/ATL/TSB over the full data window."""
+        merged = self.merged_activities
+        ctl_tc, atl_tc = self._load_constants
+        earliest = self.today - timedelta(days=365)
+        if not merged.empty and "date" in merged.columns:
+            first_date = pd.to_datetime(merged["date"]).min()
+            if pd.notna(first_date):
+                earliest = first_date.date()
+        full_range = pd.date_range(earliest, self.today)
+        daily_load = _compute_daily_load(
+            merged, full_range, self.config, self.thresholds,
+        )
+        ctl = compute_ewma_load(daily_load, time_constant=ctl_tc)
+        atl = compute_ewma_load(daily_load, time_constant=atl_tc)
+        tsb = compute_tsb(ctl, atl)
+        return {
+            "daily_load": daily_load,
+            "ctl": ctl,
+            "atl": atl,
+            "tsb": tsb,
+            "earliest": earliest,
+        }
+
+    @cached_property
+    def projection(self) -> dict:
+        ctl_tc, atl_tc = self._load_constants
+        fs = self.fitness_series
+        days = 14
+        future_loads = _estimate_plan_daily_loads(
+            self.plan, self.today, days, self.thresholds,
+            self.config.training_base,
+        )
+        current_ctl = float(fs["ctl"].iloc[-1]) if not fs["ctl"].empty else 0.0
+        current_atl = float(fs["atl"].iloc[-1]) if not fs["atl"].empty else 0.0
+        proj_ctl, proj_atl, proj_tsb = project_tsb(
+            current_ctl, current_atl, future_loads,
+            ctl_tc=ctl_tc, atl_tc=atl_tc,
+        )
+        proj_dates = [
+            (self.today + timedelta(days=i + 1)).strftime("%Y-%m-%d")
+            for i in range(days)
+        ]
+        return {
+            "ctl": proj_ctl,
+            "atl": proj_atl,
+            "tsb": proj_tsb,
+            "dates": proj_dates,
+        }
+
+    @cached_property
+    def threshold_data(self) -> dict:
+        latest, trend, cp_values, pairs = _compute_threshold_data(
+            self.merged_activities, self.config,
+            user_id=self.user_id, db=self.db,
+        )
+        return {
+            "latest": latest,
+            "trend": trend,
+            "cp_values": cp_values,
+            "pairs": pairs,
+        }
+
+    @cached_property
+    def cp_trend_chart(self) -> dict:
+        return _build_threshold_trend_chart(
+            self.merged_activities, self.config,
+            user_id=self.user_id, db=self.db,
+        )
+
+    @cached_property
+    def recovery_analysis(self) -> dict:
+        analysis, _, _, _ = _compute_recovery_analysis(self.recovery)
+        return analysis
+
+    @cached_property
+    def data_meta(self) -> dict:
+        merged = self.merged_activities
+        recovery = self.recovery
+        chart = self.cp_trend_chart
+        activity_count = len(merged) if not merged.empty else 0
+        data_days = (
+            (self.today - self.fitness_series["earliest"]).days
+            if not merged.empty else 0
+        )
+        cp_point_count = len(chart.get("dates", [])) if chart else 0
+        has_recovery = (
+            not recovery.empty if hasattr(recovery, "empty") else bool(recovery)
+        )
+        return {
+            "activity_count": activity_count,
+            "data_days": data_days,
+            "cp_points": cp_point_count,
+            "has_recovery": has_recovery,
+            "pmc_sufficient": data_days >= 42,
+            "cp_trend_sufficient": cp_point_count >= 3,
+        }
+
+    @cached_property
+    def science_notes(self) -> dict:
+        return {
+            pillar: {
+                "name": theory.name,
+                "description": getattr(theory, "simple_description", "") or "",
+                "citations": [
+                    {
+                        "label": getattr(c, "title", getattr(c, "key", "")),
+                        "url": getattr(c, "url", ""),
+                    }
+                    for c in (getattr(theory, "citations", None) or [])
+                    if getattr(c, "url", None)
+                ],
+            }
+            for pillar, theory in self.science.items()
+            if theory and hasattr(theory, "name")
+        }
+
+    @cached_property
+    def tsb_zones(self) -> list[dict]:
+        load_theory = self.science.get("load")
+        return [
+            {"min": z.min, "max": z.max, "label": z.label, "color": z.color}
+            for z in (load_theory.tsb_zones_labeled if load_theory else [])
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Local helpers (small enough to inline; not reused outside packs)
+# ---------------------------------------------------------------------------
+
+
+def _build_last_activity(merged: pd.DataFrame) -> dict | None:
+    """Pull the single most recent activity for the Today widget.
+
+    The Today page only renders the latest activity card, so building the
+    full activities list (with splits) just to take ``activities[0]`` is
+    wasted work. This helper returns the same shape ``api.views.last_activity``
+    consumes, but skips the iteration over every activity and split.
+    """
+    if merged.empty or "date" not in merged.columns:
+        return None
+    sorted_m = merged.sort_values("date", ascending=False)
+    if sorted_m.empty:
+        return None
+    row = sorted_m.iloc[0]
+    if pd.isna(row.get("date")):
+        return None
+    return {
+        "date": str(row["date"]),
+        "activity_type": row.get("activity_type", "running"),
+        "distance_km": (
+            round(float(row.get("distance_km", 0)), 2)
+            if pd.notna(row.get("distance_km")) else None
+        ),
+        "duration_sec": (
+            int(row.get("duration_sec", 0))
+            if pd.notna(row.get("duration_sec")) else None
+        ),
+        "avg_power": (
+            round(float(row.get("avg_power", 0)), 1)
+            if pd.notna(row.get("avg_power")) else None
+        ),
+        "avg_pace_min_km": (
+            str(row.get("avg_pace_min_km", ""))
+            if pd.notna(row.get("avg_pace_min_km")) else None
+        ),
+        "rss": (
+            round(float(row.get("rss", 0)), 1)
+            if pd.notna(row.get("rss")) else None
+        ),
+    }
+
+
+def _current_week_load(
+    daily_load: pd.Series, plan: pd.DataFrame, training_base: str,
+    thresholds, today: date,
+) -> dict | None:
+    """Current ISO week's actual + planned load (single-week extract).
+
+    Cheaper than ``_build_compliance`` for the 8-week chart when the caller
+    (Today widget) only renders the latest entry. Uses ISO week numbers to
+    match ``_build_compliance`` so the labels stay consistent.
+    """
+    if daily_load is None or daily_load.empty:
+        return None
+    today_ts = pd.Timestamp(today)
+    week_year = today_ts.isocalendar().year
+    week_num = today_ts.isocalendar().week
+
+    df = daily_load.reset_index()
+    df.columns = ["date", "load"]
+    df["_d"] = pd.to_datetime(df["date"])
+    df["_y"] = df["_d"].dt.isocalendar().year
+    df["_w"] = df["_d"].dt.isocalendar().week
+    actual_rows = df[(df["_y"] == week_year) & (df["_w"] == week_num)]
+    if actual_rows.empty:
+        return None
+    actual = round(float(actual_rows["load"].sum()), 1)
+
+    planned: float | None = None
+    if not plan.empty and "date" in plan.columns:
+        plan_copy = plan.copy()
+        plan_copy["_d"] = pd.to_datetime(plan_copy["date"], errors="coerce")
+        plan_copy = plan_copy.dropna(subset=["_d"])
+        plan_copy["_y"] = plan_copy["_d"].dt.isocalendar().year
+        plan_copy["_w"] = plan_copy["_d"].dt.isocalendar().week
+        plan_week = plan_copy[
+            (plan_copy["_y"] == week_year) & (plan_copy["_w"] == week_num)
+        ]
+        if not plan_week.empty:
+            total = 0.0
+            for _, row in plan_week.iterrows():
+                dur_sec = _plan_row_duration_sec(row)
+                total += _plan_workout_load(
+                    row, dur_sec, training_base, thresholds,
+                )
+            planned = round(total, 1)
+
+    return {
+        "week_label": f"W{int(week_num)}",
+        "actual": actual,
+        "planned": planned,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Packs — each returns ONLY the keys its endpoint needs.
+# ---------------------------------------------------------------------------
+
+
+def get_signal_pack(ctx: RequestContext) -> dict:
+    """Today's training signal + sparkline + recovery + warnings.
+
+    Used by ``/api/today``. Pays for: full EWMA load (for current TSB),
+    recovery analysis, warnings, projection (for sparkline tail). Does NOT
+    pay for diagnosis, threshold trends, weekly compliance, full activity
+    list, workout flags, or sleep-performance scatter.
+    """
+    fs = ctx.fitness_series
+    proj = ctx.projection
+    current_tsb = float(fs["tsb"].iloc[-1]) if not fs["tsb"].empty else 0.0
+    recovery_analysis = ctx.recovery_analysis
+
+    planned_today, planned_detail = _get_todays_plan(ctx.plan, ctx.today)
+    load_theory = ctx.science.get("load")
+    signal = daily_training_signal(
+        recovery_analysis, current_tsb, planned_today,
+        planned_detail=planned_detail,
+        signal_thresholds=load_theory.signal if load_theory else None,
+        hrv_only=True,
+    )
+    warnings = _build_warnings(
+        recovery_analysis, current_tsb, ctx.config,
+        data_dir=None, latest_cp_watts=ctx.latest_cp_watts,
+    )
+
+    display_days = 60
+    date_range = pd.date_range(
+        ctx.today - timedelta(days=display_days), ctx.today,
+    )
+    display_tsb = fs["tsb"].iloc[-len(date_range):]
+    ff_dates = [d.strftime("%Y-%m-%d") for d in date_range]
+    tsb_sparkline = {
+        "dates": ff_dates[-14:],
+        "values": [round(float(v), 1) for v in display_tsb.values][-14:],
+        "projected_dates": proj["dates"][:7],
+        "projected_values": proj["tsb"][:7],
+    }
+
+    return {
+        "signal": signal,
+        "tsb_sparkline": tsb_sparkline,
+        "recovery_analysis": recovery_analysis,
+        "warnings": warnings,
+    }
+
+
+def get_today_widgets(ctx: RequestContext) -> dict:
+    """Last activity + current-week load summary + upcoming workouts.
+
+    Used by ``/api/today``. Skips the full activity-list build: only the
+    most recent activity is rendered on the Today page, so we extract one
+    row instead of formatting all of them with splits.
+    """
+    return {
+        "last_activity": _build_last_activity(ctx.merged_activities),
+        "week_load": _current_week_load(
+            ctx.fitness_series["daily_load"], ctx.plan,
+            ctx.config.training_base, ctx.thresholds, ctx.today,
+        ),
+        "upcoming": upcoming_workouts(ctx.plan),
+    }
+
+
+def get_diagnosis_pack(ctx: RequestContext) -> dict:
+    """Zone-aware diagnosis + workout flags + sleep-performance scatter.
+
+    Used by ``/api/training``. Pays for splits and threshold-trend data.
+    """
+    cp_trend = ctx.threshold_data["trend"]
+    return {
+        "diagnosis": _compute_diagnosis(
+            ctx.merged_activities, ctx.splits, cp_trend,
+            ctx.config, ctx.thresholds, ctx.science,
+        ),
+        "workout_flags": _build_workout_flags(
+            ctx.merged_activities, ctx.recovery, ctx.config.training_base,
+        ),
+        "sleep_perf": _build_sleep_perf(
+            ctx.merged_activities, ctx.recovery, ctx.config.training_base,
+        ),
+    }
+
+
+def get_fitness_pack(ctx: RequestContext) -> dict:
+    """60-day fitness/fatigue chart + 8-week compliance + threshold trend.
+
+    Used by ``/api/training``.
+    """
+    fs = ctx.fitness_series
+    proj = ctx.projection
+    display_days = 60
+    date_range = pd.date_range(
+        ctx.today - timedelta(days=display_days), ctx.today,
+    )
+    display_ctl = fs["ctl"].iloc[-len(date_range):]
+    display_atl = fs["atl"].iloc[-len(date_range):]
+    display_tsb = fs["tsb"].iloc[-len(date_range):]
+    ff_dates = [d.strftime("%Y-%m-%d") for d in date_range]
+    fitness_fatigue = {
+        "dates": ff_dates,
+        "ctl": [round(float(v), 1) for v in display_ctl.values],
+        "atl": [round(float(v), 1) for v in display_atl.values],
+        "tsb": [round(float(v), 1) for v in display_tsb.values],
+        "projected_dates": proj["dates"],
+        "projected_ctl": proj["ctl"],
+        "projected_atl": proj["atl"],
+        "projected_tsb": proj["tsb"],
+    }
+    weekly_review = _build_compliance(
+        ctx.merged_activities, ctx.plan, ctx.config.training_base,
+        fs["daily_load"], ctx.thresholds,
+    )
+    return {
+        "fitness_fatigue": fitness_fatigue,
+        "cp_trend": ctx.cp_trend_chart,
+        "weekly_review": weekly_review,
+    }
+
+
+def get_race_pack(ctx: RequestContext) -> dict:
+    """Race countdown + threshold trend chart and series for /api/goal."""
+    td = ctx.threshold_data
+    config = ctx.config
+    race_date_str = str(config.goal.get("race_date", "")).strip()
+    raw_target = (
+        config.goal.get("target_time_sec")
+        or config.goal.get("race_target_time_sec")
+    )
+    target_time_sec = int(raw_target) if raw_target else None
+    distance_key = (
+        str(config.goal.get("distance", "marathon")).strip() or "marathon"
+    )
+    dist_config = get_distance_config(distance_key)
+    threshold_pace = ctx.thresholds.threshold_pace_sec_km
+
+    prediction_theory = ctx.science.get("prediction")
+    prediction_theory_id = config.science.get("prediction", "critical_power")
+    theory_exponent = None
+    if prediction_theory and prediction_theory.params:
+        theory_fractions = prediction_theory.params.get(
+            "distance_power_fractions", {},
+        )
+        theory_fraction = theory_fractions.get(distance_key)
+        if theory_fraction:
+            dist_config = {**dist_config, "power_fraction": theory_fraction}
+        theory_exponent = prediction_theory.params.get("riegel_exponent")
+
+    prediction_method = _select_prediction_method(
+        config.training_base, prediction_theory_id,
+        has_cp=bool(ctx.latest_cp_watts), has_pace=bool(threshold_pace),
+    )
+
+    race_countdown = _build_race_countdown(
+        race_date_str, target_time_sec,
+        latest_threshold=td["latest"],
+        latest_cp_watts=ctx.latest_cp_watts,
+        power_pace_pairs=td["pairs"],
+        cp_trend_data=td["trend"],
+        today=ctx.today,
+        distance_km=dist_config["km"],
+        power_fraction=dist_config["power_fraction"],
+        distance_label=dist_config["label"],
+        distance_key=distance_key,
+        training_base=config.training_base,
+        threshold_pace=threshold_pace,
+        riegel_exponent=theory_exponent,
+        prediction_method=prediction_method,
+        prediction_theory_name=(
+            prediction_theory.name if prediction_theory else None
+        ),
+    )
+
+    return {
+        "race_countdown": race_countdown,
+        "cp_trend": ctx.cp_trend_chart,
+        "cp_trend_data": td["trend"],
+        "latest_cp": td["latest"],
+    }
+
+
+def get_history_pack(ctx: RequestContext) -> dict:
+    """Full activities list (with splits) for /api/history.
+
+    Returns the only piece of data /api/history actually consumes — the
+    deduplication and pagination concerns stay in the route since they
+    depend on query parameters.
+    """
+    return {
+        "activities": _build_activities_list(
+            ctx.merged_activities, ctx.splits,
+        ),
+    }
+
+
+def get_science_pack(ctx: RequestContext) -> dict:
+    """Active science theories + summarized notes + TSB zone bands."""
+    return {
+        "science": ctx.science,
+        "science_notes": ctx.science_notes,
+        "tsb_zones": ctx.tsb_zones,
+    }

--- a/api/routes/goal.py
+++ b/api/routes/goal.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id
-from api.deps import get_dashboard_data
+from api.packs import RequestContext, get_race_pack
 from db.session import get_db
 
 router = APIRouter()
@@ -14,14 +14,15 @@ def get_goal(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ):
-    data = get_dashboard_data(user_id=user_id, db=db)
+    ctx = RequestContext(user_id=user_id, db=db)
+    race = get_race_pack(ctx)
     return {
-        "race_countdown": data["race_countdown"],
-        "cp_trend": data["cp_trend"],
-        "cp_trend_data": data["cp_trend_data"],
-        "latest_cp": data["latest_cp"],
-        "training_base": data["training_base"],
-        "display": data["display"],
-        "data_meta": data.get("data_meta"),
-        "science_notes": data.get("science_notes"),
+        "race_countdown": race["race_countdown"],
+        "cp_trend": race["cp_trend"],
+        "cp_trend_data": race["cp_trend_data"],
+        "latest_cp": race["latest_cp"],
+        "training_base": ctx.config.training_base,
+        "display": ctx.display,
+        "data_meta": ctx.data_meta,
+        "science_notes": ctx.science_notes,
     }

--- a/api/routes/history.py
+++ b/api/routes/history.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id
-from api.deps import get_dashboard_data
+from api.packs import RequestContext, get_history_pack
 from db.session import get_db
 
 router = APIRouter()
@@ -17,16 +17,13 @@ def get_history(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ):
-    from analysis.config import load_config_from_db
-    config = load_config_from_db(user_id, db)
-
-    data = get_dashboard_data(user_id=user_id, db=db)
-    activities = data["activities"]
+    ctx = RequestContext(user_id=user_id, db=db)
+    activities = get_history_pack(ctx)["activities"]
 
     # Smart dedup: when multiple sources have the same activity (same date +
     # similar duration), keep the primary source version. Activities that only
     # exist in one source are always shown.
-    primary_source = source or config.preferences.get("activities")
+    primary_source = source or ctx.config.preferences.get("activities")
 
     if primary_source:
         # Group by date
@@ -72,6 +69,6 @@ def get_history(
         "limit": limit,
         "offset": offset,
         "source_filter": primary_source,
-        "training_base": data["training_base"],
-        "display": data["display"],
+        "training_base": ctx.config.training_base,
+        "display": ctx.display,
     }

--- a/api/routes/science.py
+++ b/api/routes/science.py
@@ -3,13 +3,11 @@ from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id, require_write_access
-from api.deps import get_dashboard_data
 from analysis.config import (
-    load_config,
-    save_config,
     load_config_from_db,
     save_config_to_db,
 )
+from analysis.metrics import get_distance_config
 from analysis.science import (
     PILLARS,
     list_theories,
@@ -66,19 +64,27 @@ def get_science(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ) -> dict:
-    """Return active theories, all available options, and recommendations."""
-    data = get_dashboard_data(user_id=user_id, db=db)
+    """Return active theories, all available options, and recommendations.
+
+    Doesn't go through the full dashboard pipeline: loading config + science
+    is enough. The legacy `recommend_science` call only inspects DataFrame
+    inputs (the previous code passed a list[dict], which never matched the
+    isinstance check), so passing ``None`` here produces byte-identical
+    recommendations while skipping the activity / split / threshold load.
+    """
     config = load_config_from_db(user_id, db)
     locale = _resolve_locale(config.language, request)
-    science = data.get("science", {})
 
-    # Active theories — reload in requested locale so the user sees translated
-    # prose without the dashboard loader needing to know about locales.
+    # Active theories — loaded in the requested locale so the user sees
+    # translated prose without the dashboard loader needing to know about
+    # locales.
+    science = load_active_science(
+        config.science, config.zone_labels, locale=locale,
+    )
+
     active = {}
-    from analysis.science import load_active_science
-    localized = load_active_science(config.science, config.zone_labels, locale=locale) if locale else science
     for pillar in PILLARS:
-        theory = localized.get(pillar)
+        theory = science.get(pillar)
         if theory:
             summary = _theory_summary(theory)
             if theory.tsb_zones_labeled:
@@ -99,16 +105,12 @@ def get_science(
     label_sets = [{"id": ls.id, "name": ls.name} for ls in list_label_sets()]
 
     # Recommendations
-    activities = data.get("activities", None)
-    recovery_df = data.get("recovery", None)
-    # Extract goal distance from config
-    from analysis.metrics import get_distance_config
     dist_key = str(config.goal.get("distance", "marathon"))
     goal_km = get_distance_config(dist_key).get("km")
 
     recs = recommend_science(
-        activities=activities,
-        recovery=recovery_df,
+        activities=None,
+        recovery=None,
         goal_distance_km=goal_km,
         connected_platforms=config.connections,
         training_base=config.training_base,

--- a/api/routes/today.py
+++ b/api/routes/today.py
@@ -1,11 +1,13 @@
 """Today's training signal endpoint."""
-import pandas as pd
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id
-from api.deps import get_dashboard_data
-from api.views import last_activity, upcoming_workouts, week_load
+from api.packs import (
+    RequestContext,
+    get_signal_pack,
+    get_today_widgets,
+)
 from db.session import get_db
 
 router = APIRouter()
@@ -29,23 +31,21 @@ def get_today(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ):
-    data = get_dashboard_data(user_id=user_id, db=db)
-    science = data.get("science", {})
-    activities = data.get("activities", [])
-    weekly_review = data.get("weekly_review", {})
-    plan_df = data.get("plan", pd.DataFrame())
+    ctx = RequestContext(user_id=user_id, db=db)
+    signal = get_signal_pack(ctx)
+    widgets = get_today_widgets(ctx)
 
     return {
-        "signal": data["signal"],
-        "tsb_sparkline": data["tsb_sparkline"],
-        "warnings": data["warnings"],
-        "training_base": data["training_base"],
-        "display": data["display"],
-        "recovery_theory": _recovery_theory_meta(science),
-        "recovery_analysis": data.get("recovery_analysis"),
-        "last_activity": last_activity(activities),
-        "week_load": week_load(weekly_review),
-        "upcoming": upcoming_workouts(plan_df),
-        "data_meta": data.get("data_meta"),
-        "science_notes": data.get("science_notes"),
+        "signal": signal["signal"],
+        "tsb_sparkline": signal["tsb_sparkline"],
+        "warnings": signal["warnings"],
+        "training_base": ctx.config.training_base,
+        "display": ctx.display,
+        "recovery_theory": _recovery_theory_meta(ctx.science),
+        "recovery_analysis": signal["recovery_analysis"],
+        "last_activity": widgets["last_activity"],
+        "week_load": widgets["week_load"],
+        "upcoming": widgets["upcoming"],
+        "data_meta": ctx.data_meta,
+        "science_notes": ctx.science_notes,
     }

--- a/api/routes/training.py
+++ b/api/routes/training.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from api.auth import get_data_user_id
-from api.deps import get_dashboard_data
+from api.packs import RequestContext, get_diagnosis_pack, get_fitness_pack
 from db.session import get_db
 
 router = APIRouter()
@@ -14,16 +14,18 @@ def get_training(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ):
-    data = get_dashboard_data(user_id=user_id, db=db)
+    ctx = RequestContext(user_id=user_id, db=db)
+    diagnosis = get_diagnosis_pack(ctx)
+    fitness = get_fitness_pack(ctx)
     return {
-        "diagnosis": data["diagnosis"],
-        "fitness_fatigue": data["fitness_fatigue"],
-        "cp_trend": data["cp_trend"],
-        "weekly_review": data["weekly_review"],
-        "workout_flags": data["workout_flags"],
-        "sleep_perf": data["sleep_perf"],
-        "training_base": data["training_base"],
-        "display": data["display"],
-        "data_meta": data.get("data_meta"),
-        "science_notes": data.get("science_notes"),
+        "diagnosis": diagnosis["diagnosis"],
+        "fitness_fatigue": fitness["fitness_fatigue"],
+        "cp_trend": fitness["cp_trend"],
+        "weekly_review": fitness["weekly_review"],
+        "workout_flags": diagnosis["workout_flags"],
+        "sleep_perf": diagnosis["sleep_perf"],
+        "training_base": ctx.config.training_base,
+        "display": ctx.display,
+        "data_meta": ctx.data_meta,
+        "science_notes": ctx.science_notes,
     }

--- a/docs/perf-baselines/2026-04-26-checkpoint.md
+++ b/docs/perf-baselines/2026-04-26-checkpoint.md
@@ -235,6 +235,29 @@ This is what the next three optimization layers target:
 
 **L1 is required before L2 and L3 make sense** — without splitting the kitchen-sink, neither caching strategy has a sane invalidation surface. Once L1 lands, L2 is additive and L3 stays in the toolbox until the warm-visit speed of L1 stops feeling adequate.
 
+### Post-L1 anchor — code change landed (this PR, #146)
+
+Code-level summary of what shipped:
+
+- `api/packs.py` — new `RequestContext` (request-scoped `cached_property` cache for config, deduplicated activities, thresholds, science, EWMA series) plus 7 packs: `get_signal_pack`, `get_today_widgets`, `get_diagnosis_pack`, `get_fitness_pack`, `get_race_pack`, `get_history_pack`, `get_science_pack`.
+- `api/routes/{today,training,goal,history,science}.py` — each rewired to construct one `RequestContext` and call only the packs it needs.
+- `api/deps.py` — left intact for legacy callers (`api/ai.py`, `api/routes/plan.py`, `plugins/praxys/mcp-server/server.py`); gradual deprecation, not a big-bang.
+- `tests/test_packs.py` — 10 new unit tests, including a parity check that `get_signal_pack` matches `get_dashboard_data['signal']` and a cache-counting test that proves `load_data_from_db` runs exactly once per request.
+
+Concrete work skipped per endpoint relative to legacy `get_dashboard_data`:
+
+| Endpoint | Skips |
+|---|---|
+| `/api/today` | diagnosis, workout flags, sleep-perf scatter, full activity list (extracts the latest row only), 8-week compliance (computes current week only), `_compute_threshold_data` |
+| `/api/training` | full activity list, race countdown, plan-staleness warnings |
+| `/api/goal` | diagnosis, workout flags, sleep-perf scatter, weekly compliance, full activity list |
+| `/api/history` | every metric (returns the deduplicated activities list only) |
+| `/api/science` | merged activities, splits, recovery, thresholds, EWMA load, threshold trend chart — does only `load_config + load_active_science + recommend_science` |
+
+Suite: **445 passing** (435 prior + 10 new pack tests), 1 skipped.
+
+Production p50 / FCP measurements vs the 1358017 cn-pc-2 anchor are pending deploy + sweep — `scripts/perf_synthetic_load_check.py` and a cn-pc-2 sitespeed run will be re-anchored under a new `2026-04-26-<post-L1-sha>/` directory once this lands and traffic flows.
+
 ## Tooling state
 
 - **Local sitespeed runner** (`scripts/sitespeed_runner.sh`) — works against any URL, supports S1/S2/S3/S4 × desktop/mobile. The cn-pc / cn-pc-2 anchor numbers above all came from this. Gold standard for "what does the operator (and CN audience) actually feel."

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -1,0 +1,274 @@
+"""Unit tests for the per-endpoint dashboard packs (issue #146).
+
+Each pack is verified end-to-end against a small SQLite DB so the test
+exercises the same code path the real /api/* routes do (loader → dedup →
+EWMA → metrics) without going through FastAPI.
+
+The shape contracts here are the source of truth that the route wiring
+upstream depends on — if a pack drops a key the route was forwarding,
+TypeScript on the frontend would receive `undefined` for that field.
+"""
+from __future__ import annotations
+
+import tempfile
+from datetime import date, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def db_with_seeded_user(monkeypatch):
+    """Yield (db, user_id) for a SQLite DB pre-seeded with realistic data.
+
+    The seed gives each pack enough to compute non-empty results:
+    activities (with cp_estimate + power), splits, recovery rows, a plan,
+    and a profile threshold. ``RequestContext`` reads from this DB.
+    """
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY",
+        "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=",
+    )
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from db.models import (
+        Activity,
+        ActivitySplit,
+        FitnessData,
+        RecoveryData,
+        TrainingPlan,
+        User,
+    )
+
+    user_id = "test-user-packs"
+    db = db_session.SessionLocal()
+    db.add(User(id=user_id, email="packs@example.com", hashed_password="x"))
+
+    today = date.today()
+    # Two weeks of activities — enough to produce CTL/ATL movement and a
+    # CP-trend chart with ≥3 points.
+    for i in range(14):
+        d = today - timedelta(days=14 - i)
+        db.add(Activity(
+            user_id=user_id,
+            activity_id=f"act-{i}",
+            date=d,
+            activity_type="running",
+            distance_km=8.0 + (i % 3),
+            duration_sec=2400.0 + i * 60,
+            avg_power=240.0 + i,
+            max_power=300.0 + i,
+            avg_hr=150.0 + (i % 5),
+            max_hr=170.0,
+            cp_estimate=265.0 + i * 0.5,
+            rss=70.0 + i * 2,
+            source="stryd",
+        ))
+        db.add(ActivitySplit(
+            user_id=user_id,
+            activity_id=f"act-{i}",
+            split_num=1,
+            distance_km=4.0,
+            duration_sec=1200.0,
+            avg_power=245.0,
+            avg_hr=152.0,
+            avg_pace_min_km="5:00",
+        ))
+        db.add(RecoveryData(
+            user_id=user_id, date=d,
+            sleep_score=80.0 + (i % 10),
+            hrv_avg=50.0 + (i % 8),
+            resting_hr=50.0,
+            readiness_score=75.0 + (i % 15),
+            source="oura",
+        ))
+
+    db.add(FitnessData(
+        user_id=user_id, date=today, metric_type="cp_estimate",
+        value=270.0, source="stryd",
+    ))
+
+    # A planned workout for today + tomorrow so signal / week_load /
+    # upcoming all have something to render.
+    db.add(TrainingPlan(
+        user_id=user_id, date=today,
+        workout_type="tempo", planned_duration_min=45,
+        target_power_min=240, target_power_max=260,
+        source="stryd",
+    ))
+    db.add(TrainingPlan(
+        user_id=user_id, date=today + timedelta(days=1),
+        workout_type="long", planned_duration_min=90,
+        target_power_min=220, target_power_max=240,
+        source="stryd",
+    ))
+    db.commit()
+
+    try:
+        yield db, user_id
+    finally:
+        db.close()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _ctx(db_with_seeded_user):
+    from api.packs import RequestContext
+    db, user_id = db_with_seeded_user
+    return RequestContext(user_id=user_id, db=db)
+
+
+def test_request_context_caches_shared_inputs(db_with_seeded_user):
+    """cached_property must hand back the same object on second access.
+
+    A fresh deduplication or threshold resolution per pack would defeat
+    the whole point of the request-scoped cache.
+    """
+    ctx = _ctx(db_with_seeded_user)
+    assert ctx.merged_activities is ctx.merged_activities
+    assert ctx.thresholds is ctx.thresholds
+    assert ctx.science is ctx.science
+    assert ctx.fitness_series is ctx.fitness_series
+
+
+def test_signal_pack_returns_required_keys(db_with_seeded_user):
+    from api.packs import get_signal_pack
+    ctx = _ctx(db_with_seeded_user)
+    out = get_signal_pack(ctx)
+    assert set(out.keys()) == {
+        "signal", "tsb_sparkline", "recovery_analysis", "warnings",
+    }
+    assert "dates" in out["tsb_sparkline"]
+    assert "values" in out["tsb_sparkline"]
+    assert isinstance(out["warnings"], list)
+
+
+def test_today_widgets_pack_returns_required_keys(db_with_seeded_user):
+    from api.packs import get_today_widgets
+    ctx = _ctx(db_with_seeded_user)
+    out = get_today_widgets(ctx)
+    assert set(out.keys()) == {"last_activity", "week_load", "upcoming"}
+    # Last activity is the most recent of the seeded 14 — must round-trip.
+    assert out["last_activity"] is not None
+    assert out["last_activity"]["date"]
+    # Upcoming should include tomorrow's planned long run.
+    assert any(w.get("workout_type") == "long" for w in out["upcoming"])
+
+
+def test_diagnosis_pack_returns_required_keys(db_with_seeded_user):
+    from api.packs import get_diagnosis_pack
+    ctx = _ctx(db_with_seeded_user)
+    out = get_diagnosis_pack(ctx)
+    assert set(out.keys()) == {"diagnosis", "workout_flags", "sleep_perf"}
+    assert isinstance(out["workout_flags"], list)
+    # sleep_perf carries metric metadata even when pairs are empty.
+    assert "metric_label" in out["sleep_perf"]
+    assert "metric_unit" in out["sleep_perf"]
+
+
+def test_fitness_pack_returns_required_keys(db_with_seeded_user):
+    from api.packs import get_fitness_pack
+    ctx = _ctx(db_with_seeded_user)
+    out = get_fitness_pack(ctx)
+    assert set(out.keys()) == {"fitness_fatigue", "cp_trend", "weekly_review"}
+    ff = out["fitness_fatigue"]
+    assert {"dates", "ctl", "atl", "tsb"}.issubset(ff.keys())
+    assert {
+        "projected_dates", "projected_ctl", "projected_atl", "projected_tsb",
+    }.issubset(ff.keys())
+    # ctl/atl/tsb track each other; dates spans the full display window even
+    # when the EWMA series is shorter (legacy `get_dashboard_data` behavior).
+    assert len(ff["ctl"]) == len(ff["atl"]) == len(ff["tsb"])
+    assert len(ff["dates"]) >= len(ff["ctl"])
+    assert len(ff["projected_dates"]) == len(ff["projected_tsb"]) == 14
+
+
+def test_race_pack_returns_required_keys(db_with_seeded_user):
+    from api.packs import get_race_pack
+    ctx = _ctx(db_with_seeded_user)
+    out = get_race_pack(ctx)
+    assert set(out.keys()) == {
+        "race_countdown", "cp_trend", "cp_trend_data", "latest_cp",
+    }
+    # Continuous improvement (no race_date in default config) → mode set.
+    assert out["race_countdown"]["mode"] in {
+        "continuous", "cp_milestone", "race_date",
+    }
+
+
+def test_history_pack_returns_full_activity_list(db_with_seeded_user):
+    from api.packs import get_history_pack
+    ctx = _ctx(db_with_seeded_user)
+    out = get_history_pack(ctx)
+    assert set(out.keys()) == {"activities"}
+    assert len(out["activities"]) == 14, "all seeded activities should appear"
+    # Each activity carries its splits.
+    assert all("splits" in a for a in out["activities"])
+
+
+def test_science_pack_returns_required_keys(db_with_seeded_user):
+    from api.packs import get_science_pack
+    ctx = _ctx(db_with_seeded_user)
+    out = get_science_pack(ctx)
+    assert set(out.keys()) == {"science", "science_notes", "tsb_zones"}
+    assert isinstance(out["science_notes"], dict)
+    # Every pillar with a theory must contribute a note.
+    for pillar, note in out["science_notes"].items():
+        assert {"name", "description", "citations"} <= set(note.keys())
+
+
+def test_packs_share_cache_across_calls(db_with_seeded_user, monkeypatch):
+    """A route calling multiple packs must dedup the underlying loads.
+
+    We patch ``load_data_from_db`` to count invocations: even after
+    invoking three packs that all read activities/recovery/plan, the
+    loader must run exactly once.
+    """
+    from api import packs as packs_mod
+    real_loader = packs_mod.load_data_from_db
+    calls = {"n": 0}
+
+    def counting_loader(user_id, db):
+        calls["n"] += 1
+        return real_loader(user_id, db)
+
+    monkeypatch.setattr(packs_mod, "load_data_from_db", counting_loader)
+
+    db, user_id = db_with_seeded_user
+    ctx = packs_mod.RequestContext(user_id=user_id, db=db)
+    packs_mod.get_signal_pack(ctx)
+    packs_mod.get_today_widgets(ctx)
+    packs_mod.get_diagnosis_pack(ctx)
+
+    assert calls["n"] == 1, (
+        f"expected loader to run exactly once per request, got {calls['n']}"
+    )
+
+
+def test_dashboard_data_and_packs_agree_on_signal(db_with_seeded_user):
+    """Behavioral equivalence: signal_pack output equals dashboard_data['signal'].
+
+    Backstop against drift while ``get_dashboard_data`` is still in use by
+    legacy callers (api/ai.py, api/routes/plan.py, MCP server).
+    """
+    from api.deps import get_dashboard_data
+    from api.packs import RequestContext, get_signal_pack
+
+    db, user_id = db_with_seeded_user
+    full = get_dashboard_data(user_id=user_id, db=db)
+    pack = get_signal_pack(RequestContext(user_id=user_id, db=db))
+
+    assert pack["signal"] == full["signal"]
+    assert pack["tsb_sparkline"] == full["tsb_sparkline"]
+    assert pack["warnings"] == full["warnings"]


### PR DESCRIPTION
Closes #146.

## Summary

- Introduces `api/packs.py` with a request-scoped `RequestContext` (via `cached_property`) plus 7 composable packs — `signal`, `today_widgets`, `diagnosis`, `fitness`, `race`, `history`, `science`.
- Rewires the 5 target routes (`/api/today`, `/api/training`, `/api/goal`, `/api/history`, `/api/science`) to build one context and call only the packs they need; shared inputs (config, deduplicated activities, thresholds, science, EWMA series) are computed exactly once per request.
- Leaves `api/deps.py:get_dashboard_data` intact for legacy callers (`api/ai.py`, `api/routes/plan.py`, the MCP server) — gradual deprecation, not a big-bang.

## Why

Five endpoints sharing one kitchen-sink loader meant each call did ~22 top-level computations and then dropped 60-85% of the result. The four production endpoints clustering near the same 1.8-2 s p50 (post-PR-139) was the data-side fingerprint. Source narrative: `docs/perf-baselines/2026-04-26-checkpoint.md`.

Concrete work skipped per endpoint relative to legacy `get_dashboard_data`:

| Endpoint | Skips |
|---|---|
| `/api/today` | diagnosis, workout flags, sleep-perf scatter, full activity list (latest row only), 8-week compliance (current week only), `_compute_threshold_data` |
| `/api/training` | full activity list, race countdown, plan-staleness warnings |
| `/api/goal` | diagnosis, workout flags, sleep-perf scatter, weekly compliance, full activity list |
| `/api/history` | every metric (returns the deduplicated activities list only) |
| `/api/science` | merged activities, splits, recovery, thresholds, EWMA load, threshold trend chart — does only `load_config + load_active_science + recommend_science` |

## Test plan

- [x] 445 tests pass — 435 prior baseline + 10 new pack tests, 1 skipped (no regression)
- [x] `tests/test_packs.py` covers each pack's response shape on a small seeded SQLite DB
- [x] Parity check: `get_signal_pack` output equals `get_dashboard_data['signal']` (backstop while legacy callers remain)
- [x] Cache-counting test: `load_data_from_db` runs exactly once when 3 packs are invoked in the same request
- [ ] Post-deploy: `scripts/perf_synthetic_load_check.py` shows `/api/today` p50 ≤ 600 ms
- [ ] Post-deploy: cn-pc-2 sitespeed shows S1 cold-Today desktop FCP ≤ 1500 ms
- [ ] Post-deploy: cloud sweep (post PR-145) confirms the move across 3 regions
- [ ] Post-deploy: re-anchor `docs/perf-baselines/2026-04-26-checkpoint.md` with a new `2026-04-26-<post-L1-sha>/` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)