### PR TITLE
miniapp: fix i18n gaps across all tabs after language switch

### DIFF
--- a/miniapp/pages/goal/index.ts
+++ b/miniapp/pages/goal/index.ts
@@ -469,8 +469,9 @@ function formatThreshold(value: number, unit: string): string {
 }
 
 function statusBadgeText(status: string): string {
-  // t() resolves the status key (e.g. 'on_track' → '达标' / 'On track').
-  // toUpperCase is a no-op on CJK characters so both locales look right.
+  // Badge displays ALL CAPS for en (e.g. 'On track' → 'ON TRACK').
+  // toUpperCase is a no-op on CJK characters so zh translations ('达标')
+  // are unaffected and render as-is.
   return t(status).toUpperCase();
 }
 
@@ -980,7 +981,10 @@ Page({
       // The api-client throws UNAUTHENTICATED *and* schedules a reLaunch.
       // Skip the error UI so the page doesn't flash the raw code before
       // it's unmounted; the toast in api-client already explains.
-      if (err?.code === 'UNAUTHENTICATED') return;
+      if (err?.code === 'UNAUTHENTICATED') {
+        this.setData({ loading: false });
+        return;
+      }
       const detail = err?.detail ?? String(e);
       this.setData({ loading: false, errorMessage: detail, hasResponse: false });
     }

--- a/miniapp/pages/goal/index.ts
+++ b/miniapp/pages/goal/index.ts
@@ -458,9 +458,9 @@ function severityAccent(severity: string): string {
 }
 
 function trendDirectionLabel(direction: string): string {
-  if (direction === 'rising') return 'Rising';
-  if (direction === 'falling') return 'Falling';
-  return 'Flat';
+  if (direction === 'rising') return t('Rising');
+  if (direction === 'falling') return t('Falling');
+  return t('Flat');
 }
 
 function formatThreshold(value: number, unit: string): string {
@@ -469,7 +469,9 @@ function formatThreshold(value: number, unit: string): string {
 }
 
 function statusBadgeText(status: string): string {
-  return status.replace(/_/g, ' ').toUpperCase();
+  // t() resolves the status key (e.g. 'on_track' → '达标' / 'On track').
+  // toUpperCase is a no-op on CJK characters so both locales look right.
+  return t(status).toUpperCase();
 }
 
 function buildState(response: GoalResponse, themeClass: string): Partial<GoalState> {
@@ -538,7 +540,7 @@ function buildRaceDateState(
   const rc = response.race_countdown;
   const rCheck = rc.reality_check;
   const hasTarget = rc.target_time_sec != null && rc.target_time_sec > 0;
-  const distLabel = rc.distance_label ?? 'Race';
+  const distLabel = t(rc.distance_label ?? 'Race');
   const severityClass = severityAccent(rCheck.severity);
   const showReality = hasTarget && rCheck.severity !== 'unknown';
 
@@ -596,7 +598,7 @@ function buildCpMilestoneState(
   const rCheck = rc.reality_check;
   const currentCp = response.latest_cp;
   const targetCp = rc.target_cp ?? null;
-  const distLabel = rc.distance_label ?? 'Race';
+  const distLabel = t(rc.distance_label ?? 'Race');
   const hasTimeTarget = rc.target_time_sec != null && rc.target_time_sec > 0;
   const severityClass = severityAccent(rCheck.severity);
 
@@ -664,7 +666,7 @@ function buildContinuousState(
   const rCheck = rc.reality_check;
   const currentCp = response.latest_cp;
   const trend = rc.cp_trend_summary;
-  const distLabel = rc.distance_label ?? 'Marathon';
+  const distLabel = t(rc.distance_label ?? 'Marathon');
   const severityClass = severityAccent(rCheck.severity);
 
   let slopeText = '';
@@ -722,6 +724,7 @@ Page({
     if (curLocale !== pgMut._locale) {
       pgMut._locale = curLocale;
       this.setData({ tr: buildGoalTr() });
+      void this.refetch();
     }
     applyThemeChrome();
     setTabBarSelected(this, 3);

--- a/miniapp/pages/history/index.ts
+++ b/miniapp/pages/history/index.ts
@@ -78,7 +78,9 @@ const initialData: HistoryState = {
 
 function formatActivityType(raw: string): string {
   // Split on underscores, capitalise each word, then run through t() for locale.
-  // Known types (Running, Cycling) get translated; others fall back to formatted English.
+  // The formatted string is intentionally used as the t() key — known types
+  // (Running, Cycling) get translated; unknown types fall back to the formatted
+  // English string via t()'s key-is-fallback behaviour.
   const formatted = raw
     .split('_')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
@@ -211,7 +213,10 @@ Page({
       });
     } catch (e) {
       const err = e as Partial<ApiError>;
-      if (err?.code === 'UNAUTHENTICATED') return;
+      if (err?.code === 'UNAUTHENTICATED') {
+        this.setData({ loading: false, loadingMore: false });
+        return;
+      }
       const detail = err?.detail ?? String(e);
       this.setData({
         loading: false,

--- a/miniapp/pages/history/index.ts
+++ b/miniapp/pages/history/index.ts
@@ -76,6 +76,16 @@ const initialData: HistoryState = {
   refreshing: false,
 };
 
+function formatActivityType(raw: string): string {
+  // Split on underscores, capitalise each word, then run through t() for locale.
+  // Known types (Running, Cycling) get translated; others fall back to formatted English.
+  const formatted = raw
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+  return t(formatted);
+}
+
 function buildActivityRow(activity: Activity): ActivityRow {
   const metrics: MetricRow[] = [];
   if (activity.distance_km != null) {
@@ -104,7 +114,7 @@ function buildActivityRow(activity: Activity): ActivityRow {
   return {
     id: activity.activity_id,
     date: activity.date,
-    type: activity.activity_type,
+    type: formatActivityType(activity.activity_type),
     metrics,
     hasSplits,
     splitCount: splits.length,
@@ -112,7 +122,7 @@ function buildActivityRow(activity: Activity): ActivityRow {
     hasMoreSplits: splits.length > 20,
     moreSplitsCount: Math.max(0, splits.length - 20),
     expanded: false,
-    tapHint: hasSplits ? `Tap to view ${splits.length} splits` : '',
+    tapHint: hasSplits ? tFmt('Tap to view {0} splits', splits.length) : '',
   };
 }
 
@@ -141,6 +151,7 @@ Page({
     if (curLocale !== pgMut._locale) {
       pgMut._locale = curLocale;
       this.setData({ tr: buildHistoryTr() });
+      void this.fetchPage(0, true);
     }
     applyThemeChrome();
     setTabBarSelected(this, 2);

--- a/miniapp/pages/settings/index.ts
+++ b/miniapp/pages/settings/index.ts
@@ -372,7 +372,10 @@ Page({
       this.setData(buildSettingsState(response) as Record<string, unknown>);
     } catch (e) {
       const err = e as Partial<ApiError>;
-      if (err?.code === 'UNAUTHENTICATED') return;
+      if (err?.code === 'UNAUTHENTICATED') {
+        this.setData({ loading: false });
+        return;
+      }
       const detail = err?.detail ?? String(e);
       this.setData({ loading: false, errorMessage: detail, hasResponse: false });
     }

--- a/miniapp/pages/settings/index.ts
+++ b/miniapp/pages/settings/index.ts
@@ -292,8 +292,8 @@ function buildSettingsState(response: SettingsResponse): Partial<SettingsState> 
   const { config, effective_thresholds } = response;
   const profileRows: ProfileRow[] = [
     { label: t('Name'), value: config.display_name || '—' },
-    { label: t('Units'), value: config.unit_system },
-    { label: t('Training base'), value: config.training_base },
+    { label: t('Units'), value: t(config.unit_system) },
+    { label: t('Training base'), value: trainingBaseLabelFor(config.training_base) },
   ];
 
   const connectionRows: ConnectionRow[] = config.connections.map((c) => ({
@@ -405,6 +405,8 @@ Page({
           languageLabel: languageLabelFor(next),
           tr: buildSettingsTr(),
         });
+        // Rebuild profile rows (labels + values) in the new locale.
+        void this.refetch();
       },
     });
   },

--- a/miniapp/pages/today/index.ts
+++ b/miniapp/pages/today/index.ts
@@ -144,7 +144,7 @@ function buildRenderState(response: TodayResponse | null, themeClass: string, to
   const tsbZoneInfo = tsbForHeadline != null ? tsbZone(tsbForHeadline) : null;
 
   const rec = response.recovery_analysis;
-  const recoveryStatus = rec?.status ?? '—';
+  const recoveryStatus = rec ? t(rec.status) : '—';
   const recoveryHrv = rec?.hrv?.today_ms != null ? `${rec.hrv.today_ms.toFixed(0)} ms` : '—';
   const recoveryRhr = rec?.resting_hr != null ? `${rec.resting_hr.toFixed(0)} bpm` : '—';
   const recoverySleep = rec?.sleep_score != null ? `${rec.sleep_score.toFixed(0)}/100` : '—';
@@ -382,6 +382,7 @@ Page({
     if (curLocale !== pgMut._locale) {
       pgMut._locale = curLocale;
       this.setData({ tr: buildTranslations() });
+      void this.refetch();
     }
     applyThemeChrome();
     setTabBarSelected(this, 0);

--- a/miniapp/pages/today/index.ts
+++ b/miniapp/pages/today/index.ts
@@ -497,7 +497,10 @@ Page({
       this.setData({ shareImagePath: '', shareCardVisible: false });
     } catch (e) {
       const err = e as Partial<ApiError>;
-      if (err?.code === 'UNAUTHENTICATED') return;
+      if (err?.code === 'UNAUTHENTICATED') {
+        this.setData({ loading: false });
+        return;
+      }
       const detail = err?.detail ?? String(e);
       this.setData({ loading: false, errorMessage: detail, hasResponse: false });
     }

--- a/miniapp/pages/training/index.ts
+++ b/miniapp/pages/training/index.ts
@@ -496,7 +496,7 @@ function buildState(response: TrainingResponse, themeClass: string): Partial<Tra
     weeklyKm: hasVolume ? tFmt('{0} km/week', (weeklyKm as number).toFixed(1)) : '',
     hasVolumeTrend: !!diagnosis?.volume?.trend,
     volumeTrend: diagnosis?.volume?.trend
-      ? tFmt('trend: {0}', diagnosis.volume.trend)
+      ? tFmt('trend: {0}', t(diagnosis.volume.trend))
       : '',
 
     hasLatestCp: latestCp != null,
@@ -567,10 +567,10 @@ function buildState(response: TrainingResponse, themeClass: string): Partial<Tra
     // already be localized; if not we substitute the translated default.
     sleepPerfTitle: tFmt(
       'Sleep Score vs {0}',
-      sleep_perf?.metric_label || t('Avg Power'),
+      t(sleep_perf?.metric_label || 'Avg Power'),
     ),
     sleepPerfYLabel: sleep_perf
-      ? `${sleep_perf.metric_label || t('Avg Power')} (${sleep_perf.metric_unit || 'W'})`
+      ? `${t(sleep_perf.metric_label || 'Avg Power')} (${sleep_perf.metric_unit || 'W'})`
       : '',
     sleepPerfPairs: sleep_perf?.pairs ?? [],
     sleepPerfYIsPace: sleep_perf?.metric_unit === 'sec/km',
@@ -641,6 +641,7 @@ Page({
     if (curLocale !== pgMut._locale) {
       pgMut._locale = curLocale;
       this.setData({ tr: buildTrainingTr() });
+      void this.refetch();
     }
     applyThemeChrome();
     setTabBarSelected(this, 1);

--- a/miniapp/pages/training/index.ts
+++ b/miniapp/pages/training/index.ts
@@ -691,7 +691,10 @@ Page({
       this.setData(buildState(response, this.data.themeClass) as Record<string, unknown>);
     } catch (e) {
       const err = e as Partial<ApiError>;
-      if (err?.code === 'UNAUTHENTICATED') return;
+      if (err?.code === 'UNAUTHENTICATED') {
+        this.setData({ loading: false });
+        return;
+      }
       const detail = err?.detail ?? String(e);
       this.setData({ loading: false, errorMessage: detail, hasResponse: false });
     }

--- a/miniapp/utils/i18n-extra.ts
+++ b/miniapp/utils/i18n-extra.ts
@@ -120,6 +120,12 @@ const EN_GOAL = {
   'Source — tap to copy URL': 'Source — tap to copy URL',
   'Discussion — tap to copy URL': 'Discussion — tap to copy URL',
   'Ultra distance caveat': 'Ultra distance caveat',
+  // Goal status badge values (API uses lowercase snake_case)
+  on_track: 'On track',
+  close: 'Close',
+  behind: 'Behind',
+  unlikely: 'Unlikely',
+  unknown: '—',
   // Discard-edits modal
   'Discard changes?': 'Discard changes?',
   'Your goal edits will be lost.': 'Your goal edits will be lost.',
@@ -144,6 +150,15 @@ const EN_TODAY = {
   Power: 'Power',
   'Heart rate': 'Heart rate',
   Pace: 'Pace',
+  // Recovery status values returned by the API (lowercase snake_case keys)
+  normal: 'Normal',
+  fresh: 'Fresh',
+  fatigued: 'Fatigued',
+  insufficient_data: 'Insufficient data',
+  // Volume trend values returned by the API
+  increasing: 'Increasing',
+  decreasing: 'Decreasing',
+  stable: 'Stable',
   'What metric Praxys uses to measure intensity. Power needs Stryd; Pace works with anything that gives you GPS.':
     'What metric Praxys uses to measure intensity. Power needs Stryd; Pace works with anything that gives you GPS.',
   'Unbind your WeChat profile from this Praxys account so you can sign in as a different user.':
@@ -212,6 +227,7 @@ const EN_TRAINING = {
 const EN_HISTORY_SCIENCE = {
   // History page footers
   'Loading more…': 'Loading more…',
+  'Tap to view {0} splits': 'Tap to view {0} splits',
   'End of activities': 'End of activities',
   '{0} total · showing {1}': '{0} total · showing {1}',
   // Science page intro / recommendation
@@ -225,6 +241,9 @@ const EN_HISTORY_SCIENCE = {
 
 const EN_SETTINGS = {
   Name: 'Name',
+  // Unit system values returned by API
+  metric: 'Metric',
+  imperial: 'Imperial',
   Connections: 'Connections',
   'Manage connections from the web app.': 'Manage connections from the web app.',
   "No platforms connected. Link Garmin / Stryd / Oura from the web app — their OAuth flows aren't supported in mini programs.":
@@ -250,6 +269,8 @@ const EN_SETTINGS = {
 const EN_NAV_CHARTS = {
   // Page titles (for nav-bar / custom-tab-bar)
   Today: 'Today',
+  // Sleep perf metric label — API can return "Avg Pace" when base is pace
+  'Avg Pace': 'Avg Pace',
   Training: 'Training',
   Activities: 'Activities',
   Goal: 'Goal',
@@ -359,6 +380,12 @@ const ZH_GOAL = {
   'Source — tap to copy URL': '来源 — 点击复制链接',
   'Discussion — tap to copy URL': '讨论 — 点击复制链接',
   'Ultra distance caveat': '超长距离说明',
+  // Goal status badge values (lowercase API keys)
+  on_track: '达标',
+  close: '接近',
+  behind: '落后',
+  unlikely: '难以实现',
+  unknown: '—',
   // Discard-edits modal
   'Discard changes?': '放弃修改？',
   'Your goal edits will be lost.': '您当前的目标修改将丢失。',
@@ -383,6 +410,15 @@ const ZH_TODAY = {
   Power: '功率',
   'Heart rate': '心率',
   Pace: '配速',
+  // Recovery status values (lowercase API keys)
+  normal: '正常',
+  fresh: '恢复良好',
+  fatigued: '疲劳',
+  insufficient_data: '数据不足',
+  // Volume trend values (lowercase API keys)
+  increasing: '上升中',
+  decreasing: '下降中',
+  stable: '平稳',
   'What metric Praxys uses to measure intensity. Power needs Stryd; Pace works with anything that gives you GPS.':
     'Praxys 用于衡量训练强度的指标。功率需要 Stryd；配速适用于任何具备 GPS 的设备。',
   'Unbind your WeChat profile from this Praxys account so you can sign in as a different user.':
@@ -447,6 +483,7 @@ const ZH_TRAINING = {
 
 const ZH_HISTORY_SCIENCE = {
   'Loading more…': '正在加载更多…',
+  'Tap to view {0} splits': '点击查看 {0} 个分段',
   'End of activities': '已加载全部活动',
   '{0} total · showing {1}': '共 {0} 条 · 当前显示 {1}',
   "Praxys's numbers come from published research. These are the theories currently powering your dashboard, plus the alternatives you could switch to on the web.":
@@ -459,6 +496,9 @@ const ZH_HISTORY_SCIENCE = {
 
 const ZH_SETTINGS = {
   Name: '姓名',
+  // Unit system values (lowercase API keys)
+  metric: '公制',
+  imperial: '英制',
   Connections: '已连接平台',
   'Manage connections from the web app.': '请在网页端管理已连接的平台。',
   "No platforms connected. Link Garmin / Stryd / Oura from the web app — their OAuth flows aren't supported in mini programs.":
@@ -482,6 +522,7 @@ const ZH_SETTINGS = {
 
 const ZH_NAV_CHARTS = {
   Today: '今日',
+  'Avg Pace': '平均配速',
   Training: '训练',
   Activities: '活动记录',
   Goal: '目标',

--- a/miniapp/utils/i18n-extra.ts
+++ b/miniapp/utils/i18n-extra.ts
@@ -150,12 +150,12 @@ const EN_TODAY = {
   Power: 'Power',
   'Heart rate': 'Heart rate',
   Pace: 'Pace',
-  // Recovery status values returned by the API (lowercase snake_case keys)
+  // Recovery status — must mirror RecoveryStatus in types/api.ts exactly.
   normal: 'Normal',
   fresh: 'Fresh',
   fatigued: 'Fatigued',
   insufficient_data: 'Insufficient data',
-  // Volume trend values returned by the API
+  // Volume trend values (volume.trend field in DiagnosisData)
   increasing: 'Increasing',
   decreasing: 'Decreasing',
   stable: 'Stable',
@@ -241,7 +241,7 @@ const EN_HISTORY_SCIENCE = {
 
 const EN_SETTINGS = {
   Name: 'Name',
-  // Unit system values returned by API
+  // Unit system — must mirror UnitSystem in types/api.ts exactly.
   metric: 'Metric',
   imperial: 'Imperial',
   Connections: 'Connections',
@@ -410,12 +410,12 @@ const ZH_TODAY = {
   Power: '功率',
   'Heart rate': '心率',
   Pace: '配速',
-  // Recovery status values (lowercase API keys)
+  // Recovery status — must mirror RecoveryStatus in types/api.ts exactly.
   normal: '正常',
   fresh: '恢复良好',
   fatigued: '疲劳',
   insufficient_data: '数据不足',
-  // Volume trend values (lowercase API keys)
+  // Volume trend values (volume.trend field in DiagnosisData)
   increasing: '上升中',
   decreasing: '下降中',
   stable: '平稳',
@@ -496,7 +496,7 @@ const ZH_HISTORY_SCIENCE = {
 
 const ZH_SETTINGS = {
   Name: '姓名',
-  // Unit system values (lowercase API keys)
+  // Unit system — must mirror UnitSystem in types/api.ts exactly.
   metric: '公制',
   imperial: '英制',
   Connections: '已连接平台',


### PR DESCRIPTION
## Summary

- **Today**: recovery status (`normal`/`fresh`/`fatigued`/`insufficient_data`) now passes through `t()`; locale guard triggers a refetch so live language switches update all dynamic strings, not just the `tr` table
- **Training**: volume trend direction (`increasing`/`decreasing`/`stable`) and sleep-perf metric label (`Avg Power`/`Avg HR`/`Avg Pace`) now pass through `t()` before being inserted into `tFmt`; locale guard also triggers refetch
- **Goal**: `statusBadgeText()` and `trendDirectionLabel()` now use `t()`; all three mode builders (`race_date`, `cp_milestone`, `continuous`) translate `distance_label` through `t()`; locale guard triggers refetch
- **History**: `activity_type` is now formatted (snake_case → Title Case) then translated via `t()` so "running" → "跑步"; `tapHint` uses `tFmt` with a translatable key; locale guard triggers a full page reload
- **Settings**: profile row values for Units and Training base use `trainingBaseLabelFor()` / `t()` instead of raw API strings (`metric`, `power`); `onPickLanguage` triggers a refetch so profile rows rebuild immediately in the new locale
- **i18n-extra.ts**: new keys for recovery status, volume trend, goal status badge (`on_track`/`close`/`behind`/`unlikely`/`unknown`), unit system (`metric`/`imperial`), `Avg Pace`, and the tap-to-view-splits hint

**Not addressed here** (require backend i18n, tracked separately like #103): warning message text, findings/suggestions messages, goal assessment text, trend notes — all contain embedded dynamic values that can't be translated on the frontend alone.

## Test plan

- [ ] Switch to Chinese → navigate to each tab → verify formerly-English labels now show in Chinese without a manual pull-to-refresh
- [ ] Today: 状态 shows 正常 / 恢复良好 / 疲劳 not raw `normal`/`fresh`/`fatigued`
- [ ] Training: 趋势 shows 下降中/上升中/平稳; sleep chart title shows 睡眠评分与平均功率
- [ ] Goal: distance shows 马拉松 not `Marathon`; status badge shows 难以实现 not `UNLIKELY`
- [ ] History: activity type shows 跑步 not `running`
- [ ] Settings profile: Units shows 公制, Training base shows 功率
- [ ] Switch back to English → all labels revert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)