### PR TITLE
Fix stale docstrings: UniqueConstraint key includes user_id

### DIFF
--- a/db/models.py
+++ b/db/models.py
@@ -177,7 +177,7 @@ class ActivitySample(Base):
 
     One row per second per activity. Columns cover the union of all connector
     field sets; connector-specific fields are NULL for other sources. The
-    unique constraint on (activity_id, t_sec) makes re-syncs idempotent —
+    unique constraint on (user_id, activity_id, t_sec) makes re-syncs idempotent —
     duplicate writes are silently ignored via INSERT OR IGNORE.
 
     Storage estimate: ~3,600 rows/hour of running. At SQLite scale for

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -523,7 +523,7 @@ _SAMPLE_BATCH_SIZE = 500
 def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
     """Upsert per-second activity samples. Returns count of rows written.
 
-    Uses INSERT OR IGNORE keyed on (activity_id, t_sec) so re-syncing an
+    Uses INSERT OR IGNORE keyed on (user_id, activity_id, t_sec) so re-syncing an
     activity is idempotent — existing rows are left untouched. Inserts are
     batched to avoid oversized transactions for long activities.
     """


### PR DESCRIPTION
## What

Two docstrings in `db/models.py` (`ActivitySample`) and `db/sync_writer.py` (`write_samples`) still described the unique constraint key as `(activity_id, t_sec)` after the key was corrected to `(user_id, activity_id, t_sec)` in PR #217's post-review fix. Flagged during code reviews of #217 and #226 but could not be included in those PRs since the files weren't modified there.

## Changes

- `db/models.py` line 180: `(activity_id, t_sec)` → `(user_id, activity_id, t_sec)`
- `db/sync_writer.py` line 526: same

No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)