### PR TITLE
Fix garminconnect.exceptions import and stale UniqueConstraint docstrings

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -374,7 +374,7 @@ def _login_garmin_with_cn_fallback(client, creds: dict, token_dir: str) -> None:
        (``"Invalid Username or Password"``) bubbling up.
     """
     import contextlib
-    from garminconnect.exceptions import GarminConnectAuthenticationError
+    from garminconnect import GarminConnectAuthenticationError
 
     if getattr(client, "is_cn", False):
         _patch_cn_di_exchange(client.client)

--- a/db/models.py
+++ b/db/models.py
@@ -177,7 +177,7 @@ class ActivitySample(Base):
 
     One row per second per activity. Columns cover the union of all connector
     field sets; connector-specific fields are NULL for other sources. The
-    unique constraint on (activity_id, t_sec) makes re-syncs idempotent —
+    unique constraint on (user_id, activity_id, t_sec) makes re-syncs idempotent —
     duplicate writes are silently ignored via INSERT OR IGNORE.
 
     Storage estimate: ~3,600 rows/hour of running. At SQLite scale for

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -523,7 +523,7 @@ _SAMPLE_BATCH_SIZE = 500
 def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
     """Upsert per-second activity samples. Returns count of rows written.
 
-    Uses INSERT OR IGNORE keyed on (activity_id, t_sec) so re-syncing an
+    Uses INSERT OR IGNORE keyed on (user_id, activity_id, t_sec) so re-syncing an
     activity is idempotent — existing rows are left untouched. Inserts are
     batched to avoid oversized transactions for long activities.
     """

--- a/tests/test_garmin_login_fallback.py
+++ b/tests/test_garmin_login_fallback.py
@@ -65,7 +65,7 @@ def _make_client(login_behavior, *, is_cn: bool = True):
 def test_jwt_web_error_falls_back_to_portal_login(tmp_path) -> None:
     """The exact message from the upstream bug must trigger the portal
     fallback with the same credentials passed in."""
-    from garminconnect.exceptions import GarminConnectAuthenticationError
+    from garminconnect import GarminConnectAuthenticationError
     from api.routes.sync import _login_garmin_with_cn_fallback
 
     def _raise_jwt_web():
@@ -111,7 +111,7 @@ def test_successful_login_does_not_fall_back(tmp_path) -> None:
 def test_other_auth_errors_bubble_up(tmp_path) -> None:
     """Real credential failures (wrong password, etc.) must not be
     masked by the portal fallback — the user needs to see them."""
-    from garminconnect.exceptions import GarminConnectAuthenticationError
+    from garminconnect import GarminConnectAuthenticationError
     from api.routes.sync import _login_garmin_with_cn_fallback
 
     def _raise_bad_password():


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled as housekeeping before #213 work begins.

**1. garminconnect.exceptions import** — garminconnect 0.2.38 (installed version) exports `GarminConnectAuthenticationError` from the top-level module, not from a `garminconnect.exceptions` sub-module (which only exists in 0.3.x). This was causing every Garmin sync attempt to fail with `ModuleNotFoundError` and accounted for 6 of the 14 pre-existing test failures. Fixed in `api/routes/sync.py` and `tests/test_garmin_login_fallback.py`.

**2. Stale UniqueConstraint docstrings** — `db/models.py` and `db/sync_writer.py` described the `ActivitySample` unique key as `(activity_id, t_sec)` after it was corrected to `(user_id, activity_id, t_sec)` in PR #217's post-review fix. Previously couldn't be fixed because those files weren't in the earlier PRs' diffs.

## Test plan

- [x] Full suite in fix worktree: 8 failed (down from 14), 599 passed
- [x] 6 previously-failing `garminconnect.exceptions` tests now pass
- [x] Remaining 8 failures are CN-specific `garminconnect.client` incompatibilities (pre-existing, out of scope) + MCP test

🤖 Generated with [Claude Code](https://claude.com/claude-code)