### PR TITLE
Fix zone-insight lookup for zh users — add stable English key to TSB zones

### DIFF
--- a/analysis/science.py
+++ b/analysis/science.py
@@ -45,6 +45,11 @@ class TsbZoneLabeled:
     """TSB zone with boundary + display label (merged from theory + labels)."""
     min: float | None = None
     max: float | None = None
+    # Stable English identifier for client-side dictionary lookups (e.g. zone
+    # insight prose). Mirrors across locales so zh users still hit the same
+    # key. Empty when a label set predates the field — clients should fall
+    # back to `label` in that case.
+    key: str = ""
     label: str = ""
     color: str = "#64748b"
     description: str = ""
@@ -210,10 +215,16 @@ def merge_zones_with_labels(
     label_list = labels.tsb_zone_labels or []
     for i, zone in enumerate(zones):
         lbl = label_list[i] if i < len(label_list) else {}
+        label = lbl.get("label", f"Zone {i + 1}")
+        # Fall back to label when `key` isn't set so older or custom label
+        # sets don't lose the dictionary lookup path on the client. zh label
+        # files always mirror the English `key` from their en counterpart.
+        key = lbl.get("key", label)
         result.append(TsbZoneLabeled(
             min=zone.min,
             max=zone.max,
-            label=lbl.get("label", f"Zone {i + 1}"),
+            key=key,
+            label=label,
             color=lbl.get("color", "#64748b"),
             description=lbl.get("description", ""),
         ))

--- a/analysis/science.py
+++ b/analysis/science.py
@@ -46,9 +46,11 @@ class TsbZoneLabeled:
     min: float | None = None
     max: float | None = None
     # Stable English identifier for client-side dictionary lookups (e.g. zone
-    # insight prose). Mirrors across locales so zh users still hit the same
-    # key. Empty when a label set predates the field — clients should fall
-    # back to `label` in that case.
+    # insight prose). By convention, zh label files mirror the same key values
+    # as their English counterparts so lookups stay locale-invariant. When a
+    # label set predates this field, merge_zones_with_labels() falls back to
+    # the localized `label` — so key equals label in that path, and clients
+    # can treat a non-empty key as stable and a missing/empty one as "use label".
     key: str = ""
     label: str = ""
     color: str = "#64748b"
@@ -216,9 +218,11 @@ def merge_zones_with_labels(
     for i, zone in enumerate(zones):
         lbl = label_list[i] if i < len(label_list) else {}
         label = lbl.get("label", f"Zone {i + 1}")
-        # Fall back to label when `key` isn't set so older or custom label
-        # sets don't lose the dictionary lookup path on the client. zh label
-        # files always mirror the English `key` from their en counterpart.
+        # When `key` is absent from the YAML, fall back to `label` so the
+        # client's dictionary lookup still works for English (where key and
+        # label are the same). For zh, a missing key means the client's
+        # fallback to `zone.label` also fails — so zh label files must
+        # always carry `key`. This is a convention, not enforced at load time.
         key = lbl.get("key", label)
         result.append(TsbZoneLabeled(
             min=zone.min,

--- a/api/deps.py
+++ b/api/deps.py
@@ -1509,7 +1509,7 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
         },
         "data_meta": data_meta,
         "tsb_zones": [
-            {"key": z.key, "min": z.min, "max": z.max, "label": z.label, "color": z.color}
+            {**({"key": z.key} if z.key else {}), "min": z.min, "max": z.max, "label": z.label, "color": z.color}
             for z in (load_theory.tsb_zones_labeled if load_theory else [])
         ],
     }

--- a/api/deps.py
+++ b/api/deps.py
@@ -1509,7 +1509,7 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
         },
         "data_meta": data_meta,
         "tsb_zones": [
-            {"min": z.min, "max": z.max, "label": z.label, "color": z.color}
+            {"key": z.key, "min": z.min, "max": z.max, "label": z.label, "color": z.color}
             for z in (load_theory.tsb_zones_labeled if load_theory else [])
         ],
     }

--- a/api/routes/science.py
+++ b/api/routes/science.py
@@ -100,7 +100,7 @@ def get_science(
             summary = _theory_summary(theory)
             if theory.tsb_zones_labeled:
                 summary["tsb_zones"] = [
-                    {"key": z.key, "min": z.min, "max": z.max, "label": z.label, "color": z.color}
+                    {**({"key": z.key} if z.key else {}), "min": z.min, "max": z.max, "label": z.label, "color": z.color}
                     for z in theory.tsb_zones_labeled
                 ]
             active[pillar] = summary

--- a/api/routes/science.py
+++ b/api/routes/science.py
@@ -100,7 +100,7 @@ def get_science(
             summary = _theory_summary(theory)
             if theory.tsb_zones_labeled:
                 summary["tsb_zones"] = [
-                    {"min": z.min, "max": z.max, "label": z.label, "color": z.color}
+                    {"key": z.key, "min": z.min, "max": z.max, "label": z.label, "color": z.color}
                     for z in theory.tsb_zones_labeled
                 ]
             active[pillar] = summary

--- a/data/science/labels/standard.yaml
+++ b/data/science/labels/standard.yaml
@@ -2,9 +2,12 @@ id: standard
 name: "Standard"
 author: system
 
+# `key` is a stable English identifier used by clients (e.g. FormSparkline's
+# zone-insight dictionary). `label` is the localized display string. zh files
+# mirror `key` and translate `label`.
 tsb_zone_labels:
-  - {label: "Detraining", color: "#64748b"}
-  - {label: "Performance", color: "#00ff87"}
-  - {label: "Optimal", color: "#3b82f6"}
-  - {label: "Productive", color: "#22c55e"}
-  - {label: "Overreaching", color: "#ef4444"}
+  - {key: "Detraining", label: "Detraining", color: "#64748b"}
+  - {key: "Performance", label: "Performance", color: "#00ff87"}
+  - {key: "Optimal", label: "Optimal", color: "#3b82f6"}
+  - {key: "Productive", label: "Productive", color: "#22c55e"}
+  - {key: "Overreaching", label: "Overreaching", color: "#ef4444"}

--- a/data/science/labels/stryd.yaml
+++ b/data/science/labels/stryd.yaml
@@ -2,9 +2,12 @@ id: stryd
 name: "Stryd RSB"
 author: system
 
+# `key` is a stable English identifier used by clients (e.g. FormSparkline's
+# zone-insight dictionary). `label` is the localized display string. zh files
+# mirror `key` and translate `label`.
 tsb_zone_labels:
-  - {label: "Detraining", color: "#64748b"}
-  - {label: "Performance", color: "#22c55e"}
-  - {label: "Productive & Maintenance", color: "#3b82f6"}
-  - {label: "Cautionary", color: "#f59e0b"}
-  - {label: "Overreaching", color: "#ef4444"}
+  - {key: "Detraining", label: "Detraining", color: "#64748b"}
+  - {key: "Performance", label: "Performance", color: "#22c55e"}
+  - {key: "Productive & Maintenance", label: "Productive & Maintenance", color: "#3b82f6"}
+  - {key: "Cautionary", label: "Cautionary", color: "#f59e0b"}
+  - {key: "Overreaching", label: "Overreaching", color: "#ef4444"}

--- a/data/science/zh/labels/standard.yaml
+++ b/data/science/zh/labels/standard.yaml
@@ -1,14 +1,20 @@
 id: standard
 name: 标准
 author: system
+# `key` mirrors the English identifier; only `label` is translated.
 tsb_zone_labels:
-- label: 训练不足
+- key: Detraining
+  label: 训练不足
   color: '#64748b'
-- label: 竞赛状态
+- key: Performance
+  label: 竞赛状态
   color: '#00ff87'
-- label: 最佳平衡
+- key: Optimal
+  label: 最佳平衡
   color: '#3b82f6'
-- label: 高效训练
+- key: Productive
+  label: 高效训练
   color: '#22c55e'
-- label: 过度训练
+- key: Overreaching
+  label: 过度训练
   color: '#ef4444'

--- a/data/science/zh/labels/stryd.yaml
+++ b/data/science/zh/labels/stryd.yaml
@@ -1,14 +1,20 @@
 id: stryd
 name: Stryd RSB
 author: system
+# `key` mirrors the English identifier; only `label` is translated.
 tsb_zone_labels:
-- label: 训练不足
+- key: Detraining
+  label: 训练不足
   color: '#64748b'
-- label: 竞赛状态
+- key: Performance
+  label: 竞赛状态
   color: '#22c55e'
-- label: 吸收与维持
+- key: Productive & Maintenance
+  label: 吸收与维持
   color: '#3b82f6'
-- label: 需要谨慎
+- key: Cautionary
+  label: 需要谨慎
   color: '#f59e0b'
-- label: 过度训练
+- key: Overreaching
+  label: 过度训练
   color: '#ef4444'

--- a/tests/test_science.py
+++ b/tests/test_science.py
@@ -100,7 +100,32 @@ class TestMergeZonesWithLabels:
         merged = merge_zones_with_labels(zones, labels)
         assert len(merged) == 3
         assert merged[0].min == 25
-        assert merged[0].label  # Should have a label from the label set
+        assert merged[0].label == "Detraining"
+
+    def test_merge_populates_key_from_yaml(self):
+        zones = [TsbZone(min=25), TsbZone(min=5, max=25)]
+        labels = load_labels("standard")
+        merged = merge_zones_with_labels(zones, labels)
+        assert merged[0].key == "Detraining"
+        assert merged[1].key == "Performance"
+
+    def test_merge_key_is_stable_across_locales(self):
+        zones = [TsbZone(min=25), TsbZone(min=5, max=25), TsbZone(min=-10, max=5)]
+        en_labels = load_labels("standard")
+        zh_labels = load_labels("standard", locale="zh")
+        en_merged = merge_zones_with_labels(zones, en_labels)
+        zh_merged = merge_zones_with_labels(zones, zh_labels)
+        for en_z, zh_z in zip(en_merged, zh_merged):
+            assert en_z.key == zh_z.key, f"key diverged: {en_z.key!r} != {zh_z.key!r}"
+            assert zh_z.label != zh_z.key, "zh label should be translated, not equal to the English key"
+
+    def test_merge_key_falls_back_to_label_when_absent(self):
+        zones = [TsbZone(min=0)]
+        from analysis.science import LabelSet
+        labels = LabelSet(id="custom", name="Custom", tsb_zone_labels=[{"label": "Easy", "color": "#aaa"}])
+        merged = merge_zones_with_labels(zones, labels)
+        assert merged[0].key == "Easy"
+        assert merged[0].label == "Easy"
 
     def test_merge_with_fewer_labels_uses_defaults(self):
         zones = [TsbZone(min=i) for i in range(10)]
@@ -131,6 +156,24 @@ class TestLoadActiveScience:
         load = active["load"]
         assert len(load.tsb_zones_labeled) > 0
         assert load.tsb_zones_labeled[0].label
+        assert load.tsb_zones_labeled[0].key
+
+    def test_tsb_zones_labeled_key_stable_in_zh(self):
+        choices = {"load": "banister_pmc"}
+        en_active = load_active_science(choices)
+        zh_active = load_active_science(choices, locale="zh")
+        en_zones = en_active["load"].tsb_zones_labeled
+        zh_zones = zh_active["load"].tsb_zones_labeled
+        assert len(en_zones) == len(zh_zones)
+        for en_z, zh_z in zip(en_zones, zh_zones):
+            assert en_z.key == zh_z.key, f"key diverged: {en_z.key!r} != {zh_z.key!r}"
+
+    def test_stryd_zh_keys_mirror_en(self):
+        en_labels = load_labels("stryd")
+        zh_labels = load_labels("stryd", locale="zh")
+        en_keys = [lbl.get("key") for lbl in en_labels.tsb_zone_labels]
+        zh_keys = [lbl.get("key") for lbl in zh_labels.tsb_zone_labels]
+        assert en_keys == zh_keys
 
 
 class TestRecommendScience:

--- a/web/src/components/charts/FormSparkline.tsx
+++ b/web/src/components/charts/FormSparkline.tsx
@@ -19,10 +19,9 @@ import { msg } from '@lingui/core/macro';
 import type { MessageDescriptor } from '@lingui/core';
 
 // Zone insights are keyed by the stable English `key` from the science
-// label set, so the lookup survives label localization (the localized
-// `label` field is rendered separately). When `key` is missing — older
-// data, or a custom label set without keys — we fall back to looking up
-// the (English) `label` to keep the en path lossless.
+// label set, so the lookup survives label localization. When `key` is
+// missing we fall back to `label`: lossless for en (key === label in
+// English), silent miss for zh (translated label won't match any key).
 const ZONE_INSIGHTS: Record<string, MessageDescriptor> = {
   Performance: msg`Freshened up — good window for racing or testing.`,
   Optimal: msg`Good balance of fitness and recovery. Ready for quality work.`,

--- a/web/src/components/charts/FormSparkline.tsx
+++ b/web/src/components/charts/FormSparkline.tsx
@@ -8,27 +8,30 @@ import {
   Tooltip,
   XAxis,
 } from 'recharts';
-import type { TsbSparkline } from '@/types/api';
+import type { TsbSparkline, ScienceNoteInfo } from '@/types/api';
 import { useScience, tsbZoneFromConfig } from '@/contexts/ScienceContext';
 import ZoneLegend from '@/components/charts/ZoneLegend';
 import ScienceNote from '@/components/ScienceNote';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/useChartColors';
-import { Trans } from '@lingui/react/macro';
+import { Trans, useLingui } from '@lingui/react/macro';
+import { msg } from '@lingui/core/macro';
+import type { MessageDescriptor } from '@lingui/core';
 
-// NOTE: ZONE_INSIGHTS lookup is keyed by the English zone label. After zh
-// labels were translated, zh users fall through the lookup below and see
-// no insight paragraph. Proper fix needs a stable `key` field on
-// TsbZoneLabeled threaded through the API — tracked in issue #104.
-const ZONE_INSIGHTS: Record<string, string> = {
-  Performance: 'Freshened up \u2014 good window for racing or testing.',
-  Optimal: 'Good balance of fitness and recovery. Ready for quality work.',
-  Productive: 'Building fitness with manageable fatigue.',
-  Overreaching: 'High fatigue accumulation. Prioritize recovery.',
-  Detraining: 'Extended rest period. Fitness declining.',
+// Zone insights are keyed by the stable English `key` from the science
+// label set, so the lookup survives label localization (the localized
+// `label` field is rendered separately). When `key` is missing — older
+// data, or a custom label set without keys — we fall back to looking up
+// the (English) `label` to keep the en path lossless.
+const ZONE_INSIGHTS: Record<string, MessageDescriptor> = {
+  Performance: msg`Freshened up — good window for racing or testing.`,
+  Optimal: msg`Good balance of fitness and recovery. Ready for quality work.`,
+  Productive: msg`Building fitness with manageable fatigue.`,
+  'Productive & Maintenance': msg`Absorbing training while maintaining fitness.`,
+  Cautionary: msg`Fatigue is climbing — watch recovery before adding load.`,
+  Overreaching: msg`High fatigue accumulation. Prioritize recovery.`,
+  Detraining: msg`Extended rest period. Fitness declining.`,
 };
-
-import type { ScienceNoteInfo } from '@/types/api';
 
 interface Props {
   data: TsbSparkline;
@@ -66,6 +69,7 @@ function SparkTooltip({ active, payload, label, tsbZones }: any) {
 export default function FormSparkline({ data, scienceNote }: Props) {
   const chartColors = useChartColors();
   const { tsbZones } = useScience();
+  const { i18n } = useLingui();
   const { chartData, yMin, yMax, hasProjection, latestTsb } = useMemo(() => {
     const hasProjData = !!(data.projected_dates?.length && data.projected_values?.length);
 
@@ -231,17 +235,24 @@ export default function FormSparkline({ data, scienceNote }: Props) {
           )}
         </div>
 
-        {/* Form insight */}
-        {ZONE_INSIGHTS[zone.label] && (
-          <p className="text-xs text-muted-foreground mt-3" style={{ color: `${zone.color}99` }}>
-            {ZONE_INSIGHTS[zone.label]}
-          </p>
-        )}
+        {/* Form insight — prefer the stable `key`, fall back to the
+            English `label` so en-locale data without `key` still renders. */}
+        {(() => {
+          const insight =
+            (zone.key && ZONE_INSIGHTS[zone.key]) ||
+            ZONE_INSIGHTS[zone.label];
+          if (!insight) return null;
+          return (
+            <p className="text-xs text-muted-foreground mt-3" style={{ color: `${zone.color}99` }}>
+              {i18n._(insight)}
+            </p>
+          );
+        })()}
 
         <ZoneLegend zones={tsbZones} />
 
         <ScienceNote
-          text={scienceNote?.description || "Form (TSB) = Fitness (CTL) \u2212 Fatigue (ATL). Positive TSB means you're fresh; negative means fatigued."}
+          text={scienceNote?.description || "Form (TSB) = Fitness (CTL) − Fatigue (ATL). Positive TSB means you're fresh; negative means fatigued."}
           sourceUrl={scienceNote?.citations?.[0]?.url}
           sourceLabel={scienceNote?.citations?.[0]?.label || scienceNote?.name}
         />

--- a/web/src/contexts/ScienceContext.tsx
+++ b/web/src/contexts/ScienceContext.tsx
@@ -16,11 +16,11 @@ interface ScienceContextValue {
 
 /** Fallback zones if API hasn't loaded yet. */
 const DEFAULT_TSB_ZONES: TsbZoneConfig[] = [
-  { min: 25, max: null, label: 'Detraining', color: '#64748b' },
-  { min: 5, max: 25, label: 'Performance', color: '#00ff87' },
-  { min: -10, max: 5, label: 'Optimal', color: '#3b82f6' },
-  { min: -25, max: -10, label: 'Productive', color: '#22c55e' },
-  { min: null, max: -25, label: 'Overreaching', color: '#ef4444' },
+  { key: 'Detraining', min: 25, max: null, label: 'Detraining', color: '#64748b' },
+  { key: 'Performance', min: 5, max: 25, label: 'Performance', color: '#00ff87' },
+  { key: 'Optimal', min: -10, max: 5, label: 'Optimal', color: '#3b82f6' },
+  { key: 'Productive', min: -25, max: -10, label: 'Productive', color: '#22c55e' },
+  { key: 'Overreaching', min: null, max: -25, label: 'Overreaching', color: '#ef4444' },
 ];
 
 const ScienceContext = createContext<ScienceContextValue>({
@@ -86,22 +86,26 @@ export function useScience() {
   return useContext(ScienceContext);
 }
 
-/** Get zone label + color for a TSB value. Uses the active science context. */
-export function useTsbZone(tsb: number): { label: string; color: string } {
+/** Get zone key + label + color for a TSB value. Uses the active science context. */
+export function useTsbZone(tsb: number): { key?: string; label: string; color: string } {
   const { tsbZones } = useScience();
   return tsbZoneFromConfig(tsb, tsbZones);
 }
 
-/** Pure function: classify a TSB value against a zone config. */
+/** Pure function: classify a TSB value against a zone config.
+ *
+ * Returns `key` (stable English identifier) alongside `label` and `color`
+ * so callers can look up locale-invariant zone metadata (e.g. insight
+ * prose) without re-deriving it from the localized label. */
 export function tsbZoneFromConfig(
   tsb: number,
   zones: TsbZoneConfig[],
-): { label: string; color: string } {
+): { key?: string; label: string; color: string } {
   for (const zone of zones) {
     const aboveMin = zone.min == null || tsb >= zone.min;
     const belowMax = zone.max == null || tsb < zone.max;
     if (aboveMin && belowMax) {
-      return { label: zone.label, color: zone.color };
+      return { key: zone.key, label: zone.label, color: zone.color };
     }
   }
   return { label: 'Unknown', color: '#64748b' };

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -1,4 +1,4 @@
-msgid ""
+﻿msgid ""
 msgstr ""
 "POT-Creation-Date: 2026-04-18 00:00+0000\n"
 "MIME-Version: 1.0\n"
@@ -277,6 +277,35 @@ msgstr "Avg Power"
 
 #: src/components/charts/SleepPerfChart.tsx:46
 #: src/components/charts/SleepPerfChart.tsx:49
+
+#: src/components/charts/FormSparkline.tsx:27
+msgid "Freshened up — good window for racing or testing."
+msgstr "Freshened up — good window for racing or testing."
+
+#: src/components/charts/FormSparkline.tsx:28
+msgid "Good balance of fitness and recovery. Ready for quality work."
+msgstr "Good balance of fitness and recovery. Ready for quality work."
+
+#: src/components/charts/FormSparkline.tsx:29
+msgid "Building fitness with manageable fatigue."
+msgstr "Building fitness with manageable fatigue."
+
+#: src/components/charts/FormSparkline.tsx:30
+msgid "Absorbing training while maintaining fitness."
+msgstr "Absorbing training while maintaining fitness."
+
+#: src/components/charts/FormSparkline.tsx:31
+msgid "Fatigue is climbing — watch recovery before adding load."
+msgstr "Fatigue is climbing — watch recovery before adding load."
+
+#: src/components/charts/FormSparkline.tsx:32
+msgid "High fatigue accumulation. Prioritize recovery."
+msgstr "High fatigue accumulation. Prioritize recovery."
+
+#: src/components/charts/FormSparkline.tsx:33
+msgid "Extended rest period. Fitness declining."
+msgstr "Extended rest period. Fitness declining."
+
 #~ msgid "Avg Power (W)"
 #~ msgstr "Avg Power (W)"
 

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -275,9 +275,6 @@ msgstr "Avg HR"
 msgid "Avg Power"
 msgstr "Avg Power"
 
-#: src/components/charts/SleepPerfChart.tsx:46
-#: src/components/charts/SleepPerfChart.tsx:49
-
 #: src/components/charts/FormSparkline.tsx:27
 msgid "Freshened up — good window for racing or testing."
 msgstr "Freshened up — good window for racing or testing."
@@ -306,6 +303,8 @@ msgstr "High fatigue accumulation. Prioritize recovery."
 msgid "Extended rest period. Fitness declining."
 msgstr "Extended rest period. Fitness declining."
 
+#: src/components/charts/SleepPerfChart.tsx:46
+#: src/components/charts/SleepPerfChart.tsx:49
 #~ msgid "Avg Power (W)"
 #~ msgstr "Avg Power (W)"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -1,4 +1,4 @@
-msgid ""
+﻿msgid ""
 msgstr ""
 "POT-Creation-Date: 2026-04-18 00:00+0000\n"
 "MIME-Version: 1.0\n"
@@ -2001,6 +2001,35 @@ msgid "Zones & load from Threshold Pace"
 msgstr "基于阈值配速的区间与负荷"
 #: src/components/charts/SleepPerfChart.tsx:46
 #: src/components/charts/SleepPerfChart.tsx:49
+
+#: src/components/charts/FormSparkline.tsx:27
+msgid "Freshened up — good window for racing or testing."
+msgstr "状态新鲜 — 适合比赛或测试。"
+
+#: src/components/charts/FormSparkline.tsx:28
+msgid "Good balance of fitness and recovery. Ready for quality work."
+msgstr "体能与恢复均衡，适合高质量训练。"
+
+#: src/components/charts/FormSparkline.tsx:29
+msgid "Building fitness with manageable fatigue."
+msgstr "在可控疲劳下积累体能。"
+
+#: src/components/charts/FormSparkline.tsx:30
+msgid "Absorbing training while maintaining fitness."
+msgstr "在维持体能的同时吸收训练刺激。"
+
+#: src/components/charts/FormSparkline.tsx:31
+msgid "Fatigue is climbing — watch recovery before adding load."
+msgstr "疲劳上升 — 增加负荷前请注意恢复。"
+
+#: src/components/charts/FormSparkline.tsx:32
+msgid "High fatigue accumulation. Prioritize recovery."
+msgstr "疲劳大量积累，优先安排恢复。"
+
+#: src/components/charts/FormSparkline.tsx:33
+msgid "Extended rest period. Fitness declining."
+msgstr "持续休息，体能正在下降。"
+
 #~ msgid "Avg Power (W)"
 #~ msgstr "平均功率 (W)"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -1999,9 +1999,6 @@ msgstr "基于乳酸阈值心率的区间与负荷"
 #: src/pages/Setup.tsx:163
 msgid "Zones & load from Threshold Pace"
 msgstr "基于阈值配速的区间与负荷"
-#: src/components/charts/SleepPerfChart.tsx:46
-#: src/components/charts/SleepPerfChart.tsx:49
-
 #: src/components/charts/FormSparkline.tsx:27
 msgid "Freshened up — good window for racing or testing."
 msgstr "状态新鲜 — 适合比赛或测试。"
@@ -2030,6 +2027,8 @@ msgstr "疲劳大量积累，优先安排恢复。"
 msgid "Extended rest period. Fitness declining."
 msgstr "持续休息，体能正在下降。"
 
+#: src/components/charts/SleepPerfChart.tsx:46
+#: src/components/charts/SleepPerfChart.tsx:49
 #~ msgid "Avg Power (W)"
 #~ msgstr "平均功率 (W)"
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -6,6 +6,11 @@ export type SciencePillar = 'load' | 'recovery' | 'prediction' | 'zones';
 export interface TsbZoneConfig {
   min: number | null;
   max: number | null;
+  /** Stable English identifier for client-side lookups (e.g. zone-insight
+   * dictionaries). `label` is the localized display string and changes per
+   * locale; `key` is invariant. Optional because older API responses or
+   * custom label sets may omit it — clients should fall back to `label`. */
+  key?: string;
   label: string;
   color: string;
 }


### PR DESCRIPTION
Closes #104

## Summary

- Add `key` (stable English identifier) to every `tsb_zone_labels` entry in `data/science/labels/*.yaml` and `data/science/zh/labels/*.yaml` — zh files mirror the key, only `label` is translated
- Plumb `key` through `TsbZoneLabeled` → API response (`tsb_zones` dict) → `TsbZoneConfig` TS type → `tsbZoneFromConfig` return value
- Switch `ZONE_INSIGHTS` in `FormSparkline.tsx` from plain strings keyed on `zone.label` to Lingui `MessageDescriptor`s keyed on `zone.key` (with `zone.label` fallback for old data / custom label sets without keys)
- Add `Cautionary` and `Productive & Maintenance` insight entries for the Stryd RSB label set
- Add catalog entries to both `.po` files (zh translated)

## Why

After PR #100 translated zh zone labels, `ZONE_INSIGHTS[zone.label]` missed on every lookup for zh users — they saw no insight paragraph below the TSB sparkline. The fix uses a locale-invariant key so the dictionary lookup is stable across translations.

## Fallback

Old API responses or custom label sets without `key` populated fall back to `zone.label`, so en-locale behaviour is unchanged.

## Test plan

- [x] `pytest tests/test_science.py` — 19/19 pass
- [x] `tsc --noEmit` — no new type errors
- [x] Manual: confirmed `key` populated for both en and zh label sets via Python REPL
- [ ] Visual check on zh locale: Form (TSB) card should now show translated insight paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)