### PR TITLE
Pin serialize-javascript ≥ 7.0.5 to clear Dependabot alerts (#155)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11469,16 +11469,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -12217,13 +12207,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,9 @@
     "tw-animate-css": "^1.4.0",
     "web-vitals": "^5.2.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@lingui/cli": "^5.9.5",


### PR DESCRIPTION
## Summary

Closes Dependabot alerts on the default branch by pinning the transitive `serialize-javascript` to its patched release via npm `overrides`.

- **GHSA-5c6j-r48x-rmvq** (HIGH, RCE via `RegExp.flags` / `Date.prototype.toISOString()`)
- **GHSA-qj8w-gfj5-8c6v** (MEDIUM, CPU-exhaustion DoS)

Both come in through the build-time bundler chain:

```
vite-plugin-pwa@1.2.0 → workbox-build@7.4.0 → @rollup/plugin-terser@0.4.4 → serialize-javascript@6.0.x
```

`npm audit fix --force` would have downgraded `vite-plugin-pwa` to `0.19.8` (a major regression) rather than forwarding the leaf, so the right fix is an override on the leaf package.

## Why this is low risk

Both CVEs require attacker-controlled input to be passed through `serialize()` at build time. Our pipeline doesn't do that — the workbox build serializes only the precache manifest, which is generated from our own `dist/` output. So the practical exposure was minimal even before this fix; this PR just removes the noise from GitHub's security tab.

The override only **tightens** the resolved version (6.x → 7.0.5). It doesn't loosen anything or change any direct dependency declaration.

## Issue #155 status

This PR closes the **web half** of issue #155. The **miniapp half** (`git-clone`, `minimatch`) was already resolved separately — the Taro 4 → native WeChat rebuild in 060b7c9 removed the entire toolchain that pulled those packages in. `miniapp/package-lock.json` no longer references either, so no action is needed there.

## Test plan
- [x] `npm install` in `web/` resolves `serialize-javascript@7.0.5` (`npm ls serialize-javascript`)
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` succeeds — output identical to `main`
- [ ] CI deploy-frontend-appservice runs cleanly post-merge
- [ ] GitHub Dependabot re-scans and clears alerts 1, 2, 4 from issue #155

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)