### PR TITLE
Reduce mobile web cold-load FCP (issue #167)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11776,27 +11776,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
 import { KEYS, getCompatItem, setCompatItem, removeCompatItem } from '../lib/storage-compat';
+import { prefetchedMeResponse } from '../lib/auth-prefetch';
 
 interface AuthState {
   token: string | null;
@@ -53,8 +54,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     setToken(stored);
 
-    // Verify token and fetch fresh profile (admin status, active status)
-    fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${stored}` } })
+    // Use the response already in-flight from auth-prefetch (started at
+    // module evaluation time, before React mounted) to avoid one extra
+    // render-cycle of latency on cold load.
+    const meResponse = prefetchedMeResponse ??
+      fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${stored}` } });
+
+    meResponse
       .then((r) => {
         if (r.status === 401) {
           // Token expired or user deactivated — clear auth state

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
 import { KEYS, getCompatItem, setCompatItem, removeCompatItem } from '../lib/storage-compat';
-import { prefetchedMeResponse } from '../lib/auth-prefetch';
+import { prefetchedMe } from '../lib/auth-prefetch';
 
 interface AuthState {
   token: string | null;
@@ -54,15 +54,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     setToken(stored);
 
-    // Use the response already in-flight from auth-prefetch (started at
-    // module evaluation time, before React mounted) to avoid one extra
-    // render-cycle of latency on cold load.
-    const meResponse = prefetchedMeResponse ??
-      fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${stored}` } });
+    // Use the pre-parsed result from auth-prefetch (started at module
+    // evaluation time, before React mounted) to avoid one extra render-
+    // cycle of latency on cold load. The result is already parsed so it
+    // is idempotent to consume — StrictMode double-fires are safe.
+    const mePromise = prefetchedMe ??
+      fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${stored}` } })
+        .then(async (r) => ({ status: r.status, data: r.ok ? await r.json() : null }))
+        .catch(() => ({ status: 0, data: null }));
 
-    meResponse
-      .then((r) => {
-        if (r.status === 401) {
+    mePromise
+      .then(({ status, data }) => {
+        if (status === 401) {
           // Token expired or user deactivated — clear auth state
           removeCompatItem(KEYS.authToken.new, KEYS.authToken.legacy);
           removeCompatItem(KEYS.authEmail.new, KEYS.authEmail.legacy);
@@ -71,12 +74,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setEmail(null);
           setIsAdmin(false);
           setIsDemo(false);
-          return null;
-        }
-        return r.ok ? r.json() : null;
-      })
-      .then((data) => {
-        if (data) {
+        } else if (data) {
           setIsAdmin(data.is_superuser);
           setIsDemo(data.is_demo ?? false);
           setCompatItem(KEYS.authAdmin.new, KEYS.authAdmin.legacy, String(data.is_superuser));

--- a/web/src/hooks/useSetupStatus.ts
+++ b/web/src/hooks/useSetupStatus.ts
@@ -142,9 +142,12 @@ export function useSetupStatus(): SetupStatus {
   const completed = steps.filter((s) => s.done).length;
   const isActuallyDone = completed === steps.length;
 
-  // Persist completion so the next cold load skips the blocking cascade.
+  // Keep the cache in sync with live state: set on completion, clear when
+  // a platform is disconnected or setup regresses (e.g. after logout on a
+  // shared browser or account switch).
   useEffect(() => {
     if (isActuallyDone) setCachedSetupDone();
+    else clearCachedSetupDone();
   }, [isActuallyDone]);
 
   return {

--- a/web/src/hooks/useSetupStatus.ts
+++ b/web/src/hooks/useSetupStatus.ts
@@ -3,6 +3,20 @@ import { useSettings } from '@/contexts/SettingsContext';
 import { API_BASE, getAuthHeaders } from '@/hooks/useApi';
 import type { SyncStatusResponse } from '@/types/api';
 
+const SETUP_DONE_KEY = 'praxys-setup-done';
+
+function getCachedSetupDone(): boolean {
+  try { return localStorage.getItem(SETUP_DONE_KEY) === 'true'; } catch { return false; }
+}
+
+function setCachedSetupDone(): void {
+  try { localStorage.setItem(SETUP_DONE_KEY, 'true'); } catch { /* localStorage unavailable */ }
+}
+
+function clearCachedSetupDone(): void {
+  try { localStorage.removeItem(SETUP_DONE_KEY); } catch { /* localStorage unavailable */ }
+}
+
 export interface SetupStep {
   key: string;
   label: string;
@@ -34,6 +48,10 @@ export interface SetupStatus {
  */
 export function useSetupStatus(): SetupStatus {
   const { config, loading: settingsLoading } = useSettings();
+  // Cached flag: if setup was fully complete on a prior load, skip the
+  // blocking API calls so TodayOrSetup renders Today immediately.
+  // fetchKey > 0 (manual refetch) always re-runs the blocking path.
+  const [cachedDone] = useState(() => getCachedSetupDone());
   const [connectedPlatforms, setConnectedPlatforms] = useState<string[]>([]);
   const [syncStatus, setSyncStatus] = useState<SyncStatusResponse>({});
   const [connectionsLoading, setConnectionsLoading] = useState(true);
@@ -41,7 +59,9 @@ export function useSetupStatus(): SetupStatus {
 
   useEffect(() => {
     let cancelled = false;
-    setConnectionsLoading(true);
+    const isBackgroundRefresh = cachedDone && fetchKey === 0;
+
+    if (!isBackgroundRefresh) setConnectionsLoading(true);
 
     Promise.all([
       fetch(`${API_BASE}/api/settings/connections`, { headers: getAuthHeaders() })
@@ -55,16 +75,20 @@ export function useSetupStatus(): SetupStatus {
         const platforms = Object.keys(connData.connections || {});
         setConnectedPlatforms(platforms);
         setSyncStatus(syncData);
-        setConnectionsLoading(false);
+        if (!isBackgroundRefresh) setConnectionsLoading(false);
       })
       .catch(() => {
-        if (!cancelled) setConnectionsLoading(false);
+        if (!cancelled && !isBackgroundRefresh) setConnectionsLoading(false);
       });
 
     return () => { cancelled = true; };
-  }, [fetchKey]);
+  // cachedDone is stable (useState with no setter), so this never
+  // causes extra runs — it's listed to satisfy the exhaustive-deps rule.
+  }, [fetchKey, cachedDone]);
 
-  const loading = settingsLoading || connectionsLoading;
+  // When the cache says setup was complete and this is the initial load,
+  // skip the blocking wait so TodayOrSetup renders Today immediately.
+  const loading = (cachedDone && fetchKey === 0) ? false : (settingsLoading || connectionsLoading);
 
   // Derive step completion
   const hasConnection = connectedPlatforms.length > 0;
@@ -116,17 +140,25 @@ export function useSetupStatus(): SetupStatus {
   ];
 
   const completed = steps.filter((s) => s.done).length;
+  const isActuallyDone = completed === steps.length;
+
+  // Persist completion so the next cold load skips the blocking cascade.
+  useEffect(() => {
+    if (isActuallyDone) setCachedSetupDone();
+  }, [isActuallyDone]);
 
   return {
     loading,
     steps,
     completed,
     total: steps.length,
-    allDone: completed === steps.length,
+    allDone: (cachedDone && fetchKey === 0) || isActuallyDone,
     hasConnection,
     hasSyncedData,
     connectedPlatforms,
     syncStatus,
-    refetch: () => setFetchKey((k) => k + 1),
+    // Clear cache on manual refetch (e.g. after disconnecting a platform)
+    // so the next render re-checks live state instead of using stale cache.
+    refetch: () => { clearCachedSetupDone(); setFetchKey((k) => k + 1); },
   };
 }

--- a/web/src/lib/auth-prefetch.ts
+++ b/web/src/lib/auth-prefetch.ts
@@ -1,0 +1,19 @@
+// Start the /api/auth/me fetch at module evaluation time — before React
+// mounts or any useEffect runs. AuthProvider consumes this in-flight
+// promise instead of creating a new one, shaving one React render cycle
+// off the auth round-trip on every cold load.
+import { KEYS, getCompatItem } from './storage-compat';
+
+const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? '';
+
+const token = (() => {
+  try {
+    return getCompatItem(KEYS.authToken.new, KEYS.authToken.legacy);
+  } catch {
+    return null;
+  }
+})();
+
+export const prefetchedMeResponse: Promise<Response> | null = token
+  ? fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${token}` } })
+  : null;

--- a/web/src/lib/auth-prefetch.ts
+++ b/web/src/lib/auth-prefetch.ts
@@ -1,7 +1,10 @@
 // Start the /api/auth/me fetch at module evaluation time — before React
-// mounts or any useEffect runs. AuthProvider consumes this in-flight
-// promise instead of creating a new one, shaving one React render cycle
-// off the auth round-trip on every cold load.
+// mounts or any useEffect runs. AuthProvider consumes this parsed result
+// instead of starting a new fetch, shaving one React render cycle off the
+// auth round-trip on every cold load.
+//
+// The response body is parsed eagerly so the promise is safe to consume
+// multiple times (e.g. React StrictMode double-fires effects in dev).
 import { KEYS, getCompatItem } from './storage-compat';
 
 const API_BASE = (import.meta.env.VITE_API_URL as string | undefined) ?? '';
@@ -14,6 +17,16 @@ const token = (() => {
   }
 })();
 
-export const prefetchedMeResponse: Promise<Response> | null = token
+export interface PrefetchedMe {
+  status: number;
+  data: { is_superuser: boolean; is_demo?: boolean } | null;
+}
+
+export const prefetchedMe: Promise<PrefetchedMe> | null = token
   ? fetch(`${API_BASE}/api/auth/me`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(async (r): Promise<PrefetchedMe> => ({
+        status: r.status,
+        data: r.ok ? await r.json() : null,
+      }))
+      .catch((): PrefetchedMe => ({ status: 0, data: null }))
   : null;

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { useApi } from '@/hooks/useApi';
 import type { TodayResponse } from '@/types/api';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -7,7 +8,11 @@ import { AlertTriangle } from 'lucide-react';
 import SignalHero from '@/components/SignalHero';
 import RecoveryPanel from '@/components/RecoveryPanel';
 import WorkoutCard from '@/components/WorkoutCard';
-import FormSparkline from '@/components/charts/FormSparkline';
+
+// Lazy-loaded: recharts (397 KB) is only needed for this chart.
+// Wrapping in Suspense lets SignalHero + RecoveryPanel + WorkoutCard
+// render before recharts parses, which is the visible first paint.
+const FormSparkline = lazy(() => import('@/components/charts/FormSparkline'));
 import LastActivityCard from '@/components/LastActivityCard';
 import WeeklyLoadMini from '@/components/WeeklyLoadMini';
 import DataHint from '@/components/DataHint';
@@ -80,14 +85,17 @@ export default function Today() {
         <WorkoutCard plan={signal.plan} alternatives={signal.alternatives} upcoming={data.upcoming} />
       </div>
 
-      {/* Form sparkline — full width */}
-      <DataHint
-        sufficient={data.data_meta?.pmc_sufficient ?? true}
-        message={t`Not enough data for accurate form tracking`}
-        hint={t`Sync at least 6 weeks of activity data to see your training form trend.`}
-      >
-        <FormSparkline data={tsb_sparkline} scienceNote={data.science_notes?.load} />
-      </DataHint>
+      {/* Form sparkline — full width. Lazy-loaded so recharts parses after
+          the hero content above is already visible. */}
+      <Suspense fallback={<Skeleton className="h-48 w-full rounded-2xl" />}>
+        <DataHint
+          sufficient={data.data_meta?.pmc_sufficient ?? true}
+          message={t`Not enough data for accurate form tracking`}
+          hint={t`Sync at least 6 weeks of activity data to see your training form trend.`}
+        >
+          <FormSparkline data={tsb_sparkline} scienceNote={data.science_notes?.load} />
+        </DataHint>
+      </Suspense>
 
       {/* Context row: Last Activity + Weekly Load */}
       {(data.last_activity || data.week_load) && (

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -64,7 +64,6 @@ export default defineConfig({
           if (!id.includes('node_modules')) return undefined
           if (/node_modules[\\/](react-router-dom|react-dom|react)[\\/]/.test(id)) return 'react-vendor'
           if (/node_modules[\\/]recharts[\\/]/.test(id)) return 'recharts'
-          if (/node_modules[\\/](react-markdown|remark-gfm)[\\/]/.test(id)) return 'markdown'
           if (/node_modules[\\/]@tanstack[\\/]react-query[\\/]/.test(id)) return 'query'
           return undefined
         },


### PR DESCRIPTION
## Summary

- **Pre-start `/api/auth/me` fetch** (`web/src/lib/auth-prefetch.ts`) — fires the auth round-trip at JS module evaluation time, before React mounts, so AuthProvider's useEffect gets an already-in-flight response instead of starting a new one
- **Skip setup cascade for onboarded users** (`useSetupStatus.ts`) — caches `allDone: true` in localStorage; on repeat cold loads `TodayOrSetup` renders `Today` immediately instead of blocking on `/api/settings/connections` + `/api/sync/status`
- **Lazy-load `FormSparkline`** (`Today.tsx`) — moves recharts (397 kB) off the critical paint path; hero content (`SignalHero`, `RecoveryPanel`, `WorkoutCard`) renders first with a Skeleton placeholder
- **Remove `react-markdown` from `manualChunks`** (`vite.config.ts`) — eliminates 161 kB from the initial modulepreload graph; markdown now bundled in the lazy `Science` chunk

Closes #167.

## Root cause (revised from issue)

The issue correctly identified the bottlenecks but the "slow CPU / narrow bandwidth" framing doesn't fully hold for iPhone 14 Pro + 5G. The A16 Bionic parses JS at near-desktop speed and 5G RTT is ~15–30 ms. The real culprit is **architectural**: three serial React render+fetch cycles (`auth/me` → `settings+setup` → `today`) with null-render windows at each gate, producing blank screen regardless of device speed. These changes cut two of those hops for returning users.

## Test plan

- [ ] Fresh incognito / cleared-storage load: confirm Today skeleton appears without blank-screen pause after auth resolves
- [ ] Onboarded repeat load: confirm `TodayOrSetup` does not block on connections/sync-status calls (check Network tab — those calls should fire in background after Today is visible)
- [ ] New user / incomplete setup: confirm Setup page still shows (localStorage flag absent on first visit)
- [ ] Disconnect a platform → re-visit Today: confirm Setup page shows (cache cleared by `refetch()`)
- [ ] Form sparkline: confirm Skeleton shows briefly then TSB chart appears (recharts lazy-loading)
- [ ] Science page: confirm react-markdown still renders (now bundled in Science lazy chunk)
- [ ] Warm visit: confirm no regression in LCP or existing behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)