### PR TITLE
Perf-baseline: skip visual-metrics step (#163)

### DIFF
--- a/.github/workflows/perf-baseline.yml
+++ b/.github/workflows/perf-baseline.yml
@@ -153,7 +153,16 @@ jobs:
           # /usr/src/app/bin/, only added to PATH inside /start.sh.
           # Calling /start.sh directly with the same args restores the
           # image's intended startup flow.
-          BASE_ARGS="--outputFolder /sitespeed.io/out/${CELL} -n 3"
+          # Skip the per-frame video-processing step (#163). Visual-metrics
+          # writes ~200 small PNGs per iteration to the Azure File mount;
+          # eastasia ACI → eastasia storage is ~2 ms SMB RTT and finishes
+          # in seconds, but cross-region (northeurope/westus → eastasia
+          # storage) is ~250 ms RTT plus 1000-IOPS share throttling, so
+          # the step hangs past any reasonable deadline. The Speed Index
+          # value it would have produced isn't surfaced in our perf docs;
+          # FCP / LCP / TTI / TTFB / CLS are still captured natively by
+          # Chrome and remain the load-bearing metrics for the checkpoint.
+          BASE_ARGS="--outputFolder /sitespeed.io/out/${CELL} -n 3 --browsertime.visualMetrics=false"
           if [ "${{ matrix.device }}" = "mobile" ]; then
             # Viewport only — no UA override. The local runner sets a UA
             # too but ACI's --command-line argv parser splits on


### PR DESCRIPTION
## Summary

Closes #163. Companion to #162 — same workflow file, different problem.

#162 made the polling deadline survive cross-region ACI provisioning. #163's run revealed the second blocker: sitespeed.io's `Get visual metrics from the video` step hangs cross-region. **Even with the new 30-min deadline, no cross-region cell produces usable data.**

This PR turns visual-metrics off in the sitespeed CLI args. One line of bash + a paragraph of comment context.

## Root cause (full detail in #163)

Storage `stperftrainsight` lives in eastasia. Cross-region ACIs mount it via Azure File / SMB at ~250 ms RTT per op. Sitespeed's visual-metrics writes ~200 per-frame PNGs per iteration; each `create+write+close` is 3+ RTTs ≈ 750 ms cross-region. With 3 iterations this is 5-10 min of pure storage I/O — but Standard-tier shares throttle at 1000 IOPS, so a burst of frame writes can stall completely. Within-region (eastasia → eastasia, ~2 ms RTT) the same workflow finishes in 6-13 min and visual-metrics is invisible.

## Why this is OK to ship now

The metric we lose — Speed Index — is **never surfaced** in `docs/perf-baselines/2026-04-26-checkpoint.md`. Every cited number across S1-S4 × cn-pc / cn-pc-2 / eastasia / westus / northeurope is FCP / LCP / TTI / TTFB / CLS or an API p50/p95. Those are captured natively by Chrome's `PerformanceObserver` and don't go through the visual-metrics pipeline. So the loss is invisible to every consumer of the checkpoint.

## Test plan

- [x] YAML still parses.
- [ ] **`workflow_dispatch` against `probe=northeurope, scenario=s4, device=desktop` on main after merge** — should finish < 15 min wall-clock and emit FCP/LCP/TTI in the JSON.
- [ ] Sanity: `probe=eastasia, scenario=s1, device=desktop` still finishes in 6-13 min and reports the same FCP/LCP we've been anchoring against (no regression in the historical-success path).
- [ ] Once green, fill in the `n/a (cell timed out)` rows in `docs/perf-baselines/2026-04-26-checkpoint.md` for westus + northeurope on the next sweep.

## Out of scope

- **Per-region storage / no-mount + bulk upload** — both belong in #161's per-region ACI redesign, which would make this knob unnecessary again. Until then, this PR is the unblocker.
- **Re-enabling visual-metrics conditionally** — could go behind a `matrix.probe == 'eastasia'` check, but the within-region case still doesn't surface Speed Index in our docs, so there's no reason to keep paying for it. Single global toggle is simpler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)