### PR TITLE
Fix miniapp UI: share button, text wrap, goal editor cleanup

### DIFF
--- a/miniapp/pages/goal/index.scss
+++ b/miniapp/pages/goal/index.scss
@@ -390,6 +390,20 @@
 }
 .goal-share-btn { width: 100%; }
 
+// "Change goal" row — continuous mode hero, opens editor on tap.
+.goal-change-goal-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8rpx;
+  margin-top: 24rpx;
+  padding-top: 16rpx;
+  border-top: 1rpx solid var(--border-subtle);
+}
+.goal-change-goal-label {
+  font-size: 26rpx;
+}
+
 // --- Inline edit affordances -------------------------------------------
 // Shared pencil icon used inline next to the Target value and in the
 // "Change goal" row on continuous mode. Background-color shows through

--- a/miniapp/pages/goal/index.ts
+++ b/miniapp/pages/goal/index.ts
@@ -3,7 +3,7 @@ import type { IAppOption } from '../../app';
 import { apiGet, apiPut } from '../../utils/api-client';
 import type { ApiError } from '../../utils/api-client';
 import type { GoalResponse, Milestone } from '../../types/api';
-import { formatTime, formatPace, parseTimeToSeconds } from '../../utils/format';
+import { formatTime, formatPace } from '../../utils/format';
 import { applyThemeChrome, themeClassName } from '../../utils/theme';
 import {
   buildShareMessage,
@@ -29,7 +29,6 @@ function buildGoalTr() {
     // Page-level chrome
     failedToLoad: t('Failed to load'),
     retry: t('Retry'),
-    edit: t('Edit'),
     realityCheck: t('Reality Check'),
     fitnessTrend: t('Fitness Trend'),
     currentFitness: t('Current Fitness'),
@@ -59,10 +58,8 @@ function buildGoalTr() {
     save: t('Save Goal'),
     saving: t('Saving…'),
     raceDateRequired: t('Race date is required'),
-    invalidTime: t('Invalid time format. Use H:MM:SS or H:MM'),
     failedToSave: t('Failed to save goal'),
-    timeBlankRace: t('Leave blank to track predicted time only'),
-    timeBlankCont: t('What time are you working toward? Leave blank to track trend only'),
+    targetTimeHint: t('0:00:00 = no target time'),
     predicted: t('Predicted'),
     target: t('Target'),
     setTarget: t('+ Set target'),
@@ -89,21 +86,33 @@ interface EditorSnapshot {
   type: 'race' | 'continuous';
   distanceIndex: number;
   raceDate: string;
-  targetTime: string;
+  targetTimeSec: number;
 }
 
-/**
- * Return a "= H:MM:SS" preview for the target-time input, or empty
- * string if the value is blank or doesn't parse. The leading "= " is
- * intentional — it makes the line read as feedback ("here's what your
- * input parsed to") rather than yet another label.
- */
-function editorTargetPreviewFor(raw: string): string {
-  const trimmed = raw.trim();
-  if (!trimmed) return '';
-  const sec = parseTimeToSeconds(trimmed);
-  if (sec === null || sec <= 0) return '';
-  return `= ${formatTime(sec)}`;
+function buildTimeRange(): string[][] {
+  const hours = Array.from({ length: 48 }, (_, i) => `${i}h`);
+  const minutes = Array.from({ length: 60 }, (_, i) => `${String(i).padStart(2, '0')}m`);
+  const seconds = Array.from({ length: 60 }, (_, i) => `${String(i).padStart(2, '0')}s`);
+  return [hours, minutes, seconds];
+}
+
+function secondsToTimeParts(sec: number | null | undefined): [number, number, number] {
+  if (!sec || sec <= 0) return [0, 0, 0];
+  const h = Math.min(47, Math.floor(sec / 3600));
+  const m = Math.floor((sec % 3600) / 60);
+  const s = Math.floor(sec % 60);
+  return [h, m, s];
+}
+
+function timePartsToSeconds(parts: number[]): number {
+  const [h = 0, m = 0, s = 0] = parts;
+  return h * 3600 + m * 60 + s;
+}
+
+function timePartsToDisplay(parts: number[]): string {
+  const [h = 0, m = 0, s = 0] = parts;
+  if (h === 0 && m === 0 && s === 0) return '—';
+  return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
 }
 
 function buildDistanceChoices(): DistanceChoice[] {
@@ -215,19 +224,11 @@ interface GoalState {
   editorDistanceIndex: number;
   editorRaceDate: string;
   editorTodayIso: string;
-  editorTargetTime: string;
-  editorTargetPlaceholder: string;
-  editorTargetHint: string;
-  // Live preview line under the target-time input. When the user types
-  // a parseable time we show "= H:MM:SS" so they can verify the parser
-  // matched their intent before tapping Save. Empty otherwise — the
-  // hint copy below explains the optional/blank semantics.
-  editorTargetPreview: string;
+  editorTimeRange: string[][];
+  editorTimeParts: number[];
+  editorTargetDisplay: string;
   editorError: string;
   editorSaving: boolean;
-  // Becomes true the moment the user diverges from the snapshot taken
-  // when the editor opened. Drives Save enable/disable, and the modal
-  // confirm on Cancel / mask-tap.
   editorDirty: boolean;
   mode: GoalResponse['race_countdown']['mode'];
 
@@ -340,10 +341,9 @@ const initialData: GoalState = {
   editorDistanceIndex: 3, // marathon default
   editorRaceDate: '',
   editorTodayIso: todayIso(),
-  editorTargetTime: '',
-  editorTargetPlaceholder: DISTANCE_CHOICES[3].placeholder,
-  editorTargetHint: '',
-  editorTargetPreview: '',
+  editorTimeRange: buildTimeRange(),
+  editorTimeParts: [0, 0, 0],
+  editorTargetDisplay: '—',
   editorError: '',
   editorSaving: false,
   editorDirty: false,
@@ -815,18 +815,15 @@ Page({
       DISTANCE_CHOICES.findIndex((d) => d.key === distanceKey),
     );
     const editorType: 'race' | 'continuous' = goal?.race_date ? 'race' : 'continuous';
-    const editorTargetTime =
-      goal?.target_time_sec && goal.target_time_sec > 0 ? formatTime(goal.target_time_sec) : '';
+    const targetTimeSec =
+      goal?.target_time_sec && goal.target_time_sec > 0 ? goal.target_time_sec : 0;
+    const timeParts = secondsToTimeParts(targetTimeSec);
     const editorRaceDate = goal?.race_date ?? '';
-    // Snapshot initial values so we can compute dirty state without
-    // serializing the whole editor on every keystroke. Stored on `data`
-    // under a leading-underscore key so it isn't part of the rendered
-    // template state.
     (this.data as { _editorInitial?: EditorSnapshot })._editorInitial = {
       type: editorType,
       distanceIndex: idx,
       raceDate: editorRaceDate,
-      targetTime: editorTargetTime,
+      targetTimeSec,
     };
     this.setData({
       editorOpen: true,
@@ -834,10 +831,8 @@ Page({
       editorDistanceIndex: idx,
       editorRaceDate,
       editorTodayIso: todayIso(),
-      editorTargetTime,
-      editorTargetPlaceholder: DISTANCE_CHOICES[idx].placeholder,
-      editorTargetHint: editorType === 'race' ? tr.timeBlankRace : tr.timeBlankCont,
-      editorTargetPreview: editorTargetPreviewFor(editorTargetTime),
+      editorTimeParts: timeParts,
+      editorTargetDisplay: timePartsToDisplay(timeParts),
       editorError: '',
       editorSaving: false,
       editorDirty: false,
@@ -878,11 +873,7 @@ Page({
   onPickEditorType(e: WechatMiniprogram.TouchEvent) {
     const type = e.currentTarget.dataset.type as 'race' | 'continuous' | undefined;
     if (!type) return;
-    const tr = this.data.tr as ReturnType<typeof buildGoalTr>;
-    this.setData({
-      editorType: type,
-      editorTargetHint: type === 'race' ? tr.timeBlankRace : tr.timeBlankCont,
-    });
+    this.setData({ editorType: type });
     this.recomputeEditorDirty();
   },
 
@@ -901,36 +892,23 @@ Page({
     this.recomputeEditorDirty();
   },
 
-  onEditorTargetTimeInput(e: WechatMiniprogram.Input) {
-    const value = e.detail.value;
+  onPickEditorTargetTime(e: WechatMiniprogram.PickerChange) {
+    const parts = (e.detail.value as number[]) || [0, 0, 0];
     this.setData({
-      editorTargetTime: value,
-      editorTargetPreview: editorTargetPreviewFor(value),
+      editorTimeParts: parts,
+      editorTargetDisplay: timePartsToDisplay(parts),
     });
     this.recomputeEditorDirty();
   },
 
-  /**
-   * Recompute `editorDirty` against the snapshot taken in onOpenEditor.
-   * Cheap enough to call after every editor mutation. Strings compare
-   * byte-for-byte; targetTime is normalized via parse+format so "1:30"
-   * vs "1:30:00" don't both register as edits when the parsed value is
-   * identical to the snapshot.
-   */
   recomputeEditorDirty() {
     const snap = (this.data as { _editorInitial?: EditorSnapshot })._editorInitial;
     if (!snap) return;
-    const cur = {
-      type: this.data.editorType as 'race' | 'continuous',
-      distanceIndex: this.data.editorDistanceIndex as number,
-      raceDate: this.data.editorRaceDate as string,
-      targetTime: this.data.editorTargetTime as string,
-    };
     const dirty =
-      cur.type !== snap.type ||
-      cur.distanceIndex !== snap.distanceIndex ||
-      cur.raceDate !== snap.raceDate ||
-      cur.targetTime.trim() !== snap.targetTime.trim();
+      (this.data.editorType as string) !== snap.type ||
+      (this.data.editorDistanceIndex as number) !== snap.distanceIndex ||
+      (this.data.editorRaceDate as string) !== snap.raceDate ||
+      timePartsToSeconds(this.data.editorTimeParts as number[]) !== snap.targetTimeSec;
     if (dirty !== this.data.editorDirty) {
       this.setData({ editorDirty: dirty });
     }
@@ -945,21 +923,12 @@ Page({
     const editorType = this.data.editorType as 'race' | 'continuous';
     const editorDistanceIndex = this.data.editorDistanceIndex as number;
     const editorRaceDate = this.data.editorRaceDate as string;
-    const editorTargetTime = (this.data.editorTargetTime as string).trim();
 
     if (editorType === 'race' && !editorRaceDate) {
       this.setData({ editorError: tr.raceDateRequired });
       return;
     }
-    let targetTimeSec = 0;
-    if (editorTargetTime) {
-      const parsed = parseTimeToSeconds(editorTargetTime);
-      if (parsed === null) {
-        this.setData({ editorError: tr.invalidTime });
-        return;
-      }
-      targetTimeSec = parsed;
-    }
+    const targetTimeSec = timePartsToSeconds(this.data.editorTimeParts as number[]);
 
     this.setData({ editorSaving: true, editorError: '' });
     const distance = DISTANCE_CHOICES[editorDistanceIndex]?.key ?? 'marathon';

--- a/miniapp/pages/goal/index.wxml
+++ b/miniapp/pages/goal/index.wxml
@@ -1,10 +1,5 @@
 <view class="goal-root {{themeClass}}">
-  <nav-bar
-    title="Goal"
-    theme-class="{{themeClass}}"
-    right-text="{{tr.edit}}"
-    bindrightaction="onOpenEditor"
-  />
+  <nav-bar title="Goal" theme-class="{{themeClass}}" />
 
   <scroll-view
     scroll-y="{{true}}"
@@ -261,7 +256,7 @@
        header now hosts Cancel/Save (was a close ×); the bottom action
        row was removed so the sheet doesn't have two competing CTAs. -->
   <view wx:if="{{editorOpen}}" class="goal-editor-mask" bindtap="onCloseEditor">
-    <view class="goal-editor-sheet" catchtap="onSheetTap">
+    <view class="goal-editor-sheet" catch:tap="onSheetTap">
       <view class="goal-editor-header">
         <view
           class="goal-editor-header-action goal-editor-header-action--cancel {{editorSaving ? 'goal-editor-header-action--disabled' : ''}}"
@@ -327,22 +322,18 @@
       </block>
 
       <text class="goal-editor-label ts-muted">{{tr.targetTime}} <text class="ts-muted">({{tr.optional}})</text></text>
-      <input
-        class="goal-editor-input goal-editor-input--text"
-        type="text"
-        placeholder="{{editorTargetPlaceholder}}"
-        placeholder-class="goal-editor-input-placeholder"
-        value="{{editorTargetTime}}"
-        cursor-spacing="{{40}}"
-        adjust-position="{{true}}"
-        confirm-type="done"
-        bindinput="onEditorTargetTimeInput"
-      />
-      <!-- Live preview "= H:MM:SS" — appears only when the input parses.
-           Sits above the help-copy hint so the parsed value reads as
-           direct feedback, while the hint stays as steady guidance. -->
-      <text wx:if="{{editorTargetPreview}}" class="goal-editor-preview ts-primary">{{editorTargetPreview}}</text>
-      <text class="goal-editor-hint ts-muted">{{editorTargetHint}}</text>
+      <picker
+        mode="multiSelector"
+        range="{{editorTimeRange}}"
+        value="{{editorTimeParts}}"
+        bindchange="onPickEditorTargetTime"
+      >
+        <view class="goal-editor-input">
+          <text class="goal-editor-input-value {{editorTargetDisplay === '—' ? 'ts-muted' : ''}}">{{editorTargetDisplay}}</text>
+          <text class="goal-editor-input-chev ts-muted">›</text>
+        </view>
+      </picker>
+      <text class="goal-editor-hint ts-muted">{{tr.targetTimeHint}}</text>
 
       <text wx:if="{{editorError}}" class="goal-editor-error ts-destructive">{{editorError}}</text>
     </view>

--- a/miniapp/pages/today/index.scss
+++ b/miniapp/pages/today/index.scss
@@ -151,7 +151,11 @@
   text-align: center;
   line-height: 1.5;
   color: var(--text-muted);
-  max-width: 540rpx;
+  // align-self: stretch overrides the parent's align-items: center so the
+  // text element expands to the full card width. Without it the flex child
+  // sizes to its intrinsic (unwrapped) width and overflows horizontally.
+  align-self: stretch;
+  word-break: break-word;
 }
 
 // Share card overlay — fixed above everything, backdrop + centered card.

--- a/miniapp/pages/today/index.wxml
+++ b/miniapp/pages/today/index.wxml
@@ -1,5 +1,5 @@
 <view class="today-root {{themeClass}}">
-  <nav-bar title="Today" theme-class="{{themeClass}}" show-wordmark="{{true}}" right-share="{{true}}" />
+  <nav-bar title="Today" theme-class="{{themeClass}}" show-wordmark="{{true}}" />
 
   <scroll-view
     scroll-y="{{true}}"

--- a/miniapp/utils/i18n-extra.ts
+++ b/miniapp/utils/i18n-extra.ts
@@ -79,6 +79,7 @@ export const I18N_EXTRA: Record<Locale, Record<string, string>> = {
     'Race date is required': 'Race date is required',
     'Invalid time format. Use H:MM:SS or H:MM': 'Invalid time format. Use H:MM:SS or H:MM',
     'Failed to save goal': 'Failed to save goal',
+    '0:00:00 = no target time': '0:00:00 = no target time',
     'Leave blank to track predicted time only': 'Leave blank to track predicted time only',
     'What time are you working toward? Leave blank to track trend only':
       'What time are you working toward? Leave blank to track trend only',
@@ -190,6 +191,7 @@ export const I18N_EXTRA: Record<Locale, Record<string, string>> = {
     'Race date is required': '请填写比赛日期',
     'Invalid time format. Use H:MM:SS or H:MM': '时间格式无效，请使用 H:MM:SS 或 H:MM',
     'Failed to save goal': '保存目标失败',
+    '0:00:00 = no target time': '0:00:00 = 不设目标时间',
     'Leave blank to track predicted time only': '留空仅显示预测完赛时间',
     'What time are you working toward? Leave blank to track trend only':
       '您的目标时间是？留空仅追踪趋势',


### PR DESCRIPTION
## Summary

- **Today page** — Remove the duplicate share button from the nav-bar; the FAB on the signal card is the only entry point
- **Today page** — Fix `signal-reason` text overflowing horizontally by using `align-self: stretch` + `word-break: break-word` (previously `max-width` on a flex child with `align-items: center` was ignored)
- **Goal page** — Remove the `Edit` button from the nav-bar; the inline pencil icons on target cells and the change-goal row in continuous mode are the entry points
- **Goal page** — Switch `catchtap` → `catch:tap` on the editor sheet for Skyline event propagation compatibility (fixes cancel not dismissing the overlay)
- **Goal page** — Replace the freeform target-time text input with a `multiSelector` wheel picker (hours 0–47, minutes 0–59, seconds 0–59); `0:00:00` = no target time
- **Goal page** — Add missing `goal-change-goal-row` / `goal-change-goal-label` styles (continuous mode's change-goal affordance was unstyled)
- **i18n** — Add `'0:00:00 = no target time'` hint in English and Chinese

## Test plan

- [ ] Today page: verify only the FAB share button appears on the signal card, no share icon in the nav-bar
- [ ] Today page: verify long signal-reason text wraps properly (e.g. "recovery requires HRV data. Connect Oura in Settings to enable." should not overflow)
- [ ] Goal page: verify no Edit button in the nav-bar; tapping the inline pencil next to Target still opens the editor
- [ ] Goal page: verify Cancel and backdrop tap both dismiss the editor correctly
- [ ] Goal page: verify the duration picker shows H/M/S columns; existing target time pre-fills; `0:00:00` saves as no target
- [ ] Continuous mode: verify the "Change Goal" row with pencil icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)