### PR TITLE
Perf-baseline: region-aware polling deadline (#151)

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -209,14 +209,29 @@ jobs:
       - name: Wait for container to terminate
         id: wait
         run: |
-          # Poll until exit code is set OR 15-min hard timeout. We use
-          # exit-code presence as the completion signal because the
+          # Poll until exit code is set OR a region-aware hard timeout.
+          # We use exit-code presence as the completion signal because the
           # `currentState.state` field is unreliable cross-region —
           # it can stay as "Running" even after the container has
           # actually exited (we hung 15 of 15 cross-region runs on this
           # before the rewrite). Exit code is the canonical "done"
           # marker that's set exactly when the process terminates.
-          DEADLINE=$(($(date +%s) + 900))   # 15 min wall clock
+          #
+          # Region-aware deadline (#151): ACI cold-start dominates the
+          # cross-region wall-clock — westus / northeurope take ~8 min
+          # to provision against an East Asia origin (VM scheduling +
+          # 2 GB image pull + network setup), leaving < 7 min for the
+          # actual sitespeed run inside a flat 15-min budget. Eastasia
+          # provisions in ~3 min so the original budget still fits.
+          # Two-bucket case is the simplest signal that won't rot —
+          # adding a probe means adding a case, not a magic number.
+          case "${{ matrix.probe }}" in
+            eastasia) DEADLINE_SEC=900 ;;     # 15 min — provisioning ~3 min, fits
+            *)        DEADLINE_SEC=1800 ;;    # 30 min — cross-region provisioning ~8 min
+          esac
+          DEADLINE=$(($(date +%s) + DEADLINE_SEC))
+          DEADLINE_MIN=$((DEADLINE_SEC / 60))
+          echo "Deadline: ${DEADLINE_MIN} min for probe=${{ matrix.probe }}"
           EXIT_CODE=""
           while [ "$(date +%s)" -lt "$DEADLINE" ]; do
             EXIT_CODE=$(az container show \
@@ -245,7 +260,7 @@ jobs:
           # Persist the exit code (or 'timeout') as a step output so
           # downstream steps can decide whether to treat as success.
           if [ -z "$EXIT_CODE" ] || [ "$EXIT_CODE" = "null" ]; then
-            echo "::warning::Polling timed out at 15 min — container exit code never appeared. Will still attempt to download whatever made it to the share."
+            echo "::warning::Polling timed out at ${DEADLINE_MIN} min (probe=${{ matrix.probe }}) — container exit code never appeared. Will still attempt to download whatever made it to the share."
             echo "exit_code=timeout" >> "$GITHUB_OUTPUT"
           else
             echo "Container terminated with exit code: $EXIT_CODE"


### PR DESCRIPTION
## Summary

Closes #151.

The wait-for-container step's flat 15-min hard timeout is too short for cross-region cells — every westus + northeurope cell of the 24-cell matrix times out in the polling loop because ACI provisioning eats 8 of the 15 min. This change makes the deadline depend on the probe.

```bash
case "${{ matrix.probe }}" in
  eastasia) DEADLINE_SEC=900 ;;     # 15 min — unchanged, fits ~3 min provisioning
  *)        DEADLINE_SEC=1800 ;;    # 30 min — covers ~8 min cross-region provisioning
esac
```

The warning message and the new deadline log are both interpolated against `DEADLINE_SEC`, so a future timeout says exactly which budget fired and on which probe — useful when a new probe lands and we need to know whether it falls in the fast or slow bucket.

## Why this shape

Two alternatives were considered (see #151):

- **State-aware deadline** ("only fail when the state hasn't changed in N minutes") — better long-term but ~15 LOC and harder to reason about. Issue explicitly defers it until we observe the flat-time-budget breaking again (e.g. eastasia going slow during CN holidays).
- **Restructure to one ACI per region with all scenarios serial** — proper fix for the ~50 % wall-clock waste that per-cell provisioning causes. Tracked separately in #161 because it's a workflow rewrite, not a 5-line patch.

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`).
- [x] No `timeout-minutes` set on the job — GitHub Actions default is 6 h, plenty of headroom for the new 30-min deadline.
- [ ] **`workflow_dispatch` against the matrix** with at least `probe=westus` and `probe=northeurope` cells included — should land green where every prior cross-region cell timed out. This is the actual acceptance signal.
- [ ] Confirm an eastasia cell still uses the 15-min deadline (sanity — its log line will read `Deadline: 15 min for probe=eastasia`).
- [ ] Once green, re-run the perf-checkpoint sweep and fill in the `n/a (cell timed out)` rows in `docs/perf-baselines/2026-04-26-checkpoint.md` for westus + northeurope.

## Out of scope

- **Per-region ACI redesign + push-back from container** — tracked as #161. The redesign there will replace this region-aware deadline with a state-aware one anyway, so this PR is a stepping stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)