### PR TITLE
Stryd sync: persist per-second streams to activity_samples

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -760,10 +760,13 @@ def _sync_stryd(user_id: str, creds: dict, from_date: str | None,
             row["activity_id"] = f"stryd_{row.get('date', '')}_{row.get('start_time', '')}"
     act_count = sync_writer.write_activities(user_id, activity_rows, db)
 
-    # Fetch per-activity splits (lap-level power data from activity detail API)
+    # Fetch per-activity splits and per-second samples from the activity detail API.
+    # fetch_activity_splits returns both from a single API call — samples are the
+    # raw per-second arrays that were previously discarded after lap averaging.
     import time as time_mod
     from sync.stryd_sync import fetch_activity_splits
     all_splits = []
+    all_samples = []
     for idx, raw_act in enumerate(_raw):
         act_id = raw_act.get("id")
         if not act_id:
@@ -771,12 +774,15 @@ def _sync_stryd(user_id: str, creds: dict, from_date: str | None,
         with _sync_lock:
             status["stryd"]["progress"] = f"Fetching splits: {idx + 1}/{total}"
         try:
-            splits = fetch_activity_splits(str(act_id), token)
+            splits, samples = fetch_activity_splits(str(act_id), token)
             all_splits.extend(splits)
+            all_samples.extend(samples)
             time_mod.sleep(0.3)  # Rate limit
         except Exception as e:
             logger.debug("Stryd splits for %s: skipped (%s)", act_id, e)
     split_count = sync_writer.write_splits(user_id, all_splits, db)
+    sample_count = sync_writer.write_samples(user_id, all_samples, db)
+    logger.debug("Stryd sync: %d splits, %d samples written", split_count, sample_count)
 
     # CP estimates → fitness_data table (for threshold auto-detection)
     from db.models import FitnessData

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -80,14 +80,16 @@ def fetch_current_cp(user_id: str, token: str) -> float | None:
 def fetch_activity_splits(
     activity_id: str,
     token: str,
-) -> list[dict]:
-    """Fetch per-lap splits from a Stryd activity detail.
+) -> tuple[list[dict], list[dict]]:
+    """Fetch per-lap splits and per-second samples from a Stryd activity detail.
 
-    Uses the activity's lap_events timestamps and per-second time series
-    (total_power_list, heart_rate_list, speed_list, distance_list) to
-    compute per-lap averages.
+    Returns (splits, samples):
+    - splits: per-lap averages compatible with sync_writer.write_splits()
+    - samples: per-second rows compatible with sync_writer.write_samples()
 
-    Returns list of split dicts compatible with sync_writer.write_splits().
+    Both are derived from the same API call — the per-second arrays are
+    already fetched to compute lap averages; this function preserves them
+    instead of discarding after averaging.
     """
     url = STRYD_ACTIVITY_API.format(activity_id=activity_id)
     resp = requests.get(
@@ -103,16 +105,25 @@ def fetch_activity_splits(
     speed_list = data.get("speed_list", [])
     distance_list = data.get("distance_list", [])
     ts_list = data.get("timestamp_list", [])
+    cadence_list = data.get("cadence_list", [])
+    elevation_list = data.get("elevation_list", [])
+    ground_time_list = data.get("ground_time_list", [])
+    oscillation_list = data.get("oscillation_list", [])
+    leg_spring_list = data.get("leg_spring_list", [])
+    vertical_ratio_list = data.get("vertical_oscillation_ratio_list", [])
+    form_power_list = data.get("form_power_list", [])
+
     lap_events = data.get("lap_events", [])
     start_events = data.get("start_events", [])
     stop_events = data.get("stop_events", [])
 
     if not ts_list or not power_list:
-        return []
+        return [], []
 
-    # Build lap boundaries: [start, lap1, lap2, ..., end]
     start_ts = start_events[0] if start_events else ts_list[0]
     end_ts = stop_events[0] if stop_events else ts_list[-1]
+
+    # Build lap boundaries: [start, lap1, lap2, ..., end]
     boundaries = [start_ts] + lap_events + [end_ts]
 
     splits = []
@@ -162,7 +173,36 @@ def fetch_activity_splits(
             "avg_pace_min_km": str(avg_pace) if avg_pace else "",
         })
 
-    return splits
+    # Build per-second samples from the same arrays, bounded to the
+    # activity window [start_ts, end_ts] to exclude pre-start padding.
+    def _at(lst: list, i: int):
+        """Return lst[i] or None if out of range or None value."""
+        if lst and i < len(lst):
+            return lst[i]
+        return None
+
+    samples = []
+    for i, t in enumerate(ts_list):
+        if t < start_ts or t > end_ts:
+            continue
+        samples.append({
+            "activity_id": str(activity_id),
+            "source": "stryd",
+            "t_sec": t,
+            "power_watts": _at(power_list, i),
+            "hr_bpm": _at(hr_list, i),
+            "speed_ms": _at(speed_list, i),
+            "cadence_spm": _at(cadence_list, i),
+            "altitude_m": _at(elevation_list, i),
+            "distance_m": _at(distance_list, i),
+            "ground_time_ms": _at(ground_time_list, i),
+            "oscillation_mm": _at(oscillation_list, i),
+            "leg_spring_kn_m": _at(leg_spring_list, i),
+            "vertical_ratio": _at(vertical_ratio_list, i),
+            "form_power_watts": _at(form_power_list, i),
+        })
+
+    return splits, samples
 
 
 def fetch_activities_api(

--- a/tests/test_stryd_activity_samples.py
+++ b/tests/test_stryd_activity_samples.py
@@ -1,0 +1,159 @@
+"""Tests for fetch_activity_splits() — verifies splits and per-second samples."""
+from unittest.mock import patch, MagicMock
+
+from sync.stryd_sync import fetch_activity_splits
+
+
+def _mock_response(data: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.json.return_value = data
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+def _make_activity(
+    n: int = 10,
+    start_ts: int = 1000,
+    lap_events: list | None = None,
+    include_dynamics: bool = False,
+) -> dict:
+    """Build a minimal Stryd activity detail payload with n seconds of data."""
+    ts = list(range(start_ts, start_ts + n))
+    return {
+        "timestamp_list": ts,
+        "start_events": [start_ts],
+        "stop_events": [start_ts + n - 1],
+        "lap_events": lap_events or [],
+        "total_power_list": [200.0 + i for i in range(n)],
+        "heart_rate_list": [150.0 + i for i in range(n)],
+        "speed_list": [3.5] * n,
+        "distance_list": [i * 3.5 for i in range(n)],
+        "cadence_list": [172.0] * n,
+        "elevation_list": [50.0 + i * 0.1 for i in range(n)],
+        "ground_time_list": [260.0] * n if include_dynamics else [],
+        "oscillation_list": [71.0] * n if include_dynamics else [],
+        "leg_spring_list": [11.5] * n if include_dynamics else [],
+        "vertical_oscillation_ratio_list": [8.3] * n if include_dynamics else [],
+        "form_power_list": [40.0] * n if include_dynamics else [],
+    }
+
+
+# --- Return type ---
+
+def test_returns_tuple_of_splits_and_samples():
+    """fetch_activity_splits returns (splits, samples) not a plain list."""
+    payload = _make_activity(n=10, lap_events=[1005])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        result = fetch_activity_splits("act-1", "token")
+    assert isinstance(result, tuple)
+    splits, samples = result
+    assert isinstance(splits, list)
+    assert isinstance(samples, list)
+
+
+# --- Splits (existing behaviour must be preserved) ---
+
+def test_splits_still_computed_correctly():
+    """Lap split averages are unaffected by the new samples return value."""
+    # 10 seconds, lap boundary at t=1005 → 2 laps
+    payload = _make_activity(n=10, start_ts=1000, lap_events=[1005])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        splits, _ = fetch_activity_splits("act-1", "token")
+    assert len(splits) == 2
+    assert splits[0]["activity_id"] == "act-1"
+    assert splits[0]["duration_sec"] == "5"
+
+
+# --- Samples field mapping ---
+
+def test_samples_count_equals_activity_duration():
+    """One sample per timestamp inside [start_ts, end_ts]."""
+    n = 30
+    payload = _make_activity(n=n, start_ts=2000)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-2", "token")
+    assert len(samples) == n
+
+
+def test_samples_core_field_mapping():
+    """power_watts, hr_bpm, speed_ms, cadence_spm, altitude_m, distance_m mapped."""
+    payload = _make_activity(n=5, start_ts=3000)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-3", "token")
+
+    s = samples[0]
+    assert s["activity_id"] == "act-3"
+    assert s["source"] == "stryd"
+    assert s["t_sec"] == 3000
+    assert s["power_watts"] == 200.0
+    assert s["hr_bpm"] == 150.0
+    assert s["speed_ms"] == 3.5
+    assert s["cadence_spm"] == 172.0
+    assert s["altitude_m"] == 50.0
+    assert s["distance_m"] == 0.0
+
+
+def test_samples_stryd_dynamics_mapped():
+    """Stryd running dynamics columns are populated when present."""
+    payload = _make_activity(n=5, start_ts=4000, include_dynamics=True)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-4", "token")
+
+    s = samples[0]
+    assert s["ground_time_ms"] == 260.0
+    assert s["oscillation_mm"] == 71.0
+    assert s["leg_spring_kn_m"] == 11.5
+    assert s["vertical_ratio"] == 8.3
+    assert s["form_power_watts"] == 40.0
+
+
+def test_samples_dynamics_none_when_missing():
+    """Stryd dynamics columns are None when lists are absent from the payload."""
+    payload = _make_activity(n=5, start_ts=5000, include_dynamics=False)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-5", "token")
+
+    s = samples[0]
+    assert s["ground_time_ms"] is None
+    assert s["oscillation_mm"] is None
+    assert s["leg_spring_kn_m"] is None
+
+
+def test_samples_bounded_to_activity_window():
+    """Timestamps outside [start_ts, end_ts] are excluded from samples."""
+    n = 10
+    payload = _make_activity(n=n, start_ts=6000)
+    # Add padding timestamps outside the activity window
+    payload["timestamp_list"] = [5998, 5999] + payload["timestamp_list"] + [6010, 6011]
+    payload["total_power_list"] = [0.0, 0.0] + payload["total_power_list"] + [0.0, 0.0]
+    payload["heart_rate_list"] = [0.0, 0.0] + payload["heart_rate_list"] + [0.0, 0.0]
+    payload["speed_list"] = [0.0, 0.0] + payload["speed_list"] + [0.0, 0.0]
+    payload["distance_list"] = [0.0, 0.0] + payload["distance_list"] + [0.0, 0.0]
+
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-6", "token")
+
+    t_secs = [s["t_sec"] for s in samples]
+    assert 5998 not in t_secs
+    assert 5999 not in t_secs
+    assert 6010 not in t_secs
+    assert len(samples) == n
+
+
+# --- Empty / degenerate payloads ---
+
+def test_empty_payload_returns_empty_lists():
+    """Missing timestamp_list or power_list returns ([], [])."""
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response({})):
+        splits, samples = fetch_activity_splits("act-7", "token")
+    assert splits == []
+    assert samples == []
+
+
+def test_no_lap_events_produces_one_split():
+    """Activity with no lap boundaries produces a single split and full samples."""
+    payload = _make_activity(n=20, start_ts=7000, lap_events=[])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        splits, samples = fetch_activity_splits("act-8", "token")
+    assert len(splits) == 1
+    assert len(samples) == 20


### PR DESCRIPTION
## Summary

- `fetch_activity_splits()` now returns `(splits, samples)` instead of just splits — zero new API calls, the per-second arrays were already in memory and discarded after lap averaging.
- Adds the full set of Stryd fields to each sample: `power_watts`, `hr_bpm`, `speed_ms`, `cadence_spm`, `altitude_m`, `distance_m`, `ground_time_ms`, `oscillation_mm`, `leg_spring_kn_m`, `vertical_ratio`, `form_power_watts`.
- Samples bounded to `[start_ts, end_ts]` to exclude pre-start padding timestamps.
- Sync route unpacks the tuple and calls `write_samples()`; existing split logic is unchanged.

## Test plan

- [x] 9 new tests: return type, split correctness, sample count, field mapping, Stryd dynamics, window bounding, empty payload, no-lap case — all pass
- [x] Existing `test_compute_lap_splits.py` (13 tests) — all still pass
- [x] Full suite: 592 passed, same 14 pre-existing failures as base branch

Closes #212. Depends on #211 (merged into `feature/activity-samples`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)