### PR TITLE
Fix test_telemetry helper for openai 1.x APIStatusError constructor

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -324,18 +324,22 @@ def _instantiate_openai_exc(name: str):
     Older 0.x SDKs in dev environments don't expose these symbols at all;
     rather than silently passing as a no-op, we skip — the production
     behaviour is verified anywhere the right SDK is installed.
+
+    ``APIStatusError.__init__`` (the parent of AuthenticationError /
+    BadRequestError) chains ``response.request`` into ``APIError.__init__``,
+    so a ``None`` response triggers ``AttributeError`` *inside* the
+    constructor — not ``TypeError`` at the call site. We therefore build a
+    minimal ``httpx.Response`` with a real request attached, which is how
+    the real SDK constructs these exceptions in production.
     """
     openai = pytest.importorskip("openai")
+    httpx = pytest.importorskip("httpx")
     cls = getattr(openai, name, None)
     if cls is None:
         pytest.skip(f"openai {getattr(openai, '__version__', '?')} lacks {name}; needs >=1.0")
-    # Constructor signature varies across 1.x minor releases. Try the
-    # widely-stable (message, response, body) shape first; fall back to
-    # bare message.
-    try:
-        return cls("fake", response=None, body=None)
-    except TypeError:
-        return cls("fake")
+    request = httpx.Request("POST", "http://test/")
+    response = httpx.Response(401, request=request)
+    return cls("fake", response=response, body=None)
 
 
 def test_chat_json_records_auth_error(fake_meter):


### PR DESCRIPTION
## Summary

Follow-up to #231. Adding `openai>=1.50.0` to `requirements.txt` flipped CI's `tests/test_telemetry.py::test_chat_json_records_auth_error` and `..._bad_request` from passing (skipped — package absent) to failing.

The helper `_instantiate_openai_exc` tried `cls("fake", response=None, body=None)` and fell back to `cls("fake")` on `TypeError`. But openai 1.x `APIStatusError.__init__` chains `response.request` into `APIError.__init__`, so a `None` response raises **`AttributeError`** *inside* the constructor — `TypeError` never fires and the fallback is unreachable.

```
self = AuthenticationError('fake'), message = 'fake'
E   AttributeError: 'NoneType' object has no attribute 'request'
openai/_exceptions.py:101: AttributeError
```

## Fix

Build a minimal `httpx.Response` with a real `Request` attached — the same shape the SDK constructs in production. `httpx` is already in `requirements.txt` (line 32), and we `importorskip` it for parity with the openai skip path.

## Test plan

- [x] `pytest tests/test_telemetry.py -v` → 16 passed locally with `openai>=1.50.0` installed.
- [x] `pytest tests/test_telemetry.py::test_chat_json_records_auth_error tests/test_telemetry.py::test_chat_json_records_bad_request` — both pass (previously failing in CI).
- [ ] Full CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)