### PR TITLE
Stop Garmin sync retry storm: exponential backoff + auth_required state

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -241,14 +241,21 @@ def load_config_from_db(user_id: str, db) -> UserConfig:
 
 
 def _get_connections_from_db(user_id: str, db) -> list[str]:
-    """Get connected platform names from user_connections table."""
+    """Get connected platform names from user_connections table.
+
+    Includes ``auth_required`` so a CAPTCHA-locked Garmin user keeps
+    being treated as a Garmin user for analysis purposes — otherwise
+    their preferred provider would silently flip every request until
+    they reconnect.
+    """
     from db.models import UserConnection
+    from db.sync_scheduler import ACTIVE_CONNECTION_STATUSES
 
     rows = (
         db.query(UserConnection.platform)
         .filter(
             UserConnection.user_id == user_id,
-            UserConnection.status.in_(["connected", "error"]),
+            UserConnection.status.in_(ACTIVE_CONNECTION_STATUSES),
         )
         .all()
     )
@@ -259,15 +266,20 @@ def _get_preferences_from_db(user_id: str, db) -> dict:
     """Derive preferences from user_connections.
 
     Builds a category -> platform mapping from connection preferences.
+    Same status filter as ``_get_connections_from_db`` so an
+    auth_required connection's stored preferences (which provider the
+    user picked for activities / power / recovery) survive a temporary
+    auth gate.
     """
     from db.models import UserConnection
+    from db.sync_scheduler import ACTIVE_CONNECTION_STATUSES
 
     prefs = {}
     rows = (
         db.query(UserConnection)
         .filter(
             UserConnection.user_id == user_id,
-            UserConnection.status.in_(["connected", "error"]),
+            UserConnection.status.in_(ACTIVE_CONNECTION_STATUSES),
         )
         .all()
     )

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -529,10 +529,17 @@ def _upsert_connection_credentials(
     prefs = {k: v for k, v in caps.items() if v}
 
     if conn:
+        # Re-uploading credentials is the user's "I fixed it" signal —
+        # reset scheduler-backoff state so an auth_required connection
+        # rejoins the regular schedule once the user clears whatever
+        # gate (CAPTCHA, password change, MFA) blocked it.
+        from db.sync_scheduler import reset_connection_backoff
+
         conn.encrypted_credentials = encrypted_data
         conn.wrapped_dek = wrapped_dek
         conn.status = "connected"
         conn.preferences = prefs
+        reset_connection_backoff(conn)
     else:
         conn = UserConnection(
             user_id=user_id,
@@ -581,6 +588,13 @@ def get_connections(
             "status": conn.status,
             "last_sync": utc_isoformat(conn.last_sync),
             "has_credentials": conn.encrypted_credentials is not None,
+            # Surfaced so the UI can show "Reconnect required" instead of
+            # "Sync" when status is auth_required, and so it can show
+            # "Next retry in 4h" while a transient backoff is in effect.
+            # Both are read-only — the user clears them by reconnecting.
+            "next_retry_at": utc_isoformat(conn.next_retry_at),
+            "consecutive_failures": conn.consecutive_failures or 0,
+            "last_error": conn.last_error,
         }
     return {"connections": result}
 

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -236,7 +236,11 @@ def _run_sync(user_id: str, source: str, creds: dict,
                 logger.exception("Activity-derived CP refresh failed for user %s", user_id)
                 db.rollback()
 
-        # Update last_sync on the connection record
+        # Update last_sync on the connection record. Clear any prior
+        # backoff state so a previously-failed connection that the user
+        # successfully synced manually (or that recovered on its own)
+        # rejoins the regular schedule immediately.
+        from db.sync_scheduler import reset_connection_backoff
         conn = db.query(UserConnection).filter(
             UserConnection.user_id == user_id,
             UserConnection.platform == source,
@@ -244,6 +248,7 @@ def _run_sync(user_id: str, source: str, creds: dict,
         if conn:
             conn.last_sync = datetime.now(timezone.utc).replace(tzinfo=None)
             conn.status = "connected"
+            reset_connection_backoff(conn)
             db.commit()
 
         logger.info("Sync %s for user %s: %s", source, user_id, counts)
@@ -277,15 +282,17 @@ def _run_sync(user_id: str, source: str, creds: dict,
                 "last_sync": None,
                 "error": str(e),
             }
-        # Update connection status to error
+        # Update connection status with classification + backoff so the
+        # background scheduler stops hammering a stuck connection.
+        # ``_record_sync_failure`` handles its own rollback and commit.
         try:
+            from db.sync_scheduler import _record_sync_failure
             conn = db.query(UserConnection).filter(
                 UserConnection.user_id == user_id,
                 UserConnection.platform == source,
             ).first()
             if conn:
-                conn.status = "error"
-                db.commit()
+                _record_sync_failure(conn, e, db)
         except Exception:
             pass
     finally:

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -1152,6 +1152,7 @@ def get_sync_status(
 ) -> dict:
     """Return current sync status for this user's connected platforms."""
     from db.models import UserConnection
+    from db.sync_scheduler import ACTIVE_CONNECTION_STATUSES
 
     # Snapshot runtime status under lock to avoid reading partial updates.
     # _get_user_status acquires _sync_lock internally, so call it outside
@@ -1172,7 +1173,7 @@ def get_sync_status(
             "status": runtime.get("status", "idle"),
             "last_sync": utc_isoformat(conn.last_sync) or runtime.get("last_sync"),
             "error": runtime.get("error"),
-            "connected": conn.status in ("connected", "error"),
+            "connected": conn.status in ACTIVE_CONNECTION_STATUSES,
             "progress": runtime.get("progress"),
         }
 

--- a/db/models.py
+++ b/db/models.py
@@ -110,7 +110,19 @@ class UserConnection(Base):
     last_sync = Column(DateTime, nullable=True)
     status = Column(
         String(20), default="disconnected"
-    )  # connected, error, expired, disconnected
+    )  # connected, error, auth_required, expired, disconnected
+
+    # Scheduler backoff state. Without this, a stuck connection (expired
+    # token, account-locked, CAPTCHA-gated) made the scheduler retry every
+    # 10 min indefinitely, which on 2026-04-25 escalated Garmin's bot
+    # mitigation from transient 429s to a persistent CAPTCHA flag against
+    # the App Service outbound IP. consecutive_failures drives exponential
+    # backoff; next_retry_at gates the scheduler (skip while in future);
+    # last_error captures a short tag for the UI. All three reset on
+    # successful sync or when the user reconnects credentials.
+    consecutive_failures = Column(Integer, nullable=False, default=0)
+    next_retry_at = Column(DateTime, nullable=True)
+    last_error = Column(String(500), nullable=True)
 
     user = relationship("User", back_populates="connections")
     __table_args__ = (

--- a/db/session.py
+++ b/db/session.py
@@ -130,6 +130,9 @@ def init_db():
         ("users", "wechat_nickname", "VARCHAR(100) DEFAULT NULL"),
         ("users", "wechat_avatar_url", "VARCHAR(500) DEFAULT NULL"),
         ("ai_insights", "translations", "JSON DEFAULT '{}'"),
+        ("user_connections", "consecutive_failures", "INTEGER NOT NULL DEFAULT 0"),
+        ("user_connections", "next_retry_at", "DATETIME DEFAULT NULL"),
+        ("user_connections", "last_error", "VARCHAR(500) DEFAULT NULL"),
     ]
     _indexes = [
         # (index_name, table, column, unique)

--- a/db/sync_scheduler.py
+++ b/db/sync_scheduler.py
@@ -18,8 +18,137 @@ DEFAULT_SYNC_INTERVAL_HOURS = 6
 ALLOWED_SYNC_INTERVAL_HOURS = (6, 12, 24)
 DELAY_BETWEEN_SYNCS_SEC = 5  # Stagger between user/platform syncs
 
+# Exponential backoff for failed connections: 1h, 2h, 4h, 8h, 16h, then
+# capped at 24h. Without backoff, a stuck Garmin connection retried every
+# 10 min triggered Garmin's bot mitigation to escalate from transient
+# 429s to a persistent CAPTCHA flag against our outbound IP — see the
+# 2026-04-25 lockout postmortem.
+BACKOFF_BASE_SEC = 3600
+BACKOFF_MAX_SEC = 86400
+
 _scheduler_thread: threading.Thread | None = None
 _stop_event = threading.Event()
+
+
+def backoff_seconds(consecutive_failures: int) -> int:
+    """Return the retry delay (seconds) after N consecutive failures.
+
+    1h, 2h, 4h, 8h, 16h, 24h, 24h, … — doubles up to BACKOFF_MAX_SEC.
+    consecutive_failures is the count *including* the current failure
+    (so 1 means "first failure, wait 1h"; 0 is treated as 1).
+    """
+    n = max(consecutive_failures, 1)
+    return min(BACKOFF_BASE_SEC * (2 ** (n - 1)), BACKOFF_MAX_SEC)
+
+
+def classify_sync_failure(exc: BaseException) -> tuple[str, bool]:
+    """Map a sync exception to (connection_status, terminal).
+
+    ``terminal=True`` means we should not auto-retry — only the user
+    re-uploading credentials clears it. We use this for two cases:
+
+    * ``GarminConnectAuthenticationError`` — wrong password, or the CN
+      "JWT_WEB cookie not set" path that already gets a portal-fallback
+      retry inside ``_login_garmin_with_cn_fallback``; if it still
+      bubbles up to here, no amount of waiting fixes it.
+    * ``CAPTCHA_REQUIRED`` — Garmin's portal login returns this in JSON
+      when an account/IP has been flagged for human verification. Our
+      headless login has no way to satisfy a CAPTCHA, so we have to
+      stop retrying and tell the user to clear the flag in a real
+      browser before reconnecting. The marker survives the library's
+      "All login strategies exhausted: …" wrapping because the wrapped
+      response dict is preserved in the message.
+
+    Anything else is treated as transient — the caller applies exponential
+    backoff and tries again later.
+    """
+    cls_name = type(exc).__name__
+    msg = str(exc) or ""
+
+    if cls_name == "GarminConnectAuthenticationError":
+        return ("auth_required", True)
+    if "CAPTCHA_REQUIRED" in msg:
+        return ("auth_required", True)
+    return ("error", False)
+
+
+def _short_error(exc: BaseException) -> str:
+    """Compact "<ClassName>: <truncated message>" tag for the connection row.
+
+    Stored on the connection so the UI can show why a sync stopped without
+    leaking a full stack trace. Capped well under the column's 500 chars.
+    """
+    msg = (str(exc) or "").strip()
+    if len(msg) > 400:
+        msg = msg[:400] + "…"
+    return f"{type(exc).__name__}: {msg}" if msg else type(exc).__name__
+
+
+def _record_sync_failure(conn, exc: BaseException, db) -> None:
+    """Update a connection row after a sync failure with classification + backoff.
+
+    Rolls back any pending state from the failed sync, then writes the
+    new status, ``consecutive_failures``, ``next_retry_at`` and
+    ``last_error`` in a fresh transaction. Best-effort: a write failure
+    here just drops the bookkeeping — the next tick will re-classify.
+    """
+    try:
+        db.rollback()
+    except Exception:
+        pass
+
+    try:
+        # Re-fetch in case rollback detached state from the prior session.
+        from db.models import UserConnection
+
+        fresh = db.query(UserConnection).filter(
+            UserConnection.id == conn.id,
+        ).first()
+        if fresh is None:
+            return
+
+        new_failures = (fresh.consecutive_failures or 0) + 1
+        status, terminal = classify_sync_failure(exc)
+
+        fresh.consecutive_failures = new_failures
+        fresh.status = status
+        fresh.last_error = _short_error(exc)
+        if terminal:
+            # Auth_required: stop scheduling entirely until reconnect clears
+            # the gate. next_retry_at stays NULL; the scheduler skips on
+            # status alone.
+            fresh.next_retry_at = None
+        else:
+            delay = backoff_seconds(new_failures)
+            fresh.next_retry_at = datetime.utcnow() + timedelta(seconds=delay)
+        db.commit()
+        logger.info(
+            "Sync failure recorded: user=%s platform=%s status=%s "
+            "consecutive=%d next_retry_at=%s",
+            fresh.user_id, fresh.platform, status, new_failures,
+            fresh.next_retry_at,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to record sync failure metadata for user=%s platform=%s",
+            getattr(conn, "user_id", "?"), getattr(conn, "platform", "?"),
+        )
+        try:
+            db.rollback()
+        except Exception:
+            pass
+
+
+def reset_connection_backoff(conn) -> None:
+    """Reset all retry-state fields on a connection row.
+
+    Called when the user re-uploads credentials (the explicit "I fixed it,
+    try again" signal) and after every successful sync. Does not commit —
+    the caller commits as part of a larger transaction.
+    """
+    conn.consecutive_failures = 0
+    conn.next_retry_at = None
+    conn.last_error = None
 
 
 def normalize_sync_interval_hours(value: object) -> int:
@@ -105,6 +234,10 @@ def _check_and_sync():
     init_db()
     db = SessionLocal()
     try:
+        # ``auth_required`` is intentionally excluded — those connections
+        # are blocked on user action (re-upload credentials after clearing
+        # whatever account-level gate Garmin / Stryd / etc. flagged) and
+        # silently retrying just escalates the gate further.
         connections = db.query(UserConnection).filter(
             UserConnection.status.in_(["connected", "error"]),
         ).all()
@@ -112,6 +245,12 @@ def _check_and_sync():
         now = datetime.utcnow()
         sync_intervals_by_user: dict[str, int] = {}
         for conn in connections:
+            # Skip connections still in their backoff window. ``next_retry_at``
+            # is bumped after every transient failure (see _record_sync_failure)
+            # and cleared on success or reconnect (reset_connection_backoff).
+            if conn.next_retry_at and conn.next_retry_at > now:
+                continue
+
             if conn.user_id not in sync_intervals_by_user:
                 # Isolate per-user config lookup so one bad row can't skip every
                 # remaining user this tick.
@@ -137,17 +276,20 @@ def _check_and_sync():
                 continue  # Not stale yet
 
             logger.info(
-                "Scheduled sync: user=%s platform=%s (last=%s interval=%sh)",
+                "Scheduled sync: user=%s platform=%s (last=%s interval=%sh "
+                "consecutive_failures=%d)",
                 conn.user_id, conn.platform, last, interval_hours,
+                conn.consecutive_failures or 0,
             )
             try:
                 _sync_connection(conn.user_id, conn.platform, db)
                 time.sleep(DELAY_BETWEEN_SYNCS_SEC)
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     "Scheduled sync failed: user=%s platform=%s",
                     conn.user_id, conn.platform,
                 )
+                _record_sync_failure(conn, exc, db)
     finally:
         db.close()
 
@@ -207,9 +349,11 @@ def _sync_connection(user_id: str, platform: str, db):
             logger.exception("Activity-derived CP refresh failed: user=%s", user_id)
             db.rollback()
 
-    # Update last_sync
+    # Update last_sync and clear any prior backoff state — a successful
+    # sync is the strongest possible signal that the connection is healthy.
     conn.last_sync = datetime.utcnow()
     conn.status = "connected"
+    reset_connection_backoff(conn)
     db.commit()
     logger.info("Sync complete: user=%s platform=%s counts=%s", user_id, platform, counts)
 

--- a/db/sync_scheduler.py
+++ b/db/sync_scheduler.py
@@ -26,6 +26,25 @@ DELAY_BETWEEN_SYNCS_SEC = 5  # Stagger between user/platform syncs
 BACKOFF_BASE_SEC = 3600
 BACKOFF_MAX_SEC = 86400
 
+# Connection-status enums grouped by intent. Two distinct queries hit
+# user_connections.status throughout the app and mean different things,
+# so we name them explicitly to keep them from drifting:
+#
+# * SCHEDULABLE_STATUSES — what _check_and_sync attempts to retry.
+#   ``auth_required`` is intentionally excluded; the user has to
+#   reconnect credentials before we touch the connection again.
+# * ACTIVE_CONNECTION_STATUSES — "the user has a configured connection
+#   for this platform." Used by analysis/config and the connections
+#   listing endpoints to keep an auth-locked user's source preferences
+#   and platform list stable while they're stuck in auth_required.
+#   Without this, a CAPTCHA-locked Garmin user's analysis would
+#   silently fall back to a different (or no) provider on every
+#   request, until they reconnect — invisible to them.
+SCHEDULABLE_STATUSES: tuple[str, ...] = ("connected", "error")
+ACTIVE_CONNECTION_STATUSES: tuple[str, ...] = (
+    "connected", "error", "auth_required",
+)
+
 _scheduler_thread: threading.Thread | None = None
 _stop_event = threading.Event()
 
@@ -234,12 +253,13 @@ def _check_and_sync():
     init_db()
     db = SessionLocal()
     try:
-        # ``auth_required`` is intentionally excluded — those connections
-        # are blocked on user action (re-upload credentials after clearing
-        # whatever account-level gate Garmin / Stryd / etc. flagged) and
-        # silently retrying just escalates the gate further.
+        # SCHEDULABLE_STATUSES intentionally excludes ``auth_required`` —
+        # those connections are blocked on user action (re-upload
+        # credentials after clearing whatever account-level gate Garmin
+        # or Stryd flagged) and silently retrying just escalates the
+        # gate further.
         connections = db.query(UserConnection).filter(
-            UserConnection.status.in_(["connected", "error"]),
+            UserConnection.status.in_(SCHEDULABLE_STATUSES),
         ).all()
 
         now = datetime.utcnow()

--- a/miniapp/types/api.ts
+++ b/miniapp/types/api.ts
@@ -129,6 +129,15 @@ export interface PlatformConnection {
   status: string;
   last_sync: string | null;
   has_credentials: boolean;
+  // Scheduler retry-state surfaced for UI: when status is "error", the
+  // connection is in exponential backoff and `next_retry_at` says when
+  // the next attempt fires; when status is "auth_required" the user
+  // must reconnect and `next_retry_at` is null. `last_error` is a short
+  // tag for the failure cause (e.g. "GarminConnectConnectionError:
+  // Portal login failed (non-JSON): HTTP 403"), suitable for a tooltip.
+  next_retry_at?: string | null;
+  consecutive_failures?: number;
+  last_error?: string | null;
 }
 
 export interface ConnectionsResponse {
@@ -138,6 +147,8 @@ export interface ConnectionsResponse {
 export interface StravaOAuthStartRequest {
   web_origin: string;
   return_to: string;
+  client_id?: string;
+  client_secret?: string;
 }
 
 export interface StravaOAuthStartResponse {

--- a/plugins/praxys/mcp-server/server.py
+++ b/plugins/praxys/mcp-server/server.py
@@ -840,6 +840,7 @@ def get_sync_status() -> str:
             db = _local_db()
             try:
                 from db.models import UserConnection
+                from db.sync_scheduler import ACTIVE_CONNECTION_STATUSES
                 connections = db.query(UserConnection).filter(
                     UserConnection.user_id == _local_user_id()
                 ).all()
@@ -848,7 +849,7 @@ def get_sync_status() -> str:
                     data[conn.platform] = {
                         "status": "idle",
                         "last_sync": conn.last_sync.isoformat() if conn.last_sync else None,
-                        "connected": conn.status in ("connected", "error"),
+                        "connected": conn.status in ACTIVE_CONNECTION_STATUSES,
                     }
             finally:
                 db.close()

--- a/tests/test_sync_backoff.py
+++ b/tests/test_sync_backoff.py
@@ -1,0 +1,370 @@
+"""Tests for the sync-failure backoff state machine.
+
+Background — the 2026-04-25 Garmin lockout traced back to the scheduler
+retrying failed connections every 10 min indefinitely. Repeated automated
+SSO attempts from one Azure App Service IP escalated Garmin's bot
+mitigation from a transient 429 to a persistent CAPTCHA flag, which
+locked out four users until the connection-state machine learned to
+back off (transient errors) and stop entirely (auth-required errors).
+
+These tests cover the four pieces that together prevent a repeat:
+
+1. ``backoff_seconds`` — exponential schedule capped at 24h.
+2. ``classify_sync_failure`` — distinguishes terminal auth gates from
+   transient connection errors so the scheduler can stop hammering the
+   former without locking out the latter forever.
+3. ``_record_sync_failure`` — writes the new status, counter, retry
+   timestamp, and short error tag to the connection row.
+4. ``_check_and_sync`` — actually skips backed-off / auth-required rows
+   and clears state on a successful sync.
+"""
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def db_setup(monkeypatch):
+    """Init a clean SQLite DB with one seeded user for the integration tests."""
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_SYNC_SCHEDULER", "false")
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY",
+        "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=",
+    )
+
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from db.models import User
+
+    user_id = "backoff-test-user"
+    db = db_session.SessionLocal()
+    try:
+        db.add(User(id=user_id, email="backoff@example.com", hashed_password="x"))
+        db.commit()
+    finally:
+        db.close()
+
+    yield user_id, tmpdir
+
+
+# ---------------------------------------------------------------------------
+# backoff_seconds — pure math
+# ---------------------------------------------------------------------------
+
+def test_backoff_seconds_exponential_then_capped() -> None:
+    """1h, 2h, 4h, 8h, 16h, then capped at 24h regardless of further failures."""
+    from db.sync_scheduler import backoff_seconds, BACKOFF_MAX_SEC
+
+    assert backoff_seconds(1) == 3600
+    assert backoff_seconds(2) == 7200
+    assert backoff_seconds(3) == 14400
+    assert backoff_seconds(4) == 28800
+    assert backoff_seconds(5) == 57600
+    assert backoff_seconds(6) == BACKOFF_MAX_SEC  # 16h*2 = 32h → capped at 24h
+    assert backoff_seconds(20) == BACKOFF_MAX_SEC
+
+
+def test_backoff_seconds_treats_zero_as_first_failure() -> None:
+    """The retry-state init value is 0; the formula must still produce 1h."""
+    from db.sync_scheduler import backoff_seconds
+
+    assert backoff_seconds(0) == 3600
+
+
+# ---------------------------------------------------------------------------
+# classify_sync_failure — pure logic
+# ---------------------------------------------------------------------------
+
+class _FakeAuthError(Exception):
+    """Stand-in for garminconnect.GarminConnectAuthenticationError."""
+
+
+# Class name has to match exactly — classification is name-based to avoid
+# importing garminconnect from a pure-logic test.
+_FakeAuthError.__name__ = "GarminConnectAuthenticationError"
+
+
+def test_classify_authentication_error_is_terminal() -> None:
+    """Wrong-password / JWT_WEB-fallthrough errors stop the scheduler entirely."""
+    from db.sync_scheduler import classify_sync_failure
+
+    status, terminal = classify_sync_failure(
+        _FakeAuthError("401 Unauthorized (Invalid Username or Password)")
+    )
+    assert status == "auth_required"
+    assert terminal is True
+
+
+def test_classify_captcha_required_in_message_is_terminal() -> None:
+    """CAPTCHA_REQUIRED can't be solved headlessly — stop and ask the user."""
+    from db.sync_scheduler import classify_sync_failure
+
+    # The library wraps the failing strategy's error in "All login strategies
+    # exhausted: …" — the CAPTCHA marker has to survive that wrapping.
+    err = RuntimeError(
+        "All login strategies exhausted: Portal web login failed: "
+        "{'responseStatus': {'type': 'CAPTCHA_REQUIRED'}, ...}"
+    )
+    status, terminal = classify_sync_failure(err)
+    assert status == "auth_required"
+    assert terminal is True
+
+
+def test_classify_generic_connection_error_is_transient() -> None:
+    """A 403 / 429 / network blip should retry under exponential backoff."""
+    from db.sync_scheduler import classify_sync_failure
+
+    err = RuntimeError("Portal login failed (non-JSON): HTTP 403")
+    status, terminal = classify_sync_failure(err)
+    assert status == "error"
+    assert terminal is False
+
+
+# ---------------------------------------------------------------------------
+# _record_sync_failure — DB-level integration
+# ---------------------------------------------------------------------------
+
+def _make_connection(db, user_id: str, platform: str = "garmin"):
+    from db.models import UserConnection
+
+    conn = UserConnection(
+        user_id=user_id,
+        platform=platform,
+        status="connected",
+        consecutive_failures=0,
+    )
+    db.add(conn)
+    db.commit()
+    return conn
+
+
+def test_record_failure_increments_counter_and_schedules_retry(db_setup) -> None:
+    """First transient failure: counter=1, next_retry_at=+1h, status=error."""
+    from db import session as db_session
+    from db.sync_scheduler import _record_sync_failure
+    from db.models import UserConnection
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        before = datetime.utcnow()
+
+        _record_sync_failure(conn, RuntimeError("HTTP 403"), db)
+
+        fresh = db.query(UserConnection).filter(
+            UserConnection.id == conn.id,
+        ).first()
+        assert fresh.consecutive_failures == 1
+        assert fresh.status == "error"
+        assert fresh.next_retry_at is not None
+        # ~1h, with a generous window for slow CI
+        delta = (fresh.next_retry_at - before).total_seconds()
+        assert 3500 <= delta <= 3700
+        assert "HTTP 403" in (fresh.last_error or "")
+    finally:
+        db.close()
+
+
+def test_record_failure_captcha_clears_next_retry_at(db_setup) -> None:
+    """Terminal auth failures must NOT set next_retry_at — the scheduler
+    skips on status alone, and a stale timestamp would be misleading in
+    the UI."""
+    from db import session as db_session
+    from db.sync_scheduler import _record_sync_failure
+    from db.models import UserConnection
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        # Pre-populate a stale retry timestamp from an earlier transient
+        # failure to verify the terminal classification overwrites it.
+        conn.next_retry_at = datetime.utcnow() + timedelta(hours=2)
+        conn.consecutive_failures = 3
+        db.commit()
+
+        err = RuntimeError(
+            "All login strategies exhausted: Portal web login failed: "
+            "{'responseStatus': {'type': 'CAPTCHA_REQUIRED'}}"
+        )
+        _record_sync_failure(conn, err, db)
+
+        fresh = db.query(UserConnection).filter(
+            UserConnection.id == conn.id,
+        ).first()
+        assert fresh.status == "auth_required"
+        assert fresh.next_retry_at is None
+        assert fresh.consecutive_failures == 4
+        assert "CAPTCHA_REQUIRED" in (fresh.last_error or "")
+    finally:
+        db.close()
+
+
+def test_record_failure_consecutive_failures_grow(db_setup) -> None:
+    """Each successive failure increments the counter and stretches the retry."""
+    from db import session as db_session
+    from db.sync_scheduler import _record_sync_failure, backoff_seconds
+    from db.models import UserConnection
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+
+        for expected_n in (1, 2, 3):
+            before = datetime.utcnow()
+            _record_sync_failure(conn, RuntimeError("transient"), db)
+            fresh = db.query(UserConnection).filter(
+                UserConnection.id == conn.id,
+            ).first()
+            assert fresh.consecutive_failures == expected_n
+            expected_delay = backoff_seconds(expected_n)
+            actual = (fresh.next_retry_at - before).total_seconds()
+            # ±100s tolerance for slow CI runners
+            assert abs(actual - expected_delay) < 100, (
+                f"After {expected_n} failures expected ~{expected_delay}s, got {actual:.0f}s"
+            )
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# reset_connection_backoff — clear state on success / reconnect
+# ---------------------------------------------------------------------------
+
+def test_reset_clears_all_backoff_fields(db_setup) -> None:
+    """Reset wipes counter, retry timestamp, and error tag in one shot."""
+    from db import session as db_session
+    from db.sync_scheduler import reset_connection_backoff
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        conn.consecutive_failures = 5
+        conn.next_retry_at = datetime.utcnow() + timedelta(hours=4)
+        conn.last_error = "GarminConnectConnectionError: HTTP 403"
+        db.commit()
+
+        reset_connection_backoff(conn)
+        db.commit()
+
+        assert conn.consecutive_failures == 0
+        assert conn.next_retry_at is None
+        assert conn.last_error is None
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# _check_and_sync — scheduler skip behavior
+# ---------------------------------------------------------------------------
+
+def test_check_and_sync_skips_connection_in_backoff_window(db_setup, monkeypatch) -> None:
+    """A connection with next_retry_at in the future must not be synced."""
+    from db import session as db_session
+    from db import sync_scheduler
+    from db.models import UserConnection, UserConfig
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        # Park the connection 2h into the future — well inside the backoff.
+        conn.status = "error"
+        conn.next_retry_at = datetime.utcnow() + timedelta(hours=2)
+        conn.consecutive_failures = 2
+        # Stale last_sync so the freshness check would otherwise trigger.
+        conn.last_sync = datetime.utcnow() - timedelta(days=1)
+        db.add(UserConfig(user_id=user_id))
+        db.commit()
+    finally:
+        db.close()
+
+    sync_calls: list[str] = []
+
+    def _fake_sync_connection(uid, platform, db):
+        sync_calls.append(f"{uid}:{platform}")
+
+    monkeypatch.setattr(sync_scheduler, "_sync_connection", _fake_sync_connection)
+
+    sync_scheduler._check_and_sync()
+
+    assert sync_calls == [], (
+        f"Backed-off connection must be skipped; was synced as {sync_calls!r}"
+    )
+
+
+def test_check_and_sync_skips_auth_required_connections(db_setup, monkeypatch) -> None:
+    """auth_required is terminal — only user reconnect can clear it."""
+    from db import session as db_session
+    from db import sync_scheduler
+    from db.models import UserConfig
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        conn.status = "auth_required"
+        # next_retry_at None — proves the skip is on status, not timestamp.
+        conn.next_retry_at = None
+        conn.last_sync = datetime.utcnow() - timedelta(days=1)
+        db.add(UserConfig(user_id=user_id))
+        db.commit()
+    finally:
+        db.close()
+
+    sync_calls: list[str] = []
+    monkeypatch.setattr(
+        sync_scheduler, "_sync_connection",
+        lambda uid, platform, db: sync_calls.append(f"{uid}:{platform}"),
+    )
+
+    sync_scheduler._check_and_sync()
+
+    assert sync_calls == [], (
+        f"auth_required connection must be skipped; was synced as {sync_calls!r}"
+    )
+
+
+def test_check_and_sync_runs_once_window_has_passed(db_setup, monkeypatch) -> None:
+    """When next_retry_at is in the past, the scheduler tries again."""
+    from db import session as db_session
+    from db import sync_scheduler
+    from db.models import UserConfig
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        conn.status = "error"
+        conn.next_retry_at = datetime.utcnow() - timedelta(minutes=5)
+        conn.consecutive_failures = 2
+        conn.last_sync = datetime.utcnow() - timedelta(days=1)
+        db.add(UserConfig(user_id=user_id))
+        db.commit()
+    finally:
+        db.close()
+
+    sync_calls: list[str] = []
+    monkeypatch.setattr(
+        sync_scheduler, "_sync_connection",
+        lambda uid, platform, db: sync_calls.append(f"{uid}:{platform}"),
+    )
+
+    sync_scheduler._check_and_sync()
+
+    assert sync_calls == [f"{user_id}:garmin"], (
+        f"Connection past its retry window must be synced; got {sync_calls!r}"
+    )

--- a/tests/test_sync_backoff.py
+++ b/tests/test_sync_backoff.py
@@ -338,6 +338,63 @@ def test_check_and_sync_skips_auth_required_connections(db_setup, monkeypatch) -
     )
 
 
+def test_check_and_sync_routes_failure_through_record_sync_failure(
+    db_setup, monkeypatch,
+) -> None:
+    """When _sync_connection raises, the scheduler must route the exception
+    into _record_sync_failure and persist the new state.
+
+    This is the actual production code path that fires every 10 min — the
+    individual unit tests don't cover it together. A regression here
+    (e.g., a future refactor that drops the except-clause call to
+    _record_sync_failure) wouldn't be caught by the per-helper tests
+    above, but would silently restore the retry storm this PR exists
+    to prevent.
+    """
+    from db import session as db_session
+    from db import sync_scheduler
+    from db.models import UserConnection, UserConfig
+
+    user_id, _ = db_setup
+    db = db_session.SessionLocal()
+    try:
+        conn = _make_connection(db, user_id)
+        # Stale last_sync so freshness gate doesn't skip us.
+        conn.last_sync = datetime.utcnow() - timedelta(days=1)
+        db.add(UserConfig(user_id=user_id))
+        db.commit()
+        conn_id = conn.id
+    finally:
+        db.close()
+
+    def _raise_captcha(uid, platform, db):
+        raise RuntimeError(
+            "All login strategies exhausted: Portal web login failed: "
+            "{'responseStatus': {'type': 'CAPTCHA_REQUIRED'}}"
+        )
+
+    monkeypatch.setattr(sync_scheduler, "_sync_connection", _raise_captcha)
+
+    sync_scheduler._check_and_sync()
+
+    db = db_session.SessionLocal()
+    try:
+        fresh = db.query(UserConnection).filter(
+            UserConnection.id == conn_id,
+        ).first()
+        assert fresh.status == "auth_required", (
+            f"CAPTCHA error from _sync_connection must route to "
+            f"auth_required via _record_sync_failure; got {fresh.status!r}"
+        )
+        assert fresh.next_retry_at is None, (
+            "Terminal classification must clear next_retry_at"
+        )
+        assert fresh.consecutive_failures == 1
+        assert "CAPTCHA_REQUIRED" in (fresh.last_error or "")
+    finally:
+        db.close()
+
+
 def test_check_and_sync_runs_once_window_has_passed(db_setup, monkeypatch) -> None:
     """When next_retry_at is in the past, the scheduler tries again."""
     from db import session as db_session

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -126,6 +126,15 @@ export interface PlatformConnection {
   status: string;
   last_sync: string | null;
   has_credentials: boolean;
+  // Scheduler retry-state surfaced for UI: when status is "error", the
+  // connection is in exponential backoff and `next_retry_at` says when
+  // the next attempt fires; when status is "auth_required" the user
+  // must reconnect and `next_retry_at` is null. `last_error` is a short
+  // tag for the failure cause (e.g. "GarminConnectConnectionError:
+  // Portal login failed (non-JSON): HTTP 403"), suitable for a tooltip.
+  next_retry_at?: string | null;
+  consecutive_failures?: number;
+  last_error?: string | null;
 }
 
 export interface ConnectionsResponse {


### PR DESCRIPTION
## Summary

App Insights shows that since **2026-04-25 07:18 UTC**, four of five Garmin users have been stuck in a continuous sync-retry loop (~60 failures per 6h, every 6h, for 7 days). The scheduler retried failed connections every 10 min indefinitely; the retry storm escalated Garmin's bot mitigation from transient 429s to a per-account `CAPTCHA_REQUIRED` flag, which is unsolvable from a headless login. The one user with a valid cached DI Bearer token kept syncing fine — the gate is only on the SSO endpoint, not the API endpoint.

This PR adds the missing application-layer retry discipline:

- **Exponential backoff** on transient failures (1h → 2h → 4h → 8h → 16h, capped at 24h).
- **Terminal `auth_required` status** for `GarminConnectAuthenticationError` and any error carrying `CAPTCHA_REQUIRED`. The scheduler stops touching the connection until the user re-uploads credentials (their explicit "I fixed it" signal).
- **State exposed in the connections API** (`next_retry_at`, `consecutive_failures`, `last_error`) so a follow-up UI PR can show "Reconnect required" instead of a stale "Sync" button.

## Why a code change rather than a library / IP fix

Upstream `cyberjunky/python-garminconnect` issues confirm the same pattern across many users — particularly from datacenter IPs:

- #350 (Apr 13) "Login still blocked by cloudflare" — same all-strategies-fail trace we see.
- #337 (Mar 19) "429 Too Many Requests - during login" — `stevedep`: *"I have the same issue when using a Docker in Azure, but not when I run locally."*
- #344 (Apr 4) "Add SSO web widget login strategy to bypass 429" — closed by 5-strategy chain in 0.3.2 (we already use 0.3.x).
- Maintainer in #332: *"sometimes a proxy server works, but even those are mostly blocked by cloudflare."*

The library has done its part. Without backoff at our layer, we keep feeding the gate that locks our users out.

## Effect on the four stuck users after deploy

1. Next scheduler tick fails with `CAPTCHA_REQUIRED` → status flips to `auth_required`, `next_retry_at` stays NULL.
2. Subsequent ticks skip the connection entirely — IP-level pressure on Garmin drops to zero.
3. User logs into garmin.com in a real browser to clear the CAPTCHA flag, then reconnects via Settings. `_upsert_connection_credentials` resets all backoff state and the scheduler resumes.

Healthy users see no behavior change — a successful sync resets state on every tick, same as before.

## Test plan

- [x] `pytest tests/test_sync_backoff.py -v` — 12 new tests cover backoff math, classification, `_record_sync_failure`, `reset_connection_backoff`, and scheduler skip behavior (backed-off connections, `auth_required`, retry past its window).
- [x] `pytest tests/` — full suite, 698 passed / 1 skipped, no regressions.
- [ ] After deploy, watch App Insights `AppTraces | where Message has "All login strategies exhausted"` — failure count should drop from ~60/6h to 1/6h per stuck user (one final fail to flip them to `auth_required`), then to zero.
- [ ] Have one stuck user (e.g. `5307d4bb-7913-4261-a5fe-ced208f911db`) clear their CAPTCHA flag at garmin.com, reconnect via praxys.run Settings, and verify next sync succeeds.

## Follow-ups (not in this PR)

- React Settings UI: show "Reconnect required" / "Next retry in 4h" using the new fields.
- One-time admin script (or just rely on natural flow): the four stuck users will auto-flip to `auth_required` on the next tick after deploy; no DB-level intervention needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)