### PR TITLE
Show full CalVer in Settings for all build types

### DIFF
--- a/.github/workflows/miniapp-publish.yml
+++ b/.github/workflows/miniapp-publish.yml
@@ -126,6 +126,19 @@ jobs:
           fi
 
       - if: steps.gate.outputs.publish == 'true'
+        name: Stamp build version
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        shell: bash
+        run: |
+          # Write the CalVer into utils/version.ts so the mini program can
+          # display it in Settings. wx.getAccountInfoSync().miniProgram.version
+          # only returns a value for release builds; this stamps it for
+          # develop and trial builds too. The file is committed as '' and
+          # overwritten here — the change is never pushed back to git.
+          printf 'export const MINIAPP_BUILD_VERSION = "%s";\n' "$VERSION" > utils/version.ts
+
+      - if: steps.gate.outputs.publish == 'true'
         name: Write upload key
         env:
           WECHAT_MINIAPP_UPLOAD_KEY: ${{ secrets.WECHAT_MINIAPP_UPLOAD_KEY }}

--- a/miniapp/pages/settings/index.ts
+++ b/miniapp/pages/settings/index.ts
@@ -13,6 +13,7 @@ import type { IAppOption } from '../../app';
 import { getLanguagePreference, setLanguagePreference } from '../../utils/share';
 import { t, detectLocale } from '../../utils/i18n';
 import type { SettingsResponse } from '../../types/api';
+import { MINIAPP_BUILD_VERSION } from '../../utils/version';
 
 function buildSettingsTr() {
   return {
@@ -164,13 +165,18 @@ interface TrainingBaseOption {
 }
 
 function readAppVersion(): string {
+  // wx.getAccountInfoSync().miniProgram.version is only populated for
+  // release builds. For develop/trial it always returns ''. CI stamps
+  // the real CalVer into MINIAPP_BUILD_VERSION before each upload so
+  // all three environments can show the full version string.
   try {
     const info = wx.getAccountInfoSync();
     const env = info.miniProgram.envVersion;
-    const ver = info.miniProgram.version;
-    if (env === 'develop') return 'develop';
-    if (env === 'trial') return `trial${ver ? ` · ${ver}` : ''}`;
-    return ver || '';
+    const ver = MINIAPP_BUILD_VERSION || info.miniProgram.version;
+    if (env === 'release') return ver ? `Praxys mp ${ver}` : '';
+    if (env === 'develop') return ver ? `Praxys mp ${ver} (dev)` : '';
+    // trial
+    return ver ? `Praxys mp ${ver} (trial)` : '';
   } catch {
     return '';
   }

--- a/miniapp/pages/settings/index.wxml
+++ b/miniapp/pages/settings/index.wxml
@@ -124,7 +124,7 @@
         </button>
       </view>
 
-      <text wx:if="{{appVersion}}" class="settings-version ts-muted">Praxys {{appVersion}}</text>
+      <text wx:if="{{appVersion}}" class="settings-version ts-muted">{{appVersion}}</text>
     </block>
     </view>
   </scroll-view>

--- a/miniapp/utils/version.ts
+++ b/miniapp/utils/version.ts
@@ -1,0 +1,3 @@
+// Stamped by CI before each upload — do not edit manually.
+// Committed as empty string so local/DevTools builds show no version.
+export const MINIAPP_BUILD_VERSION = '';


### PR DESCRIPTION
## Summary

`wx.getAccountInfoSync().miniProgram.version` only returns a value for **release** builds. For develop and trial, it always returns `''` — which is why the previous implementation showed just "Praxys trial" with no version string.

**Fix:** CI stamps the CalVer string into `miniapp/utils/version.ts` before each upload. The file is committed as an empty placeholder; the CI step overwrites it right before `miniprogram-ci` bundles the app (never pushed back to git).

| Build | Displays |
|---|---|
| Release | `Praxys mp 2026.04.1` |
| Trial / dev upload | `Praxys mp 2026.04.29.6-add8c4c (trial)` |
| DevTools (no CI stamp) | hidden |

## Changes

- `miniapp/utils/version.ts` — new file, placeholder `''`
- `miniapp/pages/settings/index.ts` — import + use `MINIAPP_BUILD_VERSION`; `readAppVersion()` now returns the full display string including "Praxys mp"
- `miniapp/pages/settings/index.wxml` — remove now-redundant `Praxys ` prefix (function returns full string)
- `.github/workflows/miniapp-publish.yml` — new "Stamp build version" step writes `version.ts` after typecheck, before upload

## Test plan

- [ ] Next CI upload: check Settings → version shows `Praxys mp YYYY.MM.DD.N-sha (trial)`
- [ ] After release tag: check Settings → version shows `Praxys mp YYYY.MM.MICRO`
- [ ] DevTools (no CI stamp): version line is hidden (empty placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)