### PR TITLE
miniapp: CI/CD publish via miniprogram-ci

### DIFF
--- a/.github/workflows/miniapp-build.yml
+++ b/.github/workflows/miniapp-build.yml
@@ -1,12 +1,11 @@
 name: Miniapp build
 
-# Native WeChat Mini Program: WeChat DevTools (or `miniprogram-ci` in CI/CD)
-# compiles the project in-place — there's no separate `npm run build` step.
-# What we CAN catch in CI is build regressions: a TypeScript error, a stale
-# i18n catalog, or a missing page entry. So this workflow runs the
-# `pretypecheck` chain (sync-types + sync-i18n) followed by `tsc --noEmit`
-# and then sanity-checks the on-disk miniapp/ tree against the page list
-# declared in app.json.
+# Native WeChat Mini Program build-validation gate, runs on PR + main push.
+# Does NOT upload to WeChat — uploading is `miniapp-publish.yml`'s job. This
+# workflow exists so PRs get a typecheck signal: it runs the `pretypecheck`
+# chain (sync-types + sync-i18n) followed by `tsc --noEmit`, then
+# sanity-checks the on-disk miniapp/ tree against the page list declared in
+# app.json.
 #
 # i18n note: the miniapp consumes `web/src/locales/{en,zh}/messages.po` via
 # `scripts/sync-i18n.cjs` (run by `pretypecheck`). The translation pipeline
@@ -66,10 +65,11 @@ jobs:
           done
           echo "All 4 components present."
       - name: Report source size
-        # Native compiles in DevTools; we can't run `miniprogram-ci` without
-        # the platform secret. Report raw source size as a rough proxy —
-        # WeChat's main-package limit is 2 MB after compile, and the source
-        # is typically near 1:1 (no transpiled bundle to expand into).
+        # Cheap proxy for the post-compile bundle size. The actual compile
+        # happens in `miniapp-publish.yml` (or DevTools); we don't run
+        # `miniprogram-ci` here to keep PR runs fast and free of the upload
+        # secret. WeChat's main-package limit is 2 MB after compile and the
+        # source is typically near 1:1 (no transpiled bundle to expand into).
         run: |
           # Exclude node_modules and the auto-generated catalogs, which
           # would skew the comparison vs what DevTools actually packages.

--- a/.github/workflows/miniapp-publish.yml
+++ b/.github/workflows/miniapp-publish.yml
@@ -5,8 +5,10 @@ name: Miniapp publish
 #
 # Versioning: CalVer, per-component tags. `miniapp-YYYY.MM.MICRO` (e.g.
 # `miniapp-2026.04.1`) goes to robot 1 (release line). Plain `main` pushes
-# go to robot 5 (dev line) with a synthetic version `YYYY.MM.DD.<run>+<sha>`
-# so they never overwrite the release candidate.
+# go to robot 5 (dev line) with a synthetic version `YYYY.MM.DD.<run>-<sha>`
+# so they never overwrite the release candidate. The dash (not `+`) keeps
+# the version string safely within the conservative subset of characters
+# that miniprogram-ci is known to accept.
 #
 # Robots 1..30 are independent slots in 版本管理 — each robot keeps its own
 # latest 开发版. Promoting to 体验版 / 提交审核 / 发布 stays manual in
@@ -32,12 +34,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Need HEAD^ to compute the path-change diff for main pushes.
-          fetch-depth: 2
+          # 0 → fetch full history. We diff `github.event.before..sha` to
+          # cover *all* commits in a multi-commit push, not just the tip
+          # (HEAD^..HEAD would silently miss a miniapp change buried under
+          # a later unrelated commit in the same push).
+          fetch-depth: 0
 
       - name: Decide whether to publish
         id: gate
         working-directory: ${{ github.workspace }}
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         shell: bash
         run: |
           set -euo pipefail
@@ -49,15 +56,28 @@ jobs:
             echo "reason=manual" >> "$GITHUB_OUTPUT"
           else
             # main push: only publish when miniapp-relevant paths changed
-            # (web/src/locales/ and web/src/types/api.ts feed into miniapp
-            # via sync-types/sync-i18n at typecheck time, so they count).
-            changed=$(git diff --name-only HEAD^ HEAD || true)
-            if echo "$changed" | grep -qE '^(miniapp/|web/src/locales/|web/src/types/api\.ts$|\.github/workflows/miniapp-publish\.yml$)'; then
+            # across the entire push range (web/src/locales/ and
+            # web/src/types/api.ts feed into miniapp via sync-types/
+            # sync-i18n at typecheck time, so they count).
+            #
+            # github.event.before is the SHA at the prior tip of main; for
+            # a brand-new branch (impossible on main but defensive) it's
+            # 40 zeros, in which case we can't compute a diff and default
+            # to publishing rather than silently skipping.
+            null_sha="0000000000000000000000000000000000000000"
+            if [[ -z "$BEFORE_SHA" || "$BEFORE_SHA" == "$null_sha" ]]; then
               echo "publish=true" >> "$GITHUB_OUTPUT"
-              echo "reason=main-push" >> "$GITHUB_OUTPUT"
+              echo "reason=main-push-new-branch" >> "$GITHUB_OUTPUT"
+              echo "::notice::No prior SHA available; publishing unconditionally."
             else
-              echo "publish=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::No miniapp-relevant paths changed in HEAD^..HEAD; skipping upload."
+              changed=$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" || true)
+              if echo "$changed" | grep -qE '^(miniapp/|web/src/locales/|web/src/types/api\.ts$|\.github/workflows/miniapp-publish\.yml$)'; then
+                echo "publish=true" >> "$GITHUB_OUTPUT"
+                echo "reason=main-push" >> "$GITHUB_OUTPUT"
+              else
+                echo "publish=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::No miniapp-relevant paths changed in $BEFORE_SHA..$GITHUB_SHA; skipping upload."
+              fi
             fi
           fi
 
@@ -91,11 +111,17 @@ jobs:
             tag_version="${GITHUB_REF#refs/tags/miniapp-}"
             echo "robot=1" >> "$GITHUB_OUTPUT"
             echo "version=$tag_version" >> "$GITHUB_OUTPUT"
-            echo "desc=release $tag_version" >> "$GITHUB_OUTPUT"
+            # Include short_sha so 版本管理 stays self-describing even when
+            # the same tag is force-pushed to a different commit.
+            echo "desc=release $tag_version ($short_sha)" >> "$GITHUB_OUTPUT"
           else
             ymd=$(date -u +%Y.%m.%d)
             echo "robot=5" >> "$GITHUB_OUTPUT"
-            echo "version=${ymd}.${GITHUB_RUN_NUMBER}+${short_sha}" >> "$GITHUB_OUTPUT"
+            # Use `-` (not `+`) as the run/sha separator. miniprogram-ci
+            # is documented with semver-like strings; `-` is unambiguously
+            # accepted whereas `+` (semver build-metadata) is not
+            # confirmed to round-trip cleanly.
+            echo "version=${ymd}.${GITHUB_RUN_NUMBER}-${short_sha}" >> "$GITHUB_OUTPUT"
             echo "desc=main ${short_sha}" >> "$GITHUB_OUTPUT"
           fi
 
@@ -136,6 +162,11 @@ jobs:
                 'package*.json',
                 '.gitignore',
                 '*.md',
+                // Defensive: outside projectPath today (we're in miniapp/),
+                // but explicit listing prevents accidental bundling if
+                // anyone ever runs from the repo root.
+                '.github/**/*',
+                '.git/**/*',
               ],
             });
             ci.upload({

--- a/.github/workflows/miniapp-publish.yml
+++ b/.github/workflows/miniapp-publish.yml
@@ -1,0 +1,180 @@
+name: Miniapp publish
+
+# Uploads miniapp/ to WeChat using miniprogram-ci, replacing the manual
+# "上传" button in 微信开发者工具.
+#
+# Versioning: CalVer, per-component tags. `miniapp-YYYY.MM.MICRO` (e.g.
+# `miniapp-2026.04.1`) goes to robot 1 (release line). Plain `main` pushes
+# go to robot 5 (dev line) with a synthetic version `YYYY.MM.DD.<run>+<sha>`
+# so they never overwrite the release candidate.
+#
+# Robots 1..30 are independent slots in 版本管理 — each robot keeps its own
+# latest 开发版. Promoting to 体验版 / 提交审核 / 发布 stays manual in
+# mp.weixin.qq.com (审核 is human-reviewed; no first-party openapi for it).
+#
+# See docs/dev/miniapp-cicd-research.md for the full design rationale.
+
+on:
+  push:
+    branches: [main]
+    tags: ['miniapp-*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: miniapp
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need HEAD^ to compute the path-change diff for main pushes.
+          fetch-depth: 2
+
+      - name: Decide whether to publish
+        id: gate
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/miniapp-* ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "reason=tag" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual" >> "$GITHUB_OUTPUT"
+          else
+            # main push: only publish when miniapp-relevant paths changed
+            # (web/src/locales/ and web/src/types/api.ts feed into miniapp
+            # via sync-types/sync-i18n at typecheck time, so they count).
+            changed=$(git diff --name-only HEAD^ HEAD || true)
+            if echo "$changed" | grep -qE '^(miniapp/|web/src/locales/|web/src/types/api\.ts$|\.github/workflows/miniapp-publish\.yml$)'; then
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              echo "reason=main-push" >> "$GITHUB_OUTPUT"
+            else
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::No miniapp-relevant paths changed in HEAD^..HEAD; skipping upload."
+            fi
+          fi
+
+      - if: steps.gate.outputs.publish == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: miniapp/package-lock.json
+
+      - if: steps.gate.outputs.publish == 'true'
+        name: Install miniapp deps
+        run: npm ci --no-audit --no-fund
+
+      - if: steps.gate.outputs.publish == 'true'
+        name: Typecheck (sync-types + sync-i18n + tsc --noEmit)
+        run: npm run typecheck
+
+      - if: steps.gate.outputs.publish == 'true'
+        name: Install miniprogram-ci
+        run: npm install --no-save miniprogram-ci
+
+      - if: steps.gate.outputs.publish == 'true'
+        name: Decide robot + version
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          if [[ "$GITHUB_REF" == refs/tags/miniapp-* ]]; then
+            tag_version="${GITHUB_REF#refs/tags/miniapp-}"
+            echo "robot=1" >> "$GITHUB_OUTPUT"
+            echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+            echo "desc=release $tag_version" >> "$GITHUB_OUTPUT"
+          else
+            ymd=$(date -u +%Y.%m.%d)
+            echo "robot=5" >> "$GITHUB_OUTPUT"
+            echo "version=${ymd}.${GITHUB_RUN_NUMBER}+${short_sha}" >> "$GITHUB_OUTPUT"
+            echo "desc=main ${short_sha}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.gate.outputs.publish == 'true'
+        name: Write upload key
+        env:
+          WECHAT_MINIAPP_UPLOAD_KEY: ${{ secrets.WECHAT_MINIAPP_UPLOAD_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${WECHAT_MINIAPP_UPLOAD_KEY:-}" ]; then
+            echo "::error::WECHAT_MINIAPP_UPLOAD_KEY secret is not set"
+            exit 1
+          fi
+          umask 077
+          printf '%s' "$WECHAT_MINIAPP_UPLOAD_KEY" > "$RUNNER_TEMP/wechat.key"
+
+      - if: steps.gate.outputs.publish == 'true'
+        name: Upload to WeChat
+        env:
+          APPID: ${{ secrets.WECHAT_MINIAPP_APPID }}
+          KEY_PATH: ${{ runner.temp }}/wechat.key
+          VERSION: ${{ steps.meta.outputs.version }}
+          DESC: ${{ steps.meta.outputs.desc }}
+          ROBOT: ${{ steps.meta.outputs.robot }}
+        run: |
+          node -e "
+            const ci = require('miniprogram-ci');
+            const project = new ci.Project({
+              appid: process.env.APPID,
+              type: 'miniProgram',
+              projectPath: '.',
+              privateKeyPath: process.env.KEY_PATH,
+              ignores: [
+                'node_modules/**/*',
+                'scripts/**/*',
+                'tsconfig.json',
+                'package*.json',
+                '.gitignore',
+                '*.md',
+              ],
+            });
+            ci.upload({
+              project,
+              version: process.env.VERSION,
+              desc: process.env.DESC,
+              setting: {
+                es6: true,
+                minify: true,
+                codeProtect: false,
+                autoPrefixWXSS: true,
+                uploadWithSourceMap: true,
+              },
+              robot: Number(process.env.ROBOT),
+              threads: 4,
+            }).then((r) => {
+              console.log('upload result:');
+              console.log(JSON.stringify(r, null, 2));
+            }).catch((e) => {
+              console.error('upload failed:', e && e.stack || e);
+              process.exit(1);
+            });
+          "
+
+      - if: always() && steps.gate.outputs.publish == 'true'
+        name: Job summary
+        shell: bash
+        run: |
+          {
+            echo '## Miniapp publish'
+            echo ''
+            echo '| field | value |'
+            echo '|---|---|'
+            echo '| trigger | `${{ steps.gate.outputs.reason }}` |'
+            echo '| robot | `${{ steps.meta.outputs.robot }}` |'
+            echo '| version | `${{ steps.meta.outputs.version }}` |'
+            echo '| desc | `${{ steps.meta.outputs.desc }}` |'
+            echo '| ref | `${{ github.ref }}` |'
+            echo '| sha | `${{ github.sha }}` |'
+            echo ''
+            echo 'To ship: open mp.weixin.qq.com → 版本管理 → robot ${{ steps.meta.outputs.robot }} → 选为体验版 → 提交审核 → 发布.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,12 @@ Required env vars (set only if you're running a mini program):
 - `WECHAT_MINIAPP_SECRET` — same page; rotate like any secret
 - If unset, the endpoints return 503 `WECHAT_NOT_CONFIGURED` (the rest of the app is unaffected)
 
+### Publishing the mini program
+
+Don't tell the user to "open WeChat DevTools and click 上传." Uploads are CI-driven via `.github/workflows/miniapp-publish.yml` (uses `miniprogram-ci`). Versioning is **CalVer, per-component tags** — `miniapp-YYYY.MM.MICRO` (e.g. `miniapp-2026.04.1`) for releases; `main` pushes auto-publish to robot 5 with a synthetic `YYYY.MM.DD.<run>+<sha>` version. The release line is robot 1; robots are independent slots in 版本管理. Promoting 开发版 → 体验版 and 提交审核 / 发布 stay manual in mp.weixin.qq.com (no first-party openapi for them). Full design rationale: `docs/dev/miniapp-cicd-research.md`.
+
+Secrets (already configured): `WECHAT_MINIAPP_APPID`, `WECHAT_MINIAPP_UPLOAD_KEY`. IP whitelist is intentionally off — the upload key is the security boundary.
+
 ## Documentation
 
 See `docs/dev/contributing.md` for which files to update with code changes. Key dev docs:

--- a/docs/dev/miniapp-cicd-research.md
+++ b/docs/dev/miniapp-cicd-research.md
@@ -1,0 +1,204 @@
+# WeChat Mini Program CI/CD & Versioning — Research
+
+**Status:** Research / proposal. No code wired yet.
+**Question:** Can we replace the manual "上传" click in 微信开发者工具 with a CI/CD or API-driven publish, and version the mini program properly?
+
+## TL;DR
+
+Yes. Tencent ships an official, supported npm package — **`miniprogram-ci`** — that does *exactly* what the "上传" / "预览" buttons in DevTools do, headlessly. We can drive it from a GitHub Actions workflow on every push (or tag), with the project AppID + a private key stored as repo secrets.
+
+| Stage | Automatable? | How |
+|---|---|---|
+| Upload to **开发版** (dev) | ✅ fully | `ci.upload({ robot: N, version, desc })` |
+| Generate preview QR (临时预览) | ✅ fully | `ci.preview()` |
+| Promote 开发版 → **体验版** (trial) | ⚠️ admin click | mp.weixin.qq.com → 版本管理 → "选为体验版" (trivial, ~2 sec) |
+| **提交审核** (submit for audit) | ❌ self-hosted apps only via web | WeChat exposes `code/submit_audit` only to 第三方平台 / 服务商, not to first-party operators |
+| **发布** to 正式版 (release) | ❌ self-hosted apps only via web | Same — manual click, gated on 审核 anyway |
+
+**Net win:** every code change gets a versioned 开发版 in WeChat with a proper version string and changelog, no laptop with DevTools required. Promoting that to 体验版 / submitting for review remains a 2-click manual step (which we already have to do because audit is human-reviewed and takes 1–7 days).
+
+---
+
+## 1. The `miniprogram-ci` package
+
+- npm: `miniprogram-ci` (Tencent-maintained, latest 2.1.x as of early 2026)
+- Node.js library + CLI; same compile pipeline as DevTools
+- Capabilities: `upload`, `preview`, `packNpm`, `getDevSourceMap`, cloud function deploys (we don't use those)
+- Source: [WeChat official CI docs](https://developers.weixin.qq.com/miniprogram/dev/devtools/ci.html)
+
+### Minimal upload sketch
+```js
+const ci = require('miniprogram-ci');
+
+const project = new ci.Project({
+  appid: process.env.WECHAT_MINIAPP_APPID,
+  type: 'miniProgram',
+  projectPath: './miniapp',                              // our miniapp/ directory
+  privateKeyPath: './private.key',                        // injected from secret
+  ignores: ['node_modules/**/*', '.github/**/*'],
+});
+
+await ci.upload({
+  project,
+  version: '0.3.1',                                       // shown in 版本管理
+  desc: `${process.env.GITHUB_SHA.slice(0,7)} — ${process.env.COMMIT_MSG}`,
+  setting: { es6: true, minify: true, codeProtect: false, autoPrefixWXSS: true },
+  robot: 1,                                               // see §3
+  threads: 4,
+});
+```
+
+---
+
+## 2. Versioning model — CalVer, per-component tags
+
+WeChat does not enforce a version format — whatever string we pass to `ci.upload({ version, desc })` is shown verbatim in 版本管理. So we pick the scheme that matches how Praxys actually ships.
+
+**Decision: CalVer (`YYYY.MM.MICRO`), per-component tags.**
+
+The three components (backend, web, miniapp) ship at different cadences, so each gets its own tag namespace:
+
+| Component | Tag pattern | Example |
+|---|---|---|
+| Mini program | `miniapp-YYYY.MM.MICRO` | `miniapp-2026.04.1` |
+| Web frontend | `web-YYYY.MM.MICRO` | `web-2026.04.1` |
+| Backend API | `api-YYYY.MM.MICRO` | `api-2026.04.1` |
+
+`MICRO` increments within a calendar month; reset to `1` at the start of the next month. Multiple ships per month → `2026.04.1`, `2026.04.2`, `2026.04.3`. First ship in May → `2026.05.1`.
+
+**Why CalVer over semver here:** Praxys components are deployed apps, not libraries — there's no external consumer reading a version to decide compatibility, so semver's "MAJOR vs MINOR vs PATCH" judgment calls add overhead without value. CalVer encodes "when did this ship," which is what we actually want to know when debugging "what's running in 体验版?"
+
+**Dev / non-tag pushes** to `main` get a synthetic version: `YYYY.MM.DD.<run_number>+<sha7>` (e.g., `2026.04.29.42+abc1234`). This goes to robot 5, separate from the tag release line on robot 1, so dev iteration never overwrites the release candidate.
+
+**`miniapp/package.json` `version` field** stays as a project-marker (currently `0.2.0`); the publish workflow does **not** read it. Tags are the source of truth. This removes the "did I remember to bump package.json?" failure mode.
+
+This scheme extends naturally to `web/` and `api/` whenever we wire up automated deploys for those — same prefix-based tag pattern, separate workflows, independent cadences.
+
+---
+
+## 3. The "robot" model — important to internalize
+
+`robot` is `1..30`. **Each robot is a separate slot in 版本管理**. Each robot keeps the *latest* version it uploaded; uploading again with the same robot overwrites that robot's 开发版. mp.weixin.qq.com only allows **one 体验版 globally**, but you choose which robot's 开发版 is currently selected as the 体验版.
+
+Practical consequence:
+- Different branches / environments → different robots → independent 开发版 slots that don't clobber each other
+- Recommended mapping for Praxys (we have one mini program, a few branches):
+
+| Robot | Purpose | Trigger |
+|---|---|---|
+| 1 | Release candidate (will become 体验版 → 正式版) | Tag `miniapp-v*` |
+| 5 | Main branch dev | Push to `main` |
+| 10 | Per-PR preview | PR opened/updated (use `ci.preview()` not upload, generates QR) |
+
+Each robot upload is logged in 版本管理 with the robot index + commit-derived `desc`, so we can see who uploaded what.
+
+---
+
+## 4. One-time setup checklist
+
+These steps happen **once**, by the mini program admin (Feitao):
+
+1. **Generate the upload private key**
+   - Log in to [mp.weixin.qq.com](https://mp.weixin.qq.com) → 开发管理 → 开发设置 → 小程序代码上传 (scroll near bottom)
+   - Click "生成" — downloads `private.<appid>.key` (a PEM-style RSA private key, ~1.7 KB)
+   - **This is a credential** — treat like a deploy key. Anyone with this file + the AppID can publish to our mini program
+
+2. **Configure IP whitelist** (recommended) or disable it
+   - Same panel; either:
+     - Whitelist GitHub Actions runner IPs — but those are **dynamic**, this isn't practical for hosted runners. You'd need a self-hosted runner with a fixed egress IP.
+     - **Disable the whitelist** entirely (option labelled 关闭IP白名单). The private key alone gates access.
+   - For Praxys we should disable IP whitelist (we don't have self-hosted runners) and rely on the secret. WeChat's own docs explicitly support this trade-off.
+
+3. **Add GitHub Actions secrets** (under repo Settings → Secrets and variables → Actions):
+   - `WECHAT_MINIAPP_APPID` — the AppID `wx65e36494e7cf3ffb` (note: this is already in `miniapp/project.config.json` and isn't really sensitive, but keeping it as a secret matches the existing backend `.env` convention)
+   - `WECHAT_MINIAPP_UPLOAD_KEY` — paste the contents of `private.<appid>.key`. CI will write it back to a temp file at runtime.
+
+---
+
+## 5. GitHub Actions workflow
+
+The actual implementation lives at **`.github/workflows/miniapp-publish.yml`** in this branch — see that file for the canonical YAML. High-level shape:
+
+- **Triggers:** push to `main` (path-gated by inline `git diff` since GitHub's `paths:` filter doesn't compose cleanly with tag triggers), tag pushes matching `miniapp-*`, and `workflow_dispatch` for manual reruns.
+- **Gate step decides** whether to run: tag push → always; manual → always; main push → only if any of `miniapp/**`, `web/src/locales/**`, `web/src/types/api.ts`, or the workflow file itself changed in `HEAD^..HEAD`.
+- **Always run typecheck first** (`npm run typecheck` includes `sync-types` + `sync-i18n` + `tsc`). A typecheck failure aborts the upload — we never publish a broken build.
+- **Robot + version** chosen by the meta step:
+  - `refs/tags/miniapp-2026.04.1` → robot 1, version `2026.04.1`, desc `release 2026.04.1`
+  - main push → robot 5, version `YYYY.MM.DD.<run_number>+<sha7>`, desc `main <sha7>`
+- **Upload step** uses `miniprogram-ci` with `setting.uploadWithSourceMap: true` so server-side stack traces remain useful. Result JSON (compiled package sizes, etc.) is logged.
+- **Job summary** writes a markdown table to GitHub Actions UI showing trigger / robot / version / desc / ref / sha for at-a-glance audit.
+
+**To release miniapp 2026.04.1:**
+```bash
+git tag miniapp-2026.04.1
+git push origin miniapp-2026.04.1
+# → workflow runs, robot 1's 开发版 in 版本管理 becomes 2026.04.1
+# → in mp.weixin.qq.com 版本管理: click "选为体验版" on robot 1's row
+# → scan QR with WeChat, verify
+# → click "提交审核" → wait for review → click "发布"
+```
+
+**For PR previews (future):** add a job triggered on `pull_request` that calls `ci.preview()` with `qrcodeOutputDest: '$RUNNER_TEMP/preview.png'` on robot 10, then uploads the QR as an artifact and posts it as a PR comment. Not in scope for the first iteration.
+
+---
+
+## 6. What stays manual
+
+- **审核 → 发布**: For self-hosted mini programs (i.e., us, not 第三方平台 service providers), the WeChat openapi `code/submit_audit` and `code/release` are gated to 服务商 accounts. A first-party operator must click "提交审核" and then "发布" in the admin web UI. This is unavoidable; audit is a human review (1–7 days) so it isn't actually a CI bottleneck.
+- **Selecting which 开发版 is the 体验版**: One click in 版本管理. Doable via the same 服务商 API, same constraint.
+- **Renaming a robot's developer label**: No public API; cosmetic only.
+
+In practice the manual surface shrinks from "every dev iteration requires opening DevTools and clicking 上传" to "once per release, click 提交审核 → wait → click 发布."
+
+---
+
+## 7. Risks and gotchas
+
+1. **The private key is high-value.** Anyone who exfiltrates `WECHAT_MINIAPP_UPLOAD_KEY` can publish to our mini program. Treat like prod DB credentials. Rotate via the same admin panel ("重置" button).
+2. **`miniprogram-ci` does its own compile.** It will re-compile TS/Sass internally — *not* using the WeChat DevTools `useCompilerPlugins` setting. Confirm before first run that there's no behavior gap with what DevTools produces. The existing `miniapp-build.yml` doesn't actually compile the project (only typechecks), so the first CI upload is the first time we'll see what `miniprogram-ci`'s output looks like in 体验版.
+3. **Source-map upload setting**: `project.config.json` has `"uploadWithSourceMap": true`. `miniprogram-ci` honors this only if we set `setting: { uploadWithSourceMap: true }` explicitly (it doesn't read `project.config.json` for everything). Add to the `setting` block above if we want sourcemaps in the WeChat error logs.
+4. **`packNpm`**: WeChat needs `npm run miniprogram-ci` style npm-build for any miniapp `npm` deps. Praxys mini program has no runtime npm deps (devDeps only — `miniprogram-api-typings`, `typescript`), so we can skip `ci.packNpm()`. If we ever add a runtime dep like `weui-miniprogram`, add a `ci.packNpm()` call before `ci.upload()`.
+5. **2 MB main package limit** still applies — `miniapp-build.yml` already guards on raw source size. After first CI upload, watch the actual compiled size in `ci.upload()`'s response (it returns `subPackageInfo[]` with byte counts).
+6. **Robot collision with manual uploads**: If Feitao continues to "上传" via DevTools while CI runs, both sides may be writing to the same robot slot (DevTools defaults to a per-developer robot, but there's only one 体验版). Either: (a) reserve robots 1 & 5 exclusively for CI and document "humans use robot 30 in DevTools", or (b) stop using manual upload for the project entirely once CI works.
+
+---
+
+## 8. Comparison to status quo
+
+| Dimension | Current (manual DevTools) | Proposed (miniprogram-ci) |
+|---|---|---|
+| Trigger | Open DevTools, click 上传, fill version + desc | `git push` |
+| Reproducibility | Depends on local DevTools version, OS, plugins | CI sets exact Node + CLI version |
+| Version discipline | Whatever the human types | Derived from `package.json` + tags |
+| Audit trail | DevTools logs (local) | GitHub Actions run + `desc` carries SHA |
+| Multi-developer | Each developer = separate 开发版, easy to lose track | One robot per environment, deterministic slots |
+| Speed of dev → 体验版 | Manual (5 min context switch) | Automatic on push to main |
+| 提交审核 → 发布 | Manual click | Still manual click (audit is human anyway) |
+
+---
+
+## 9. Status / next steps
+
+Done:
+- [x] IP whitelist disabled in mp.weixin.qq.com
+- [x] `WECHAT_MINIAPP_APPID` + `WECHAT_MINIAPP_UPLOAD_KEY` added as repo secrets
+- [x] `.github/workflows/miniapp-publish.yml` drafted in this branch
+- [x] Versioning scheme decided (CalVer, per-component tags)
+
+To do:
+1. Review the workflow file diff, merge the branch.
+2. **Dry-run on `main`**: push any miniapp-touching commit to `main`; watch Actions. Should upload to robot 5 with version `2026.04.29.X+<sha>`. Verify a 开发版 appears in 版本管理 row "robot 5."
+3. **Dry-run a tag**: `git tag miniapp-2026.04.1 && git push origin miniapp-2026.04.1`. Robot 1 should get 开发版 `2026.04.1`. Promote to 体验版; scan QR; smoke-test.
+4. After successful first 体验版 from CI, update `miniapp-build.yml`'s comment ("we can't run `miniprogram-ci` without the platform secret") — it's now outdated. Replace with a link to the publish workflow.
+5. Add a one-liner to `trail-running/CLAUDE.md` mini program section pointing to this doc + the workflow.
+6. (Later) Add a `pull_request` job for PR previews on robot 10 (`ci.preview()` + QR artifact + PR comment).
+
+---
+
+## Sources
+
+- [WeChat official miniprogram-ci docs](https://developers.weixin.qq.com/miniprogram/dev/devtools/ci.html)
+- [echoings/actions.mini-program (GitHub Action wrapper)](https://github.com/echoings/actions.mini-program)
+- [WeChat community: 开发版 / 体验版 / 正式版 区别](https://developers.weixin.qq.com/community/minihome/doc/00020c26fd8030b0963d9a8f050000)
+- [小程序发布了 miniprogram-ci](https://developers.weixin.qq.com/community/develop/article/doc/000aea788a4ae0354ec85c57e56c13)
+- [Taro plugin-mini-ci docs (cross-platform wrapper, not used by us but informative)](https://nervjs.github.io/taro-docs/en/docs/plugin-mini-ci/)

--- a/docs/dev/miniapp-cicd-research.md
+++ b/docs/dev/miniapp-cicd-research.md
@@ -68,7 +68,7 @@ The three components (backend, web, miniapp) ship at different cadences, so each
 
 **Why CalVer over semver here:** Praxys components are deployed apps, not libraries — there's no external consumer reading a version to decide compatibility, so semver's "MAJOR vs MINOR vs PATCH" judgment calls add overhead without value. CalVer encodes "when did this ship," which is what we actually want to know when debugging "what's running in 体验版?"
 
-**Dev / non-tag pushes** to `main` get a synthetic version: `YYYY.MM.DD.<run_number>+<sha7>` (e.g., `2026.04.29.42+abc1234`). This goes to robot 5, separate from the tag release line on robot 1, so dev iteration never overwrites the release candidate.
+**Dev / non-tag pushes** to `main` get a synthetic version: `YYYY.MM.DD.<run_number>-<sha7>` (e.g., `2026.04.29.42-abc1234`). This goes to robot 5, separate from the tag release line on robot 1, so dev iteration never overwrites the release candidate. The dash separator (rather than semver's `+` build-metadata) is the conservative pick — `+` is not confirmed to round-trip cleanly through `miniprogram-ci`'s server-side validation.
 
 **`miniapp/package.json` `version` field** stays as a project-marker (currently `0.2.0`); the publish workflow does **not** read it. Tags are the source of truth. This removes the "did I remember to bump package.json?" failure mode.
 
@@ -120,11 +120,11 @@ These steps happen **once**, by the mini program admin (Feitao):
 The actual implementation lives at **`.github/workflows/miniapp-publish.yml`** in this branch — see that file for the canonical YAML. High-level shape:
 
 - **Triggers:** push to `main` (path-gated by inline `git diff` since GitHub's `paths:` filter doesn't compose cleanly with tag triggers), tag pushes matching `miniapp-*`, and `workflow_dispatch` for manual reruns.
-- **Gate step decides** whether to run: tag push → always; manual → always; main push → only if any of `miniapp/**`, `web/src/locales/**`, `web/src/types/api.ts`, or the workflow file itself changed in `HEAD^..HEAD`.
+- **Gate step decides** whether to run: tag push → always; manual → always; main push → only if any of `miniapp/**`, `web/src/locales/**`, `web/src/types/api.ts`, or the workflow file itself changed across the **entire push range** (`github.event.before..github.sha`, with `fetch-depth: 0` so the prior tip is in the local clone). Using the full range — not just `HEAD^..HEAD` — covers multi-commit pushes where a miniapp change might be buried under a later unrelated commit.
 - **Always run typecheck first** (`npm run typecheck` includes `sync-types` + `sync-i18n` + `tsc`). A typecheck failure aborts the upload — we never publish a broken build.
 - **Robot + version** chosen by the meta step:
   - `refs/tags/miniapp-2026.04.1` → robot 1, version `2026.04.1`, desc `release 2026.04.1`
-  - main push → robot 5, version `YYYY.MM.DD.<run_number>+<sha7>`, desc `main <sha7>`
+  - main push → robot 5, version `YYYY.MM.DD.<run_number>-<sha7>`, desc `main <sha7>`
 - **Upload step** uses `miniprogram-ci` with `setting.uploadWithSourceMap: true` so server-side stack traces remain useful. Result JSON (compiled package sizes, etc.) is logged.
 - **Job summary** writes a markdown table to GitHub Actions UI showing trigger / robot / version / desc / ref / sha for at-a-glance audit.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/miniapp-publish.yml` — uploads `miniapp/` to WeChat via `miniprogram-ci`, replacing the manual 上传 click in 微信开发者工具.
- Versioning: CalVer, per-component tags. `miniapp-YYYY.MM.MICRO` (e.g. `miniapp-2026.04.1`) → robot 1; `main` pushes → robot 5 with `YYYY.MM.DD.<run>+<sha7>`.
- Updates `CLAUDE.md` so future Claude sessions know not to instruct the user to open DevTools.
- Updates `miniapp-build.yml`'s stale comment ("we can't run miniprogram-ci without the platform secret").
- Adds `docs/dev/miniapp-cicd-research.md` with full design rationale + sources.

## Design highlights

- **Triggers:** `tags: ['miniapp-*']`, `branches: [main]`, `workflow_dispatch`. Path-gating for the `main` trigger uses an inline `git diff HEAD^..HEAD` in the gate step (GitHub's `paths:` filter doesn't compose cleanly with tag triggers in one block) covering `miniapp/**`, `web/src/locales/**`, `web/src/types/api.ts`, and the workflow file itself.
- **Always typecheck before upload** — `npm run typecheck` chains `sync-types` + `sync-i18n` + `tsc --noEmit`. Failure aborts the publish.
- **Robot model:** robots 1..30 are independent slots in 版本管理. Robot 1 = tag releases, robot 5 = main dev. Robots 10..30 reserved for future PR previews.
- **`uploadWithSourceMap: true`** so server-side stack traces stay useful.
- **Job summary** writes a markdown table to the Actions UI showing trigger / robot / version / desc / ref / sha.

## What stays manual

- 选为体验版 — one click in mp.weixin.qq.com 版本管理
- 提交审核 — gated to 第三方平台 openapi, not us
- 发布 — same gating; audit is human-reviewed (1–7 days) so this isn't a CI bottleneck

## Test plan

- [ ] Merge this PR — the merge commit on `main` will trigger the workflow path-gate (workflow file changed). Should upload to robot 5 with version like `2026.04.29.1+<sha>`. Verify a 开发版 appears in mp.weixin.qq.com → 版本管理 under robot 5.
- [ ] After merge, `git tag miniapp-2026.04.1 && git push origin miniapp-2026.04.1`. Verify robot 1 gets 开发版 `2026.04.1`. Promote to 体验版, scan QR, smoke-test against the prior DevTools-uploaded 体验版 to confirm parity.
- [ ] If parity check passes: 提交审核 → 发布 from mp.weixin.qq.com.
- [ ] Rollback path is unchanged: open DevTools, click 上传 to overwrite robot 1, revert 体验版.

🤖 Generated with [Claude Code](https://claude.com/claude-code)