### PR TITLE
Fix miniapp: goal editor re-tappable after discard; clean share image

### DIFF
--- a/miniapp/pages/goal/index.ts
+++ b/miniapp/pages/goal/index.ts
@@ -861,6 +861,11 @@ Page({
       success: (res) => {
         if (res.confirm) {
           this.setData({ editorOpen: false, editorError: '' });
+        } else {
+          // Skyline requires a setData call after wx.showModal closes to
+          // re-register touch events on the overlay. Without it, subsequent
+          // taps on Cancel (or anywhere in the sheet) go undelivered.
+          this.setData({ editorDirty: this.data.editorDirty as boolean });
         }
       },
     });

--- a/miniapp/pages/today/index.wxml
+++ b/miniapp/pages/today/index.wxml
@@ -141,9 +141,8 @@
   <!-- Share card overlay — appears above everything when FAB is tapped.
        User long-presses the image to get WeChat's native "Save image"
        context menu, then shares from camera roll. Tap the backdrop to
-       dismiss. -->
-  <!-- Share card overlay: the "长按图片转发" hint is baked into the
-       canvas image itself so there's no need to repeat it here. -->
+       dismiss. show-menu-by-longpress on the <image> surfaces the native
+       save/forward sheet; no extra hint text is needed. -->
   <view wx:if="{{shareCardVisible}}" class="share-overlay" bindtap="onShareCardToggle">
     <view class="share-overlay-sheet" catchtap="noop">
       <view wx:if="{{!shareImagePath}}" class="share-overlay-loading">

--- a/miniapp/utils/share-image.ts
+++ b/miniapp/utils/share-image.ts
@@ -243,13 +243,11 @@ export async function generateShareCard(input: ShareCardInput): Promise<string> 
   reasonLines.forEach((line, i) => ctx.fillText(line, CX, reasonY0 + i * REASON_LINE_H));
 
   // ── Divider — positioned dynamically so reason text never overlaps it ───
-  const BAR_H = 46;
   // Bottom of last reason line (font size 30, textBaseline 'top' → +32px)
   const reasonEndY = reasonLines.length > 0
     ? reasonY0 + (reasonLines.length - 1) * REASON_LINE_H + 32
     : reasonY0 - 20;
-  // Always at least 20px below reason, but keep footer legible above accent bar
-  const divY = Math.max(reasonEndY + 20, H - BAR_H - 110);
+  const divY = Math.max(reasonEndY + 20, H - 110);
   ctx.strokeStyle = C.border;
   ctx.lineWidth = 1;
   ctx.beginPath();
@@ -271,15 +269,6 @@ export async function generateShareCard(input: ShareCardInput): Promise<string> 
   ctx.fillStyle = C.primary;
   ctx.font = '500 21px -apple-system, BlinkMacSystemFont, system-ui, sans-serif';
   ctx.fillText('praxys.run', W - 40, footerY);
-
-  // ── Accent bar with CTA ──────────────────────────────────────────────────
-  ctx.fillStyle = C.primary;
-  ctx.fillRect(0, H - BAR_H, W, BAR_H);
-  ctx.font = '500 20px -apple-system, BlinkMacSystemFont, system-ui, sans-serif';
-  ctx.fillStyle = C.cta;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  ctx.fillText(locale === 'zh' ? '长按图片转发' : 'Long press to share', W / 2, H - BAR_H / 2);
 
   return new Promise<string>((resolve, reject) => {
     wx.canvasToTempFilePath({


### PR DESCRIPTION
## Summary

- **Goal editor cancel re-tappable**: After `wx.showModal` closes in Skyline with "Keep editing", no `setData` was called, leaving the touch system frozen — subsequent taps on Cancel (or anywhere in the sheet) were silently dropped. Fix: call `setData({ editorDirty })` as a no-op in the `else` branch to re-register touch events.

- **Share image bar removed**: The green "Long press to share" / "长按图片转发" accent bar drawn at the bottom of the canvas image was misleading (users get WeChat's native save/forward sheet via `show-menu-by-longpress` on the overlay `<image>` already). Removed the bar and updated `divY` accordingly.

## Test plan

- [ ] Goal editor: open editor, change something (marks dirty), tap Cancel → "Keep editing" → verify Cancel can be tapped again
- [ ] Goal editor: open editor, change something, tap Cancel → "Discard" → verify editor closes
- [ ] Share card: tap FAB on Today page, verify shared image has no green bar at the bottom; long-press image to confirm native save/share sheet still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)