### PR TITLE
ci: sync all App Service settings on every backend deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -60,6 +60,24 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Sync App Service settings
+        run: |
+          az webapp config appsettings set \
+            --name trainsight-app \
+            --resource-group rg-trainsight \
+            --settings \
+              AZURE_AI_ENDPOINT="${{ vars.AZURE_AI_ENDPOINT }}" \
+              KEY_VAULT_URL="${{ vars.KEY_VAULT_URL }}" \
+              KEY_VAULT_KEY_NAME="${{ vars.KEY_VAULT_KEY_NAME }}" \
+              APPLICATIONINSIGHTS_CONNECTION_STRING="${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}" \
+              PRAXYS_JWT_SECRET="${{ secrets.PRAXYS_JWT_SECRET }}" \
+              WECHAT_MINIAPP_APPID="${{ secrets.WECHAT_MINIAPP_APPID }}" \
+              WECHAT_MINIAPP_SECRET="${{ secrets.WECHAT_MINIAPP_SECRET }}" \
+              WEBSITES_PORT="8000" \
+              DATA_DIR="/home/data" \
+              SCM_DO_BUILD_DURING_DEPLOYMENT="true" \
+              WEBSITE_HTTPLOGGING_RETENTION_DAYS="3"
+
       - name: Deploy to App Service
         uses: azure/webapps-deploy@v3
         with:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -61,18 +61,34 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Sync App Service settings
+        env:
+          AZURE_AI_ENDPOINT: ${{ vars.AZURE_AI_ENDPOINT }}
+          KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}
+          KEY_VAULT_KEY_NAME: ${{ vars.KEY_VAULT_KEY_NAME }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          PRAXYS_JWT_SECRET: ${{ secrets.PRAXYS_JWT_SECRET }}
+          WECHAT_MINIAPP_APPID: ${{ secrets.WECHAT_MINIAPP_APPID }}
+          WECHAT_MINIAPP_SECRET: ${{ secrets.WECHAT_MINIAPP_SECRET }}
         run: |
+          for var in AZURE_AI_ENDPOINT KEY_VAULT_URL KEY_VAULT_KEY_NAME \
+                     APPLICATIONINSIGHTS_CONNECTION_STRING PRAXYS_JWT_SECRET \
+                     WECHAT_MINIAPP_APPID WECHAT_MINIAPP_SECRET; do
+            if [[ -z "${!var}" ]]; then
+              echo "ERROR: required setting '${var}' is empty or undefined" >&2
+              exit 1
+            fi
+          done
           az webapp config appsettings set \
             --name trainsight-app \
             --resource-group rg-trainsight \
             --settings \
-              AZURE_AI_ENDPOINT="${{ vars.AZURE_AI_ENDPOINT }}" \
-              KEY_VAULT_URL="${{ vars.KEY_VAULT_URL }}" \
-              KEY_VAULT_KEY_NAME="${{ vars.KEY_VAULT_KEY_NAME }}" \
-              APPLICATIONINSIGHTS_CONNECTION_STRING="${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}" \
-              PRAXYS_JWT_SECRET="${{ secrets.PRAXYS_JWT_SECRET }}" \
-              WECHAT_MINIAPP_APPID="${{ secrets.WECHAT_MINIAPP_APPID }}" \
-              WECHAT_MINIAPP_SECRET="${{ secrets.WECHAT_MINIAPP_SECRET }}" \
+              AZURE_AI_ENDPOINT="${AZURE_AI_ENDPOINT}" \
+              KEY_VAULT_URL="${KEY_VAULT_URL}" \
+              KEY_VAULT_KEY_NAME="${KEY_VAULT_KEY_NAME}" \
+              APPLICATIONINSIGHTS_CONNECTION_STRING="${APPLICATIONINSIGHTS_CONNECTION_STRING}" \
+              PRAXYS_JWT_SECRET="${PRAXYS_JWT_SECRET}" \
+              WECHAT_MINIAPP_APPID="${WECHAT_MINIAPP_APPID}" \
+              WECHAT_MINIAPP_SECRET="${WECHAT_MINIAPP_SECRET}" \
               WEBSITES_PORT="8000" \
               DATA_DIR="/home/data" \
               SCM_DO_BUILD_DURING_DEPLOYMENT="true" \


### PR DESCRIPTION
## Summary

- Adds a **Sync App Service settings** step to `deploy-backend.yml` that runs before code deploy, applying all 11 required App Service settings idempotently on every push to `main`
- Root cause fixed: `AZURE_AI_ENDPOINT` was missing from the App Service config, silently disabling LLM-based insights and falling back to rule-based prose even though the managed identity role assignment was correct
- Wires environment-specific public config from GitHub repo **Variables** (`vars.*`), credentials from **Secrets** (`secrets.*`), and hardcodes 4 static Azure platform constants directly

## What each setting covers

| Setting | Source |
|---------|--------|
| `AZURE_AI_ENDPOINT` | `vars.AZURE_AI_ENDPOINT` |
| `KEY_VAULT_URL` | `vars.KEY_VAULT_URL` |
| `KEY_VAULT_KEY_NAME` | `vars.KEY_VAULT_KEY_NAME` |
| `APPLICATIONINSIGHTS_CONNECTION_STRING` | `vars.APPLICATIONINSIGHTS_CONNECTION_STRING` |
| `PRAXYS_JWT_SECRET` | `secrets.PRAXYS_JWT_SECRET` |
| `WECHAT_MINIAPP_APPID` | `secrets.WECHAT_MINIAPP_APPID` |
| `WECHAT_MINIAPP_SECRET` | `secrets.WECHAT_MINIAPP_SECRET` |
| `WEBSITES_PORT` | hardcoded `8000` |
| `DATA_DIR` | hardcoded `/home/data` |
| `SCM_DO_BUILD_DURING_DEPLOYMENT` | hardcoded `true` |
| `WEBSITE_HTTPLOGGING_RETENTION_DAYS` | hardcoded `3` |

## Test plan

- [x] LLM insights verified working in production after manually applying `AZURE_AI_ENDPOINT` (triggered sync, insights generated successfully)
- [x] GitHub Actions variables created: `KEY_VAULT_URL`, `KEY_VAULT_KEY_NAME`, `APPLICATIONINSIGHTS_CONNECTION_STRING`, `AZURE_AI_ENDPOINT`
- [ ] Add `PRAXYS_JWT_SECRET` and `WECHAT_MINIAPP_SECRET` as GitHub Secrets before merging (if not already present)
- [ ] Confirm next deploy to `main` completes the settings sync step without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)