### PR TITLE
Pin openai package required by Coach insight generator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,14 @@ httpx>=0.27.0
 # for FastAPI, requests, SQLAlchemy, and logging.
 azure-monitor-opentelemetry>=1.6.0
 
+# Azure OpenAI client used by api/llm.py for the post-sync Coach insight
+# generator. >=1.50.0 because chat_json passes max_completion_tokens
+# (introduced in openai 1.40) and response_format={"type": "json_object"}.
+# When unavailable, get_client() returns None and the rule-based prose
+# elsewhere serves as the fallback — but in production we want the LLM
+# path live, so this is a hard requirement, not optional.
+openai>=1.50.0
+
 # ── Visual asset generation ──────────────────────────────────────────
 # Headless Chromium via Playwright is used by scripts/generate_og_card.py
 # to rasterize web/public/og-card*.html into PNGs for OpenGraph / WeChat


### PR DESCRIPTION
## Summary

- `api/llm.py::get_client()` imports `openai.AzureOpenAI`, but the package was never added to `requirements.txt` in #210. The deployed worker hits `ImportError`, `get_client()` returns `None`, and every post-sync run logs `generator_returned_none` while the rule-based fallback silently serves prose.
- Production trace from `appi-trainsight` confirmed the failure mode:
  ```
  Azure OpenAI SDK missing — AI insights disabled, rule-based fallback active (No module named 'openai')
  ```
- Pinning `openai>=1.50.0` because `chat_json` passes `max_completion_tokens` (introduced in openai 1.40) and `response_format={"type": "json_object"}`.

## Why CI didn't catch this

`pytest` passes locally because `openai` happens to be present in the dev venv (and the insight tests stub the client anyway). CI doesn't currently run a post-install import smoke test, so a missing pin slips through. Worth a follow-up — out of scope for this fix.

## Rollout note

`get_client()` is `lru_cache`-memoised. After the deploy lands, **restart the App Service** — otherwise workers hold the cached `None` client from the pre-fix start.

## Test plan

- [ ] Deploy completes on `praxys-api`.
- [ ] App Service restarted post-deploy.
- [ ] Startup log shows `Azure OpenAI client initialised: endpoint=... insight_model=gpt-5.4 ...`.
- [ ] Trigger a non-no-op sync; `Insight generation for user X: {...}` no longer shows `generator_returned_none` for all three types.
- [ ] KQL on `appi-trainsight`: `customMetrics | where name == "praxys.coach_tokens" | where timestamp > ago(1h) | summarize sum(value)` is non-zero.
- [ ] Web `AiInsightsCard` renders generated prose (not the rule-based fallback) for a user whose data just synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)