### PR TITLE
Fix Stryd field mapping and paused-activity window

### DIFF
--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -107,11 +107,13 @@ def fetch_activity_splits(
     ts_list = data.get("timestamp_list", [])
     cadence_list = data.get("cadence_list", [])
     elevation_list = data.get("elevation_list", [])
+    grade_list = data.get("grade_list", [])
+    loc_list = data.get("loc_list", [])
+    temperature_list = data.get("temperature_device_list", [])
     ground_time_list = data.get("ground_time_list", [])
     oscillation_list = data.get("oscillation_list", [])
     leg_spring_list = data.get("leg_spring_list", [])
-    vertical_ratio_list = data.get("vertical_oscillation_ratio_list", [])
-    form_power_list = data.get("form_power_list", [])
+    vertical_ratio_list = data.get("vertical_ratio_list", [])
 
     lap_events = data.get("lap_events", [])
     start_events = data.get("start_events", [])
@@ -121,7 +123,10 @@ def fetch_activity_splits(
         return [], []
 
     start_ts = start_events[0] if start_events else ts_list[0]
-    end_ts = stop_events[0] if stop_events else ts_list[-1]
+    # Use the last stop event — for paused/resumed activities stop_events has
+    # one entry per pause; [0] would clip at the first pause and discard all
+    # samples after the resume.
+    end_ts = stop_events[-1] if stop_events else ts_list[-1]
 
     # Build lap boundaries: [start, lap1, lap2, ..., end]
     boundaries = [start_ts] + lap_events + [end_ts]
@@ -185,6 +190,7 @@ def fetch_activity_splits(
     for i, t in enumerate(ts_list):
         if t < start_ts or t > end_ts:
             continue
+        loc = _at(loc_list, i)
         samples.append({
             "activity_id": str(activity_id),
             "source": "stryd",
@@ -195,11 +201,14 @@ def fetch_activity_splits(
             "cadence_spm": _at(cadence_list, i),
             "altitude_m": _at(elevation_list, i),
             "distance_m": _at(distance_list, i),
+            "lat": loc["Lat"] if isinstance(loc, dict) else None,
+            "lng": loc["Lng"] if isinstance(loc, dict) else None,
+            "grade_pct": _at(grade_list, i),
+            "temperature_c": _at(temperature_list, i),
             "ground_time_ms": _at(ground_time_list, i),
             "oscillation_mm": _at(oscillation_list, i),
             "leg_spring_kn_m": _at(leg_spring_list, i),
             "vertical_ratio": _at(vertical_ratio_list, i),
-            "form_power_watts": _at(form_power_list, i),
         })
 
     return splits, samples

--- a/tests/test_stryd_activity_samples.py
+++ b/tests/test_stryd_activity_samples.py
@@ -1,4 +1,5 @@
 """Tests for fetch_activity_splits() — verifies splits and per-second samples."""
+import pytest
 from unittest.mock import patch, MagicMock
 
 from sync.stryd_sync import fetch_activity_splits
@@ -16,13 +17,14 @@ def _make_activity(
     start_ts: int = 1000,
     lap_events: list | None = None,
     include_dynamics: bool = False,
+    stop_events: list | None = None,
 ) -> dict:
     """Build a minimal Stryd activity detail payload with n seconds of data."""
     ts = list(range(start_ts, start_ts + n))
     return {
         "timestamp_list": ts,
         "start_events": [start_ts],
-        "stop_events": [start_ts + n - 1],
+        "stop_events": stop_events if stop_events is not None else [start_ts + n - 1],
         "lap_events": lap_events or [],
         "total_power_list": [200.0 + i for i in range(n)],
         "heart_rate_list": [150.0 + i for i in range(n)],
@@ -30,11 +32,13 @@ def _make_activity(
         "distance_list": [i * 3.5 for i in range(n)],
         "cadence_list": [172.0] * n,
         "elevation_list": [50.0 + i * 0.1 for i in range(n)],
+        "grade_list": [1.0] * n if include_dynamics else [],
+        "loc_list": [{"Lat": 31.18 + i * 0.001, "Lng": 121.25 + i * 0.001} for i in range(n)] if include_dynamics else [],
+        "temperature_device_list": [25.0] * n if include_dynamics else [],
         "ground_time_list": [260.0] * n if include_dynamics else [],
         "oscillation_list": [71.0] * n if include_dynamics else [],
         "leg_spring_list": [11.5] * n if include_dynamics else [],
-        "vertical_oscillation_ratio_list": [8.3] * n if include_dynamics else [],
-        "form_power_list": [40.0] * n if include_dynamics else [],
+        "vertical_ratio_list": [8.3] * n if include_dynamics else [],
     }
 
 
@@ -94,7 +98,7 @@ def test_samples_core_field_mapping():
 
 
 def test_samples_stryd_dynamics_mapped():
-    """Stryd running dynamics columns are populated when present."""
+    """Stryd running dynamics and GPS columns are populated when present."""
     payload = _make_activity(n=5, start_ts=4000, include_dynamics=True)
     with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
         _, samples = fetch_activity_splits("act-4", "token")
@@ -104,7 +108,10 @@ def test_samples_stryd_dynamics_mapped():
     assert s["oscillation_mm"] == 71.0
     assert s["leg_spring_kn_m"] == 11.5
     assert s["vertical_ratio"] == 8.3
-    assert s["form_power_watts"] == 40.0
+    assert s["grade_pct"] == 1.0
+    assert s["lat"] == pytest.approx(31.18)
+    assert s["lng"] == pytest.approx(121.25)
+    assert s["temperature_c"] == 25.0
 
 
 def test_samples_dynamics_none_when_missing():
@@ -117,6 +124,25 @@ def test_samples_dynamics_none_when_missing():
     assert s["ground_time_ms"] is None
     assert s["oscillation_mm"] is None
     assert s["leg_spring_kn_m"] is None
+    assert s["lat"] is None
+    assert s["lng"] is None
+    assert s["grade_pct"] is None
+    assert s["temperature_c"] is None
+
+
+def test_samples_paused_activity_uses_last_stop_event():
+    """For paused/resumed activities, end_ts uses stop_events[-1], not [0]."""
+    # Simulate pause at t=1005, resume, end at t=1019 (20 total active seconds)
+    n = 20
+    payload = _make_activity(n=n, start_ts=1000, stop_events=[1005, 1019])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-pause", "token")
+
+    # All 20 timestamps (1000–1019) should be included, not just the 6 before pause
+    assert len(samples) == n
+    t_secs = [s["t_sec"] for s in samples]
+    assert 1019 in t_secs   # actual end is included
+    assert 1005 in t_secs   # pause moment is still included (it's in timestamp_list)
 
 
 def test_samples_bounded_to_activity_window():


### PR DESCRIPTION
## What

Bugs found during real-data verification after merging #222.

## Changes

**`vertical_ratio_list` field name** — the assumed name `vertical_oscillation_ratio_list` doesn't exist in the Stryd API. Correct name is `vertical_ratio_list`. Was 0% populated, now 100%.

**`form_power_watts` removed from Stryd mapping** — `form_power_list` doesn't exist in the API response. Column stays in schema (nullable), just won't be populated from Stryd.

**`stop_events[-1]` instead of `stop_events[0]`** — for paused/resumed activities, `stop_events` has one entry per pause. Using `[0]` clipped `end_ts` at the first pause, discarding all samples after the resume. Verified on a real marathon activity (8,640 s duration): was capturing 4,857 samples, now captures 8,642.

**Three new fields added** — confirmed available in real API payload: `grade_list → grade_pct`, `loc_list → lat/lng`, `temperature_device_list → temperature_c`. All map to existing nullable schema columns.

## Test plan

- [x] 10 tests pass including new `test_samples_paused_activity_uses_last_stop_event`
- [x] Full suite: 593 passed, same 14 pre-existing failures
- [x] Verified against real Stryd data: `vertical_ratio` 100% populated, paused marathon activity captures full 8,642 samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)