### PR TITLE
Per-second activity stream ingestion and analysis (activity_samples)

### DIFF
--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -380,6 +380,33 @@ def load_data_from_db(user_id: str, db: Session) -> dict[str, pd.DataFrame]:
     }
 
 
+def load_activity_samples(
+    user_id: str,
+    db,
+    activity_ids: list[str] | None = None,
+) -> pd.DataFrame:
+    """Load per-second stream samples from activity_samples for analysis.
+
+    Returns a DataFrame with columns: activity_id, t_sec, power_watts,
+    hr_bpm, pace_sec_km, source. Columns not populated by a given connector
+    will be present but NaN.
+
+    If activity_ids is provided, only samples for those activities are
+    returned — pass the recent activity IDs from the loaded activities
+    DataFrame to avoid loading all historical samples on every request.
+    """
+    df = pd.read_sql(
+        "SELECT activity_id, t_sec, power_watts, hr_bpm, pace_sec_km, source "
+        "FROM activity_samples WHERE user_id = :uid",
+        db.bind,
+        params={"uid": user_id},
+    )
+    if activity_ids is not None and not df.empty:
+        ids_set = {str(a) for a in activity_ids}
+        df = df[df["activity_id"].astype(str).isin(ids_set)]
+    return df
+
+
 def _pivot_fitness(raw: pd.DataFrame) -> pd.DataFrame:
     """Pivot fitness_data rows into a wide DataFrame with one column per metric."""
     if raw.empty:

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -920,10 +920,13 @@ def diagnose_training(
     zone_names: list[str] | None = None,
     target_distribution: list[float] | None = None,
     theory_name: str | None = None,
+    samples: pd.DataFrame | None = None,
 ) -> dict:
     """Analyze recent training and diagnose issues holding back threshold progression.
 
-    Uses split-level data for accurate intensity analysis. Supports power, HR, and pace bases.
+    Uses per-second stream samples when available for 1-second zone resolution;
+    falls back to split-level duration weighting for activities without samples.
+    Supports power, HR, and pace bases.
 
     Args:
         merged_activities: merged activity data
@@ -937,6 +940,8 @@ def diagnose_training(
         zone_names: names for each zone (must be len(boundaries)+1); defaults per base
         target_distribution: target fraction for each zone (must sum to ~1.0); optional
         theory_name: name of the zone theory (e.g. "Seiler Polarized 3-Zone"); optional
+        samples: per-second stream DataFrame with columns activity_id, power_watts,
+            hr_bpm, pace_sec_km (from activity_samples table); optional
     """
     today = current_date or date.today()
     cutoff = today - timedelta(weeks=lookback_weeks)
@@ -1090,6 +1095,7 @@ def diagnose_training(
     splits_copy[metric_col] = pd.to_numeric(splits_copy[metric_col], errors="coerce")
     splits_copy["duration_sec"] = pd.to_numeric(splits_copy["duration_sec"], errors="coerce")
 
+    recent_ids: set[str] = set()
     if "activity_id" in splits_copy.columns and "activity_id" in recent.columns:
         recent_ids = set(recent["activity_id"].astype(str).values)
         splits_copy["_aid"] = splits_copy["activity_id"].astype(str)
@@ -1182,20 +1188,56 @@ def diagnose_training(
                 return i + 1
         return 0
 
-    # Time-in-zone from split durations. Target distributions (Coggan /
-    # Seiler 2006 / Filipas 2022) are defined as fraction of training TIME
-    # in each zone. Classifying each activity by its peak split and then
-    # counting activities per zone inflates higher zones whenever the
-    # athlete does any short stride or interval, which made the displayed
-    # distribution nonsensical for mixed easy + interval weeks.
+    # Time-in-zone computation. Target distributions (Coggan / Seiler 2006 /
+    # Filipas 2022) are fractions of training TIME per zone.
     #
-    # metric_col / duration_sec were coerced to numeric on splits_copy above
-    # before recent_splits was sliced out, so values read back as floats or
-    # NaN without re-coercing here.
+    # When per-second samples are available (activity_samples table), each row
+    # contributes 1 second to the zone it falls in — giving true 1-second
+    # resolution. For activities without samples, the split-duration fallback
+    # is used: each split's average metric is classified and its full duration
+    # added to that zone. The two paths are mixed per-activity so newly synced
+    # activities get full resolution immediately while historical ones still
+    # contribute via splits.
+
+    # Column names in the samples DataFrame per training base
+    _SAMPLE_COL = {"power": "power_watts", "hr": "hr_bpm", "pace": "pace_sec_km"}
+    sample_col = _SAMPLE_COL.get(base, "power_watts")
+
+    # Determine which recent activities have samples available
+    aids_with_samples: set[str] = set()
+    recent_samples_filtered = pd.DataFrame()
+    if (
+        samples is not None
+        and not samples.empty
+        and sample_col in samples.columns
+        and "activity_id" in samples.columns
+    ):
+        s = samples.copy()
+        s[sample_col] = pd.to_numeric(s[sample_col], errors="coerce")
+        s = s[s["activity_id"].astype(str).isin(recent_ids)]
+        s = s[s[sample_col].notna() & (s[sample_col] > 0)]
+        if not s.empty:
+            recent_samples_filtered = s
+            aids_with_samples = set(s["activity_id"].astype(str).unique())
+
     zone_time = [0.0] * n_zones
     total_time = 0.0
+
+    # Per-second path: 1 second per sample row
+    if not recent_samples_filtered.empty:
+        for _, srow in recent_samples_filtered.iterrows():
+            val = float(srow[sample_col])
+            aid = str(srow.get("activity_id", ""))
+            act_cp = _cp_by_aid.get(aid, current_cp)
+            zone_time[_classify(val, act_cp)] += 1
+            total_time += 1
+
+    # Split-duration fallback for activities that have no samples
     if not recent_splits.empty:
-        for _, srow in recent_splits.iterrows():
+        fallback_splits = recent_splits[
+            ~recent_splits["activity_id"].astype(str).isin(aids_with_samples)
+        ] if aids_with_samples else recent_splits
+        for _, srow in fallback_splits.iterrows():
             val = srow.get(metric_col)
             dur = srow.get("duration_sec")
             if pd.isna(val) or pd.isna(dur) or val <= 0 or dur <= 0:
@@ -1204,6 +1246,8 @@ def diagnose_training(
             act_cp = _cp_by_aid.get(aid, current_cp)
             zone_time[_classify(float(val), act_cp)] += float(dur)
             total_time += float(dur)
+
+    resolution = "samples" if aids_with_samples else "splits"
 
     if total_time > 0:
         result["distribution"] = [
@@ -1220,6 +1264,7 @@ def diagnose_training(
             for i in range(n_zones)
         ]
 
+    result["data_meta"] = {"distribution_resolution": resolution}
     result["zone_ranges"] = compute_zones(base, current_cp, bounds, names if zone_names else None)
     result["theory_name"] = theory_name or ("Coggan 5-Zone" if len(bounds) == 4 else f"{n_zones}-Zone")
 

--- a/api/deps.py
+++ b/api/deps.py
@@ -1224,6 +1224,7 @@ def _build_warnings(
 def _compute_diagnosis(
     merged: pd.DataFrame, splits: pd.DataFrame,
     cp_trend_data: dict, config, thresholds, science: dict,
+    samples: pd.DataFrame | None = None,
 ) -> dict:
     """Run zone-aware training diagnosis."""
     if config.training_base == "power":
@@ -1255,6 +1256,7 @@ def _compute_diagnosis(
         zone_names=zone_names_list,
         target_distribution=target_dist,
         theory_name=zone_theory_name,
+        samples=samples,
     )
 
 
@@ -1466,9 +1468,21 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
     sleep_perf = _build_sleep_perf(merged, recovery, config.training_base)
     warnings = _build_warnings(recovery_analysis, current_tsb, config, data_dir=data_dir, latest_cp_watts=latest_cp_watts)
 
-    # Diagnosis
+    # Diagnosis — use per-second samples when available for 1s zone resolution
     splits = data["splits"]
-    diagnosis = _compute_diagnosis(merged, splits, cp_trend_data, config, thresholds, science)
+    samples = pd.DataFrame()
+    if user_id and db:
+        from analysis.data_loader import load_activity_samples
+        # Load samples only for recent activities to avoid reading all history
+        _lookback_cutoff = today - timedelta(weeks=8)
+        if not merged.empty and "activity_id" in merged.columns and "date" in merged.columns:
+            _recent_aids = list(
+                merged[pd.to_datetime(merged["date"]).dt.date >= _lookback_cutoff]["activity_id"]
+                .astype(str).unique()
+            )
+            if _recent_aids:
+                samples = load_activity_samples(user_id, db, _recent_aids)
+    diagnosis = _compute_diagnosis(merged, splits, cp_trend_data, config, thresholds, science, samples=samples)
 
     # Activities for history
     activities_list = _build_activities_list(merged, splits)

--- a/api/main.py
+++ b/api/main.py
@@ -149,6 +149,9 @@ app.include_router(wechat_auth_router, prefix="/api")
 from api.routes.admin import router as admin_router
 app.include_router(admin_router, prefix="/api", tags=["admin"])
 
+from api.routes.announcements import router as announcements_router
+app.include_router(announcements_router, prefix="/api", tags=["announcements"])
+
 # Data routes
 from api.routes import today, training, goal, history, plan, settings, sync, science, insights
 from api.routes import ai as ai_routes

--- a/api/packs.py
+++ b/api/packs.py
@@ -134,6 +134,27 @@ class RequestContext:
         return self._data["splits"]
 
     @cached_property
+    def samples(self) -> pd.DataFrame:
+        """Per-second stream samples for recent activities (last 8 weeks).
+
+        Returns an empty DataFrame when the activity_samples table has no rows
+        for this user — gracefully degrades to split-based zone analysis.
+        """
+        from analysis.data_loader import load_activity_samples
+        from datetime import timedelta
+        cutoff = self.today - timedelta(weeks=8)
+        merged = self.merged_activities
+        if merged.empty or "activity_id" not in merged.columns or "date" not in merged.columns:
+            return pd.DataFrame()
+        recent_aids = list(
+            merged[pd.to_datetime(merged["date"]).dt.date >= cutoff]["activity_id"]
+            .astype(str).unique()
+        )
+        if not recent_aids:
+            return pd.DataFrame()
+        return load_activity_samples(self.user_id, self.db, recent_aids)
+
+    @cached_property
     def recovery(self) -> pd.DataFrame:
         return self._data["recovery"]
 
@@ -483,6 +504,7 @@ def get_diagnosis_pack(ctx: RequestContext) -> dict:
         "diagnosis": _compute_diagnosis(
             ctx.merged_activities, ctx.splits, cp_trend,
             ctx.config, ctx.thresholds, ctx.science,
+            samples=ctx.samples,
         ),
         "workout_flags": _build_workout_flags(
             ctx.merged_activities, ctx.recovery, ctx.config.training_base,

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -11,18 +11,10 @@ from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user_id
-from api.views import utc_isoformat
+from api.views import utc_isoformat, require_admin as _require_admin
 from db.session import get_db
 
 router = APIRouter(prefix="/admin")
-
-
-def _require_admin(user_id: str, db: Session) -> None:
-    """Raise 403 if user is not a superuser."""
-    from db.models import User
-    user = db.query(User).filter(User.id == user_id).first()
-    if not user or not user.is_superuser:
-        raise HTTPException(403, "Admin access required")
 
 
 def _generate_code() -> str:

--- a/api/routes/announcements.py
+++ b/api/routes/announcements.py
@@ -1,0 +1,152 @@
+"""System announcement endpoints — site-wide notification banners.
+
+GET /api/announcements        — all authenticated users; returns active banners
+POST /api/admin/announcements — admin only; create
+PATCH /api/admin/announcements/{id} — admin only; update
+DELETE /api/admin/announcements/{id} — admin only; delete
+"""
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from api.auth import get_current_user_id
+from api.views import utc_isoformat, require_admin
+from db.session import get_db
+
+router = APIRouter()
+
+
+def _serialize(ann) -> dict:
+    """Serialize a SystemAnnouncement ORM row to a response dict."""
+    return {
+        "id": ann.id,
+        "title": ann.title,
+        "body": ann.body,
+        "type": ann.type,
+        "is_active": ann.is_active,
+        "link_text": ann.link_text,
+        "link_url": ann.link_url,
+        "created_at": utc_isoformat(ann.created_at),
+        "updated_at": utc_isoformat(ann.updated_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public — all authenticated users
+# ---------------------------------------------------------------------------
+
+@router.get("/announcements")
+def get_announcements(
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """Return all active system announcements."""
+    from db.models import SystemAnnouncement
+    rows = (
+        db.query(SystemAnnouncement)
+        .filter(SystemAnnouncement.is_active == True)  # noqa: E712
+        .order_by(SystemAnnouncement.created_at.desc())
+        .all()
+    )
+    return [_serialize(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Admin CRUD
+# ---------------------------------------------------------------------------
+
+class AnnouncementCreate(BaseModel):
+    """Payload for creating a system announcement."""
+    title: str
+    body: str
+    type: str = "info"
+    is_active: bool = True
+    link_text: str | None = None
+    link_url: str | None = None
+
+
+class AnnouncementUpdate(BaseModel):
+    """Partial update payload — all fields optional."""
+    title: str | None = None
+    body: str | None = None
+    type: str | None = None
+    is_active: bool | None = None
+    link_text: str | None = None
+    link_url: str | None = None
+
+
+@router.post("/admin/announcements")
+def create_announcement(
+    payload: AnnouncementCreate,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Create a system announcement. Admin only."""
+    require_admin(user_id, db)
+    from db.models import SystemAnnouncement
+    if payload.type not in ("info", "warning", "success"):
+        raise HTTPException(422, "type must be info, warning, or success")
+    ann = SystemAnnouncement(
+        title=payload.title,
+        body=payload.body,
+        type=payload.type,
+        is_active=payload.is_active,
+        link_text=payload.link_text,
+        link_url=payload.link_url,
+    )
+    db.add(ann)
+    db.commit()
+    db.refresh(ann)
+    return _serialize(ann)
+
+
+@router.patch("/admin/announcements/{ann_id}")
+def update_announcement(
+    ann_id: int,
+    payload: AnnouncementUpdate,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Update a system announcement. Admin only."""
+    require_admin(user_id, db)
+    from db.models import SystemAnnouncement
+    ann = db.query(SystemAnnouncement).filter(SystemAnnouncement.id == ann_id).first()
+    if not ann:
+        raise HTTPException(404, "Announcement not found")
+    if payload.title is not None:
+        ann.title = payload.title
+    if payload.body is not None:
+        ann.body = payload.body
+    if payload.type is not None:
+        if payload.type not in ("info", "warning", "success"):
+            raise HTTPException(422, "type must be info, warning, or success")
+        ann.type = payload.type
+    if payload.is_active is not None:
+        ann.is_active = payload.is_active
+    if payload.link_text is not None:
+        ann.link_text = payload.link_text
+    if payload.link_url is not None:
+        ann.link_url = payload.link_url
+    ann.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(ann)
+    return _serialize(ann)
+
+
+@router.delete("/admin/announcements/{ann_id}")
+def delete_announcement(
+    ann_id: int,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Delete a system announcement. Admin only."""
+    require_admin(user_id, db)
+    from db.models import SystemAnnouncement
+    ann = db.query(SystemAnnouncement).filter(SystemAnnouncement.id == ann_id).first()
+    if not ann:
+        raise HTTPException(404, "Announcement not found")
+    db.delete(ann)
+    db.commit()
+    return {"deleted": ann_id}

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -374,7 +374,7 @@ def _login_garmin_with_cn_fallback(client, creds: dict, token_dir: str) -> None:
        (``"Invalid Username or Password"``) bubbling up.
     """
     import contextlib
-    from garminconnect.exceptions import GarminConnectAuthenticationError
+    from garminconnect import GarminConnectAuthenticationError
 
     if getattr(client, "is_cn", False):
         _patch_cn_di_exchange(client.client)

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -760,10 +760,13 @@ def _sync_stryd(user_id: str, creds: dict, from_date: str | None,
             row["activity_id"] = f"stryd_{row.get('date', '')}_{row.get('start_time', '')}"
     act_count = sync_writer.write_activities(user_id, activity_rows, db)
 
-    # Fetch per-activity splits (lap-level power data from activity detail API)
+    # Fetch per-activity splits and per-second samples from the activity detail API.
+    # fetch_activity_splits returns both from a single API call — samples are the
+    # raw per-second arrays that were previously discarded after lap averaging.
     import time as time_mod
     from sync.stryd_sync import fetch_activity_splits
     all_splits = []
+    all_samples = []
     for idx, raw_act in enumerate(_raw):
         act_id = raw_act.get("id")
         if not act_id:
@@ -771,12 +774,15 @@ def _sync_stryd(user_id: str, creds: dict, from_date: str | None,
         with _sync_lock:
             status["stryd"]["progress"] = f"Fetching splits: {idx + 1}/{total}"
         try:
-            splits = fetch_activity_splits(str(act_id), token)
+            splits, samples = fetch_activity_splits(str(act_id), token)
             all_splits.extend(splits)
+            all_samples.extend(samples)
             time_mod.sleep(0.3)  # Rate limit
         except Exception as e:
             logger.debug("Stryd splits for %s: skipped (%s)", act_id, e)
     split_count = sync_writer.write_splits(user_id, all_splits, db)
+    sample_count = sync_writer.write_samples(user_id, all_samples, db)
+    logger.debug("Stryd sync: %d splits, %d samples written", split_count, sample_count)
 
     # CP estimates → fitness_data table (for threshold auto-detection)
     from db.models import FitnessData

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -405,9 +405,10 @@ def _sync_garmin(user_id: str, creds: dict, from_date: str | None,
     from db import sync_writer
     from garminconnect import Garmin
     from sync.garmin_sync import (
-        parse_activities, parse_splits, parse_daily_metrics,
-        parse_lactate_threshold, parse_user_profile, parse_heart_rates,
-        parse_running_ftp, RATE_LIMIT_DELAY,
+        parse_activities, parse_splits, parse_activity_stream,
+        parse_daily_metrics, parse_lactate_threshold, parse_user_profile,
+        parse_heart_rates, parse_running_ftp, RATE_LIMIT_DELAY,
+        GARMIN_MAX_CHART_SIZE,
     )
     import time
 
@@ -508,6 +509,30 @@ def _sync_garmin(user_id: str, creds: dict, from_date: str | None,
             split_failures, total, user_id,
         )
     split_count = sync_writer.write_splits(user_id, all_splits, db)
+
+    # Fetch per-second streams and write to activity_samples. One extra API
+    # call per activity (get_activity_details). Rate-limited the same as splits.
+    # Power is not available in the Garmin stream for ConnectIQ-based devices
+    # (Stryd pod) — it only surfaces in lap splits via the CIQ developer field.
+    all_samples = []
+    stream_failures = 0
+    for idx, aid in enumerate(activity_ids):
+        with _sync_lock:
+            status["garmin"]["progress"] = f"Fetching streams: {idx + 1}/{total}"
+        try:
+            details = client.get_activity_details(aid, maxchart=GARMIN_MAX_CHART_SIZE) or {}
+            all_samples.extend(parse_activity_stream(aid, details))
+            time.sleep(RATE_LIMIT_DELAY)
+        except Exception as e:
+            stream_failures += 1
+            logger.debug("Stream for %s: skipped (%s)", aid, e)
+    if total and stream_failures >= max(3, total // 2):
+        logger.warning(
+            "Garmin stream fetch failed for %d of %d activities (user %s)",
+            stream_failures, total, user_id,
+        )
+    sample_count = sync_writer.write_samples(user_id, all_samples, db)
+    logger.debug("Garmin sync: %d splits, %d samples written", split_count, sample_count)
 
     # Lactate threshold. Log at warning so intermittent failures surface
     # instead of vanishing at debug level — the previous behaviour silently

--- a/api/views.py
+++ b/api/views.py
@@ -8,6 +8,19 @@ from datetime import date, datetime, timezone
 import pandas as pd
 
 
+def require_admin(user_id: str, db) -> None:
+    """Raise HTTP 403 if the user is not a superuser.
+
+    Shared guard used by admin-only routes in api/routes/admin.py and
+    api/routes/announcements.py. Lives here per the shared-helpers convention.
+    """
+    from fastapi import HTTPException
+    from db.models import User
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user or not user.is_superuser:
+        raise HTTPException(403, "Admin access required")
+
+
 def utc_isoformat(dt: datetime | None) -> str | None:
     """Serialize a UTC datetime as an ISO-8601 string with a UTC offset.
 

--- a/db/models.py
+++ b/db/models.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from sqlalchemy import (
     CheckConstraint,
     Column,
+    Index,
     String,
     Float,
     Integer,
@@ -169,6 +170,60 @@ class ActivitySplit(Base):
     avg_pace_sec_km = Column(Float, nullable=True)
     avg_cadence = Column(Float, nullable=True)
     elevation_change_m = Column(Float, nullable=True)
+
+
+class ActivitySample(Base):
+    """Per-second time-series data for an activity.
+
+    One row per second per activity. Columns cover the union of all connector
+    field sets; connector-specific fields are NULL for other sources. The
+    unique constraint on (activity_id, t_sec) makes re-syncs idempotent —
+    duplicate writes are silently ignored via INSERT OR IGNORE.
+
+    Storage estimate: ~3,600 rows/hour of running. At SQLite scale for
+    personal use this is negligible; multi-user growth is managed by the
+    user_id index enabling efficient per-user pruning.
+    """
+
+    __tablename__ = "activity_samples"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
+    activity_id = Column(String(100), nullable=False)
+    source = Column(String(20), nullable=False)  # stryd | garmin | coros | strava
+
+    # Seconds since epoch — the time axis for all other fields
+    t_sec = Column(Integer, nullable=False)
+
+    # Core — present across all connectors
+    power_watts = Column(Float, nullable=True)
+    hr_bpm = Column(Float, nullable=True)
+    speed_ms = Column(Float, nullable=True)
+    pace_sec_km = Column(Float, nullable=True)
+    cadence_spm = Column(Float, nullable=True)
+    altitude_m = Column(Float, nullable=True)
+    distance_m = Column(Float, nullable=True)  # cumulative from activity start
+
+    # GPS — Garmin, Strava, COROS
+    lat = Column(Float, nullable=True)
+    lng = Column(Float, nullable=True)
+    grade_pct = Column(Float, nullable=True)
+    temperature_c = Column(Float, nullable=True)
+
+    # Stryd running dynamics
+    ground_time_ms = Column(Float, nullable=True)
+    oscillation_mm = Column(Float, nullable=True)
+    leg_spring_kn_m = Column(Float, nullable=True)
+    vertical_ratio = Column(Float, nullable=True)
+    form_power_watts = Column(Float, nullable=True)
+
+    # Garmin-specific
+    respiration_rate = Column(Float, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "activity_id", "t_sec", name="uq_sample_user_activity_t"),
+        Index("ix_sample_activity", "activity_id"),
+    )
 
 
 class RecoveryData(Base):

--- a/db/models.py
+++ b/db/models.py
@@ -390,3 +390,25 @@ class TrainingPlan(Base):
             "user_id", "date", "source", "workout_type", name="uq_user_date_plan"
         ),
     )
+
+
+class SystemAnnouncement(Base):
+    """Admin-configurable site-wide notification banners.
+
+    Active announcements are returned by GET /api/announcements to all
+    authenticated users and rendered as dismissible banners in the web UI.
+    Dismissed banner IDs are stored client-side (localStorage) so they
+    don't re-appear after reload without server-side per-user tracking.
+    """
+
+    __tablename__ = "system_announcements"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    title = Column(String(200), nullable=False)
+    body = Column(Text, nullable=False)
+    type = Column(String(20), default="info", nullable=False)  # info | warning | success
+    is_active = Column(Boolean, default=True, nullable=False)
+    link_text = Column(String(100), nullable=True)
+    link_url = Column(String(500), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/db/models.py
+++ b/db/models.py
@@ -177,7 +177,7 @@ class ActivitySample(Base):
 
     One row per second per activity. Columns cover the union of all connector
     field sets; connector-specific fields are NULL for other sources. The
-    unique constraint on (activity_id, t_sec) makes re-syncs idempotent —
+    unique constraint on (user_id, activity_id, t_sec) makes re-syncs idempotent —
     duplicate writes are silently ignored via INSERT OR IGNORE.
 
     Storage estimate: ~3,600 rows/hour of running. At SQLite scale for

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -523,7 +523,7 @@ _SAMPLE_BATCH_SIZE = 500
 def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
     """Upsert per-second activity samples. Returns count of rows written.
 
-    Uses INSERT OR IGNORE keyed on (activity_id, t_sec) so re-syncing an
+    Uses INSERT OR IGNORE keyed on (user_id, activity_id, t_sec) so re-syncing an
     activity is idempotent — existing rows are left untouched. Inserts are
     batched to avoid oversized transactions for long activities.
     """

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -9,7 +9,7 @@ from datetime import date, datetime
 from sqlalchemy.orm import Session
 
 from db.cache_revision import bump_revisions
-from db.models import Activity, ActivitySplit, RecoveryData, FitnessData, TrainingPlan
+from db.models import Activity, ActivitySample, ActivitySplit, RecoveryData, FitnessData, TrainingPlan
 
 logger = logging.getLogger(__name__)
 
@@ -515,6 +515,63 @@ def write_lactate_threshold(user_id: str, rows: list[dict], db: Session) -> int:
     if count > 0:
         bump_revisions(db, user_id, ["fitness"])
     return count
+
+
+_SAMPLE_BATCH_SIZE = 500
+
+
+def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
+    """Upsert per-second activity samples. Returns count of rows written.
+
+    Uses INSERT OR IGNORE keyed on (activity_id, t_sec) so re-syncing an
+    activity is idempotent — existing rows are left untouched. Inserts are
+    batched to avoid oversized transactions for long activities.
+    """
+    if not rows:
+        return 0
+
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+    total = 0
+    for batch_start in range(0, len(rows), _SAMPLE_BATCH_SIZE):
+        batch = rows[batch_start : batch_start + _SAMPLE_BATCH_SIZE]
+        records = []
+        for row in batch:
+            t = row.get("t_sec")
+            aid = row.get("activity_id")
+            if t is None or not aid:
+                continue
+            speed = _float(row.get("speed_ms"))
+            records.append({
+                "user_id": user_id,
+                "activity_id": str(aid),
+                "source": str(row.get("source", "")),
+                "t_sec": int(t),
+                "power_watts": _float(row.get("power_watts")),
+                "hr_bpm": _float(row.get("hr_bpm")),
+                "speed_ms": speed,
+                "pace_sec_km": round(1000.0 / speed, 2) if speed and speed > 0 else _float(row.get("pace_sec_km")),
+                "cadence_spm": _float(row.get("cadence_spm")),
+                "altitude_m": _float(row.get("altitude_m")),
+                "distance_m": _float(row.get("distance_m")),
+                "lat": _float(row.get("lat")),
+                "lng": _float(row.get("lng")),
+                "grade_pct": _float(row.get("grade_pct")),
+                "temperature_c": _float(row.get("temperature_c")),
+                "ground_time_ms": _float(row.get("ground_time_ms")),
+                "oscillation_mm": _float(row.get("oscillation_mm")),
+                "leg_spring_kn_m": _float(row.get("leg_spring_kn_m")),
+                "vertical_ratio": _float(row.get("vertical_ratio")),
+                "form_power_watts": _float(row.get("form_power_watts")),
+                "respiration_rate": _float(row.get("respiration_rate")),
+            })
+        if not records:
+            continue
+        stmt = sqlite_insert(ActivitySample).values(records)
+        stmt = stmt.on_conflict_do_nothing(index_elements=["user_id", "activity_id", "t_sec"])
+        result = db.execute(stmt)
+        total += result.rowcount
+    return total
 
 
 def write_training_plan(user_id: str, rows: list[dict], source: str,

--- a/sync/garmin_sync.py
+++ b/sync/garmin_sync.py
@@ -164,6 +164,88 @@ def parse_splits(activity_id: str, splits_data: dict) -> list[dict]:
     return rows
 
 
+# maxChartSize to pass to get_activity_details(). Garmin samples at ~2s
+# intervals, so a 100-mile ultra (~28h) produces ~50,400 rows. 100,000
+# covers any conceivable endurance event with a large safety margin.
+# The API response includes totalMetricsCount so truncation is detectable.
+GARMIN_MAX_CHART_SIZE = 100_000
+
+
+def parse_activity_stream(activity_id: str, details: dict) -> list[dict]:
+    """Parse per-sample stream data from get_activity_details() into sample dicts.
+
+    Garmin returns activityDetailMetrics as a list of rows, each containing a
+    metrics array indexed by metricDescriptors. Field names and their positions
+    vary by device model, so the index map is built dynamically from descriptors.
+
+    Timestamps are in milliseconds; sampling is typically every 2 seconds
+    (half the row count of a 1Hz Stryd stream for the same activity duration).
+    Power is not available in the stream for ConnectIQ-based devices — it only
+    appears in lap splits via the CIQ developer field.
+
+    Returns an empty list and logs a warning when the response was truncated
+    (metricsCount < totalMetricsCount), which would indicate GARMIN_MAX_CHART_SIZE
+    needs to be raised.
+    """
+    import logging as _log
+    _logger = _log.getLogger(__name__)
+
+    descriptors = details.get("metricDescriptors") or []
+    rows = details.get("activityDetailMetrics") or []
+    if not descriptors or not rows:
+        return []
+
+    metrics_count = details.get("metricsCount") or len(rows)
+    total_metrics_count = details.get("totalMetricsCount") or len(rows)
+    if metrics_count < total_metrics_count:
+        _logger.warning(
+            "Garmin stream truncated for activity %s: got %d of %d rows "
+            "(raise GARMIN_MAX_CHART_SIZE above %d)",
+            activity_id, metrics_count, total_metrics_count, GARMIN_MAX_CHART_SIZE,
+        )
+
+    key_idx: dict[str, int] = {
+        m["key"]: m["metricsIndex"]
+        for m in descriptors
+        if "key" in m and "metricsIndex" in m
+    }
+
+    ts_idx = key_idx.get("directTimestamp")
+    if ts_idx is None:
+        return []
+
+    def _val(metrics: list, key: str) -> float | None:
+        idx = key_idx.get(key)
+        if idx is None or idx >= len(metrics):
+            return None
+        v = metrics[idx]
+        return float(v) if v is not None else None
+
+    samples = []
+    for row in rows:
+        metrics = row.get("metrics") or []
+        if ts_idx >= len(metrics) or metrics[ts_idx] is None:
+            continue
+        speed = _val(metrics, "directSpeed")
+        samples.append({
+            "activity_id": str(activity_id),
+            "source": "garmin",
+            "t_sec": int(metrics[ts_idx] / 1000),
+            "hr_bpm": _val(metrics, "directHeartRate"),
+            "cadence_spm": _val(metrics, "directDoubleCadence"),
+            "speed_ms": speed,
+            "altitude_m": _val(metrics, "directElevation"),
+            "distance_m": _val(metrics, "sumDistance"),
+            "lat": _val(metrics, "directLatitude"),
+            "lng": _val(metrics, "directLongitude"),
+            "ground_time_ms": _val(metrics, "directGroundContactTime"),
+            "oscillation_mm": _val(metrics, "directVerticalOscillation"),
+            "vertical_ratio": _val(metrics, "directVerticalRatio"),
+        })
+
+    return samples
+
+
 def parse_user_profile(profile: dict | None) -> dict:
     """Extract LTHR and (when present) max HR from Garmin user profile.
 

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -107,11 +107,13 @@ def fetch_activity_splits(
     ts_list = data.get("timestamp_list", [])
     cadence_list = data.get("cadence_list", [])
     elevation_list = data.get("elevation_list", [])
+    grade_list = data.get("grade_list", [])
+    loc_list = data.get("loc_list", [])
+    temperature_list = data.get("temperature_device_list", [])
     ground_time_list = data.get("ground_time_list", [])
     oscillation_list = data.get("oscillation_list", [])
     leg_spring_list = data.get("leg_spring_list", [])
-    vertical_ratio_list = data.get("vertical_oscillation_ratio_list", [])
-    form_power_list = data.get("form_power_list", [])
+    vertical_ratio_list = data.get("vertical_ratio_list", [])
 
     lap_events = data.get("lap_events", [])
     start_events = data.get("start_events", [])
@@ -121,7 +123,10 @@ def fetch_activity_splits(
         return [], []
 
     start_ts = start_events[0] if start_events else ts_list[0]
-    end_ts = stop_events[0] if stop_events else ts_list[-1]
+    # Use the last stop event — for paused/resumed activities stop_events has
+    # one entry per pause; [0] would clip at the first pause and discard all
+    # samples after the resume.
+    end_ts = stop_events[-1] if stop_events else ts_list[-1]
 
     # Build lap boundaries: [start, lap1, lap2, ..., end]
     boundaries = [start_ts] + lap_events + [end_ts]
@@ -185,6 +190,7 @@ def fetch_activity_splits(
     for i, t in enumerate(ts_list):
         if t < start_ts or t > end_ts:
             continue
+        loc = _at(loc_list, i)
         samples.append({
             "activity_id": str(activity_id),
             "source": "stryd",
@@ -195,11 +201,14 @@ def fetch_activity_splits(
             "cadence_spm": _at(cadence_list, i),
             "altitude_m": _at(elevation_list, i),
             "distance_m": _at(distance_list, i),
+            "lat": loc["Lat"] if isinstance(loc, dict) else None,
+            "lng": loc["Lng"] if isinstance(loc, dict) else None,
+            "grade_pct": _at(grade_list, i),
+            "temperature_c": _at(temperature_list, i),
             "ground_time_ms": _at(ground_time_list, i),
             "oscillation_mm": _at(oscillation_list, i),
             "leg_spring_kn_m": _at(leg_spring_list, i),
             "vertical_ratio": _at(vertical_ratio_list, i),
-            "form_power_watts": _at(form_power_list, i),
         })
 
     return splits, samples

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -80,14 +80,16 @@ def fetch_current_cp(user_id: str, token: str) -> float | None:
 def fetch_activity_splits(
     activity_id: str,
     token: str,
-) -> list[dict]:
-    """Fetch per-lap splits from a Stryd activity detail.
+) -> tuple[list[dict], list[dict]]:
+    """Fetch per-lap splits and per-second samples from a Stryd activity detail.
 
-    Uses the activity's lap_events timestamps and per-second time series
-    (total_power_list, heart_rate_list, speed_list, distance_list) to
-    compute per-lap averages.
+    Returns (splits, samples):
+    - splits: per-lap averages compatible with sync_writer.write_splits()
+    - samples: per-second rows compatible with sync_writer.write_samples()
 
-    Returns list of split dicts compatible with sync_writer.write_splits().
+    Both are derived from the same API call — the per-second arrays are
+    already fetched to compute lap averages; this function preserves them
+    instead of discarding after averaging.
     """
     url = STRYD_ACTIVITY_API.format(activity_id=activity_id)
     resp = requests.get(
@@ -103,16 +105,25 @@ def fetch_activity_splits(
     speed_list = data.get("speed_list", [])
     distance_list = data.get("distance_list", [])
     ts_list = data.get("timestamp_list", [])
+    cadence_list = data.get("cadence_list", [])
+    elevation_list = data.get("elevation_list", [])
+    ground_time_list = data.get("ground_time_list", [])
+    oscillation_list = data.get("oscillation_list", [])
+    leg_spring_list = data.get("leg_spring_list", [])
+    vertical_ratio_list = data.get("vertical_oscillation_ratio_list", [])
+    form_power_list = data.get("form_power_list", [])
+
     lap_events = data.get("lap_events", [])
     start_events = data.get("start_events", [])
     stop_events = data.get("stop_events", [])
 
     if not ts_list or not power_list:
-        return []
+        return [], []
 
-    # Build lap boundaries: [start, lap1, lap2, ..., end]
     start_ts = start_events[0] if start_events else ts_list[0]
     end_ts = stop_events[0] if stop_events else ts_list[-1]
+
+    # Build lap boundaries: [start, lap1, lap2, ..., end]
     boundaries = [start_ts] + lap_events + [end_ts]
 
     splits = []
@@ -162,7 +173,36 @@ def fetch_activity_splits(
             "avg_pace_min_km": str(avg_pace) if avg_pace else "",
         })
 
-    return splits
+    # Build per-second samples from the same arrays, bounded to the
+    # activity window [start_ts, end_ts] to exclude pre-start padding.
+    def _at(lst: list, i: int):
+        """Return lst[i] or None if out of range or None value."""
+        if lst and i < len(lst):
+            return lst[i]
+        return None
+
+    samples = []
+    for i, t in enumerate(ts_list):
+        if t < start_ts or t > end_ts:
+            continue
+        samples.append({
+            "activity_id": str(activity_id),
+            "source": "stryd",
+            "t_sec": t,
+            "power_watts": _at(power_list, i),
+            "hr_bpm": _at(hr_list, i),
+            "speed_ms": _at(speed_list, i),
+            "cadence_spm": _at(cadence_list, i),
+            "altitude_m": _at(elevation_list, i),
+            "distance_m": _at(distance_list, i),
+            "ground_time_ms": _at(ground_time_list, i),
+            "oscillation_mm": _at(oscillation_list, i),
+            "leg_spring_kn_m": _at(leg_spring_list, i),
+            "vertical_ratio": _at(vertical_ratio_list, i),
+            "form_power_watts": _at(form_power_list, i),
+        })
+
+    return splits, samples
 
 
 def fetch_activities_api(

--- a/tests/test_announcements.py
+++ b/tests/test_announcements.py
@@ -1,0 +1,103 @@
+"""Tests for system announcement endpoints."""
+import tempfile
+import pytest
+
+
+@pytest.fixture
+def db_with_admin(monkeypatch):
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_LOCAL_ENCRYPTION_KEY", "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=")
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+    from db.models import User
+    db = db_session.SessionLocal()
+    admin_id = "admin-ann-test"
+    user_id = "user-ann-test"
+    db.add(User(id=admin_id, email="admin@ann.test", hashed_password="x", is_superuser=True))
+    db.add(User(id=user_id, email="user@ann.test", hashed_password="x", is_superuser=False))
+    db.commit()
+    try:
+        yield db, admin_id, user_id
+    finally:
+        db.close()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def test_create_and_list_announcement(db_with_admin):
+    from api.routes.announcements import create_announcement, get_announcements, AnnouncementCreate
+    db, admin_id, user_id = db_with_admin
+
+    payload = AnnouncementCreate(
+        title="Test banner",
+        body="Please backfill your data.",
+        type="info",
+        link_text="Settings",
+        link_url="/settings",
+    )
+    ann = create_announcement(payload, user_id=admin_id, db=db)
+    assert ann["id"] is not None
+    assert ann["title"] == "Test banner"
+    assert ann["is_active"] is True
+
+    # Regular user can see active announcements
+    visible = get_announcements(user_id=user_id, db=db)
+    assert len(visible) == 1
+    assert visible[0]["title"] == "Test banner"
+
+
+def test_non_admin_cannot_create(db_with_admin):
+    from api.routes.announcements import create_announcement, AnnouncementCreate
+    from fastapi import HTTPException
+    db, admin_id, user_id = db_with_admin
+
+    with pytest.raises(HTTPException) as exc:
+        create_announcement(AnnouncementCreate(title="X", body=""), user_id=user_id, db=db)
+    assert exc.value.status_code == 403
+
+
+def test_deactivate_hides_from_users(db_with_admin):
+    from api.routes.announcements import create_announcement, update_announcement, get_announcements
+    from api.routes.announcements import AnnouncementCreate, AnnouncementUpdate
+    db, admin_id, user_id = db_with_admin
+
+    ann = create_announcement(AnnouncementCreate(title="X", body=""), user_id=admin_id, db=db)
+    update_announcement(ann["id"], AnnouncementUpdate(is_active=False), user_id=admin_id, db=db)
+
+    visible = get_announcements(user_id=user_id, db=db)
+    assert len(visible) == 0
+
+
+def test_delete_announcement(db_with_admin):
+    from api.routes.announcements import create_announcement, delete_announcement, get_announcements
+    from api.routes.announcements import AnnouncementCreate
+    db, admin_id, user_id = db_with_admin
+
+    ann = create_announcement(AnnouncementCreate(title="Gone", body=""), user_id=admin_id, db=db)
+    delete_announcement(ann["id"], user_id=admin_id, db=db)
+
+    visible = get_announcements(user_id=user_id, db=db)
+    assert len(visible) == 0
+
+
+def test_invalid_type_rejected(db_with_admin):
+    from api.routes.announcements import create_announcement, AnnouncementCreate
+    from fastapi import HTTPException
+    db, admin_id, _ = db_with_admin
+
+    with pytest.raises(HTTPException) as exc:
+        create_announcement(
+            AnnouncementCreate(title="X", body="", type="critical"),  # type: ignore
+            user_id=admin_id, db=db,
+        )
+    assert exc.value.status_code == 422

--- a/tests/test_diagnose_with_samples.py
+++ b/tests/test_diagnose_with_samples.py
@@ -1,0 +1,218 @@
+"""Tests for diagnose_training() using per-second activity_samples."""
+import pandas as pd
+import pytest
+from datetime import date, timedelta
+
+from analysis.metrics import diagnose_training
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _activities(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def _splits(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def _samples(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def _today() -> date:
+    return date.today()
+
+
+def _recent(weeks_ago: int = 1) -> str:
+    return (_today() - timedelta(weeks=weeks_ago)).isoformat()
+
+
+def _cp_trend(cp: float = 250.0) -> dict:
+    return {"current": cp, "avg_recent": cp, "direction": "stable",
+            "slope_per_month": 0.0, "months_flat": 3}
+
+
+# ---------------------------------------------------------------------------
+# 1. samples=None falls back to splits (no regression)
+# ---------------------------------------------------------------------------
+
+def test_no_samples_uses_splits():
+    """With samples=None, zone distribution comes from splits unchanged."""
+    today = _today()
+    acts = _activities([{
+        "activity_id": "act-1", "date": _recent(1),
+        "distance_km": 10, "duration_sec": 3600,
+        "avg_power": 200, "source": "stryd",
+    }])
+    sp = _splits([
+        {"activity_id": "act-1", "split_num": 1,
+         "avg_power": 175, "duration_sec": 1800},  # endurance
+        {"activity_id": "act-1", "split_num": 2,
+         "avg_power": 175, "duration_sec": 1800},
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(250), samples=None, threshold_value=250)
+    assert result["distribution"]
+    assert result["data_meta"]["distribution_resolution"] == "splits"
+
+
+# ---------------------------------------------------------------------------
+# 2. samples provided — resolution switches to "samples"
+# ---------------------------------------------------------------------------
+
+def test_samples_resolution_reported():
+    """When samples with valid power exist, resolution is 'samples'."""
+    acts = _activities([{
+        "activity_id": "act-1", "date": _recent(1),
+        "distance_km": 10, "duration_sec": 3600,
+        "avg_power": 200, "source": "stryd",
+    }])
+    sp = _splits([
+        {"activity_id": "act-1", "split_num": 1,
+         "avg_power": 175, "duration_sec": 1800},
+    ])
+    samp = _samples([
+        {"activity_id": "act-1", "t_sec": 1_000_000 + i,
+         "power_watts": 175.0, "hr_bpm": 150.0, "pace_sec_km": None, "source": "stryd"}
+        for i in range(100)
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(250), samples=samp, threshold_value=250)
+    assert result["data_meta"]["distribution_resolution"] == "samples"
+
+
+# ---------------------------------------------------------------------------
+# 3. Samples produce correct zone distribution (all in endurance zone)
+# ---------------------------------------------------------------------------
+
+def test_samples_all_endurance():
+    """100 seconds at 70% CP → 100% endurance zone (Coggan zone 2)."""
+    cp = 250.0
+    acts = _activities([{
+        "activity_id": "act-1", "date": _recent(1),
+        "distance_km": 5, "duration_sec": 100,
+        "avg_power": 175, "source": "stryd",
+    }])
+    # No splits — all zone info from samples
+    sp = _splits([])
+    samp = _samples([
+        {"activity_id": "act-1", "t_sec": 1_000_000 + i,
+         "power_watts": cp * 0.70,  # 175W = 70% CP → endurance
+         "hr_bpm": None, "pace_sec_km": None, "source": "stryd"}
+        for i in range(100)
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(cp), samples=samp, threshold_value=cp)
+    dist = {d["name"]: d["actual_pct"] for d in result["distribution"]}
+    # Zone 1 (recovery) < 55% CP; zone 2 (endurance) 55-75%; 70% → zone 2
+    assert dist.get("Endurance", 0) == 100
+
+
+# ---------------------------------------------------------------------------
+# 4. Mixed: samples for one activity, splits fallback for another
+# ---------------------------------------------------------------------------
+
+def test_mixed_samples_and_splits():
+    """act-1 has samples (endurance); act-2 has only splits (threshold).
+    Both contribute to the distribution correctly.
+    """
+    cp = 250.0
+    acts = _activities([
+        {"activity_id": "act-1", "date": _recent(1),
+         "distance_km": 5, "duration_sec": 1800,
+         "avg_power": 175, "source": "stryd"},
+        {"activity_id": "act-2", "date": _recent(2),
+         "distance_km": 5, "duration_sec": 1800,
+         "avg_power": 240, "source": "garmin"},
+    ])
+    # Splits only for act-2 (threshold zone)
+    sp = _splits([
+        {"activity_id": "act-2", "split_num": 1,
+         "avg_power": 240.0, "duration_sec": 1800},  # 96% CP → threshold
+    ])
+    # Samples only for act-1 (endurance zone), 1800 seconds
+    samp = _samples([
+        {"activity_id": "act-1", "t_sec": 1_000_000 + i,
+         "power_watts": 175.0, "hr_bpm": None, "pace_sec_km": None, "source": "stryd"}
+        for i in range(1800)
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(cp), samples=samp, threshold_value=cp)
+    assert result["data_meta"]["distribution_resolution"] == "samples"
+    dist = {d["name"]: d["actual_pct"] for d in result["distribution"]}
+    # 1800s endurance + 1800s threshold → ~50% each
+    assert dist.get("Endurance", 0) > 0
+    assert dist.get("Threshold", 0) > 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Samples with all-null power column → graceful fallback to splits
+# ---------------------------------------------------------------------------
+
+def test_samples_all_null_power_falls_back_to_splits():
+    """Samples present but power_watts all NaN → falls back to splits path."""
+    cp = 250.0
+    acts = _activities([{
+        "activity_id": "act-1", "date": _recent(1),
+        "distance_km": 5, "duration_sec": 1800,
+        "avg_power": 175, "source": "garmin",
+    }])
+    sp = _splits([
+        {"activity_id": "act-1", "split_num": 1,
+         "avg_power": 175.0, "duration_sec": 1800},
+    ])
+    samp = _samples([
+        {"activity_id": "act-1", "t_sec": 1_000_000 + i,
+         "power_watts": None, "hr_bpm": None, "pace_sec_km": None, "source": "garmin"}
+        for i in range(100)
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(cp), samples=samp, threshold_value=cp)
+    assert result["data_meta"]["distribution_resolution"] == "splits"
+
+
+# ---------------------------------------------------------------------------
+# 6. Empty samples DataFrame → fallback to splits, no crash
+# ---------------------------------------------------------------------------
+
+def test_empty_samples_df_no_crash():
+    """Empty samples DataFrame should not crash and should use splits."""
+    cp = 250.0
+    acts = _activities([{
+        "activity_id": "act-1", "date": _recent(1),
+        "distance_km": 5, "duration_sec": 1800,
+        "avg_power": 175, "source": "stryd",
+    }])
+    sp = _splits([
+        {"activity_id": "act-1", "split_num": 1,
+         "avg_power": 175.0, "duration_sec": 1800},
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(cp),
+                               samples=pd.DataFrame(), threshold_value=cp)
+    assert result["data_meta"]["distribution_resolution"] == "splits"
+    assert result["distribution"]
+
+
+# ---------------------------------------------------------------------------
+# 7. HR base uses hr_bpm column from samples
+# ---------------------------------------------------------------------------
+
+def test_samples_hr_base():
+    """When base='hr', samples use hr_bpm for zone classification."""
+    lthr = 172.0
+    acts = _activities([{
+        "activity_id": "act-1", "date": _recent(1),
+        "distance_km": 5, "duration_sec": 1800,
+        "avg_hr": 145, "source": "garmin",
+    }])
+    sp = _splits([
+        {"activity_id": "act-1", "split_num": 1,
+         "avg_hr": 145.0, "duration_sec": 1800},
+    ])
+    samp = _samples([
+        {"activity_id": "act-1", "t_sec": 1_000_000 + i,
+         "power_watts": None, "hr_bpm": 145.0, "pace_sec_km": None, "source": "garmin"}
+        for i in range(100)
+    ])
+    result = diagnose_training(acts, sp, _cp_trend(lthr), base="hr",
+                               samples=samp, threshold_value=lthr)
+    assert result["data_meta"]["distribution_resolution"] == "samples"
+    assert result["distribution"]

--- a/tests/test_garmin_activity_stream.py
+++ b/tests/test_garmin_activity_stream.py
@@ -1,0 +1,165 @@
+"""Tests for parse_activity_stream() in sync/garmin_sync.py."""
+import pytest
+from sync.garmin_sync import parse_activity_stream
+
+
+def _make_details(
+    n: int = 5,
+    start_ms: int = 1_000_000_000_000,
+    step_ms: int = 2000,
+    include_gps: bool = True,
+    include_dynamics: bool = True,
+) -> dict:
+    """Build a minimal get_activity_details() response with n rows."""
+    descriptors = [
+        {"metricsIndex": 0, "key": "directTimestamp"},
+        {"metricsIndex": 1, "key": "directHeartRate"},
+        {"metricsIndex": 2, "key": "directDoubleCadence"},
+        {"metricsIndex": 3, "key": "directSpeed"},
+        {"metricsIndex": 4, "key": "directElevation"},
+        {"metricsIndex": 5, "key": "sumDistance"},
+        {"metricsIndex": 6, "key": "directLatitude"},
+        {"metricsIndex": 7, "key": "directLongitude"},
+        {"metricsIndex": 8, "key": "directGroundContactTime"},
+        {"metricsIndex": 9, "key": "directVerticalOscillation"},
+        {"metricsIndex": 10, "key": "directVerticalRatio"},
+    ]
+    rows = []
+    for i in range(n):
+        ts = start_ms + i * step_ms
+        metrics = [
+            float(ts),          # 0 directTimestamp (ms)
+            150.0 + i,          # 1 directHeartRate
+            172.0,              # 2 directDoubleCadence
+            3.5,                # 3 directSpeed (m/s)
+            50.0 + i * 0.1,    # 4 directElevation
+            i * 7.0,            # 5 sumDistance (cumulative m)
+            31.18 + i * 0.001 if include_gps else None,  # 6 lat
+            121.25 + i * 0.001 if include_gps else None, # 7 lng
+            260.0 if include_dynamics else None,          # 8 ground_time
+            7.2 if include_dynamics else None,            # 9 oscillation
+            6.8 if include_dynamics else None,            # 10 vertical_ratio
+        ]
+        rows.append({"metrics": metrics})
+    return {"metricDescriptors": descriptors, "activityDetailMetrics": rows}
+
+
+def test_returns_one_sample_per_row():
+    """Each activityDetailMetrics row produces one sample."""
+    details = _make_details(n=10)
+    samples = parse_activity_stream("act-1", details)
+    assert len(samples) == 10
+
+
+def test_timestamp_converted_from_ms_to_sec():
+    """directTimestamp (milliseconds) is divided by 1000 for t_sec."""
+    details = _make_details(n=1, start_ms=1_777_540_905_000)
+    samples = parse_activity_stream("act-2", details)
+    assert samples[0]["t_sec"] == 1_777_540_905
+
+
+def test_two_second_sampling_preserved():
+    """2-second step between rows is reflected in consecutive t_sec values."""
+    details = _make_details(n=3, start_ms=1_000_000_000_000, step_ms=2000)
+    samples = parse_activity_stream("act-3", details)
+    assert samples[1]["t_sec"] - samples[0]["t_sec"] == 2
+    assert samples[2]["t_sec"] - samples[1]["t_sec"] == 2
+
+
+def test_core_fields_mapped():
+    """hr_bpm, cadence_spm, speed_ms, altitude_m, distance_m populated."""
+    details = _make_details(n=1)
+    s = parse_activity_stream("act-4", details)[0]
+    assert s["source"] == "garmin"
+    assert s["activity_id"] == "act-4"
+    assert s["hr_bpm"] == 150.0
+    assert s["cadence_spm"] == 172.0
+    assert s["speed_ms"] == 3.5
+    assert s["altitude_m"] == pytest.approx(50.0)
+    assert s["distance_m"] == 0.0
+
+
+def test_gps_fields_populated():
+    """lat and lng extracted when directLatitude/directLongitude present."""
+    details = _make_details(n=1, include_gps=True)
+    s = parse_activity_stream("act-5", details)[0]
+    assert s["lat"] == pytest.approx(31.18)
+    assert s["lng"] == pytest.approx(121.25)
+
+
+def test_gps_none_when_missing():
+    """lat and lng are None when GPS metrics absent from row."""
+    details = _make_details(n=1, include_gps=False)
+    s = parse_activity_stream("act-6", details)[0]
+    assert s["lat"] is None
+    assert s["lng"] is None
+
+
+def test_dynamics_populated():
+    """ground_time_ms, oscillation_mm, vertical_ratio extracted."""
+    details = _make_details(n=1, include_dynamics=True)
+    s = parse_activity_stream("act-7", details)[0]
+    assert s["ground_time_ms"] == 260.0
+    assert s["oscillation_mm"] == 7.2
+    assert s["vertical_ratio"] == pytest.approx(6.8)
+
+
+def test_no_power_in_output():
+    """power_watts is not in the sample dict — unavailable in Garmin stream."""
+    details = _make_details(n=1)
+    s = parse_activity_stream("act-8", details)[0]
+    assert "power_watts" not in s
+
+
+def test_dynamic_descriptor_order():
+    """Index mapping is built from metricDescriptors regardless of order."""
+    details = _make_details(n=1)
+    # Shuffle the descriptor order
+    details["metricDescriptors"] = list(reversed(details["metricDescriptors"]))
+    # Metrics array order is still by metricsIndex, not descriptor list order
+    samples = parse_activity_stream("act-9", details)
+    assert len(samples) == 1
+    assert samples[0]["hr_bpm"] == 150.0
+
+
+def test_missing_timestamp_row_skipped():
+    """Rows with None timestamp are skipped."""
+    details = _make_details(n=3)
+    details["activityDetailMetrics"][1]["metrics"][0] = None
+    samples = parse_activity_stream("act-10", details)
+    assert len(samples) == 2
+
+
+def test_empty_payload_returns_empty():
+    """Missing descriptors or rows returns empty list."""
+    assert parse_activity_stream("act-11", {}) == []
+    assert parse_activity_stream("act-12", {"metricDescriptors": [], "activityDetailMetrics": []}) == []
+
+
+def test_missing_directtimestamp_descriptor_returns_empty():
+    """Without directTimestamp in descriptors, cannot build samples."""
+    details = _make_details(n=3)
+    details["metricDescriptors"] = [
+        m for m in details["metricDescriptors"] if m["key"] != "directTimestamp"
+    ]
+    assert parse_activity_stream("act-13", details) == []
+
+
+def test_truncation_warning_logged(caplog):
+    """Warning is logged when metricsCount < totalMetricsCount (response was capped)."""
+    import logging
+    details = _make_details(n=5)
+    details["metricsCount"] = 5
+    details["totalMetricsCount"] = 10  # pretend 10 rows exist but only 5 returned
+    with caplog.at_level(logging.WARNING, logger="sync.garmin_sync"):
+        samples = parse_activity_stream("act-14", details)
+    assert len(samples) == 5  # returns what it got
+    assert "truncated" in caplog.text
+    assert "act-14" in caplog.text
+
+
+def test_garmin_max_chart_size_covers_ultra_marathon():
+    """GARMIN_MAX_CHART_SIZE is large enough for a 100-mile ultra at 2s sampling."""
+    from sync.garmin_sync import GARMIN_MAX_CHART_SIZE
+    # 100-mile ultra worst case: ~30 hours = 108,000 seconds / 2s = 54,000 rows
+    assert GARMIN_MAX_CHART_SIZE >= 54_000

--- a/tests/test_garmin_login_fallback.py
+++ b/tests/test_garmin_login_fallback.py
@@ -65,7 +65,7 @@ def _make_client(login_behavior, *, is_cn: bool = True):
 def test_jwt_web_error_falls_back_to_portal_login(tmp_path) -> None:
     """The exact message from the upstream bug must trigger the portal
     fallback with the same credentials passed in."""
-    from garminconnect.exceptions import GarminConnectAuthenticationError
+    from garminconnect import GarminConnectAuthenticationError
     from api.routes.sync import _login_garmin_with_cn_fallback
 
     def _raise_jwt_web():
@@ -111,7 +111,7 @@ def test_successful_login_does_not_fall_back(tmp_path) -> None:
 def test_other_auth_errors_bubble_up(tmp_path) -> None:
     """Real credential failures (wrong password, etc.) must not be
     masked by the portal fallback — the user needs to see them."""
-    from garminconnect.exceptions import GarminConnectAuthenticationError
+    from garminconnect import GarminConnectAuthenticationError
     from api.routes.sync import _login_garmin_with_cn_fallback
 
     def _raise_bad_password():

--- a/tests/test_stryd_activity_samples.py
+++ b/tests/test_stryd_activity_samples.py
@@ -1,0 +1,159 @@
+"""Tests for fetch_activity_splits() — verifies splits and per-second samples."""
+from unittest.mock import patch, MagicMock
+
+from sync.stryd_sync import fetch_activity_splits
+
+
+def _mock_response(data: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.json.return_value = data
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+def _make_activity(
+    n: int = 10,
+    start_ts: int = 1000,
+    lap_events: list | None = None,
+    include_dynamics: bool = False,
+) -> dict:
+    """Build a minimal Stryd activity detail payload with n seconds of data."""
+    ts = list(range(start_ts, start_ts + n))
+    return {
+        "timestamp_list": ts,
+        "start_events": [start_ts],
+        "stop_events": [start_ts + n - 1],
+        "lap_events": lap_events or [],
+        "total_power_list": [200.0 + i for i in range(n)],
+        "heart_rate_list": [150.0 + i for i in range(n)],
+        "speed_list": [3.5] * n,
+        "distance_list": [i * 3.5 for i in range(n)],
+        "cadence_list": [172.0] * n,
+        "elevation_list": [50.0 + i * 0.1 for i in range(n)],
+        "ground_time_list": [260.0] * n if include_dynamics else [],
+        "oscillation_list": [71.0] * n if include_dynamics else [],
+        "leg_spring_list": [11.5] * n if include_dynamics else [],
+        "vertical_oscillation_ratio_list": [8.3] * n if include_dynamics else [],
+        "form_power_list": [40.0] * n if include_dynamics else [],
+    }
+
+
+# --- Return type ---
+
+def test_returns_tuple_of_splits_and_samples():
+    """fetch_activity_splits returns (splits, samples) not a plain list."""
+    payload = _make_activity(n=10, lap_events=[1005])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        result = fetch_activity_splits("act-1", "token")
+    assert isinstance(result, tuple)
+    splits, samples = result
+    assert isinstance(splits, list)
+    assert isinstance(samples, list)
+
+
+# --- Splits (existing behaviour must be preserved) ---
+
+def test_splits_still_computed_correctly():
+    """Lap split averages are unaffected by the new samples return value."""
+    # 10 seconds, lap boundary at t=1005 → 2 laps
+    payload = _make_activity(n=10, start_ts=1000, lap_events=[1005])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        splits, _ = fetch_activity_splits("act-1", "token")
+    assert len(splits) == 2
+    assert splits[0]["activity_id"] == "act-1"
+    assert splits[0]["duration_sec"] == "5"
+
+
+# --- Samples field mapping ---
+
+def test_samples_count_equals_activity_duration():
+    """One sample per timestamp inside [start_ts, end_ts]."""
+    n = 30
+    payload = _make_activity(n=n, start_ts=2000)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-2", "token")
+    assert len(samples) == n
+
+
+def test_samples_core_field_mapping():
+    """power_watts, hr_bpm, speed_ms, cadence_spm, altitude_m, distance_m mapped."""
+    payload = _make_activity(n=5, start_ts=3000)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-3", "token")
+
+    s = samples[0]
+    assert s["activity_id"] == "act-3"
+    assert s["source"] == "stryd"
+    assert s["t_sec"] == 3000
+    assert s["power_watts"] == 200.0
+    assert s["hr_bpm"] == 150.0
+    assert s["speed_ms"] == 3.5
+    assert s["cadence_spm"] == 172.0
+    assert s["altitude_m"] == 50.0
+    assert s["distance_m"] == 0.0
+
+
+def test_samples_stryd_dynamics_mapped():
+    """Stryd running dynamics columns are populated when present."""
+    payload = _make_activity(n=5, start_ts=4000, include_dynamics=True)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-4", "token")
+
+    s = samples[0]
+    assert s["ground_time_ms"] == 260.0
+    assert s["oscillation_mm"] == 71.0
+    assert s["leg_spring_kn_m"] == 11.5
+    assert s["vertical_ratio"] == 8.3
+    assert s["form_power_watts"] == 40.0
+
+
+def test_samples_dynamics_none_when_missing():
+    """Stryd dynamics columns are None when lists are absent from the payload."""
+    payload = _make_activity(n=5, start_ts=5000, include_dynamics=False)
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-5", "token")
+
+    s = samples[0]
+    assert s["ground_time_ms"] is None
+    assert s["oscillation_mm"] is None
+    assert s["leg_spring_kn_m"] is None
+
+
+def test_samples_bounded_to_activity_window():
+    """Timestamps outside [start_ts, end_ts] are excluded from samples."""
+    n = 10
+    payload = _make_activity(n=n, start_ts=6000)
+    # Add padding timestamps outside the activity window
+    payload["timestamp_list"] = [5998, 5999] + payload["timestamp_list"] + [6010, 6011]
+    payload["total_power_list"] = [0.0, 0.0] + payload["total_power_list"] + [0.0, 0.0]
+    payload["heart_rate_list"] = [0.0, 0.0] + payload["heart_rate_list"] + [0.0, 0.0]
+    payload["speed_list"] = [0.0, 0.0] + payload["speed_list"] + [0.0, 0.0]
+    payload["distance_list"] = [0.0, 0.0] + payload["distance_list"] + [0.0, 0.0]
+
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-6", "token")
+
+    t_secs = [s["t_sec"] for s in samples]
+    assert 5998 not in t_secs
+    assert 5999 not in t_secs
+    assert 6010 not in t_secs
+    assert len(samples) == n
+
+
+# --- Empty / degenerate payloads ---
+
+def test_empty_payload_returns_empty_lists():
+    """Missing timestamp_list or power_list returns ([], [])."""
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response({})):
+        splits, samples = fetch_activity_splits("act-7", "token")
+    assert splits == []
+    assert samples == []
+
+
+def test_no_lap_events_produces_one_split():
+    """Activity with no lap boundaries produces a single split and full samples."""
+    payload = _make_activity(n=20, start_ts=7000, lap_events=[])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        splits, samples = fetch_activity_splits("act-8", "token")
+    assert len(splits) == 1
+    assert len(samples) == 20

--- a/tests/test_stryd_activity_samples.py
+++ b/tests/test_stryd_activity_samples.py
@@ -1,4 +1,5 @@
 """Tests for fetch_activity_splits() — verifies splits and per-second samples."""
+import pytest
 from unittest.mock import patch, MagicMock
 
 from sync.stryd_sync import fetch_activity_splits
@@ -16,13 +17,14 @@ def _make_activity(
     start_ts: int = 1000,
     lap_events: list | None = None,
     include_dynamics: bool = False,
+    stop_events: list | None = None,
 ) -> dict:
     """Build a minimal Stryd activity detail payload with n seconds of data."""
     ts = list(range(start_ts, start_ts + n))
     return {
         "timestamp_list": ts,
         "start_events": [start_ts],
-        "stop_events": [start_ts + n - 1],
+        "stop_events": stop_events if stop_events is not None else [start_ts + n - 1],
         "lap_events": lap_events or [],
         "total_power_list": [200.0 + i for i in range(n)],
         "heart_rate_list": [150.0 + i for i in range(n)],
@@ -30,11 +32,13 @@ def _make_activity(
         "distance_list": [i * 3.5 for i in range(n)],
         "cadence_list": [172.0] * n,
         "elevation_list": [50.0 + i * 0.1 for i in range(n)],
+        "grade_list": [1.0] * n if include_dynamics else [],
+        "loc_list": [{"Lat": 31.18 + i * 0.001, "Lng": 121.25 + i * 0.001} for i in range(n)] if include_dynamics else [],
+        "temperature_device_list": [25.0] * n if include_dynamics else [],
         "ground_time_list": [260.0] * n if include_dynamics else [],
         "oscillation_list": [71.0] * n if include_dynamics else [],
         "leg_spring_list": [11.5] * n if include_dynamics else [],
-        "vertical_oscillation_ratio_list": [8.3] * n if include_dynamics else [],
-        "form_power_list": [40.0] * n if include_dynamics else [],
+        "vertical_ratio_list": [8.3] * n if include_dynamics else [],
     }
 
 
@@ -94,7 +98,7 @@ def test_samples_core_field_mapping():
 
 
 def test_samples_stryd_dynamics_mapped():
-    """Stryd running dynamics columns are populated when present."""
+    """Stryd running dynamics and GPS columns are populated when present."""
     payload = _make_activity(n=5, start_ts=4000, include_dynamics=True)
     with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
         _, samples = fetch_activity_splits("act-4", "token")
@@ -104,7 +108,10 @@ def test_samples_stryd_dynamics_mapped():
     assert s["oscillation_mm"] == 71.0
     assert s["leg_spring_kn_m"] == 11.5
     assert s["vertical_ratio"] == 8.3
-    assert s["form_power_watts"] == 40.0
+    assert s["grade_pct"] == 1.0
+    assert s["lat"] == pytest.approx(31.18)
+    assert s["lng"] == pytest.approx(121.25)
+    assert s["temperature_c"] == 25.0
 
 
 def test_samples_dynamics_none_when_missing():
@@ -117,6 +124,25 @@ def test_samples_dynamics_none_when_missing():
     assert s["ground_time_ms"] is None
     assert s["oscillation_mm"] is None
     assert s["leg_spring_kn_m"] is None
+    assert s["lat"] is None
+    assert s["lng"] is None
+    assert s["grade_pct"] is None
+    assert s["temperature_c"] is None
+
+
+def test_samples_paused_activity_uses_last_stop_event():
+    """For paused/resumed activities, end_ts uses stop_events[-1], not [0]."""
+    # Simulate pause at t=1005, resume, end at t=1019 (20 total active seconds)
+    n = 20
+    payload = _make_activity(n=n, start_ts=1000, stop_events=[1005, 1019])
+    with patch("sync.stryd_sync.requests.get", return_value=_mock_response(payload)):
+        _, samples = fetch_activity_splits("act-pause", "token")
+
+    # All 20 timestamps (1000–1019) should be included, not just the 6 before pause
+    assert len(samples) == n
+    t_secs = [s["t_sec"] for s in samples]
+    assert 1019 in t_secs   # actual end is included
+    assert 1005 in t_secs   # pause moment is still included (it's in timestamp_list)
 
 
 def test_samples_bounded_to_activity_window():

--- a/tests/test_write_samples.py
+++ b/tests/test_write_samples.py
@@ -1,0 +1,176 @@
+"""Tests for write_samples() in db/sync_writer.py."""
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def db_with_user(monkeypatch):
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY",
+        "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=",
+    )
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from db.models import User
+    user_id = "test-user-samples"
+    db = db_session.SessionLocal()
+    db.add(User(id=user_id, email="samples@example.com", hashed_password="x"))
+    db.commit()
+    try:
+        yield db, user_id
+    finally:
+        db.close()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _make_sample(activity_id: str, t_sec: int, **kwargs) -> dict:
+    base = {
+        "activity_id": activity_id,
+        "source": "stryd",
+        "t_sec": t_sec,
+        "power_watts": 220.0,
+        "hr_bpm": 155.0,
+        "speed_ms": 3.5,
+        "cadence_spm": 172.0,
+        "altitude_m": 50.0,
+        "distance_m": float(t_sec) * 3.5,
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_write_samples_inserts_rows(db_with_user):
+    """Basic round-trip: written rows appear in the table with correct values."""
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    samples = [_make_sample("act-1", t) for t in range(1000, 1010)]
+
+    count = sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+
+    assert count == 10
+    rows = db.query(ActivitySample).filter(ActivitySample.activity_id == "act-1").all()
+    assert len(rows) == 10
+    assert rows[0].power_watts == 220.0
+    assert rows[0].hr_bpm == 155.0
+    assert rows[0].user_id == user_id
+
+
+def test_write_samples_idempotent(db_with_user):
+    """Writing the same samples twice leaves exactly one copy in the table."""
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    samples = [_make_sample("act-2", t) for t in range(2000, 2005)]
+
+    sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+    sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+
+    rows = db.query(ActivitySample).filter(ActivitySample.activity_id == "act-2").all()
+    assert len(rows) == 5
+
+
+def test_write_samples_pace_derived_from_speed(db_with_user):
+    """pace_sec_km is computed from speed_ms when not explicitly provided."""
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    # 4.0 m/s → 250 sec/km
+    samples = [_make_sample("act-3", 3000, speed_ms=4.0, power_watts=None)]
+
+    sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+
+    row = db.query(ActivitySample).filter(ActivitySample.activity_id == "act-3").first()
+    assert row is not None
+    assert row.pace_sec_km == pytest.approx(250.0, rel=1e-3)
+
+
+def test_write_samples_stryd_dynamics_stored(db_with_user):
+    """Stryd-specific running dynamics columns are persisted."""
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    samples = [_make_sample(
+        "act-4", 4000,
+        ground_time_ms=258.0,
+        oscillation_mm=71.2,
+        leg_spring_kn_m=11.5,
+        vertical_ratio=8.3,
+        form_power_watts=40.0,
+    )]
+
+    sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+
+    row = db.query(ActivitySample).filter(ActivitySample.activity_id == "act-4").first()
+    assert row.ground_time_ms == 258.0
+    assert row.oscillation_mm == 71.2
+    assert row.leg_spring_kn_m == 11.5
+    assert row.form_power_watts == 40.0
+
+
+def test_write_samples_skips_rows_missing_t_sec(db_with_user):
+    """Rows without t_sec or activity_id are silently dropped."""
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    samples = [
+        _make_sample("act-5", 5000),
+        {"activity_id": "act-5", "source": "stryd", "power_watts": 200.0},  # no t_sec
+        {"source": "stryd", "t_sec": 5001, "power_watts": 200.0},           # no activity_id
+    ]
+
+    count = sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+
+    assert count == 1
+    rows = db.query(ActivitySample).filter(ActivitySample.activity_id == "act-5").all()
+    assert len(rows) == 1
+
+
+def test_write_samples_batching(db_with_user):
+    """Writing more than _SAMPLE_BATCH_SIZE rows completes correctly."""
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    n = sync_writer._SAMPLE_BATCH_SIZE + 50
+    samples = [_make_sample("act-6", t) for t in range(6000, 6000 + n)]
+
+    count = sync_writer.write_samples(user_id, samples, db)
+    db.commit()
+
+    assert count == n
+    total = db.query(ActivitySample).filter(ActivitySample.activity_id == "act-6").count()
+    assert total == n
+
+
+def test_write_samples_empty_input(db_with_user):
+    """Empty input returns 0 without error."""
+    from db import sync_writer
+
+    db, user_id = db_with_user
+    assert sync_writer.write_samples(user_id, [], db) == 0

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/AppSidebar';
+import SystemBanner from '@/components/SystemBanner';
 import { useAuth } from '@/hooks/useAuth';
 import { Eye } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
@@ -15,6 +16,7 @@ export default function Layout() {
         <header className="sticky top-0 z-40 flex h-12 items-center gap-2 border-b border-border bg-background/80 backdrop-blur-sm px-4 lg:hidden">
           <SidebarTrigger />
         </header>
+        <SystemBanner />
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <Outlet />
         </div>

--- a/web/src/components/SystemBanner.tsx
+++ b/web/src/components/SystemBanner.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { X, Info, AlertTriangle, CheckCircle } from 'lucide-react';
+import { API_BASE, getAuthHeaders } from '@/hooks/useApi';
+import type { SystemAnnouncement } from '@/types/api';
+
+const STORAGE_KEY = 'praxys_dismissed_banners';
+
+function getDismissed(): Set<number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return new Set(raw ? JSON.parse(raw) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveDismissed(ids: Set<number>): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+}
+
+const TYPE_STYLES = {
+  info:    'bg-accent-cobalt/10 border-accent-cobalt/30 text-foreground',
+  warning: 'bg-amber-500/10  border-amber-500/30  text-foreground',
+  success: 'bg-primary/10    border-primary/30    text-foreground',
+};
+
+const TYPE_ICONS = {
+  info:    <Info    className="h-4 w-4 text-accent-cobalt shrink-0 mt-0.5" />,
+  warning: <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />,
+  success: <CheckCircle   className="h-4 w-4 text-primary shrink-0 mt-0.5" />,
+};
+
+export default function SystemBanner() {
+  const [banners, setBanners] = useState<SystemAnnouncement[]>([]);
+
+  useEffect(() => {
+    const headers = getAuthHeaders();
+    if (!headers) return;
+    fetch(`${API_BASE}/api/announcements`, { headers })
+      .then((r) => r.ok ? r.json() : [])
+      .then((data: SystemAnnouncement[]) => {
+        const dismissed = getDismissed();
+        setBanners(data.filter((b) => !dismissed.has(b.id)));
+      })
+      .catch(() => {});
+  }, []);
+
+  function dismiss(id: number) {
+    const dismissed = getDismissed();
+    dismissed.add(id);
+    saveDismissed(dismissed);
+    setBanners((prev) => prev.filter((b) => b.id !== id));
+  }
+
+  if (banners.length === 0) return null;
+
+  return (
+    <div className="space-y-2 px-4 pt-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
+      {banners.map((banner) => {
+        const type = (banner.type as keyof typeof TYPE_STYLES) in TYPE_STYLES
+          ? (banner.type as keyof typeof TYPE_STYLES)
+          : 'info';
+        return (
+          <div
+            key={banner.id}
+            className={`flex items-start gap-3 rounded-lg border px-4 py-3 text-sm ${TYPE_STYLES[type]}`}
+          >
+            {TYPE_ICONS[type]}
+            <div className="flex-1 min-w-0">
+              <span className="font-medium">{banner.title}</span>
+              {banner.body && (
+                <span className="ml-1 text-muted-foreground">{banner.body}</span>
+              )}
+              {banner.link_url && banner.link_text && (
+                <a
+                  href={banner.link_url}
+                  className="ml-2 underline underline-offset-2 font-medium hover:opacity-80"
+                >
+                  {banner.link_text}
+                </a>
+              )}
+            </div>
+            <button
+              onClick={() => dismiss(banner.id)}
+              className="shrink-0 rounded p-0.5 hover:bg-black/10 transition-colors"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -23,7 +23,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Users, Ticket, Copy, Check, Trash2, Plus, ShieldCheck, ChevronUp, ChevronDown, Eye } from 'lucide-react';
+import { Users, Ticket, Copy, Check, Trash2, Plus, ShieldCheck, ChevronUp, ChevronDown, Eye, Megaphone } from 'lucide-react';
+import type { SystemAnnouncement } from '@/types/api';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 interface UserInfo {
@@ -65,18 +66,75 @@ export default function Admin() {
   const [creatingDemo, setCreatingDemo] = useState(false);
   const [demoError, setDemoError] = useState<string | null>(null);
 
+  // Announcements
+  const [announcements, setAnnouncements] = useState<SystemAnnouncement[]>([]);
+  const [newTitle, setNewTitle] = useState('');
+  const [newBody, setNewBody] = useState('');
+  const [newType, setNewType] = useState<'info' | 'warning' | 'success'>('info');
+  const [newLinkText, setNewLinkText] = useState('');
+  const [newLinkUrl, setNewLinkUrl] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
   const fetchData = () => {
     setLoading(true);
     Promise.all([
       fetch(`${API_BASE}/api/admin/users`, { headers: getAuthHeaders() }).then((r) => r.json()),
       fetch(`${API_BASE}/api/admin/invitations`, { headers: getAuthHeaders() }).then((r) => r.json()),
+      fetch(`${API_BASE}/api/announcements`, { headers: getAuthHeaders() }).then((r) => r.ok ? r.json() : []),
     ])
-      .then(([u, i]) => {
+      .then(([u, i, a]) => {
         setUsers(u.users || []);
         setInvitations(i.invitations || []);
+        setAnnouncements(Array.isArray(a) ? a : []);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
+  };
+
+  const handleCreateAnnouncement = async () => {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    setCreateError(null);
+    const res = await fetch(`${API_BASE}/api/admin/announcements`, {
+      method: 'POST',
+      headers: { ...getAuthHeaders() as Record<string, string>, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: newTitle.trim(),
+        body: newBody.trim(),
+        type: newType,
+        link_text: newLinkText.trim() || null,
+        link_url: newLinkUrl.trim() || null,
+      }),
+    });
+    setCreating(false);
+    if (res.ok) {
+      const created = await res.json();
+      setAnnouncements((prev) => [created, ...prev]);
+      setNewTitle(''); setNewBody(''); setNewType('info'); setNewLinkText(''); setNewLinkUrl('');
+    } else {
+      setCreateError('Failed to create announcement');
+    }
+  };
+
+  const handleToggleAnnouncement = async (ann: SystemAnnouncement) => {
+    const res = await fetch(`${API_BASE}/api/admin/announcements/${ann.id}`, {
+      method: 'PATCH',
+      headers: { ...getAuthHeaders() as Record<string, string>, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_active: !ann.is_active }),
+    });
+    if (res.ok) {
+      const updated = await res.json();
+      setAnnouncements((prev) => prev.map((a) => a.id === ann.id ? updated : a));
+    }
+  };
+
+  const handleDeleteAnnouncement = async (id: number) => {
+    const res = await fetch(`${API_BASE}/api/admin/announcements/${id}`, {
+      method: 'DELETE',
+      headers: getAuthHeaders(),
+    });
+    if (res.ok) setAnnouncements((prev) => prev.filter((a) => a.id !== id));
   };
 
   useEffect(() => { fetchData(); }, []);
@@ -481,6 +539,98 @@ export default function Admin() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* System Announcements */}
+      <Card className="mt-8">
+        <CardHeader>
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+              <Megaphone className="h-4 w-4" />
+            </div>
+            <div>
+              <CardTitle className="text-base"><Trans>System Announcements</Trans></CardTitle>
+              <CardDescription className="text-xs"><Trans>Dismissible banners shown to all users</Trans></CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Create form */}
+          <div className="rounded-lg border border-dashed border-border p-4 space-y-3">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide"><Trans>New announcement</Trans></p>
+            <Input
+              placeholder={t`Title`}
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+            />
+            <Input
+              placeholder={t`Body (optional)`}
+              value={newBody}
+              onChange={(e) => setNewBody(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <select
+                value={newType}
+                onChange={(e) => setNewType(e.target.value as 'info' | 'warning' | 'success')}
+                className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="info">info</option>
+                <option value="warning">warning</option>
+                <option value="success">success</option>
+              </select>
+              <Input
+                placeholder={t`Link text (optional)`}
+                value={newLinkText}
+                onChange={(e) => setNewLinkText(e.target.value)}
+              />
+              <Input
+                placeholder={t`Link URL (optional)`}
+                value={newLinkUrl}
+                onChange={(e) => setNewLinkUrl(e.target.value)}
+              />
+            </div>
+            {createError && <p className="text-xs text-destructive">{createError}</p>}
+            <Button size="sm" onClick={handleCreateAnnouncement} disabled={creating || !newTitle.trim()}>
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              {creating ? <Trans>Creating...</Trans> : <Trans>Create</Trans>}
+            </Button>
+          </div>
+
+          {/* Existing announcements */}
+          {announcements.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4"><Trans>No announcements yet</Trans></p>
+          ) : (
+            <div className="space-y-2">
+              {announcements.map((ann) => (
+                <div key={ann.id} className={`flex items-start gap-3 rounded-lg border p-3 text-sm ${ann.is_active ? '' : 'opacity-50'}`}>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className="text-xs shrink-0">{ann.type}</Badge>
+                      <span className="font-medium truncate">{ann.title}</span>
+                    </div>
+                    {ann.body && <p className="text-xs text-muted-foreground mt-0.5 truncate">{ann.body}</p>}
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      variant="ghost" size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={() => handleToggleAnnouncement(ann)}
+                    >
+                      {ann.is_active ? <Trans>Deactivate</Trans> : <Trans>Activate</Trans>}
+                    </Button>
+                    <Button
+                      variant="ghost" size="sm"
+                      className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                      onClick={() => handleDeleteAnnouncement(ann.id)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -507,3 +507,15 @@ export interface HistoryResponse {
   limit: number;
   offset: number;
 }
+
+export interface SystemAnnouncement {
+  id: number;
+  title: string;
+  body: string;
+  type: 'info' | 'warning' | 'success';
+  is_active: boolean;
+  link_text: string | null;
+  link_url: string | null;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary

Implements #94 end-to-end: ingests per-second streams from Garmin and Stryd into a new `activity_samples` table, and wires `diagnose_training()` to use 1-second zone resolution instead of lap-split averages.

## What's included

**Infrastructure**
- `activity_samples` table (#211) — one row per second per activity, all connector field sets, unique on `(user_id, activity_id, t_sec)`
- `write_samples()` — batched INSERT OR IGNORE, idempotent

**Connectors**
- Stryd (#212) — per-second arrays already fetched; now persisted instead of discarded. Verified: 35,505 rows, 8 activities, all fields 100% populated
- Garmin (#213) — new `get_activity_details()` call, dynamic descriptor index map, `GARMIN_MAX_CHART_SIZE=100_000` covers 100-mile ultras. Verified: 16,136 rows, 4 activities, ratio ≈ 2.0 (2s sampling)
- COROS (#214) and Strava (#215) — PRs open, awaiting real-data verification; graceful fallback to splits until merged

**Analysis wiring** (#216)
- `diagnose_training()` gains a `samples` parameter; zone-time loop uses 1s samples when available, split-duration fallback per activity for historical data
- `data_meta.distribution_resolution: "samples" | "splits"` surfaced in API response
- Verified locally: both accounts show `"distribution_resolution": "samples"`

**System banners** (#237)
- Admin-configurable dismissible notification banners (SystemAnnouncement table, /api/announcements, /api/admin/announcements CRUD)
- SystemBanner component in Layout, Admin management UI
- First use: prompt users to backfill Stryd/Garmin data

## Housekeeping also included
- Fix `garminconnect.exceptions` import (was breaking Garmin sync on v0.2.38)
- Stale `UniqueConstraint` docstrings fixed
- `require_admin` consolidated in `api/views.py` (removed duplicate)

## Notes

- COROS (#214) and Strava (#215) PRs target this branch and will be retargeted to main once verified
- Do **not** delete `feature/activity-samples` until those two PRs are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)