### PR TITLE
Fix CI failures from #210

### DIFF
--- a/api/llm.py
+++ b/api/llm.py
@@ -102,7 +102,11 @@ def chat_json(
     differently from noisy transient ones.
     """
     # SDK exception classes — imported here so this module stays importable
-    # without the openai SDK (chat_json is unreachable in that case anyway).
+    # without the openai SDK (chat_json is unreachable in that case because
+    # ``get_client`` returns None first). When the SDK is missing we still
+    # need real BaseException subclasses in the ``except`` clauses below;
+    # falling back to ``()`` made Python reject the tuple at runtime
+    # ("catching classes that do not inherit from BaseException").
     try:
         from openai import (  # type: ignore[import-not-found]
             APIError,
@@ -111,7 +115,10 @@ def chat_json(
             RateLimitError,
         )
     except ImportError:  # pragma: no cover — get_client returns None first
-        AuthenticationError = BadRequestError = RateLimitError = APIError = ()  # type: ignore[assignment]
+        class _SdkUnavailable(BaseException):
+            """Sentinel that never matches — keeps except clauses syntactically valid."""
+
+        AuthenticationError = BadRequestError = RateLimitError = APIError = _SdkUnavailable  # type: ignore[assignment]
 
     last_err: Exception | None = None
     for attempt in range(retry + 1):

--- a/scripts/translate_missing.py
+++ b/scripts/translate_missing.py
@@ -346,6 +346,15 @@ def _client():
     # insight generation use the same auth scaffolding. The CLI exits hard
     # when the client is unavailable; the insight generator returns None
     # and the app falls back to rule-based prose.
+    #
+    # When this script is invoked as ``python scripts/translate_missing.py``
+    # (CI workflow), sys.path[0] is ``scripts/`` and ``api`` isn't
+    # importable. Inject the project root once before the import so it
+    # resolves regardless of CWD.
+    project_root = str(Path(__file__).resolve().parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
     from api import llm as _llm
 
     client = _llm.get_client()


### PR DESCRIPTION
## Summary

Hotfix for two CI failures introduced by #210:

1. ``api/llm.py::chat_json`` — when openai SDK isn't installed, the ImportError fallback assigned exception classes to ``()``. ``except (RateLimitError, APIError, json.JSONDecodeError)`` then becomes a tuple containing empty tuples, which Python rejects at runtime (\"catching classes that do not inherit from BaseException\"). Replaced with a private ``_SdkUnavailable(BaseException)`` sentinel. ([failed run](https://github.com/dddtc2005/praxys/actions/runs/25153657237))
2. ``scripts/translate_missing.py::_client`` — the refactor to delegate to ``api.llm.get_client`` works from the project root but breaks when invoked directly as ``python scripts/translate_missing.py`` (CI translate workflow), because ``api`` isn't on sys.path. Inject project root before the import. ([failed run](https://github.com/dddtc2005/praxys/actions/runs/25153657282))

## Test plan
- [x] CI re-runs on this PR — both ``test`` and ``translate`` jobs should now go green
- [ ] Once green, squash-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)