### PR TITLE
Silence Azure Monitor exporter self-trace to cut AppTraces ingestion

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -41,6 +41,22 @@ if os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING"):
     else:
         configure_azure_monitor()
 
+    # configure_azure_monitor attaches a LoggingHandler to the root logger,
+    # which means anything these libraries log at INFO gets shipped back into
+    # AppTraces — and the exporter / HTTP-policy loggers narrate every
+    # outbound /v2.1/track call ("Request URL ...", "Response status: 200",
+    # "Transmission succeeded: Item received: 3"). At our traffic that was
+    # ~95% of AppTraces volume (≈0.45 GB/wk → near zero after this clamp),
+    # forming a self-amplifying loop where each batch produced more telemetry
+    # to batch. Clamping to WARNING keeps real failures (which the SDK logs
+    # at WARNING+) while dropping the success-path narration.
+    for _noisy in (
+        "azure.core.pipeline.policies.http_logging_policy",
+        "azure.monitor.opentelemetry.exporter",
+        "azure.identity",
+    ):
+        logging.getLogger(_noisy).setLevel(logging.WARNING)
+
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware


### PR DESCRIPTION
## Why

`configure_azure_monitor()` in `api/main.py` attaches a `LoggingHandler` to the root logger, so anything `azure.monitor.opentelemetry.exporter` and the underlying `azure.core.pipeline.policies.http_logging_policy` log at INFO gets shipped back into `AppTraces`. That formed a **self-amplifying loop**: every successful `/v2.1/track` POST produced 2–3 trace records narrating itself, which were then themselves batched and re-sent.

## Production measurement (last 7 days, `appi-trainsight`)

| Table | GB | Share |
|---|---:|---:|
| **AppTraces** | **0.45** | **73%** |
| AppPerformanceCounters | 0.06 | 10% |
| AppDependencies | 0.04 | 7% |
| AppMetrics | 0.04 | 6% |
| AppRequests | 0.013 | 2% |
| AppExceptions | 0.011 | 2% |

Top 4 `AppTraces` message prefixes by count over 2 days:

| Records | Prefix |
|---:|---|
| 39,950 | ``Request URL: 'https://eastasia-0.in.applicationinsights.azure.com//v2.1/track'`` |
| 39,949 | `Response status: 200 / Response headers: ...` |
| 23,583 | `Transmission succeeded: Item received: 3. Items accepted: 3` |
| 4,485 | `Transmission succeeded: Item received: 6. Items accepted: 6` |

Real app logs (scheduled-sync ticks, Garmin 429s) are buried at the long tail.

## What this changes

Clamps three libraries to `WARNING` immediately after `configure_azure_monitor` returns:

- `azure.core.pipeline.policies.http_logging_policy` — the source of "Request URL / Response status" lines
- `azure.monitor.opentelemetry.exporter` — the source of "Transmission succeeded ..." lines
- `azure.identity` — same shape of MI/AAD token-acquisition narration

Failure-path messages (401/403/429 from the exporter, MI token errors) still log, since those libraries emit them at WARNING+.

## Expected effect

- `AppTraces` ingestion drops ~95% (0.45 GB/wk → ~0.02 GB/wk)
- Total billable ingestion ≈ 25 MB/day, well under the 5 GB/month free tier
- Daily App Insights cost on this workspace should approach zero (availability tests aside)

## Scope guard

The clamp lives inside the existing `if APPLICATIONINSIGHTS_CONNECTION_STRING:` block, so no-Azure dev environments are untouched.

## Test plan

- [x] `python -m pytest tests/test_telemetry.py -v` — 16/16 pass
- [x] `python -c "import api.main"` — imports cleanly with no env var set
- [ ] After merge, watch Azure Portal → `appi-trainsight` → Logs:
  ```kusto
  AppTraces
  | where TimeGenerated > ago(24h)
  | summarize n=count() by bin(TimeGenerated, 1h)
  | order by TimeGenerated asc
  ```
  Expect a ~95% drop within ~1h of the App Service restart that follows deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)