### PR TITLE
Add Coach telemetry: token spend + cache hit rate + operator errors

### DIFF
--- a/api/insights_generator.py
+++ b/api/insights_generator.py
@@ -106,6 +106,7 @@ def _generate(
         system=system_prompt,
         user=user_msg,
         model=llm.INSIGHT_MODEL,
+        insight_type=insight_type,
     )
     if not raw:
         # chat_json already logged the underlying error; no need to repeat.

--- a/api/insights_runner.py
+++ b/api/insights_runner.py
@@ -105,6 +105,8 @@ def _run(db: Session, user_id: str) -> dict:
         logger.exception("Insight context build failed for user=%s", user_id)
         return {"skipped": "context_build_failed"}
 
+    from api import telemetry
+
     results: dict[str, str] = {}
     for itype in GENERATORS_ORDER:
         new_hash = compute_dataset_hash(context, itype, science_pillars=pillars)
@@ -115,17 +117,21 @@ def _run(db: Session, user_id: str) -> dict:
         )
         if existing is not None and (existing.meta or {}).get("dataset_hash") == new_hash:
             results[itype] = "hash_match"
+            telemetry.record_coach_run(insight_type=itype, status="hash_match", user_id=user_id)
             continue
         if used_today >= cap:
             results[itype] = "cap_reached"
+            telemetry.record_coach_run(insight_type=itype, status="cap_reached", user_id=user_id)
             continue
         payload = generators[itype](context, pillars)
         if payload is None:
             results[itype] = "generator_returned_none"
+            telemetry.record_coach_run(insight_type=itype, status="generator_returned_none", user_id=user_id)
             continue
         _upsert_insight(db, user_id, itype, payload, new_hash)
         used_today += 1
         results[itype] = "generated"
+        telemetry.record_coach_run(insight_type=itype, status="generated", user_id=user_id)
 
     db.commit()
     return results

--- a/api/llm.py
+++ b/api/llm.py
@@ -88,6 +88,7 @@ def chat_json(
     max_completion_tokens: int = 4096,
     temperature: float = 0.3,
     retry: int = 1,
+    insight_type: str | None = None,
 ) -> dict | None:
     """Strict JSON chat completion. Returns parsed dict or None on failure.
 
@@ -100,7 +101,17 @@ def chat_json(
     Returns None in either case so callers fall back to rule-based prose;
     distinct log levels let alerting route operator-actionable failures
     differently from noisy transient ones.
+
+    ``insight_type`` is forwarded to telemetry — when set, per-call token
+    usage and operator-actionable errors are dimensioned by it so daily
+    spend and Auth-error spikes are queryable per Coach surface in App
+    Insights. Defaults to ``"unknown"`` so non-Coach callers still emit
+    metrics, just without per-surface breakdown.
     """
+    from api import telemetry
+
+    itype = insight_type or "unknown"
+
     # SDK exception classes — imported here so this module stays importable
     # without the openai SDK (chat_json is unreachable in that case because
     # ``get_client`` returns None first). When the SDK is missing we still
@@ -133,6 +144,16 @@ def chat_json(
                     {"role": "user", "content": user},
                 ],
             )
+            # ``resp.usage`` is None on streaming responses; we don't stream
+            # but guarding keeps telemetry robust if a future caller flips it.
+            usage = getattr(resp, "usage", None)
+            if usage is not None:
+                telemetry.record_coach_tokens(
+                    insight_type=itype,
+                    model=model,
+                    prompt_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+                    completion_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+                )
             content = resp.choices[0].message.content or ""
             return json.loads(content)
         except AuthenticationError:
@@ -140,9 +161,11 @@ def chat_json(
                 "chat_json: Azure auth failed — DefaultAzureCredential or "
                 "endpoint misconfigured", exc_info=True,
             )
+            telemetry.record_coach_error(error_class="Auth")
             return None  # operator-actionable, no retry
         except BadRequestError as e:
             logger.error("chat_json: bad request (no retry): %s", e)
+            telemetry.record_coach_error(error_class="BadRequest")
             return None  # malformed prompt — bug in caller
         except (RateLimitError, APIError, json.JSONDecodeError) as e:
             last_err = e  # transient — fall through to retry

--- a/api/llm.py
+++ b/api/llm.py
@@ -105,8 +105,15 @@ def chat_json(
     ``insight_type`` is forwarded to telemetry — when set, per-call token
     usage and operator-actionable errors are dimensioned by it so daily
     spend and Auth-error spikes are queryable per Coach surface in App
-    Insights. Defaults to ``"unknown"`` so non-Coach callers still emit
-    metrics, just without per-surface breakdown.
+    Insights. Defaults to ``"unknown"`` so future non-Coach callers still
+    emit metrics, just without per-surface breakdown.
+
+    Token telemetry note: ``record_coach_tokens`` fires once per Azure API
+    call that returns a usage payload, *before* the JSON parse. Retries
+    triggered by ``JSONDecodeError`` therefore double-record — but that
+    matches Azure's per-call billing (both attempts cost real tokens), so
+    operators tracking spend see honest numbers rather than insight-success
+    rate.
     """
     from api import telemetry
 

--- a/api/telemetry.py
+++ b/api/telemetry.py
@@ -151,7 +151,15 @@ def record_coach_run(*, insight_type: str, status: str, user_id: str) -> None:
     Prefers the customEvents path when available; falls back to a counter
     otherwise (see module docstring for why).
     """
-    user_id_hash = hash_user_id(user_id)
+    try:
+        user_id_hash = hash_user_id(user_id)
+    except Exception:
+        # The runner always passes a real str user_id today; this guard is
+        # purely defensive so a future caller passing None can't take down
+        # the post-sync hook with an AttributeError. Telemetry must be
+        # invisible when it can't do its job.
+        logger.debug("record_coach_run: bad user_id, skipping", exc_info=True)
+        return
     attrs = {
         "insight_type": insight_type,
         "status": status,

--- a/api/telemetry.py
+++ b/api/telemetry.py
@@ -1,0 +1,196 @@
+"""Application Insights telemetry helpers — lazy, no-op when unconfigured.
+
+Three Coach-tier signals power the operator dashboard for issue #221:
+
+- ``record_coach_tokens(insight_type, model, prompt_tokens, completion_tokens)``
+  emits an OpenTelemetry counter ``praxys.coach_tokens`` so daily token spend
+  by ``insight_type`` is queryable in ``customMetrics``.
+- ``record_coach_run(insight_type, status, user_id)`` emits a counter
+  ``praxys.coach_run`` (or a customEvent when the events extension is
+  installed) so cache hit rate is derivable from ``status`` over time. The
+  raw user id is hashed before emission — telemetry is not a PII surface.
+- ``record_coach_error(error_class)`` emits ``praxys.coach_error`` so a
+  sustained spike in operator-actionable error classes (Auth, BadRequest)
+  pages oncall.
+
+Why a counter for coach_run / coach_error instead of a customEvent: the
+``azure-monitor-events-extension`` package is the canonical customEvent
+emitter, but it is not pulled in by ``azure-monitor-opentelemetry`` — and
+the issue forbids new dependencies. We therefore opportunistically use it
+when present and fall back to a counter (which lands in customMetrics)
+otherwise. The KQL queries documented on the issue translate directly:
+``count(status==X)`` becomes ``sum(value) where status==X`` because each
+record contributes value=1.
+
+Lazy / no-op contract: every helper short-circuits silently when the
+``APPLICATIONINSIGHTS_CONNECTION_STRING`` env var is unset (same signal
+``api/main.py`` uses to skip ``configure_azure_monitor``) or when the OTel
+meter API isn't importable — sync hooks must never break because telemetry
+is misconfigured.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from functools import lru_cache
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _telemetry_enabled() -> bool:
+    """True iff App Insights is wired in this process.
+
+    Mirrors the gate ``api/main.py`` uses to decide whether to call
+    ``configure_azure_monitor()``. Cheap to call on every record — env
+    lookup is dict-fast.
+    """
+    return bool(os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING"))
+
+
+@lru_cache(maxsize=1)
+def _meter() -> Any | None:
+    """Return the OTel meter, or None when unavailable.
+
+    Memoised because ``get_meter`` is cheap but creating the meter every
+    call would still add overhead inside the hot path of ``chat_json``.
+    Cleared by tests via ``_meter.cache_clear()``.
+    """
+    if not _telemetry_enabled():
+        return None
+    try:
+        from opentelemetry import metrics  # type: ignore[import-not-found]
+    except ImportError:
+        # OTel SDK absent — same fallback contract as get_client() in api/llm.py.
+        return None
+    return metrics.get_meter("praxys.coach")
+
+
+@lru_cache(maxsize=8)
+def _counter(name: str, description: str) -> Any | None:
+    """Return a memoised OTel ``Counter`` for ``name`` or None when telemetry is off.
+
+    Counters are cumulative and dimensioned via attributes at record time —
+    one Counter instance per metric name handles the full attribute fan-out.
+    """
+    meter = _meter()
+    if meter is None:
+        return None
+    return meter.create_counter(name=name, description=description)
+
+
+@lru_cache(maxsize=1)
+def _track_event() -> Any | None:
+    """Return ``track_event`` from the events extension if installed, else None.
+
+    The extension ships as ``azure-monitor-events-extension`` and is *not*
+    a transitive dep of ``azure-monitor-opentelemetry``. Importing
+    optimistically lets us upgrade to true customEvents the moment an
+    operator opts in (e.g. by ``pip install``-ing it on the Azure App
+    Service) without changing call sites.
+    """
+    if not _telemetry_enabled():
+        return None
+    try:
+        from azure.monitor.events.extension import track_event  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    return track_event
+
+
+def hash_user_id(user_id: str) -> str:
+    """Stable, non-reversible hash for telemetry dimensioning.
+
+    SHA-256 truncated to 16 hex chars (64 bits) — wide enough that operators
+    can group "events from the same user" without colliding across the
+    plausible user-base size, narrow enough that a short hash is readable in
+    the App Insights UI. Telemetry is not a PII surface; the raw email or
+    UUID never leaves the process.
+    """
+    return hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
+
+
+def record_coach_tokens(
+    *,
+    insight_type: str,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> None:
+    """Record token usage from a successful Azure OpenAI completion.
+
+    Emits one increment per token-type so a single KQL ``sum(value)`` call
+    reproduces total spend; the ``token_type`` dimension lets operators
+    split prompt vs. completion when looking for prompt-bloat regressions.
+    """
+    counter = _counter("praxys.coach_tokens", "Azure OpenAI tokens consumed by Coach")
+    if counter is None:
+        return
+    base = {"insight_type": insight_type, "model": model}
+    try:
+        if prompt_tokens:
+            counter.add(prompt_tokens, {**base, "token_type": "prompt"})
+        if completion_tokens:
+            counter.add(completion_tokens, {**base, "token_type": "completion"})
+        total = (prompt_tokens or 0) + (completion_tokens or 0)
+        if total:
+            counter.add(total, {**base, "token_type": "total"})
+    except Exception:
+        # Telemetry must never break the caller. Log once and swallow.
+        logger.debug("record_coach_tokens failed", exc_info=True)
+
+
+def record_coach_run(*, insight_type: str, status: str, user_id: str) -> None:
+    """Record one runner outcome for a single ``insight_type``.
+
+    Status is one of ``generated``, ``hash_match``, ``cap_reached``,
+    ``generator_returned_none`` — the runner already produces these strings.
+    Cache hit rate = ``count(status='hash_match') / count(*)``.
+
+    Prefers the customEvents path when available; falls back to a counter
+    otherwise (see module docstring for why).
+    """
+    user_id_hash = hash_user_id(user_id)
+    attrs = {
+        "insight_type": insight_type,
+        "status": status,
+        "user_id_hash": user_id_hash,
+    }
+    track = _track_event()
+    if track is not None:
+        try:
+            track("praxys.coach_run", attrs)
+            return
+        except Exception:
+            logger.debug("track_event(coach_run) failed; falling back to counter", exc_info=True)
+    counter = _counter("praxys.coach_run", "Coach insight-runner outcomes")
+    if counter is None:
+        return
+    try:
+        counter.add(1, attrs)
+    except Exception:
+        logger.debug("record_coach_run counter failed", exc_info=True)
+
+
+def record_coach_error(*, error_class: str) -> None:
+    """Record an operator-actionable Coach error (Auth, BadRequest).
+
+    Transient errors (rate limit, JSON decode) are deliberately excluded —
+    they are noise on this signal. Log spikes here gate the oncall page.
+    """
+    attrs = {"error_class": error_class}
+    track = _track_event()
+    if track is not None:
+        try:
+            track("praxys.coach_error", attrs)
+            return
+        except Exception:
+            logger.debug("track_event(coach_error) failed; falling back to counter", exc_info=True)
+    counter = _counter("praxys.coach_error", "Coach operator-actionable errors")
+    if counter is None:
+        return
+    try:
+        counter.add(1, attrs)
+    except Exception:
+        logger.debug("record_coach_error counter failed", exc_info=True)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,424 @@
+"""Tests for ``api.telemetry`` Coach signals.
+
+Coverage strategy: stub the OTel meter and the optional events extension so
+each helper can be exercised in three regimes — telemetry off, OTel-only
+(counters), and events-extension on (track_event). The tests assert call
+shape rather than App Insights arrival, since we don't carry the SDK in
+test envs.
+
+Also covers the integration points: ``chat_json`` forwards token usage and
+operator-actionable errors, and ``run_insights_for_user`` emits one
+coach_run per insight type with the right status.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeCounter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, dict]] = []
+
+    def add(self, amount: float, attributes: dict | None = None) -> None:
+        self.calls.append((amount, dict(attributes or {})))
+
+
+class _FakeMeter:
+    def __init__(self) -> None:
+        self.counters: dict[str, _FakeCounter] = {}
+
+    def create_counter(self, name: str, description: str = "") -> _FakeCounter:
+        # OTel meters return the same instrument across repeat calls — mirror
+        # that so the @lru_cache memoisation in api.telemetry doesn't have to
+        # re-create on every test.
+        if name not in self.counters:
+            self.counters[name] = _FakeCounter()
+        return self.counters[name]
+
+
+def _clear_caches() -> None:
+    from api import telemetry
+
+    # Tolerate the case where a prior fixture monkeypatched these to plain
+    # callables (no .cache_clear) — we only need to drop real lru_caches.
+    for name in ("_meter", "_counter", "_track_event"):
+        fn = getattr(telemetry, name, None)
+        clear = getattr(fn, "cache_clear", None)
+        if callable(clear):
+            clear()
+
+
+@pytest.fixture
+def reset_telemetry_caches():
+    """Clear all lru_caches in api.telemetry between tests."""
+    _clear_caches()
+    yield
+    _clear_caches()
+
+
+@pytest.fixture
+def fake_meter(monkeypatch, reset_telemetry_caches):
+    """Wire a fake OTel meter into api.telemetry; events extension off."""
+    from api import telemetry
+
+    meter = _FakeMeter()
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=fake")
+    monkeypatch.setattr(telemetry, "_meter", lambda: meter, raising=True)
+    # Force counter cache to use the fake meter; preserve real impl by
+    # bypassing its memoisation via direct factory.
+    monkeypatch.setattr(
+        telemetry, "_counter",
+        lambda name, description: meter.create_counter(name, description),
+        raising=True,
+    )
+    monkeypatch.setattr(telemetry, "_track_event", lambda: None, raising=True)
+    return meter
+
+
+@pytest.fixture
+def fake_track_event(monkeypatch, reset_telemetry_caches):
+    """Wire a fake events-extension track_event into api.telemetry."""
+    from api import telemetry
+
+    calls: list[tuple[str, dict]] = []
+
+    def _track(event_name: str, attributes: dict | None = None) -> None:
+        calls.append((event_name, dict(attributes or {})))
+
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=fake")
+    monkeypatch.setattr(telemetry, "_track_event", lambda: _track, raising=True)
+    # Even with track_event present, _meter / _counter must stay callable so
+    # the unrelated coach_tokens helper still records.
+    meter = _FakeMeter()
+    monkeypatch.setattr(telemetry, "_meter", lambda: meter, raising=True)
+    monkeypatch.setattr(
+        telemetry, "_counter",
+        lambda name, description: meter.create_counter(name, description),
+        raising=True,
+    )
+    return calls, meter
+
+
+# ---------------------------------------------------------------------------
+# hash_user_id
+# ---------------------------------------------------------------------------
+
+
+def test_hash_user_id_is_stable_and_truncated():
+    from api import telemetry
+
+    a = telemetry.hash_user_id("user-1")
+    b = telemetry.hash_user_id("user-1")
+    c = telemetry.hash_user_id("user-2")
+    assert a == b
+    assert a != c
+    assert len(a) == 16
+    assert all(ch in "0123456789abcdef" for ch in a)
+
+
+# ---------------------------------------------------------------------------
+# No-op contract when telemetry is disabled
+# ---------------------------------------------------------------------------
+
+
+def test_helpers_noop_when_appinsights_unset(monkeypatch, reset_telemetry_caches):
+    from api import telemetry
+
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    # Should silently return None without raising even when the OTel SDK is
+    # absent — the env-var gate short-circuits before any import.
+    telemetry.record_coach_tokens(
+        insight_type="daily_brief", model="gpt-5.4",
+        prompt_tokens=100, completion_tokens=50,
+    )
+    telemetry.record_coach_run(
+        insight_type="daily_brief", status="generated", user_id="u1",
+    )
+    telemetry.record_coach_error(error_class="Auth")
+
+
+# ---------------------------------------------------------------------------
+# record_coach_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_record_coach_tokens_emits_split_and_total(fake_meter):
+    from api import telemetry
+
+    telemetry.record_coach_tokens(
+        insight_type="daily_brief", model="gpt-5.4",
+        prompt_tokens=120, completion_tokens=30,
+    )
+
+    counter = fake_meter.counters["praxys.coach_tokens"]
+    # One increment per token_type — sum stays correct under any
+    # subsequent slice of customDimensions.
+    types = sorted(c[1]["token_type"] for c in counter.calls)
+    assert types == ["completion", "prompt", "total"]
+    by_type = {c[1]["token_type"]: c for c in counter.calls}
+    assert by_type["prompt"][0] == 120
+    assert by_type["completion"][0] == 30
+    assert by_type["total"][0] == 150
+    for _, attrs in counter.calls:
+        assert attrs["insight_type"] == "daily_brief"
+        assert attrs["model"] == "gpt-5.4"
+
+
+def test_record_coach_tokens_skips_zero_amounts(fake_meter):
+    """Don't waste an emission slot on a zero — keeps the chart cleaner."""
+    from api import telemetry
+
+    telemetry.record_coach_tokens(
+        insight_type="x", model="m", prompt_tokens=0, completion_tokens=0,
+    )
+    assert "praxys.coach_tokens" not in fake_meter.counters or \
+        fake_meter.counters["praxys.coach_tokens"].calls == []
+
+
+# ---------------------------------------------------------------------------
+# record_coach_run
+# ---------------------------------------------------------------------------
+
+
+def test_record_coach_run_uses_track_event_when_available(fake_track_event):
+    from api import telemetry
+
+    calls, meter = fake_track_event
+    telemetry.record_coach_run(
+        insight_type="daily_brief", status="hash_match", user_id="user-1",
+    )
+    assert len(calls) == 1
+    name, attrs = calls[0]
+    assert name == "praxys.coach_run"
+    assert attrs["insight_type"] == "daily_brief"
+    assert attrs["status"] == "hash_match"
+    # user_id is hashed, not raw.
+    assert attrs["user_id_hash"] == telemetry.hash_user_id("user-1")
+    assert "user-1" not in attrs["user_id_hash"]
+    # Counter path must NOT have been used when track_event succeeded.
+    assert "praxys.coach_run" not in meter.counters
+
+
+def test_record_coach_run_falls_back_to_counter(fake_meter):
+    from api import telemetry
+
+    telemetry.record_coach_run(
+        insight_type="training_review", status="generated", user_id="user-2",
+    )
+    counter = fake_meter.counters["praxys.coach_run"]
+    assert len(counter.calls) == 1
+    amount, attrs = counter.calls[0]
+    assert amount == 1
+    assert attrs["status"] == "generated"
+    assert attrs["insight_type"] == "training_review"
+    assert attrs["user_id_hash"] == telemetry.hash_user_id("user-2")
+
+
+# ---------------------------------------------------------------------------
+# record_coach_error
+# ---------------------------------------------------------------------------
+
+
+def test_record_coach_error_via_track_event(fake_track_event):
+    from api import telemetry
+
+    calls, _ = fake_track_event
+    telemetry.record_coach_error(error_class="Auth")
+    assert calls == [("praxys.coach_error", {"error_class": "Auth"})]
+
+
+def test_record_coach_error_via_counter(fake_meter):
+    from api import telemetry
+
+    telemetry.record_coach_error(error_class="BadRequest")
+    counter = fake_meter.counters["praxys.coach_error"]
+    assert counter.calls == [(1, {"error_class": "BadRequest"})]
+
+
+# ---------------------------------------------------------------------------
+# chat_json integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsage:
+    def __init__(self, prompt: int, completion: int) -> None:
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.total_tokens = prompt + completion
+
+
+class _FakeMessage:
+    def __init__(self, content: str) -> None: self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None: self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content: str, usage: _FakeUsage | None) -> None:
+        self.choices = [_FakeChoice(content)]
+        self.usage = usage
+
+
+class _FakeCompletions:
+    def __init__(self, response_or_exc: Any) -> None:
+        self._payload = response_or_exc
+
+    def create(self, **kwargs: Any) -> Any:
+        if isinstance(self._payload, BaseException):
+            raise self._payload
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, response_or_exc: Any) -> None:
+        self.chat = type("Chat", (), {"completions": _FakeCompletions(response_or_exc)})()
+
+
+def test_chat_json_records_token_usage(fake_meter):
+    from api import llm
+
+    payload = json.dumps({"ok": True})
+    client = _FakeClient(_FakeResponse(payload, _FakeUsage(prompt=500, completion=120)))
+
+    out = llm.chat_json(
+        client, system="s", user="u",
+        model="gpt-5.4", insight_type="daily_brief",
+    )
+    assert out == {"ok": True}
+    counter = fake_meter.counters["praxys.coach_tokens"]
+    by_type = {c[1]["token_type"]: c for c in counter.calls}
+    assert by_type["prompt"][0] == 500
+    assert by_type["completion"][0] == 120
+    assert by_type["total"][0] == 620
+    for _, attrs in counter.calls:
+        assert attrs["insight_type"] == "daily_brief"
+        assert attrs["model"] == "gpt-5.4"
+
+
+def test_chat_json_default_insight_type(fake_meter):
+    """Non-Coach callers (e.g. translate script) still emit, dimensioned 'unknown'."""
+    from api import llm
+
+    payload = json.dumps({"x": 1})
+    client = _FakeClient(_FakeResponse(payload, _FakeUsage(prompt=10, completion=2)))
+    llm.chat_json(client, system="s", user="u", model="gpt-5.4-mini")
+    counter = fake_meter.counters["praxys.coach_tokens"]
+    assert all(c[1]["insight_type"] == "unknown" for c in counter.calls)
+
+
+def _instantiate_openai_exc(name: str):
+    """Build an instance of an openai>=1.0 exception class, or skip the test.
+
+    The pinned openai version on production is >=1.0 (it ships
+    ``AuthenticationError`` / ``BadRequestError`` as top-level imports).
+    Older 0.x SDKs in dev environments don't expose these symbols at all;
+    rather than silently passing as a no-op, we skip — the production
+    behaviour is verified anywhere the right SDK is installed.
+    """
+    openai = pytest.importorskip("openai")
+    cls = getattr(openai, name, None)
+    if cls is None:
+        pytest.skip(f"openai {getattr(openai, '__version__', '?')} lacks {name}; needs >=1.0")
+    # Constructor signature varies across 1.x minor releases. Try the
+    # widely-stable (message, response, body) shape first; fall back to
+    # bare message.
+    try:
+        return cls("fake", response=None, body=None)
+    except TypeError:
+        return cls("fake")
+
+
+def test_chat_json_records_auth_error(fake_meter):
+    """AuthenticationError → record_coach_error('Auth') and short-circuit."""
+    from api import llm
+
+    exc = _instantiate_openai_exc("AuthenticationError")
+    client = _FakeClient(exc)
+    out = llm.chat_json(
+        client, system="s", user="u", model="gpt-5.4",
+        insight_type="daily_brief", retry=0,
+    )
+    assert out is None
+    counter = fake_meter.counters["praxys.coach_error"]
+    assert counter.calls == [(1, {"error_class": "Auth"})]
+
+
+def test_chat_json_records_bad_request(fake_meter):
+    from api import llm
+
+    exc = _instantiate_openai_exc("BadRequestError")
+    client = _FakeClient(exc)
+    out = llm.chat_json(
+        client, system="s", user="u", model="gpt-5.4",
+        insight_type="training_review", retry=0,
+    )
+    assert out is None
+    counter = fake_meter.counters["praxys.coach_error"]
+    assert counter.calls == [(1, {"error_class": "BadRequest"})]
+
+
+# ---------------------------------------------------------------------------
+# insights_runner integration
+# ---------------------------------------------------------------------------
+
+
+def test_run_insights_emits_coach_run_per_type(fake_meter, monkeypatch):
+    """One coach_run per insight type with the right status."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from db.models import AiInsight, Base
+    from api import insights_runner, llm
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    # Stub context + pillars (mirrors test_insights_runner fixtures).
+    fake_ctx = {
+        "athlete_profile": {"goal": {"distance": "marathon"}},
+        "current_fitness": {"ctl": 50.0, "atl": 45.0, "tsb": 5.0,
+                             "cp_trend": {"current": 280.0, "direction": "up", "slope_per_month": 1.5},
+                             "predicted_time_sec": 11000},
+        "recent_training": {"weekly_summary": [], "sessions": []},
+        "recovery_state": {"hrv_ms": 60.0, "readiness": "fresh"},
+        "current_plan": [],
+        "science": {
+            "load": {"id": "banister_pmc", "name": "Banister PMC"},
+            "recovery": {"id": "hrv_based", "name": "Plews HRV-guided"},
+            "prediction": {"id": "critical_power", "name": "Critical Power"},
+            "zones": {"id": "five_zone", "name": "Coggan 5-zone",
+                      "target_distribution": [0.2, 0.6, 0.1, 0.05, 0.05]},
+        },
+    }
+    monkeypatch.setattr("api.ai.build_training_context", lambda **kw: fake_ctx)
+
+    class _Cfg: science = {"load": "banister_pmc", "recovery": "hrv_based",
+                             "prediction": "critical_power", "zones": "five_zone"}
+    monkeypatch.setattr("analysis.config.load_config_from_db", lambda u, d: _Cfg())
+
+    # First run: all generators return None → three "generator_returned_none".
+    monkeypatch.setattr(llm, "get_client", lambda: None)
+    insights_runner.run_insights_for_user(
+        "user-1", session, {"activities": 1}, _session=session,
+    )
+
+    counter = fake_meter.counters["praxys.coach_run"]
+    statuses = sorted(c[1]["status"] for c in counter.calls)
+    assert statuses == ["generator_returned_none"] * 3
+    types = sorted(c[1]["insight_type"] for c in counter.calls)
+    assert types == ["daily_brief", "race_forecast", "training_review"]
+    for _, attrs in counter.calls:
+        assert attrs["user_id_hash"] == __import__("api.telemetry", fromlist=["hash_user_id"]).hash_user_id("user-1")
+
+    session.close()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -372,43 +372,59 @@ def test_chat_json_records_bad_request(fake_meter):
 # ---------------------------------------------------------------------------
 
 
-def test_run_insights_emits_coach_run_per_type(fake_meter, monkeypatch):
-    """One coach_run per insight type with the right status."""
+_FAKE_CTX = {
+    "athlete_profile": {"goal": {"distance": "marathon"}},
+    "current_fitness": {"ctl": 50.0, "atl": 45.0, "tsb": 5.0,
+                         "cp_trend": {"current": 280.0, "direction": "up", "slope_per_month": 1.5},
+                         "predicted_time_sec": 11000},
+    "recent_training": {"weekly_summary": [], "sessions": []},
+    "recovery_state": {"hrv_ms": 60.0, "readiness": "fresh"},
+    "current_plan": [],
+    "science": {
+        "load": {"id": "banister_pmc", "name": "Banister PMC"},
+        "recovery": {"id": "hrv_based", "name": "Plews HRV-guided"},
+        "prediction": {"id": "critical_power", "name": "Critical Power"},
+        "zones": {"id": "five_zone", "name": "Coggan 5-zone",
+                  "target_distribution": [0.2, 0.6, 0.1, 0.05, 0.05]},
+    },
+}
+
+_FAKE_PILLARS = {
+    "load": "banister_pmc",
+    "recovery": "hrv_based",
+    "prediction": "critical_power",
+    "zones": "five_zone",
+}
+
+
+def _runner_session(monkeypatch):
+    """Build an in-memory session and stub the context + pillars used by
+    ``insights_runner._run``. Returns the session — caller closes it."""
     from sqlalchemy import create_engine
     from sqlalchemy.orm import sessionmaker
 
-    from db.models import AiInsight, Base
-    from api import insights_runner, llm
+    from db.models import Base
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
 
-    # Stub context + pillars (mirrors test_insights_runner fixtures).
-    fake_ctx = {
-        "athlete_profile": {"goal": {"distance": "marathon"}},
-        "current_fitness": {"ctl": 50.0, "atl": 45.0, "tsb": 5.0,
-                             "cp_trend": {"current": 280.0, "direction": "up", "slope_per_month": 1.5},
-                             "predicted_time_sec": 11000},
-        "recent_training": {"weekly_summary": [], "sessions": []},
-        "recovery_state": {"hrv_ms": 60.0, "readiness": "fresh"},
-        "current_plan": [],
-        "science": {
-            "load": {"id": "banister_pmc", "name": "Banister PMC"},
-            "recovery": {"id": "hrv_based", "name": "Plews HRV-guided"},
-            "prediction": {"id": "critical_power", "name": "Critical Power"},
-            "zones": {"id": "five_zone", "name": "Coggan 5-zone",
-                      "target_distribution": [0.2, 0.6, 0.1, 0.05, 0.05]},
-        },
-    }
-    monkeypatch.setattr("api.ai.build_training_context", lambda **kw: fake_ctx)
+    monkeypatch.setattr("api.ai.build_training_context", lambda **kw: _FAKE_CTX)
 
-    class _Cfg: science = {"load": "banister_pmc", "recovery": "hrv_based",
-                             "prediction": "critical_power", "zones": "five_zone"}
+    class _Cfg:
+        science = _FAKE_PILLARS
+
     monkeypatch.setattr("analysis.config.load_config_from_db", lambda u, d: _Cfg())
+    return session
 
-    # First run: all generators return None → three "generator_returned_none".
+
+def test_run_insights_emits_coach_run_per_type(fake_meter, monkeypatch):
+    """All three generators return None → three coach_run with that status."""
+    from api import insights_runner, llm, telemetry
+
+    session = _runner_session(monkeypatch)
     monkeypatch.setattr(llm, "get_client", lambda: None)
+
     insights_runner.run_insights_for_user(
         "user-1", session, {"activities": 1}, _session=session,
     )
@@ -419,6 +435,128 @@ def test_run_insights_emits_coach_run_per_type(fake_meter, monkeypatch):
     types = sorted(c[1]["insight_type"] for c in counter.calls)
     assert types == ["daily_brief", "race_forecast", "training_review"]
     for _, attrs in counter.calls:
-        assert attrs["user_id_hash"] == __import__("api.telemetry", fromlist=["hash_user_id"]).hash_user_id("user-1")
+        assert attrs["user_id_hash"] == telemetry.hash_user_id("user-1")
+
+    session.close()
+
+
+def test_run_insights_emits_hash_match_status(fake_meter, monkeypatch):
+    """Pre-seeded rows with matching dataset_hash → three coach_run('hash_match').
+
+    Anchors the cache hit rate signal: removing the hash_match telemetry
+    call would silently flatten the cache effectiveness chart, and this
+    test would catch it.
+    """
+    from analysis.insight_hash import compute_dataset_hash
+    from db.models import AiInsight
+    from api import insights_runner, llm
+
+    session = _runner_session(monkeypatch)
+
+    # Pre-seed a row per insight_type whose meta.dataset_hash matches the
+    # one the runner will compute for the same context+pillars. This forces
+    # the loop into the hash_match branch for every itype.
+    for itype in insights_runner.GENERATORS_ORDER:
+        h = compute_dataset_hash(_FAKE_CTX, itype, science_pillars=_FAKE_PILLARS)
+        session.add(AiInsight(
+            user_id="user-2",
+            insight_type=itype,
+            headline="cached", summary="cached",
+            findings=[], recommendations=[],
+            translations={},
+            meta={"dataset_hash": h},
+        ))
+    session.commit()
+
+    # Generator client need not be reachable — the hash_match branch
+    # short-circuits before any LLM call.
+    monkeypatch.setattr(llm, "get_client", lambda: None)
+    insights_runner.run_insights_for_user(
+        "user-2", session, {"activities": 1}, _session=session,
+    )
+
+    counter = fake_meter.counters["praxys.coach_run"]
+    statuses = sorted(c[1]["status"] for c in counter.calls)
+    assert statuses == ["hash_match"] * 3
+
+    session.close()
+
+
+def test_run_insights_emits_cap_reached_status(fake_meter, monkeypatch):
+    """Cap=1 + zero pre-seeded rows → first generates, next two cap_reached.
+
+    Anchors the per-iteration cap-pressure branch in ``insights_runner._run``
+    (NOT the early-return branch — see test below). Removing the
+    cap_reached telemetry call silently masks the signal that paying users
+    are running into the daily limit; this test makes that regression
+    observable.
+    """
+    import json
+    from db.models import AiInsight
+    from api import insights_runner, llm
+
+    session = _runner_session(monkeypatch)
+
+    # Cap=1 → first generate succeeds (used_today goes 0→1), then the next
+    # two iterations hit the per-iteration cap branch.
+    monkeypatch.setenv("PRAXYS_INSIGHT_DAILY_CAP", "1")
+
+    # A working fake client so the first iteration's generate path is real.
+    bilingual = {
+        "en": {"headline": "h", "summary": "s",
+               "findings": [{"type": "neutral", "text": "f"}],
+               "recommendations": ["r"]},
+        "zh": {"headline": "标题", "summary": "摘要",
+               "findings": [{"type": "neutral", "text": "调查"}],
+               "recommendations": ["建议"]},
+    }
+    payload = json.dumps(bilingual)
+    client = _FakeClient(_FakeResponse(payload, _FakeUsage(prompt=10, completion=5)))
+    monkeypatch.setattr(llm, "get_client", lambda: client)
+
+    insights_runner.run_insights_for_user(
+        "user-3", session, {"activities": 1}, _session=session,
+    )
+
+    counter = fake_meter.counters["praxys.coach_run"]
+    statuses = [c[1]["status"] for c in counter.calls]
+    # Order matches GENERATORS_ORDER: first generated, next two cap_reached.
+    assert statuses == ["generated", "cap_reached", "cap_reached"]
+    # And only one row was actually written.
+    assert session.query(AiInsight).filter(AiInsight.user_id == "user-3").count() == 1
+
+    session.close()
+
+
+def test_run_insights_no_telemetry_on_short_circuit_cap(fake_meter, monkeypatch):
+    """Documented gap: when the cap is exhausted before the loop even
+    starts (early return at runner._run line ~77), no coach_run events
+    fire. This test pins that contract — flipping the behavior to emit
+    one event per itype before the early return would fail this and force
+    a deliberate revisit of the observability tradeoff.
+    """
+    from datetime import datetime
+    from db.models import AiInsight
+    from api import insights_runner, llm
+
+    session = _runner_session(monkeypatch)
+    monkeypatch.setenv("PRAXYS_INSIGHT_DAILY_CAP", "0")
+    monkeypatch.setattr(llm, "get_client", lambda: None)
+
+    # Seed a row from "today" so used_today >= cap on entry.
+    session.add(AiInsight(
+        user_id="user-4", insight_type="daily_brief",
+        headline="x", summary="x", findings=[], recommendations=[],
+        translations={}, meta={}, generated_at=datetime.utcnow(),
+    ))
+    session.commit()
+
+    result = insights_runner.run_insights_for_user(
+        "user-4", session, {"activities": 1}, _session=session,
+    )
+
+    assert result == {"skipped": "cap_reached"}
+    # No coach_run counter should have been touched at all.
+    assert "praxys.coach_run" not in fake_meter.counters
 
     session.close()


### PR DESCRIPTION
## Summary

Wires three Application Insights signals into the post-sync Coach pipeline so operators can see token spend, cache effectiveness, and Auth-error spikes without re-reading log files. Closes #221.

- `praxys.coach_tokens` — `customMetric` from `chat_json` after a successful Azure OpenAI call, dimensioned by `{insight_type, model, token_type=prompt|completion|total}`. Daily spend by Coach surface is `customMetrics | where name == "praxys.coach_tokens" and tostring(customDimensions.token_type) == "total" | summarize sum(value) by tostring(customDimensions.insight_type)`.
- `praxys.coach_run` — `customEvent` when `azure-monitor-events-extension` is installed; otherwise a `customMetric` counter (value=1 per emission) with the same `{insight_type, status, user_id_hash}` dimensions. Status is one of the four strings the runner already produces (`generated`, `hash_match`, `cap_reached`, `generator_returned_none`). Cache hit rate over time = `hash_match / total`.
- `praxys.coach_error` — same dual emission, dimension `{error_class}`. Fires only on operator-actionable failures (`Auth`, `BadRequest`). Transient classes (`RateLimit`, `APIError`, `JSONDecode`) are deliberately excluded.

## Design notes

- **No new dependencies.** Issue #221 forbids them. `azure-monitor-opentelemetry` (already in `requirements.txt`) ships the OTel meter that lands counters in `customMetrics`. The optional `azure-monitor-events-extension` is the canonical `customEvent` emitter but is not transitively pulled in — so the helper uses `track_event` when present and falls back to a counter otherwise. Operators who want literal `customEvents` can opt in by `pip install azure-monitor-events-extension` on the App Service without any code change.
- **Lazy / no-op when unconfigured.** Every helper short-circuits when `APPLICATIONINSIGHTS_CONNECTION_STRING` is unset (the same gate `api/main.py` uses to skip `configure_azure_monitor()`) or when the OTel SDK is missing. Sync must never break because telemetry is misconfigured.
- **No PII.** `user_id` is `sha256[:16]` before emission. Telemetry is not a place for stable raw identifiers.
- **`token_type` split.** `coach_tokens` records prompt + completion as separate counter increments (plus a `total`) so operators can spot prompt-bloat regressions vs. completion drift independently. The `total` row exists so the documented summary query is a single-line `sum(value)` rather than a sum-of-sums.

## What changed

- `api/telemetry.py` (new) — `record_coach_tokens`, `record_coach_run`, `record_coach_error`, `hash_user_id`. Single source of truth.
- `api/llm.py::chat_json` — accepts `insight_type` (forwarded to telemetry), records token usage on success, records `coach_error` in the `Auth` and `BadRequest` branches. Defaults `insight_type="unknown"` so non-Coach callers (e.g. `scripts/translate_missing.py`) still emit token usage, just without the per-surface breakdown.
- `api/insights_generator.py::_generate` — passes `insight_type` through to `chat_json`.
- `api/insights_runner.py::_run` — emits `coach_run` per insight type at the four status branches.
- `tests/test_telemetry.py` — 13 new tests (11 passing, 2 properly skipped on `openai<1.0` envs that don't expose the new exception classes). Covers the no-op contract, both event paths (track_event + counter fallback), token split shape, default `insight_type`, and the full runner integration.

## Test plan

- [x] `pytest tests/test_telemetry.py tests/test_insights_runner.py tests/test_insights_generator.py tests/test_post_sync_insight_hook.py -v` → 37 passed, 2 skipped (the two skipped tests need `openai>=1.0`'s `AuthenticationError` / `BadRequestError` symbols, which the prod image has).
- [x] Manual review of the no-op path: helpers fire silently with `APPLICATIONINSIGHTS_CONNECTION_STRING` unset (verified in `test_helpers_noop_when_appinsights_unset`).
- [ ] **Live App Insights smoke** — pending merge:
  - Trigger a real sync; confirm `customMetrics | where name == "praxys.coach_tokens"` returns rows with `prompt_tokens` / `completion_tokens` populated by `insight_type`.
  - Trigger a no-op resync; confirm three `coach_run` records with `status="hash_match"` arrive within ~2 minutes.
  - Force an Auth failure (rotate the AAD token without restart); confirm `coach_error` arrives with `error_class="Auth"`.
