### PR TITLE
AppSidebar: grouped clusters + cobalt-color reasoning + proper wordmark

### DIFF
--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -47,19 +47,26 @@ type NavItem = { to: string; icon: ComponentType<SVGProps<SVGSVGElement>>; label
 // Single-row nav button with the new active-state treatment: 3px primary
 // left edge + bolder weight, no background fill (per DESIGN.md sidebar
 // rule). Overrides shadcn's default data-[active=true]:bg-sidebar-accent.
+//
+// The 3px indicator is anchored to SidebarMenuItem (which has `relative`
+// and no overflow-hidden), not the inner button (which IS overflow-hidden
+// per shadcn's sidebarMenuButtonVariants). Painting the pseudo-element
+// on the button would clip the rounded-r corner.
 function NavItemRow({ item, isActive, tooltip }: { item: NavItem; isActive: boolean; tooltip?: string }) {
   const { icon: Icon, label, to } = item;
   return (
-    <SidebarMenuItem>
+    <SidebarMenuItem
+      className={
+        isActive
+          ? 'before:absolute before:inset-y-1.5 before:left-0 before:w-[3px] before:bg-primary before:rounded-r-sm'
+          : ''
+      }
+    >
       <SidebarMenuButton
         render={<NavLink to={to} />}
         isActive={isActive}
         tooltip={tooltip ?? label}
-        className={
-          isActive
-            ? '!bg-transparent !text-foreground font-semibold relative before:absolute before:inset-y-1.5 before:left-0 before:w-[3px] before:bg-primary before:rounded-r-sm'
-            : 'relative'
-        }
+        className={isActive ? '!bg-transparent !text-foreground font-semibold' : ''}
       >
         <Icon />
         <span>{label}</span>
@@ -118,15 +125,18 @@ export default function AppSidebar() {
 
   // Setup is shown as a dashed-border callout row above the active cluster
   // when onboarding is incomplete, instead of replacing the Today slot.
-  // Two-state-in-one-row was the prior pattern; separating them keeps
-  // Today stable as the home anchor.
+  // Routes to /setup (the dedicated wizard page) so the user lands
+  // somewhere different from Today's row directly below — otherwise the
+  // banner would just duplicate Today's link and never reflect "active"
+  // when the user is on /today.
   const setupIncomplete = !setup.allDone && !setup.loading;
   const setupBanner = setupIncomplete ? (
     <SidebarMenuItem>
       <SidebarMenuButton
-        render={<NavLink to="/today" />}
+        render={<NavLink to="/setup" />}
+        isActive={location.pathname.startsWith('/setup')}
         tooltip={`${t`Setup`} (${setup.completed}/${setup.total})`}
-        className="border border-dashed border-primary/40 bg-primary/5 hover:bg-primary/10"
+        className="border border-dashed border-primary/40 bg-primary/5 hover:bg-primary/10 data-[active=true]:bg-primary/10"
       >
         <ListChecks />
         <span>{`${t`Setup`} (${setup.completed}/${setup.total})`}</span>

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink, useLocation } from 'react-router-dom';
+import type { ComponentType, SVGProps } from 'react';
 import { Sun, Moon, Monitor, TrendingUp, Target, Clock, FlaskConical, Settings, LogOut, ListChecks, ShieldCheck } from 'lucide-react';
 import { PraxysFlag } from '@/components/PraxysFlag';
 import {
@@ -30,6 +31,43 @@ const THEME_LABEL: Record<typeof THEME_CYCLE[number], MessageDescriptor> = {
   system: msg`System`,
 };
 
+// Praxys wordmark — "Pra" + green X + "ys" per the brand guide. Plain
+// text was wrong; this puts the brand identity in the chrome where it
+// belongs.
+function PraxysWordmark() {
+  return (
+    <span className="text-lg font-semibold tracking-tight text-foreground group-data-[collapsible=icon]:hidden">
+      Pra<span className="text-primary">x</span>ys
+    </span>
+  );
+}
+
+type NavItem = { to: string; icon: ComponentType<SVGProps<SVGSVGElement>>; label: string };
+
+// Single-row nav button with the new active-state treatment: 3px primary
+// left edge + bolder weight, no background fill (per DESIGN.md sidebar
+// rule). Overrides shadcn's default data-[active=true]:bg-sidebar-accent.
+function NavItemRow({ item, isActive, tooltip }: { item: NavItem; isActive: boolean; tooltip?: string }) {
+  const { icon: Icon, label, to } = item;
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        render={<NavLink to={to} />}
+        isActive={isActive}
+        tooltip={tooltip ?? label}
+        className={
+          isActive
+            ? '!bg-transparent !text-foreground font-semibold relative before:absolute before:inset-y-1.5 before:left-0 before:w-[3px] before:bg-primary before:rounded-r-sm'
+            : 'relative'
+        }
+      >
+        <Icon />
+        <span>{label}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
 function UserInitials({ name, email }: { name?: string; email: string | null }) {
   let initials = '?';
   if (name && name.trim()) {
@@ -56,20 +94,45 @@ export default function AppSidebar() {
   const { t, i18n } = useLingui();
   const displayName = config?.display_name || null;
 
-  // Dynamic nav: show Setup instead of Today when onboarding is incomplete
-  const homeItem = setup.allDone || setup.loading
-    ? { to: '/today', icon: Sun, label: t`Today` }
-    : { to: '/today', icon: ListChecks, label: `${t`Setup`} (${setup.completed}/${setup.total})` };
-
-  const navItems = [
-    homeItem,
+  // Active-cluster: daily-use training surfaces. Today, Training, Goal,
+  // Activities. The home item stays "Today" regardless of setup state —
+  // setup gets its own dedicated banner row above the active cluster.
+  const activeItems: NavItem[] = [
+    { to: '/today', icon: Sun, label: t`Today` },
     { to: '/training', icon: TrendingUp, label: t`Training` },
     { to: '/goal', icon: Target, label: t`Goal` },
     { to: '/history', icon: Clock, label: t`Activities` },
+  ];
+  // Reference: theory + methodology surfaces.
+  const referenceItems: NavItem[] = [
     { to: '/science', icon: FlaskConical, label: t`Science` },
+  ];
+  // Configuration: the user adjusts the system here (rare, deliberate).
+  const configItems: NavItem[] = [
     { to: '/settings', icon: Settings, label: t`Settings` },
     ...(isAdmin ? [{ to: '/admin', icon: ShieldCheck, label: t`Admin` }] : []),
   ];
+
+  const isActive = (to: string) =>
+    to === '/today' ? location.pathname === '/today' : location.pathname.startsWith(to);
+
+  // Setup is shown as a dashed-border callout row above the active cluster
+  // when onboarding is incomplete, instead of replacing the Today slot.
+  // Two-state-in-one-row was the prior pattern; separating them keeps
+  // Today stable as the home anchor.
+  const setupIncomplete = !setup.allDone && !setup.loading;
+  const setupBanner = setupIncomplete ? (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        render={<NavLink to="/today" />}
+        tooltip={`${t`Setup`} (${setup.completed}/${setup.total})`}
+        className="border border-dashed border-primary/40 bg-primary/5 hover:bg-primary/10"
+      >
+        <ListChecks />
+        <span>{`${t`Setup`} (${setup.completed}/${setup.total})`}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  ) : null;
 
   const cycleTheme = () => {
     const idx = THEME_CYCLE.indexOf(theme);
@@ -79,76 +142,89 @@ export default function AppSidebar() {
 
   const ThemeIcon = THEME_ICON[theme] ?? Monitor;
 
+  // Header / footer are identical across all three variants — extract once.
+  const headerContent = (
+    <SidebarHeader>
+      <div className="flex items-center gap-2.5 px-2 py-2">
+        <PraxysFlag className="h-8 w-8 shrink-0" />
+        <PraxysWordmark />
+      </div>
+    </SidebarHeader>
+  );
+
+  const footerContent = (
+    <SidebarFooter>
+      {email && (
+        <>
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <UserInitials name={displayName ?? undefined} email={email} />
+            <div className="flex flex-col overflow-hidden group-data-[collapsible=icon]:hidden">
+              {displayName ? (
+                <>
+                  <span className="truncate text-xs font-medium text-foreground">{displayName}</span>
+                  <span className="truncate text-[10px] text-muted-foreground">{email}</span>
+                </>
+              ) : (
+                <span className="truncate text-xs text-muted-foreground">{email}</span>
+              )}
+            </div>
+          </div>
+          <SidebarSeparator />
+        </>
+      )}
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton onClick={cycleTheme} tooltip={`${t`Theme`}: ${i18n._(THEME_LABEL[theme])}`}>
+            <ThemeIcon />
+            <span>{i18n._(THEME_LABEL[theme])}</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton onClick={logout} tooltip={t`Log out`}>
+            <LogOut />
+            <span>{t`Log out`}</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarFooter>
+  );
+
   return (
     <Sidebar collapsible="icon">
-      <SidebarHeader>
-        <div className="flex items-center gap-3 px-2 py-2">
-          <PraxysFlag className="h-8 w-8 shrink-0" />
-          <span className="text-lg font-semibold text-foreground group-data-[collapsible=icon]:hidden">
-            Praxys
-          </span>
-        </div>
-      </SidebarHeader>
+      {headerContent}
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {navItems.map(({ to, icon: Icon, label }) => {
-                const isActive =
-                  to === '/today'
-                    ? location.pathname === '/today'
-                    : location.pathname.startsWith(to);
-                return (
-                  <SidebarMenuItem key={to}>
-                    <SidebarMenuButton
-                      render={<NavLink to={to} />}
-                      isActive={isActive}
-                      tooltip={label}
-                    >
-                      <Icon />
-                      <span>{label}</span>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                );
-              })}
+              {setupBanner}
+              {activeItems.map((item) => (
+                <NavItemRow key={item.to} item={item} isActive={isActive(item.to)} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarSeparator />
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {referenceItems.map((item) => (
+                <NavItemRow key={item.to} item={item} isActive={isActive(item.to)} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarSeparator />
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {configItems.map((item) => (
+                <NavItemRow key={item.to} item={item} isActive={isActive(item.to)} />
+              ))}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter>
-        {email && (
-          <>
-            <div className="flex items-center gap-2 px-2 py-1.5">
-              <UserInitials name={displayName ?? undefined} email={email} />
-              <div className="flex flex-col overflow-hidden group-data-[collapsible=icon]:hidden">
-                {displayName ? (
-                  <>
-                    <span className="truncate text-xs font-medium text-foreground">{displayName}</span>
-                    <span className="truncate text-[10px] text-muted-foreground">{email}</span>
-                  </>
-                ) : (
-                  <span className="truncate text-xs text-muted-foreground">{email}</span>
-                )}
-              </div>
-            </div>
-            <SidebarSeparator />
-          </>
-        )}
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton onClick={cycleTheme} tooltip={`${t`Theme`}: ${i18n._(THEME_LABEL[theme])}`}>
-              <ThemeIcon />
-              <span>{i18n._(THEME_LABEL[theme])}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-              <SidebarMenuButton onClick={logout} tooltip={t`Log out`}>
-                <LogOut />
-                <span>{t`Log out`}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarFooter>
+      {footerContent}
     </Sidebar>
   );
 }

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -181,7 +181,7 @@ msgstr "Activate"
 msgid "Active"
 msgstr "Active"
 
-#: src/components/AppSidebar.tsx:68
+#: src/components/AppSidebar.tsx:104
 #: src/pages/History.tsx:38
 #: src/pages/Settings.tsx:53
 #: src/pages/Settings.tsx:60
@@ -212,7 +212,7 @@ msgstr "Actual"
 msgid "Adjust Workout"
 msgstr "Adjust Workout"
 
-#: src/components/AppSidebar.tsx:71
+#: src/components/AppSidebar.tsx:113
 #: src/pages/Admin.tsx:233
 #: src/pages/Admin.tsx:280
 msgid "Admin"
@@ -544,7 +544,7 @@ msgstr "Currently set to {0}-based training"
 msgid "Cycling"
 msgstr "Cycling"
 
-#: src/components/AppSidebar.tsx:28
+#: src/components/AppSidebar.tsx:29
 msgid "Dark"
 msgstr "Dark"
 
@@ -912,7 +912,7 @@ msgstr "Go Easy"
 msgid "Go to dashboard"
 msgstr "Go to dashboard"
 
-#: src/components/AppSidebar.tsx:67
+#: src/components/AppSidebar.tsx:103
 #: src/pages/Settings.tsx:1129
 msgid "Goal"
 msgstr "Goal"
@@ -1080,7 +1080,7 @@ msgstr "Leave blank for the first account. Required after that."
 msgid "Leave blank to track predicted time only"
 msgstr "Leave blank to track predicted time only"
 
-#: src/components/AppSidebar.tsx:29
+#: src/components/AppSidebar.tsx:30
 msgid "Light"
 msgstr "Light"
 
@@ -1116,8 +1116,8 @@ msgstr "Load & Fitness"
 msgid "Log in to connect your CLI plugin"
 msgstr "Log in to connect your CLI plugin"
 
-#: src/components/AppSidebar.tsx:145
-#: src/components/AppSidebar.tsx:147
+#: src/components/AppSidebar.tsx:183
+#: src/components/AppSidebar.tsx:185
 msgid "Log out"
 msgstr "Log out"
 
@@ -1676,7 +1676,7 @@ msgstr "Save Goal"
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/components/AppSidebar.tsx:69
+#: src/components/AppSidebar.tsx:108
 msgid "Science"
 msgstr "Science"
 
@@ -1707,12 +1707,13 @@ msgstr "Set Your Goal"
 msgid "Set your name"
 msgstr "Set your name"
 
-#: src/components/AppSidebar.tsx:70
+#: src/components/AppSidebar.tsx:112
 #: src/pages/Settings.tsx:547
 msgid "Settings"
 msgstr "Settings"
 
-#: src/components/AppSidebar.tsx:62
+#: src/components/AppSidebar.tsx:128
+#: src/components/AppSidebar.tsx:132
 msgid "Setup"
 msgstr "Setup"
 
@@ -1867,7 +1868,7 @@ msgstr "Syncing"
 msgid "Syncing..."
 msgstr "Syncing..."
 
-#: src/components/AppSidebar.tsx:30
+#: src/components/AppSidebar.tsx:31
 msgid "System"
 msgstr "System"
 
@@ -1904,7 +1905,7 @@ msgstr "Target Time"
 msgid "Tempo"
 msgstr "Tempo"
 
-#: src/components/AppSidebar.tsx:139
+#: src/components/AppSidebar.tsx:177
 msgid "Theme"
 msgstr "Theme"
 
@@ -1935,7 +1936,7 @@ msgstr "Thresholds"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/AppSidebar.tsx:61
+#: src/components/AppSidebar.tsx:101
 #: src/components/charts/FitnessFatigueChart.tsx:216
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
@@ -1955,7 +1956,7 @@ msgstr "Today's recovery hasn't synced yet. Showing the latest reading from {lat
 msgid "Train toward a specific race date"
 msgstr "Train toward a specific race date"
 
-#: src/components/AppSidebar.tsx:66
+#: src/components/AppSidebar.tsx:102
 msgid "Training"
 msgstr "Training"
 

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -181,7 +181,7 @@ msgstr "Activate"
 msgid "Active"
 msgstr "Active"
 
-#: src/components/AppSidebar.tsx:104
+#: src/components/AppSidebar.tsx:111
 #: src/pages/History.tsx:38
 #: src/pages/Settings.tsx:53
 #: src/pages/Settings.tsx:60
@@ -212,7 +212,7 @@ msgstr "Actual"
 msgid "Adjust Workout"
 msgstr "Adjust Workout"
 
-#: src/components/AppSidebar.tsx:113
+#: src/components/AppSidebar.tsx:120
 #: src/pages/Admin.tsx:233
 #: src/pages/Admin.tsx:280
 msgid "Admin"
@@ -912,7 +912,7 @@ msgstr "Go Easy"
 msgid "Go to dashboard"
 msgstr "Go to dashboard"
 
-#: src/components/AppSidebar.tsx:103
+#: src/components/AppSidebar.tsx:110
 #: src/pages/Settings.tsx:1129
 msgid "Goal"
 msgstr "Goal"
@@ -1116,8 +1116,8 @@ msgstr "Load & Fitness"
 msgid "Log in to connect your CLI plugin"
 msgstr "Log in to connect your CLI plugin"
 
-#: src/components/AppSidebar.tsx:183
-#: src/components/AppSidebar.tsx:185
+#: src/components/AppSidebar.tsx:193
+#: src/components/AppSidebar.tsx:195
 msgid "Log out"
 msgstr "Log out"
 
@@ -1676,7 +1676,7 @@ msgstr "Save Goal"
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/components/AppSidebar.tsx:108
+#: src/components/AppSidebar.tsx:115
 msgid "Science"
 msgstr "Science"
 
@@ -1707,13 +1707,13 @@ msgstr "Set Your Goal"
 msgid "Set your name"
 msgstr "Set your name"
 
-#: src/components/AppSidebar.tsx:112
+#: src/components/AppSidebar.tsx:119
 #: src/pages/Settings.tsx:547
 msgid "Settings"
 msgstr "Settings"
 
-#: src/components/AppSidebar.tsx:128
-#: src/components/AppSidebar.tsx:132
+#: src/components/AppSidebar.tsx:138
+#: src/components/AppSidebar.tsx:142
 msgid "Setup"
 msgstr "Setup"
 
@@ -1905,7 +1905,7 @@ msgstr "Target Time"
 msgid "Tempo"
 msgstr "Tempo"
 
-#: src/components/AppSidebar.tsx:177
+#: src/components/AppSidebar.tsx:187
 msgid "Theme"
 msgstr "Theme"
 
@@ -1936,7 +1936,7 @@ msgstr "Thresholds"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/AppSidebar.tsx:101
+#: src/components/AppSidebar.tsx:108
 #: src/components/charts/FitnessFatigueChart.tsx:216
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
@@ -1956,7 +1956,7 @@ msgstr "Today's recovery hasn't synced yet. Showing the latest reading from {lat
 msgid "Train toward a specific race date"
 msgstr "Train toward a specific race date"
 
-#: src/components/AppSidebar.tsx:102
+#: src/components/AppSidebar.tsx:109
 msgid "Training"
 msgstr "Training"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -181,7 +181,7 @@ msgstr "激活"
 msgid "Active"
 msgstr "当前使用"
 
-#: src/components/AppSidebar.tsx:104
+#: src/components/AppSidebar.tsx:111
 #: src/pages/History.tsx:38
 #: src/pages/Settings.tsx:53
 #: src/pages/Settings.tsx:60
@@ -212,7 +212,7 @@ msgstr "实际"
 msgid "Adjust Workout"
 msgstr "调整训练"
 
-#: src/components/AppSidebar.tsx:113
+#: src/components/AppSidebar.tsx:120
 #: src/pages/Admin.tsx:233
 #: src/pages/Admin.tsx:280
 msgid "Admin"
@@ -912,7 +912,7 @@ msgstr "轻松进行"
 msgid "Go to dashboard"
 msgstr "前往仪表盘"
 
-#: src/components/AppSidebar.tsx:103
+#: src/components/AppSidebar.tsx:110
 #: src/pages/Settings.tsx:1129
 msgid "Goal"
 msgstr "目标"
@@ -1116,8 +1116,8 @@ msgstr "负荷与体能"
 msgid "Log in to connect your CLI plugin"
 msgstr "登录以连接 CLI 插件"
 
-#: src/components/AppSidebar.tsx:183
-#: src/components/AppSidebar.tsx:185
+#: src/components/AppSidebar.tsx:193
+#: src/components/AppSidebar.tsx:195
 msgid "Log out"
 msgstr "退出登录"
 
@@ -1676,7 +1676,7 @@ msgstr "保存目标"
 msgid "Saving..."
 msgstr "保存中..."
 
-#: src/components/AppSidebar.tsx:108
+#: src/components/AppSidebar.tsx:115
 msgid "Science"
 msgstr "科学"
 
@@ -1707,13 +1707,13 @@ msgstr "设置您的目标"
 msgid "Set your name"
 msgstr "设置您的名字"
 
-#: src/components/AppSidebar.tsx:112
+#: src/components/AppSidebar.tsx:119
 #: src/pages/Settings.tsx:547
 msgid "Settings"
 msgstr "设置"
 
-#: src/components/AppSidebar.tsx:128
-#: src/components/AppSidebar.tsx:132
+#: src/components/AppSidebar.tsx:138
+#: src/components/AppSidebar.tsx:142
 msgid "Setup"
 msgstr "设置向导"
 
@@ -1905,7 +1905,7 @@ msgstr "目标时间"
 msgid "Tempo"
 msgstr "节奏跑"
 
-#: src/components/AppSidebar.tsx:177
+#: src/components/AppSidebar.tsx:187
 msgid "Theme"
 msgstr "主题"
 
@@ -1936,7 +1936,7 @@ msgstr "阈值"
 msgid "Title"
 msgstr "标题"
 
-#: src/components/AppSidebar.tsx:101
+#: src/components/AppSidebar.tsx:108
 #: src/components/charts/FitnessFatigueChart.tsx:216
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
@@ -1956,7 +1956,7 @@ msgstr "今日的恢复尚未同步。显示 {latestDateLabel} 的最新读数�
 msgid "Train toward a specific race date"
 msgstr "围绕特定比赛日期进行训练"
 
-#: src/components/AppSidebar.tsx:102
+#: src/components/AppSidebar.tsx:109
 msgid "Training"
 msgstr "训练"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -181,7 +181,7 @@ msgstr "激活"
 msgid "Active"
 msgstr "当前使用"
 
-#: src/components/AppSidebar.tsx:68
+#: src/components/AppSidebar.tsx:104
 #: src/pages/History.tsx:38
 #: src/pages/Settings.tsx:53
 #: src/pages/Settings.tsx:60
@@ -212,7 +212,7 @@ msgstr "实际"
 msgid "Adjust Workout"
 msgstr "调整训练"
 
-#: src/components/AppSidebar.tsx:71
+#: src/components/AppSidebar.tsx:113
 #: src/pages/Admin.tsx:233
 #: src/pages/Admin.tsx:280
 msgid "Admin"
@@ -544,7 +544,7 @@ msgstr "当前设置为基于 {0} 的训练"
 msgid "Cycling"
 msgstr "骑行"
 
-#: src/components/AppSidebar.tsx:28
+#: src/components/AppSidebar.tsx:29
 msgid "Dark"
 msgstr "深色"
 
@@ -912,7 +912,7 @@ msgstr "轻松进行"
 msgid "Go to dashboard"
 msgstr "前往仪表盘"
 
-#: src/components/AppSidebar.tsx:67
+#: src/components/AppSidebar.tsx:103
 #: src/pages/Settings.tsx:1129
 msgid "Goal"
 msgstr "目标"
@@ -1080,7 +1080,7 @@ msgstr "首个账号可留空，之后必填。"
 msgid "Leave blank to track predicted time only"
 msgstr "留空则仅追踪预测时间"
 
-#: src/components/AppSidebar.tsx:29
+#: src/components/AppSidebar.tsx:30
 msgid "Light"
 msgstr "浅色"
 
@@ -1116,8 +1116,8 @@ msgstr "负荷与体能"
 msgid "Log in to connect your CLI plugin"
 msgstr "登录以连接 CLI 插件"
 
-#: src/components/AppSidebar.tsx:145
-#: src/components/AppSidebar.tsx:147
+#: src/components/AppSidebar.tsx:183
+#: src/components/AppSidebar.tsx:185
 msgid "Log out"
 msgstr "退出登录"
 
@@ -1676,7 +1676,7 @@ msgstr "保存目标"
 msgid "Saving..."
 msgstr "保存中..."
 
-#: src/components/AppSidebar.tsx:69
+#: src/components/AppSidebar.tsx:108
 msgid "Science"
 msgstr "科学"
 
@@ -1707,12 +1707,13 @@ msgstr "设置您的目标"
 msgid "Set your name"
 msgstr "设置您的名字"
 
-#: src/components/AppSidebar.tsx:70
+#: src/components/AppSidebar.tsx:112
 #: src/pages/Settings.tsx:547
 msgid "Settings"
 msgstr "设置"
 
-#: src/components/AppSidebar.tsx:62
+#: src/components/AppSidebar.tsx:128
+#: src/components/AppSidebar.tsx:132
 msgid "Setup"
 msgstr "设置向导"
 
@@ -1867,7 +1868,7 @@ msgstr "同步中"
 msgid "Syncing..."
 msgstr "同步中..."
 
-#: src/components/AppSidebar.tsx:30
+#: src/components/AppSidebar.tsx:31
 msgid "System"
 msgstr "跟随系统"
 
@@ -1904,7 +1905,7 @@ msgstr "目标时间"
 msgid "Tempo"
 msgstr "节奏跑"
 
-#: src/components/AppSidebar.tsx:139
+#: src/components/AppSidebar.tsx:177
 msgid "Theme"
 msgstr "主题"
 
@@ -1935,7 +1936,7 @@ msgstr "阈值"
 msgid "Title"
 msgstr "标题"
 
-#: src/components/AppSidebar.tsx:61
+#: src/components/AppSidebar.tsx:101
 #: src/components/charts/FitnessFatigueChart.tsx:216
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
@@ -1955,7 +1956,7 @@ msgstr "今日的恢复尚未同步。显示 {latestDateLabel} 的最新读数�
 msgid "Train toward a specific race date"
 msgstr "围绕特定比赛日期进行训练"
 
-#: src/components/AppSidebar.tsx:66
+#: src/components/AppSidebar.tsx:102
 msgid "Training"
 msgstr "训练"
 


### PR DESCRIPTION
## Summary

Audit + redesign of the navigation panel (`AppSidebar`) following the impeccable critique flow. Four findings addressed:

1. **Three semantic clusters** replace the prior flat 7-item list — Active (Today/Training/Goal/Activities), Reference (Science), Configuration (Settings/Admin) — separated by `SidebarSeparator`. Per DESIGN.md "Vary spacing for rhythm" and matches the user's mental mode shift between daily / reference / configuration tasks.

2. **Setup is now a separate dashed-border callout row** above the active cluster when onboarding is incomplete. Today stays as the stable home anchor regardless. Resolves the "two states in one row" confusion where Today's label silently swapped to "Setup (3/5)" and back depending on setup progress.

3. **Active route indicator** switched from shadcn's default background fill (`data-[active=true]:bg-sidebar-accent`) to the DESIGN.md-prescribed treatment: 3px primary green left edge + bolder weight + transparent background. The sidebar stays calm; the active mark is delicate, not a full row tint.

4. **Header wordmark** now uses the proper `Pra` + green `x` + `ys` brand-guide treatment via a new inline `PraxysWordmark` component. Plain text was wrong; the brand identity belongs in the chrome.

## Implementation

- **`PraxysWordmark`** — small inline component for the header wordmark
- **`NavItemRow`** — reusable nav-row helper with the new active-state styling. Keeps the indicator treatment DRY across the three clusters.
- **`activeItems` / `referenceItems` / `configItems`** — explicit clustering arrays. The home item ("Today") is permanent; previously it was conditionally swapped based on setup state.
- **`setupBanner`** — dashed-border `SidebarMenuButton` rendered above the active cluster when `setup.allDone` is false. Same `/today` destination as before.

## Live mode iteration

Three variants generated (separators-only / labeled-groups / two-tier-hierarchy). User accepted **V1 (separators-only)** as the cleanest signal without text-label noise.

## Verification

- `npx tsc --noEmit` — clean (only the pre-existing `baseUrl` deprecation warning, unrelated)
- `npx eslint web/src/components/AppSidebar.tsx` — clean
- `npm run i18n:extract` — 0 missing in zh

## Test plan

- [ ] Open any page; verify sidebar shows three clusters with separators (Active / Reference / Configuration)
- [ ] Active route shows a 3px green left-edge indicator; no background fill
- [ ] Switch theme to dark; active indicator + cobalt accents render correctly in dark
- [ ] Switch locale to zh; all sidebar labels translate
- [ ] Trigger an incomplete-setup state; verify the dashed Setup banner row renders above the active cluster, links to /today, shows progress (`Setup (3/5)`)
- [ ] Collapse sidebar to icon mode (desktop); verify all icons still render and active indicator still shows
- [ ] Mobile (`<lg`); sidebar opens as sheet drawer; clusters and separators render correctly
- [ ] Header wordmark shows `Pra` + green `x` + `ys`; theme cycler + log out still work in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)