### PR TITLE
Add admin-configurable system notification banners

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -149,6 +149,9 @@ app.include_router(wechat_auth_router, prefix="/api")
 from api.routes.admin import router as admin_router
 app.include_router(admin_router, prefix="/api", tags=["admin"])
 
+from api.routes.announcements import router as announcements_router
+app.include_router(announcements_router, prefix="/api", tags=["announcements"])
+
 # Data routes
 from api.routes import today, training, goal, history, plan, settings, sync, science, insights
 from api.routes import ai as ai_routes

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -11,18 +11,10 @@ from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user_id
-from api.views import utc_isoformat
+from api.views import utc_isoformat, require_admin as _require_admin
 from db.session import get_db
 
 router = APIRouter(prefix="/admin")
-
-
-def _require_admin(user_id: str, db: Session) -> None:
-    """Raise 403 if user is not a superuser."""
-    from db.models import User
-    user = db.query(User).filter(User.id == user_id).first()
-    if not user or not user.is_superuser:
-        raise HTTPException(403, "Admin access required")
 
 
 def _generate_code() -> str:

--- a/api/routes/announcements.py
+++ b/api/routes/announcements.py
@@ -12,18 +12,10 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user_id
-from api.views import utc_isoformat
+from api.views import utc_isoformat, require_admin
 from db.session import get_db
 
 router = APIRouter()
-
-
-def _require_admin(user_id: str, db: Session) -> None:
-    """Raise 403 if user is not a superuser."""
-    from db.models import User
-    user = db.query(User).filter(User.id == user_id).first()
-    if not user or not user.is_superuser:
-        raise HTTPException(403, "Admin access required")
 
 
 def _serialize(ann) -> dict:
@@ -92,7 +84,7 @@ def create_announcement(
     db: Session = Depends(get_db),
 ) -> dict:
     """Create a system announcement. Admin only."""
-    _require_admin(user_id, db)
+    require_admin(user_id, db)
     from db.models import SystemAnnouncement
     if payload.type not in ("info", "warning", "success"):
         raise HTTPException(422, "type must be info, warning, or success")
@@ -118,7 +110,7 @@ def update_announcement(
     db: Session = Depends(get_db),
 ) -> dict:
     """Update a system announcement. Admin only."""
-    _require_admin(user_id, db)
+    require_admin(user_id, db)
     from db.models import SystemAnnouncement
     ann = db.query(SystemAnnouncement).filter(SystemAnnouncement.id == ann_id).first()
     if not ann:
@@ -150,7 +142,7 @@ def delete_announcement(
     db: Session = Depends(get_db),
 ) -> dict:
     """Delete a system announcement. Admin only."""
-    _require_admin(user_id, db)
+    require_admin(user_id, db)
     from db.models import SystemAnnouncement
     ann = db.query(SystemAnnouncement).filter(SystemAnnouncement.id == ann_id).first()
     if not ann:

--- a/api/routes/announcements.py
+++ b/api/routes/announcements.py
@@ -1,0 +1,160 @@
+"""System announcement endpoints — site-wide notification banners.
+
+GET /api/announcements        — all authenticated users; returns active banners
+POST /api/admin/announcements — admin only; create
+PATCH /api/admin/announcements/{id} — admin only; update
+DELETE /api/admin/announcements/{id} — admin only; delete
+"""
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from api.auth import get_current_user_id
+from api.views import utc_isoformat
+from db.session import get_db
+
+router = APIRouter()
+
+
+def _require_admin(user_id: str, db: Session) -> None:
+    """Raise 403 if user is not a superuser."""
+    from db.models import User
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user or not user.is_superuser:
+        raise HTTPException(403, "Admin access required")
+
+
+def _serialize(ann) -> dict:
+    """Serialize a SystemAnnouncement ORM row to a response dict."""
+    return {
+        "id": ann.id,
+        "title": ann.title,
+        "body": ann.body,
+        "type": ann.type,
+        "is_active": ann.is_active,
+        "link_text": ann.link_text,
+        "link_url": ann.link_url,
+        "created_at": utc_isoformat(ann.created_at),
+        "updated_at": utc_isoformat(ann.updated_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public — all authenticated users
+# ---------------------------------------------------------------------------
+
+@router.get("/announcements")
+def get_announcements(
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """Return all active system announcements."""
+    from db.models import SystemAnnouncement
+    rows = (
+        db.query(SystemAnnouncement)
+        .filter(SystemAnnouncement.is_active == True)  # noqa: E712
+        .order_by(SystemAnnouncement.created_at.desc())
+        .all()
+    )
+    return [_serialize(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Admin CRUD
+# ---------------------------------------------------------------------------
+
+class AnnouncementCreate(BaseModel):
+    """Payload for creating a system announcement."""
+    title: str
+    body: str
+    type: str = "info"
+    is_active: bool = True
+    link_text: str | None = None
+    link_url: str | None = None
+
+
+class AnnouncementUpdate(BaseModel):
+    """Partial update payload — all fields optional."""
+    title: str | None = None
+    body: str | None = None
+    type: str | None = None
+    is_active: bool | None = None
+    link_text: str | None = None
+    link_url: str | None = None
+
+
+@router.post("/admin/announcements")
+def create_announcement(
+    payload: AnnouncementCreate,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Create a system announcement. Admin only."""
+    _require_admin(user_id, db)
+    from db.models import SystemAnnouncement
+    if payload.type not in ("info", "warning", "success"):
+        raise HTTPException(422, "type must be info, warning, or success")
+    ann = SystemAnnouncement(
+        title=payload.title,
+        body=payload.body,
+        type=payload.type,
+        is_active=payload.is_active,
+        link_text=payload.link_text,
+        link_url=payload.link_url,
+    )
+    db.add(ann)
+    db.commit()
+    db.refresh(ann)
+    return _serialize(ann)
+
+
+@router.patch("/admin/announcements/{ann_id}")
+def update_announcement(
+    ann_id: int,
+    payload: AnnouncementUpdate,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Update a system announcement. Admin only."""
+    _require_admin(user_id, db)
+    from db.models import SystemAnnouncement
+    ann = db.query(SystemAnnouncement).filter(SystemAnnouncement.id == ann_id).first()
+    if not ann:
+        raise HTTPException(404, "Announcement not found")
+    if payload.title is not None:
+        ann.title = payload.title
+    if payload.body is not None:
+        ann.body = payload.body
+    if payload.type is not None:
+        if payload.type not in ("info", "warning", "success"):
+            raise HTTPException(422, "type must be info, warning, or success")
+        ann.type = payload.type
+    if payload.is_active is not None:
+        ann.is_active = payload.is_active
+    if payload.link_text is not None:
+        ann.link_text = payload.link_text
+    if payload.link_url is not None:
+        ann.link_url = payload.link_url
+    ann.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(ann)
+    return _serialize(ann)
+
+
+@router.delete("/admin/announcements/{ann_id}")
+def delete_announcement(
+    ann_id: int,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Delete a system announcement. Admin only."""
+    _require_admin(user_id, db)
+    from db.models import SystemAnnouncement
+    ann = db.query(SystemAnnouncement).filter(SystemAnnouncement.id == ann_id).first()
+    if not ann:
+        raise HTTPException(404, "Announcement not found")
+    db.delete(ann)
+    db.commit()
+    return {"deleted": ann_id}

--- a/api/views.py
+++ b/api/views.py
@@ -8,6 +8,19 @@ from datetime import date, datetime, timezone
 import pandas as pd
 
 
+def require_admin(user_id: str, db) -> None:
+    """Raise HTTP 403 if the user is not a superuser.
+
+    Shared guard used by admin-only routes in api/routes/admin.py and
+    api/routes/announcements.py. Lives here per the shared-helpers convention.
+    """
+    from fastapi import HTTPException
+    from db.models import User
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user or not user.is_superuser:
+        raise HTTPException(403, "Admin access required")
+
+
 def utc_isoformat(dt: datetime | None) -> str | None:
     """Serialize a UTC datetime as an ISO-8601 string with a UTC offset.
 

--- a/db/models.py
+++ b/db/models.py
@@ -390,3 +390,25 @@ class TrainingPlan(Base):
             "user_id", "date", "source", "workout_type", name="uq_user_date_plan"
         ),
     )
+
+
+class SystemAnnouncement(Base):
+    """Admin-configurable site-wide notification banners.
+
+    Active announcements are returned by GET /api/announcements to all
+    authenticated users and rendered as dismissible banners in the web UI.
+    Dismissed banner IDs are stored client-side (localStorage) so they
+    don't re-appear after reload without server-side per-user tracking.
+    """
+
+    __tablename__ = "system_announcements"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    title = Column(String(200), nullable=False)
+    body = Column(Text, nullable=False)
+    type = Column(String(20), default="info", nullable=False)  # info | warning | success
+    is_active = Column(Boolean, default=True, nullable=False)
+    link_text = Column(String(100), nullable=True)
+    link_url = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/tests/test_announcements.py
+++ b/tests/test_announcements.py
@@ -1,0 +1,103 @@
+"""Tests for system announcement endpoints."""
+import tempfile
+import pytest
+
+
+@pytest.fixture
+def db_with_admin(monkeypatch):
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_LOCAL_ENCRYPTION_KEY", "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=")
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+    from db.models import User
+    db = db_session.SessionLocal()
+    admin_id = "admin-ann-test"
+    user_id = "user-ann-test"
+    db.add(User(id=admin_id, email="admin@ann.test", hashed_password="x", is_superuser=True))
+    db.add(User(id=user_id, email="user@ann.test", hashed_password="x", is_superuser=False))
+    db.commit()
+    try:
+        yield db, admin_id, user_id
+    finally:
+        db.close()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def test_create_and_list_announcement(db_with_admin):
+    from api.routes.announcements import create_announcement, get_announcements, AnnouncementCreate
+    db, admin_id, user_id = db_with_admin
+
+    payload = AnnouncementCreate(
+        title="Test banner",
+        body="Please backfill your data.",
+        type="info",
+        link_text="Settings",
+        link_url="/settings",
+    )
+    ann = create_announcement(payload, user_id=admin_id, db=db)
+    assert ann["id"] is not None
+    assert ann["title"] == "Test banner"
+    assert ann["is_active"] is True
+
+    # Regular user can see active announcements
+    visible = get_announcements(user_id=user_id, db=db)
+    assert len(visible) == 1
+    assert visible[0]["title"] == "Test banner"
+
+
+def test_non_admin_cannot_create(db_with_admin):
+    from api.routes.announcements import create_announcement, AnnouncementCreate
+    from fastapi import HTTPException
+    db, admin_id, user_id = db_with_admin
+
+    with pytest.raises(HTTPException) as exc:
+        create_announcement(AnnouncementCreate(title="X", body=""), user_id=user_id, db=db)
+    assert exc.value.status_code == 403
+
+
+def test_deactivate_hides_from_users(db_with_admin):
+    from api.routes.announcements import create_announcement, update_announcement, get_announcements
+    from api.routes.announcements import AnnouncementCreate, AnnouncementUpdate
+    db, admin_id, user_id = db_with_admin
+
+    ann = create_announcement(AnnouncementCreate(title="X", body=""), user_id=admin_id, db=db)
+    update_announcement(ann["id"], AnnouncementUpdate(is_active=False), user_id=admin_id, db=db)
+
+    visible = get_announcements(user_id=user_id, db=db)
+    assert len(visible) == 0
+
+
+def test_delete_announcement(db_with_admin):
+    from api.routes.announcements import create_announcement, delete_announcement, get_announcements
+    from api.routes.announcements import AnnouncementCreate
+    db, admin_id, user_id = db_with_admin
+
+    ann = create_announcement(AnnouncementCreate(title="Gone", body=""), user_id=admin_id, db=db)
+    delete_announcement(ann["id"], user_id=admin_id, db=db)
+
+    visible = get_announcements(user_id=user_id, db=db)
+    assert len(visible) == 0
+
+
+def test_invalid_type_rejected(db_with_admin):
+    from api.routes.announcements import create_announcement, AnnouncementCreate
+    from fastapi import HTTPException
+    db, admin_id, _ = db_with_admin
+
+    with pytest.raises(HTTPException) as exc:
+        create_announcement(
+            AnnouncementCreate(title="X", body="", type="critical"),  # type: ignore
+            user_id=admin_id, db=db,
+        )
+    assert exc.value.status_code == 422

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/AppSidebar';
+import SystemBanner from '@/components/SystemBanner';
 import { useAuth } from '@/hooks/useAuth';
 import { Eye } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
@@ -15,6 +16,7 @@ export default function Layout() {
         <header className="sticky top-0 z-40 flex h-12 items-center gap-2 border-b border-border bg-background/80 backdrop-blur-sm px-4 lg:hidden">
           <SidebarTrigger />
         </header>
+        <SystemBanner />
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <Outlet />
         </div>

--- a/web/src/components/SystemBanner.tsx
+++ b/web/src/components/SystemBanner.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { X, Info, AlertTriangle, CheckCircle } from 'lucide-react';
+import { API_BASE, getAuthHeaders } from '@/hooks/useApi';
+import type { SystemAnnouncement } from '@/types/api';
+
+const STORAGE_KEY = 'praxys_dismissed_banners';
+
+function getDismissed(): Set<number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return new Set(raw ? JSON.parse(raw) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveDismissed(ids: Set<number>): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+}
+
+const TYPE_STYLES = {
+  info:    'bg-accent-cobalt/10 border-accent-cobalt/30 text-foreground',
+  warning: 'bg-amber-500/10  border-amber-500/30  text-foreground',
+  success: 'bg-primary/10    border-primary/30    text-foreground',
+};
+
+const TYPE_ICONS = {
+  info:    <Info    className="h-4 w-4 text-accent-cobalt shrink-0 mt-0.5" />,
+  warning: <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />,
+  success: <CheckCircle   className="h-4 w-4 text-primary shrink-0 mt-0.5" />,
+};
+
+export default function SystemBanner() {
+  const [banners, setBanners] = useState<SystemAnnouncement[]>([]);
+
+  useEffect(() => {
+    const headers = getAuthHeaders();
+    if (!headers) return;
+    fetch(`${API_BASE}/api/announcements`, { headers })
+      .then((r) => r.ok ? r.json() : [])
+      .then((data: SystemAnnouncement[]) => {
+        const dismissed = getDismissed();
+        setBanners(data.filter((b) => !dismissed.has(b.id)));
+      })
+      .catch(() => {});
+  }, []);
+
+  function dismiss(id: number) {
+    const dismissed = getDismissed();
+    dismissed.add(id);
+    saveDismissed(dismissed);
+    setBanners((prev) => prev.filter((b) => b.id !== id));
+  }
+
+  if (banners.length === 0) return null;
+
+  return (
+    <div className="space-y-2 px-4 pt-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
+      {banners.map((banner) => {
+        const type = (banner.type as keyof typeof TYPE_STYLES) in TYPE_STYLES
+          ? (banner.type as keyof typeof TYPE_STYLES)
+          : 'info';
+        return (
+          <div
+            key={banner.id}
+            className={`flex items-start gap-3 rounded-lg border px-4 py-3 text-sm ${TYPE_STYLES[type]}`}
+          >
+            {TYPE_ICONS[type]}
+            <div className="flex-1 min-w-0">
+              <span className="font-medium">{banner.title}</span>
+              {banner.body && (
+                <span className="ml-1 text-muted-foreground">{banner.body}</span>
+              )}
+              {banner.link_url && banner.link_text && (
+                <a
+                  href={banner.link_url}
+                  className="ml-2 underline underline-offset-2 font-medium hover:opacity-80"
+                >
+                  {banner.link_text}
+                </a>
+              )}
+            </div>
+            <button
+              onClick={() => dismiss(banner.id)}
+              className="shrink-0 rounded p-0.5 hover:bg-black/10 transition-colors"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -23,7 +23,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Users, Ticket, Copy, Check, Trash2, Plus, ShieldCheck, ChevronUp, ChevronDown, Eye } from 'lucide-react';
+import { Users, Ticket, Copy, Check, Trash2, Plus, ShieldCheck, ChevronUp, ChevronDown, Eye, Megaphone } from 'lucide-react';
+import type { SystemAnnouncement } from '@/types/api';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 interface UserInfo {
@@ -65,18 +66,75 @@ export default function Admin() {
   const [creatingDemo, setCreatingDemo] = useState(false);
   const [demoError, setDemoError] = useState<string | null>(null);
 
+  // Announcements
+  const [announcements, setAnnouncements] = useState<SystemAnnouncement[]>([]);
+  const [newTitle, setNewTitle] = useState('');
+  const [newBody, setNewBody] = useState('');
+  const [newType, setNewType] = useState<'info' | 'warning' | 'success'>('info');
+  const [newLinkText, setNewLinkText] = useState('');
+  const [newLinkUrl, setNewLinkUrl] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
   const fetchData = () => {
     setLoading(true);
     Promise.all([
       fetch(`${API_BASE}/api/admin/users`, { headers: getAuthHeaders() }).then((r) => r.json()),
       fetch(`${API_BASE}/api/admin/invitations`, { headers: getAuthHeaders() }).then((r) => r.json()),
+      fetch(`${API_BASE}/api/announcements`, { headers: getAuthHeaders() }).then((r) => r.ok ? r.json() : []),
     ])
-      .then(([u, i]) => {
+      .then(([u, i, a]) => {
         setUsers(u.users || []);
         setInvitations(i.invitations || []);
+        setAnnouncements(Array.isArray(a) ? a : []);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
+  };
+
+  const handleCreateAnnouncement = async () => {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    setCreateError(null);
+    const res = await fetch(`${API_BASE}/api/admin/announcements`, {
+      method: 'POST',
+      headers: { ...getAuthHeaders() as Record<string, string>, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: newTitle.trim(),
+        body: newBody.trim(),
+        type: newType,
+        link_text: newLinkText.trim() || null,
+        link_url: newLinkUrl.trim() || null,
+      }),
+    });
+    setCreating(false);
+    if (res.ok) {
+      const created = await res.json();
+      setAnnouncements((prev) => [created, ...prev]);
+      setNewTitle(''); setNewBody(''); setNewType('info'); setNewLinkText(''); setNewLinkUrl('');
+    } else {
+      setCreateError('Failed to create announcement');
+    }
+  };
+
+  const handleToggleAnnouncement = async (ann: SystemAnnouncement) => {
+    const res = await fetch(`${API_BASE}/api/admin/announcements/${ann.id}`, {
+      method: 'PATCH',
+      headers: { ...getAuthHeaders() as Record<string, string>, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_active: !ann.is_active }),
+    });
+    if (res.ok) {
+      const updated = await res.json();
+      setAnnouncements((prev) => prev.map((a) => a.id === ann.id ? updated : a));
+    }
+  };
+
+  const handleDeleteAnnouncement = async (id: number) => {
+    const res = await fetch(`${API_BASE}/api/admin/announcements/${id}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    });
+    if (res.ok) setAnnouncements((prev) => prev.filter((a) => a.id !== id));
   };
 
   useEffect(() => { fetchData(); }, []);
@@ -481,6 +539,98 @@ export default function Admin() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* System Announcements */}
+      <Card className="mt-8">
+        <CardHeader>
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+              <Megaphone className="h-4 w-4" />
+            </div>
+            <div>
+              <CardTitle className="text-base"><Trans>System Announcements</Trans></CardTitle>
+              <CardDescription className="text-xs"><Trans>Dismissible banners shown to all users</Trans></CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Create form */}
+          <div className="rounded-lg border border-dashed border-border p-4 space-y-3">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide"><Trans>New announcement</Trans></p>
+            <Input
+              placeholder={t`Title`}
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+            />
+            <Input
+              placeholder={t`Body (optional)`}
+              value={newBody}
+              onChange={(e) => setNewBody(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <select
+                value={newType}
+                onChange={(e) => setNewType(e.target.value as 'info' | 'warning' | 'success')}
+                className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="info">info</option>
+                <option value="warning">warning</option>
+                <option value="success">success</option>
+              </select>
+              <Input
+                placeholder={t`Link text (optional)`}
+                value={newLinkText}
+                onChange={(e) => setNewLinkText(e.target.value)}
+              />
+              <Input
+                placeholder={t`Link URL (optional)`}
+                value={newLinkUrl}
+                onChange={(e) => setNewLinkUrl(e.target.value)}
+              />
+            </div>
+            {createError && <p className="text-xs text-destructive">{createError}</p>}
+            <Button size="sm" onClick={handleCreateAnnouncement} disabled={creating || !newTitle.trim()}>
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              {creating ? <Trans>Creating...</Trans> : <Trans>Create</Trans>}
+            </Button>
+          </div>
+
+          {/* Existing announcements */}
+          {announcements.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4"><Trans>No announcements yet</Trans></p>
+          ) : (
+            <div className="space-y-2">
+              {announcements.map((ann) => (
+                <div key={ann.id} className={`flex items-start gap-3 rounded-lg border p-3 text-sm ${ann.is_active ? '' : 'opacity-50'}`}>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className="text-xs shrink-0">{ann.type}</Badge>
+                      <span className="font-medium truncate">{ann.title}</span>
+                    </div>
+                    {ann.body && <p className="text-xs text-muted-foreground mt-0.5 truncate">{ann.body}</p>}
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      variant="ghost" size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => handleToggleAnnouncement(ann)}
+                    >
+                      {ann.is_active ? <Trans>Deactivate</Trans> : <Trans>Activate</Trans>}
+                    </Button>
+                    <Button
+                      variant="ghost" size="sm"
+                      className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                      onClick={() => handleDeleteAnnouncement(ann.id)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -507,3 +507,15 @@ export interface HistoryResponse {
   limit: number;
   offset: number;
 }
+
+export interface SystemAnnouncement {
+  id: number;
+  title: string;
+  body: string;
+  type: 'info' | 'warning' | 'success';
+  is_active: boolean;
+  link_text: string | null;
+  link_url: string | null;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary

Implements #237. Admins can create site-wide dismissible notification banners from the Admin page. All authenticated users see active banners at the top of every page.

## What's included

**Backend**
- `SystemAnnouncement` table: `title`, `body`, `type` (info/warning/success), `is_active`, optional `link_text`/`link_url`
- `GET /api/announcements` — all authenticated users, returns active banners
- `POST /api/admin/announcements` — admin only, create
- `PATCH /api/admin/announcements/{id}` — admin only, update (toggle active, edit fields)
- `DELETE /api/admin/announcements/{id}` — admin only, delete

**Frontend**
- `SystemAnnouncement` type in `web/src/types/api.ts`
- `SystemBanner` component: type-coloured (cobalt/amber/green), dismissible via localStorage (won't reappear after reload)
- Rendered above page content in `Layout.tsx` for all authenticated routes
- Admin page: create form (title, body, type, optional link) + list with activate/deactivate and delete buttons

## First use

After deployment: go to Admin → System Announcements → create the backfill notification for the activity_samples feature.

## Test plan

- [x] 5 backend tests: create/list, non-admin blocked (403), deactivate hides from users, delete, invalid type rejected
- [x] Full suite: 625 passed, same 8 pre-existing failures

Closes #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)