### PR TITLE
Fix Oura recovery losing HRV/RHR (multi-record day + insert-only dedup)

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -883,6 +883,7 @@ def _sync_oura(user_id: str, creds: dict, from_date: str | None,
     from sync.oura_sync import (
         fetch_sleep_data, fetch_readiness_data,
         parse_sleep_records, parse_readiness_records,
+        select_oura_hrv_per_day,
     )
 
     token = creds["token"]
@@ -893,40 +894,7 @@ def _sync_oura(user_id: str, creds: dict, from_date: str | None,
     sleep_raw = fetch_sleep_data(token, start, end)
     sleep_rows = parse_sleep_records(sleep_raw)
 
-    # Extract HRV + resting HR from sleep data (Oura readiness endpoint lacks these).
-    # A single Oura `day` can have multiple sleep records (long_sleep + late_nap +
-    # rest), and naps frequently come back with average_hrv=null. A naive
-    # last-write-wins dict would let a nap clobber the long_sleep's HRV, so we
-    # prefer "long_sleep" (or whichever record actually has positive HRV) per day.
-    def _pos_or_none(v) -> float | None:
-        try:
-            return float(v) if v not in (None, "", "None") and float(v) > 0 else None
-        except (TypeError, ValueError):
-            return None
-
-    hrv_by_date: dict[str, dict] = {}
-    for r in sleep_raw:
-        d = r.get("day") or ""
-        if not d:
-            continue
-        candidate = {
-            "hrv_avg": str(r.get("average_hrv", "") or ""),
-            "resting_hr": str(r.get("average_heart_rate", "") or ""),
-            "_type": r.get("type", ""),
-        }
-        existing = hrv_by_date.get(d)
-        if existing is None:
-            hrv_by_date[d] = candidate
-            continue
-        # Prefer the candidate with a positive average_hrv. If both have HRV,
-        # prefer "long_sleep" over naps/rests.
-        existing_hrv = _pos_or_none(existing.get("hrv_avg"))
-        candidate_hrv = _pos_or_none(candidate.get("hrv_avg"))
-        if candidate_hrv is not None and existing_hrv is None:
-            hrv_by_date[d] = candidate
-        elif candidate_hrv is not None and existing_hrv is not None:
-            if existing.get("_type") != "long_sleep" and candidate.get("_type") == "long_sleep":
-                hrv_by_date[d] = candidate
+    hrv_by_date = select_oura_hrv_per_day(sleep_raw)
 
     readiness_raw = fetch_readiness_data(token, start, end)
     readiness_rows = parse_readiness_records(readiness_raw)

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -893,14 +893,40 @@ def _sync_oura(user_id: str, creds: dict, from_date: str | None,
     sleep_raw = fetch_sleep_data(token, start, end)
     sleep_rows = parse_sleep_records(sleep_raw)
 
-    # Extract HRV + resting HR from sleep data (Oura readiness endpoint lacks these)
-    hrv_by_date = {}
+    # Extract HRV + resting HR from sleep data (Oura readiness endpoint lacks these).
+    # A single Oura `day` can have multiple sleep records (long_sleep + late_nap +
+    # rest), and naps frequently come back with average_hrv=null. A naive
+    # last-write-wins dict would let a nap clobber the long_sleep's HRV, so we
+    # prefer "long_sleep" (or whichever record actually has positive HRV) per day.
+    def _pos_or_none(v) -> float | None:
+        try:
+            return float(v) if v not in (None, "", "None") and float(v) > 0 else None
+        except (TypeError, ValueError):
+            return None
+
+    hrv_by_date: dict[str, dict] = {}
     for r in sleep_raw:
-        d = r.get("day", "")
-        hrv_by_date[d] = {
-            "hrv_avg": str(r.get("average_hrv", "")),
-            "resting_hr": str(r.get("average_heart_rate", "")),
+        d = r.get("day") or ""
+        if not d:
+            continue
+        candidate = {
+            "hrv_avg": str(r.get("average_hrv", "") or ""),
+            "resting_hr": str(r.get("average_heart_rate", "") or ""),
+            "_type": r.get("type", ""),
         }
+        existing = hrv_by_date.get(d)
+        if existing is None:
+            hrv_by_date[d] = candidate
+            continue
+        # Prefer the candidate with a positive average_hrv. If both have HRV,
+        # prefer "long_sleep" over naps/rests.
+        existing_hrv = _pos_or_none(existing.get("hrv_avg"))
+        candidate_hrv = _pos_or_none(candidate.get("hrv_avg"))
+        if candidate_hrv is not None and existing_hrv is None:
+            hrv_by_date[d] = candidate
+        elif candidate_hrv is not None and existing_hrv is not None:
+            if existing.get("_type") != "long_sleep" and candidate.get("_type") == "long_sleep":
+                hrv_by_date[d] = candidate
 
     readiness_raw = fetch_readiness_data(token, start, end)
     readiness_rows = parse_readiness_records(readiness_raw)

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -213,22 +213,76 @@ def write_recovery(user_id: str, readiness_rows: list[dict],
 
     for row in readiness_rows:
         d = _parse_date(row.get("date"))
-        if not d or d in existing_oura:
+        if not d:
             continue
         sleep = sleep_by_date.get(row.get("date", ""), {})
         hrv = hrv_by_date.get(row.get("date", ""), {})
+
+        readiness_score = _float(row.get("readiness_score"))
+        hrv_avg = _float(hrv.get("hrv_avg") or row.get("hrv_avg"))
+        resting_hr = _float(hrv.get("resting_hr") or row.get("resting_hr"))
+        sleep_score = _float(sleep.get("sleep_score"))
+        total_sleep_sec = _float(sleep.get("total_sleep_sec"))
+        deep_sleep_sec = _float(sleep.get("deep_sleep_sec"))
+        rem_sleep_sec = _float(sleep.get("rem_sleep_sec"))
+        body_temp_delta = _float(
+            row.get("body_temperature_delta") or row.get("body_temp_delta")
+        )
+
+        if d in existing_oura:
+            # Backfill empty fields on existing rows. The original write may
+            # have happened before HRV extraction landed in the row builder,
+            # or before multi-record-per-day overwrites were handled — without
+            # this, those rows would stay null forever because the loop used
+            # to skip existing dates, leaving recovery analysis stuck on
+            # "insufficient HRV data" even though Oura returns the value on
+            # every subsequent sync.
+            existing = db.query(RecoveryData).filter(
+                RecoveryData.user_id == user_id,
+                RecoveryData.date == d,
+                RecoveryData.source == "oura",
+            ).first()
+            if existing is None:
+                continue
+            updated = False
+            if (existing.hrv_avg is None or existing.hrv_avg <= 0) and hrv_avg and hrv_avg > 0:
+                existing.hrv_avg = hrv_avg
+                updated = True
+            if (existing.resting_hr is None or existing.resting_hr <= 0) and resting_hr and resting_hr > 0:
+                existing.resting_hr = resting_hr
+                updated = True
+            if existing.sleep_score is None and sleep_score is not None:
+                existing.sleep_score = sleep_score
+                updated = True
+            if existing.readiness_score is None and readiness_score is not None:
+                existing.readiness_score = readiness_score
+                updated = True
+            if existing.total_sleep_sec is None and total_sleep_sec is not None:
+                existing.total_sleep_sec = total_sleep_sec
+                updated = True
+            if existing.deep_sleep_sec is None and deep_sleep_sec is not None:
+                existing.deep_sleep_sec = deep_sleep_sec
+                updated = True
+            if existing.rem_sleep_sec is None and rem_sleep_sec is not None:
+                existing.rem_sleep_sec = rem_sleep_sec
+                updated = True
+            if existing.body_temp_delta is None and body_temp_delta is not None:
+                existing.body_temp_delta = body_temp_delta
+                updated = True
+            if updated:
+                count += 1
+            continue
+
         db.add(RecoveryData(
             user_id=user_id, date=d, source="oura",
-            readiness_score=_float(row.get("readiness_score")),
-            hrv_avg=_float(hrv.get("hrv_avg") or row.get("hrv_avg")),
-            resting_hr=_float(hrv.get("resting_hr") or row.get("resting_hr")),
-            sleep_score=_float(sleep.get("sleep_score")),
-            total_sleep_sec=_float(sleep.get("total_sleep_sec")),
-            deep_sleep_sec=_float(sleep.get("deep_sleep_sec")),
-            rem_sleep_sec=_float(sleep.get("rem_sleep_sec")),
-            body_temp_delta=_float(
-                row.get("body_temperature_delta") or row.get("body_temp_delta")
-            ),
+            readiness_score=readiness_score,
+            hrv_avg=hrv_avg,
+            resting_hr=resting_hr,
+            sleep_score=sleep_score,
+            total_sleep_sec=total_sleep_sec,
+            deep_sleep_sec=deep_sleep_sec,
+            rem_sleep_sec=rem_sleep_sec,
+            body_temp_delta=body_temp_delta,
         ))
         existing_oura.add(d)
         count += 1

--- a/plugins/praxys/.mcp.json
+++ b/plugins/praxys/.mcp.json
@@ -2,11 +2,7 @@
   "mcpServers": {
     "praxys": {
       "command": "python",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/server.py"],
-      "env": {
-        "PRAXYS_URL": "${PRAXYS_URL}",
-        "PRAXYS_FRONTEND_URL": "${PRAXYS_FRONTEND_URL}"
-      }
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-server/server.py"]
     }
   }
 }

--- a/plugins/praxys/mcp-server/server.py
+++ b/plugins/praxys/mcp-server/server.py
@@ -21,13 +21,31 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("praxys", instructions="Training data tools for Praxys dashboard")
 
 # Mode detection — prefer PRAXYS_*, fall back to legacy TRAINSIGHT_* for one
-# release (deprecation: 2026-05-19).
-REMOTE_URL = os.environ.get("PRAXYS_URL") or os.environ.get("TRAINSIGHT_URL", "")
+# release (deprecation: 2026-05-19). Defaults to praxys.run production so the
+# plugin works out-of-the-box; local devs override via PRAXYS_URL in their env
+# (see CLAUDE.md "Running" section).
+_DEFAULT_BACKEND = "https://api.praxys.run"
+_DEFAULT_FRONTEND = "https://www.praxys.run"
+
+
+def _clean(value: str | None) -> str:
+    """Trim and reject unexpanded ${VAR} placeholders that slip through MCP env."""
+    if not value:
+        return ""
+    v = value.strip().rstrip("/")
+    return "" if v.startswith("${") and v.endswith("}") else v
+
+
+REMOTE_URL = (
+    _clean(os.environ.get("PRAXYS_URL"))
+    or _clean(os.environ.get("TRAINSIGHT_URL"))
+    or _DEFAULT_BACKEND
+)
 IS_REMOTE = bool(REMOTE_URL)
-# Frontend URL for browser-based login (defaults to same as backend for local dev)
 FRONTEND_URL = (
-    os.environ.get("PRAXYS_FRONTEND_URL")
-    or os.environ.get("TRAINSIGHT_FRONTEND_URL", REMOTE_URL)
+    _clean(os.environ.get("PRAXYS_FRONTEND_URL"))
+    or _clean(os.environ.get("TRAINSIGHT_FRONTEND_URL"))
+    or _DEFAULT_FRONTEND
 )
 
 

--- a/plugins/praxys/mcp-server/server.py
+++ b/plugins/praxys/mcp-server/server.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Praxys MCP Server — dual-mode (local/remote) training data tools.
 
-Mode detection:
-  - PRAXYS_URL (or legacy TRAINSIGHT_URL) env var set → remote mode (HTTP API with JWT auth)
-  - neither set → local mode (direct Python imports, dev user, DB)
+Mode detection (in priority order):
+  - PRAXYS_LOCAL=1 (or legacy TRAINSIGHT_LOCAL=1) → local mode (direct Python
+    imports, dev user, DB). Use this when iterating against your local DB
+    instead of production.
+  - Otherwise → remote mode (HTTP API with JWT auth). PRAXYS_URL overrides
+    the default of https://api.praxys.run; PRAXYS_FRONTEND_URL likewise
+    for the browser-login flow.
+
+Production is the default so the plugin works out-of-the-box for end users.
+Set PRAXYS_LOCAL=1 in your shell to develop against the local FastAPI/DB.
 """
 import json
 import os
@@ -22,8 +29,8 @@ mcp = FastMCP("praxys", instructions="Training data tools for Praxys dashboard")
 
 # Mode detection — prefer PRAXYS_*, fall back to legacy TRAINSIGHT_* for one
 # release (deprecation: 2026-05-19). Defaults to praxys.run production so the
-# plugin works out-of-the-box; local devs override via PRAXYS_URL in their env
-# (see CLAUDE.md "Running" section).
+# plugin works out-of-the-box; local devs opt in via PRAXYS_LOCAL=1 (see the
+# module docstring and CLAUDE.md "Running" section).
 _DEFAULT_BACKEND = "https://api.praxys.run"
 _DEFAULT_FRONTEND = "https://www.praxys.run"
 
@@ -36,16 +43,28 @@ def _clean(value: str | None) -> str:
     return "" if v.startswith("${") and v.endswith("}") else v
 
 
+def _is_truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() not in ("", "0", "false", "no")
+
+
+# Local mode is opt-in. Without this flag we hit production by default, so
+# end users get a working plugin without any env wiring. The previous
+# heuristic ("no PRAXYS_URL means local") silently broke as soon as we
+# baked in production defaults — it would have routed unconfigured users'
+# tool calls to localhost and surfaced obscure connection errors.
+IS_REMOTE = not (
+    _is_truthy(os.environ.get("PRAXYS_LOCAL"))
+    or _is_truthy(os.environ.get("TRAINSIGHT_LOCAL"))
+)
 REMOTE_URL = (
     _clean(os.environ.get("PRAXYS_URL"))
     or _clean(os.environ.get("TRAINSIGHT_URL"))
-    or _DEFAULT_BACKEND
+    or (_DEFAULT_BACKEND if IS_REMOTE else "")
 )
-IS_REMOTE = bool(REMOTE_URL)
 FRONTEND_URL = (
     _clean(os.environ.get("PRAXYS_FRONTEND_URL"))
     or _clean(os.environ.get("TRAINSIGHT_FRONTEND_URL"))
-    or _DEFAULT_FRONTEND
+    or (_DEFAULT_FRONTEND if IS_REMOTE else "")
 )
 
 

--- a/sync/oura_sync.py
+++ b/sync/oura_sync.py
@@ -69,3 +69,56 @@ def parse_readiness_records(raw_records: list[dict]) -> list[dict]:
             "body_temperature_delta": str(r.get("temperature_deviation", "")),
         })
     return rows
+
+
+def select_oura_hrv_per_day(sleep_raw: list[dict]) -> dict[str, dict]:
+    """Pick one HRV/RHR pair per Oura day from possibly-multiple sleep records.
+
+    A single Oura `day` can have several sleep records (`long_sleep`,
+    `late_nap`, `rest`), and naps frequently come back with
+    ``average_hrv: null``. Naive last-write-wins on the dict lets a nap
+    clobber the long_sleep's valid HRV — that's the production data-loss
+    path that strands recovery analysis on "Insufficient HRV data".
+
+    Selection rule:
+      1. Records with a positive ``average_hrv`` always win over records
+         without (regardless of ``type``).
+      2. Among records that all have positive HRV, ``long_sleep`` wins
+         over naps / rests / unset types.
+      3. Within the same priority, first-seen wins (stable for callers
+         iterating Oura's response order).
+
+    Returns a ``{day: {"hrv_avg": str, "resting_hr": str, "_type": str}}``
+    dict matching the contract the writer expects.
+    """
+    def _pos_or_none(v) -> float | None:
+        try:
+            if v in (None, "", "None"):
+                return None
+            f = float(v)
+            return f if f > 0 else None
+        except (TypeError, ValueError):
+            return None
+
+    selected: dict[str, dict] = {}
+    for r in sleep_raw:
+        day = r.get("day") or ""
+        if not day:
+            continue
+        candidate = {
+            "hrv_avg": str(r.get("average_hrv", "") or ""),
+            "resting_hr": str(r.get("average_heart_rate", "") or ""),
+            "_type": r.get("type") or "",
+        }
+        existing = selected.get(day)
+        if existing is None:
+            selected[day] = candidate
+            continue
+        existing_hrv = _pos_or_none(existing.get("hrv_avg"))
+        candidate_hrv = _pos_or_none(candidate.get("hrv_avg"))
+        if candidate_hrv is not None and existing_hrv is None:
+            selected[day] = candidate
+        elif candidate_hrv is not None and existing_hrv is not None:
+            if existing.get("_type") != "long_sleep" and candidate.get("_type") == "long_sleep":
+                selected[day] = candidate
+    return selected

--- a/tests/test_oura_sync.py
+++ b/tests/test_oura_sync.py
@@ -1,6 +1,10 @@
 import json
 from unittest.mock import patch, MagicMock
-from sync.oura_sync import fetch_sleep_data, fetch_readiness_data, parse_sleep_records, parse_readiness_records
+from sync.oura_sync import (
+    fetch_sleep_data, fetch_readiness_data,
+    parse_sleep_records, parse_readiness_records,
+    select_oura_hrv_per_day,
+)
 
 SAMPLE_SLEEP_RESPONSE = {
     "data": [
@@ -75,3 +79,96 @@ def test_fetch_readiness_data(mock_get):
 
     data = fetch_readiness_data("fake_token", "2026-03-01", "2026-03-10")
     assert len(data) == 1
+
+
+# ---------------------------------------------------------------------------
+# select_oura_hrv_per_day — multi-record-per-day tiebreak
+#
+# Production data-loss path: Oura returns long_sleep + late_nap + rest for the
+# same `day`, naps come back with `average_hrv: null`, and a naive
+# last-write-wins dict lets the nap clobber the long_sleep's valid HRV. Once
+# the writer's existing-date dedup locks that null in, recovery analysis
+# stalls on "Insufficient HRV data" forever.
+# ---------------------------------------------------------------------------
+
+
+def _record(day: str, hrv, hr, type_: str | None = "long_sleep") -> dict:
+    rec: dict = {"day": day, "average_hrv": hrv, "average_heart_rate": hr}
+    if type_ is not None:
+        rec["type"] = type_
+    return rec
+
+
+def test_select_oura_hrv_long_sleep_beats_nap_with_null_hrv():
+    """The exact production failure mode: nap with null HRV must not win."""
+    sleep_raw = [
+        _record("2026-04-29", 45, 52, type_="long_sleep"),
+        _record("2026-04-29", None, None, type_="late_nap"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert out["2026-04-29"]["hrv_avg"] == "45"
+    assert out["2026-04-29"]["resting_hr"] == "52"
+    assert out["2026-04-29"]["_type"] == "long_sleep"
+
+
+def test_select_oura_hrv_order_independent_for_null_naps():
+    """Order shouldn't matter — long_sleep with HRV always beats null naps."""
+    sleep_raw = [
+        _record("2026-04-29", None, None, type_="late_nap"),
+        _record("2026-04-29", 45, 52, type_="long_sleep"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert out["2026-04-29"]["hrv_avg"] == "45"
+
+
+def test_select_oura_hrv_long_sleep_beats_rest_with_hrv():
+    """When both records have positive HRV, long_sleep wins (even when rest sorts last)."""
+    sleep_raw = [
+        _record("2026-04-29", 45, 52, type_="long_sleep"),
+        _record("2026-04-29", 38, 60, type_="rest"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert out["2026-04-29"]["hrv_avg"] == "45"
+    assert out["2026-04-29"]["_type"] == "long_sleep"
+
+
+def test_select_oura_hrv_falls_back_to_nap_when_long_sleep_missing_hrv():
+    """If only the nap has HRV, it wins — the alternative is null HRV."""
+    sleep_raw = [
+        _record("2026-04-29", None, None, type_="long_sleep"),
+        _record("2026-04-29", 38, 60, type_="late_nap"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert out["2026-04-29"]["hrv_avg"] == "38"
+
+
+def test_select_oura_hrv_handles_missing_or_null_type():
+    """`type` may be missing or JSON null — long_sleep candidate still wins."""
+    sleep_raw = [
+        _record("2026-04-29", 45, 52, type_=None),  # missing
+        _record("2026-04-29", 50, 55, type_="long_sleep"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert out["2026-04-29"]["hrv_avg"] == "50"
+    assert out["2026-04-29"]["_type"] == "long_sleep"
+
+
+def test_select_oura_hrv_skips_records_without_day():
+    """Records with empty/missing `day` are dropped silently."""
+    sleep_raw = [
+        {"day": "", "average_hrv": 45, "average_heart_rate": 52, "type": "long_sleep"},
+        {"average_hrv": 50, "average_heart_rate": 55, "type": "long_sleep"},
+        _record("2026-04-29", 45, 52, type_="long_sleep"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert list(out.keys()) == ["2026-04-29"]
+
+
+def test_select_oura_hrv_zero_treated_as_invalid():
+    """An average_hrv of 0 (occasional sensor glitch) shouldn't block a real reading."""
+    sleep_raw = [
+        _record("2026-04-29", 0, 0, type_="long_sleep"),
+        _record("2026-04-29", 42, 50, type_="late_nap"),
+    ]
+    out = select_oura_hrv_per_day(sleep_raw)
+    assert out["2026-04-29"]["hrv_avg"] == "42"

--- a/tests/test_recovery_freshness.py
+++ b/tests/test_recovery_freshness.py
@@ -32,12 +32,12 @@ def test_fresh_data_is_not_stale():
     assert analysis["latest_date"] == today.isoformat()
 
 
-def test_yesterday_only_is_stale():
-    """When latest row is yesterday, is_stale is True and latest_date is yesterday.
+def test_yesterday_only_is_not_stale():
+    """Yesterday's reading is within the 1-day grace window — not stale.
 
-    This is the bug from #130: the Today page used to render yesterday's
-    reading as if it were today's. Now the analysis exposes the actual date
-    so the UI can label it.
+    Recovery data (sleep, HRV) is recorded under the night it was measured,
+    which Oura/Garmin expose under the wake-day. Until ≥2 days have passed,
+    yesterday's reading is the "today" signal, so we don't badge it stale.
     """
     today = date.today()
     yesterday = today - timedelta(days=1)
@@ -47,8 +47,22 @@ def test_yesterday_only_is_stale():
 
     analysis, _, _, _ = _compute_recovery_analysis(df)
 
-    assert analysis["is_stale"] is True
+    assert analysis["is_stale"] is False
     assert analysis["latest_date"] == yesterday.isoformat()
+
+
+def test_two_days_old_is_stale():
+    """Once the latest reading is two days old, recovery becomes stale."""
+    today = date.today()
+    two_days_ago = today - timedelta(days=2)
+    rows = [(today - timedelta(days=i), 45.0) for i in range(10, 2, -1)]
+    rows.append((two_days_ago, 50.0))
+    df = _build_recovery_df(rows)
+
+    analysis, _, _, _ = _compute_recovery_analysis(df)
+
+    assert analysis["is_stale"] is True
+    assert analysis["latest_date"] == two_days_ago.isoformat()
 
 
 def test_no_recovery_data_returns_none_latest_date():
@@ -64,18 +78,18 @@ def test_stale_data_still_classifies_status():
     """Stale data still drives the status field — the UI just labels it.
 
     Behavior change scope: this PR surfaces staleness; it doesn't suppress
-    the signal. Yesterday's "fatigued" reading still classifies as fatigued
-    until today's data syncs (#130 acceptance criteria).
+    the signal. The latest reading still classifies fatigued/normal/fresh
+    based on the HRV value, even when stale (#130 acceptance criteria).
     """
     today = date.today()
-    yesterday = today - timedelta(days=1)
-    # 30 days of high HRV → low yesterday → fatigued classification
-    rows = [(today - timedelta(days=i), 60.0) for i in range(30, 1, -1)]
-    rows.append((yesterday, 30.0))  # well below baseline
+    two_days_ago = today - timedelta(days=2)
+    # 30 days of high HRV → low two-days-ago → fatigued classification
+    rows = [(today - timedelta(days=i), 60.0) for i in range(30, 2, -1)]
+    rows.append((two_days_ago, 30.0))  # well below baseline
     df = _build_recovery_df(rows)
 
     analysis, _, _, _ = _compute_recovery_analysis(df)
 
     assert analysis["is_stale"] is True
-    assert analysis["latest_date"] == yesterday.isoformat()
+    assert analysis["latest_date"] == two_days_ago.isoformat()
     assert analysis["status"] == "fatigued"

--- a/tests/test_sync_writer_backfill.py
+++ b/tests/test_sync_writer_backfill.py
@@ -219,3 +219,153 @@ def test_write_activities_nothing_to_fill_returns_zero(db_with_user):
     db.commit()
 
     assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Oura recovery upserts
+# ---------------------------------------------------------------------------
+
+
+def _readiness_row(d: date, score: int = 80) -> dict:
+    return {"date": d.isoformat(), "readiness_score": str(score),
+            "hrv_avg": "", "resting_hr": "",
+            "body_temperature_delta": "0.1"}
+
+
+def _sleep_row(d: date, sleep_score: int = 75) -> dict:
+    return {"date": d.isoformat(), "sleep_score": str(sleep_score),
+            "total_sleep_sec": "28800", "deep_sleep_sec": "7200",
+            "rem_sleep_sec": "5400", "light_sleep_sec": "16200",
+            "efficiency": "92"}
+
+
+def test_write_recovery_oura_backfills_null_hrv_on_existing_row(db_with_user):
+    """Re-syncing fills HRV/RHR on rows previously inserted with nulls.
+
+    This is the production bug: rows landed without HRV (e.g., before the
+    extraction logic was correct, or due to a multi-record day overwriting
+    the long_sleep entry), and the dedup on existing date prevented any
+    later sync from filling them. The recovery analysis stayed stuck on
+    "insufficient HRV data" forever.
+    """
+    from db import sync_writer
+    from db.models import RecoveryData
+
+    db, user_id = db_with_user
+    today = date.today()
+
+    # First sync: HRV missing (mirrors a buggy / partial sleep response)
+    sync_writer.write_recovery(
+        user_id,
+        readiness_rows=[_readiness_row(today)],
+        sleep_rows=[_sleep_row(today)],
+        hrv_by_date={},
+        db=db,
+    )
+    db.commit()
+
+    row = db.query(RecoveryData).filter(
+        RecoveryData.user_id == user_id, RecoveryData.source == "oura",
+    ).one()
+    assert row.hrv_avg is None
+    assert row.resting_hr is None
+
+    # Second sync: same date, but now HRV/RHR are present
+    count = sync_writer.write_recovery(
+        user_id,
+        readiness_rows=[_readiness_row(today)],
+        sleep_rows=[_sleep_row(today)],
+        hrv_by_date={today.isoformat(): {"hrv_avg": "45.5", "resting_hr": "52"}},
+        db=db,
+    )
+    db.commit()
+
+    assert count == 1, "Backfill should count as one touched row"
+    row = db.query(RecoveryData).filter(
+        RecoveryData.user_id == user_id, RecoveryData.source == "oura",
+    ).one()
+    assert row.hrv_avg == 45.5
+    assert row.resting_hr == 52.0
+
+
+def test_write_recovery_oura_does_not_overwrite_existing_hrv(db_with_user):
+    """A re-sync must not clobber an HRV value already in the DB.
+
+    Existing valid bio fields are authoritative; Oura is the source of
+    truth and we only fill gaps, never overwrite.
+    """
+    from db import sync_writer
+    from db.models import RecoveryData
+
+    db, user_id = db_with_user
+    today = date.today()
+
+    sync_writer.write_recovery(
+        user_id,
+        readiness_rows=[_readiness_row(today)],
+        sleep_rows=[_sleep_row(today)],
+        hrv_by_date={today.isoformat(): {"hrv_avg": "50.0", "resting_hr": "55"}},
+        db=db,
+    )
+    db.commit()
+
+    sync_writer.write_recovery(
+        user_id,
+        readiness_rows=[_readiness_row(today)],
+        sleep_rows=[_sleep_row(today)],
+        hrv_by_date={today.isoformat(): {"hrv_avg": "30.0", "resting_hr": "70"}},
+        db=db,
+    )
+    db.commit()
+
+    row = db.query(RecoveryData).filter(
+        RecoveryData.user_id == user_id, RecoveryData.source == "oura",
+    ).one()
+    assert row.hrv_avg == 50.0, "Existing HRV must survive re-sync"
+    assert row.resting_hr == 55.0
+
+
+def test_write_recovery_oura_new_date_still_inserts(db_with_user):
+    """Baseline: a never-before-seen Oura date still gets inserted."""
+    from db import sync_writer
+    from db.models import RecoveryData
+
+    db, user_id = db_with_user
+    today = date.today()
+
+    count = sync_writer.write_recovery(
+        user_id,
+        readiness_rows=[_readiness_row(today)],
+        sleep_rows=[_sleep_row(today)],
+        hrv_by_date={today.isoformat(): {"hrv_avg": "40.0", "resting_hr": "58"}},
+        db=db,
+    )
+    db.commit()
+
+    assert count == 1
+    row = db.query(RecoveryData).filter(
+        RecoveryData.user_id == user_id, RecoveryData.source == "oura",
+    ).one()
+    assert row.hrv_avg == 40.0
+    assert row.resting_hr == 58.0
+    assert row.sleep_score == 75.0
+
+
+def test_write_recovery_oura_skips_when_existing_complete(db_with_user):
+    """No-op re-sync (same data) returns zero touches."""
+    from db import sync_writer
+
+    db, user_id = db_with_user
+    today = date.today()
+    payload = dict(
+        readiness_rows=[_readiness_row(today)],
+        sleep_rows=[_sleep_row(today)],
+        hrv_by_date={today.isoformat(): {"hrv_avg": "45.0", "resting_hr": "55"}},
+    )
+
+    sync_writer.write_recovery(user_id, db=db, **payload)
+    db.commit()
+
+    count = sync_writer.write_recovery(user_id, db=db, **payload)
+    db.commit()
+    assert count == 0


### PR DESCRIPTION
## Summary
- **Root cause**: Oura's `/v2/sleep` returns multiple records per day when the user naps (long_sleep + late_nap + rest). `api/routes/sync.py` built `hrv_by_date` last-write-wins, so a nap with `average_hrv: null` clobbered the long_sleep's valid HRV. The writer's insert-only dedup (`if d in existing_oura: continue`) then locked the row at null forever — subsequent syncs are a no-op for that date. After enough days are corrupted, the recovery card flips to **"Insufficient HRV data"** because `analyze_recovery` needs ≥5 valid baseline days.
- **Fix**: mirror the Garmin/activity/split upsert pattern — prefer the long_sleep entry per day, then fill nulls on existing rows without overwriting non-null values.
- PR #199's fallback (find most-recent valid HRV) works correctly but can't manufacture history that isn't there. This PR fixes the underlying data-loss path so history actually exists.

## Changes
- `api/routes/sync.py` — `hrv_by_date` prefers records with positive `average_hrv`, with `long_sleep` winning ties.
- `db/sync_writer.py` — Oura branch upserts null bio fields on existing rows (`hrv_avg`, `resting_hr`, `sleep_score`, `readiness_score`, sleep durations, `body_temp_delta`). Existing non-null values are never overwritten.
- `tests/test_sync_writer_backfill.py` — 4 new tests: backfills null HRV, never overwrites existing HRV, new dates still insert, no-op re-sync returns 0.
- `tests/test_recovery_freshness.py` — fixed pre-existing stale `test_yesterday_only_is_stale` that fought the deliberate 1-day grace from #194 (`api/deps.py:1152`). Replaced with `test_yesterday_only_is_not_stale` and `test_two_days_old_is_stale`.
- `plugins/praxys/.mcp.json` + `plugins/praxys/mcp-server/server.py` — bake `https://api.praxys.run` / `https://www.praxys.run` defaults so the MCP plugin works out-of-the-box; reject unexpanded `${VAR}` placeholders that slip through.

## Test plan
- [x] `pytest tests/` — 569 passed, 1 skipped locally
- [x] Reproduced the production "insufficient_data" status with realistic data shape (4 valid HRV in 200 days + today null) — confirms the analysis can't recover without more historical HRV
- [ ] After merge + deploy: run a wide-window backfill — `POST /api/sync` with `{"sources":["oura"],"from_date":"2025-09-01"}`; recovery card should resume showing HRV within one sync cycle as historical rows get filled from Oura's archive