### PR TITLE
miniapp Science: parity with web — tab strip + chiclet switcher

### DIFF
--- a/miniapp/pages/science/index.scss
+++ b/miniapp/pages/science/index.scss
@@ -1,3 +1,10 @@
+// Mobile parity for the web Science page redesign. Web uses a master-
+// detail layout (sticky left rail + detail panel); Skyline phones don't
+// have horizontal real estate for that, so the same feature set lands
+// here as a horizontal pillar tab strip + a vertical detail panel.
+// Chiclet switcher with preview-then-commit, advanced disclosure, and
+// zone-labels footer all match web behavior.
+
 .sci-root {
   display: flex;
   flex-direction: column;
@@ -11,15 +18,20 @@
 }
 
 .sci-content {
-  padding: 32rpx 32rpx 200rpx;
+  padding: 24rpx 32rpx 200rpx;
 }
 
-.sci-header {
-  font-size: 52rpx;
-  font-weight: 700;
-  color: var(--text);
+// --- Header ---
+
+.sci-eyebrow {
   display: block;
-  margin-bottom: 24rpx;
+  font-family: var(--font-mono, monospace);
+  font-size: 20rpx;
+  font-weight: 600;
+  letter-spacing: 4rpx;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 12rpx;
 }
 
 .sci-intro {
@@ -27,133 +39,353 @@
   font-size: 26rpx;
   color: var(--text-muted);
   line-height: 1.6;
+  margin-bottom: 28rpx;
+}
+
+// --- Pillar tab strip ---
+// Horizontal scroll so 4 tabs fit on narrow phones without truncation.
+// Focused tab gets a cobalt bottom edge — this whole page is the
+// "show your work / reasoning" surface, so cobalt is on-brand here.
+
+.sci-tabs-wrap {
+  margin: 0 -32rpx 28rpx;
+  padding: 0;
+  white-space: nowrap;
+  border-bottom: 1rpx solid var(--border);
+}
+
+.sci-tabs {
+  display: inline-flex;
+  padding: 0 32rpx;
+  gap: 8rpx;
+}
+
+.sci-tab {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 16rpx 20rpx 18rpx;
+  min-height: 88rpx; // ≥80rpx tap target.
+  border-bottom: 4rpx solid transparent;
+  transition: border-color 150ms ease-out, color 150ms ease-out;
+}
+
+.sci-tab--focused {
+  border-bottom-color: var(--accent-cobalt);
+}
+
+.sci-tab--hover {
+  background-color: var(--surface-subtle);
+}
+
+.sci-tab-num {
+  font-family: var(--font-mono, monospace);
+  font-size: 20rpx;
+  letter-spacing: 2rpx;
+  color: var(--text-placeholder);
+  margin-bottom: 2rpx;
+}
+
+.sci-tab-label {
+  font-size: 26rpx;
+  font-weight: 600;
+  color: var(--text);
+}
+
+// Tiny amber dot on tabs whose recommendation differs from the active
+// theory. Top-right of the tab cell so it reads as a status indicator
+// without crowding the label.
+.sci-tab-rec-dot {
+  position: absolute;
+  top: 12rpx;
+  right: 12rpx;
+  width: 10rpx;
+  height: 10rpx;
+  border-radius: 50%;
+  background-color: var(--warning);
+}
+
+// --- Detail panel ---
+
+.sci-detail {
   margin-bottom: 32rpx;
 }
 
-.sci-pillar-section {
-  margin-bottom: 48rpx;
+.sci-detail-eyebrow {
+  display: block;
+  font-family: var(--font-mono, monospace);
+  font-size: 20rpx;
+  font-weight: 600;
+  letter-spacing: 3rpx;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 8rpx;
 }
 
-.sci-pillar-heading {
+.sci-detail-num {
+  color: var(--text);
+}
+
+.sci-detail-eyebrow-sep {
+  color: var(--text-placeholder);
+}
+
+.sci-detail-question {
   display: block;
   font-size: 36rpx;
   font-weight: 700;
   color: var(--text);
+  line-height: 1.3;
+  margin-bottom: 24rpx;
+}
+
+// --- Chiclet switcher ---
+// Pill-shaped buttons in a horizontal scroll row. Active = filled muted
+// background; previewing = cobalt outline (this is the "you're staging
+// a swap" state, so cobalt = "the system is showing you why"); rec halo
+// = amber border before commit.
+
+.sci-chiclets-wrap {
+  margin: 0 -32rpx 24rpx;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.sci-chiclets {
+  display: inline-flex;
+  padding: 0 32rpx;
+  gap: 12rpx;
+}
+
+.sci-chiclet {
+  display: inline-flex;
+  align-items: center;
+  gap: 8rpx;
+  padding: 12rpx 22rpx;
+  border-radius: 999rpx;
+  border: 1rpx solid var(--border);
+  background-color: transparent;
+  min-height: 64rpx;
+  transition: border-color 150ms ease-out, background-color 150ms ease-out;
+}
+
+.sci-chiclet--hover {
+  background-color: var(--surface-subtle);
+}
+
+.sci-chiclet--active {
+  background-color: var(--surface-subtle);
+  border-color: var(--border);
+}
+
+.sci-chiclet--previewing {
+  border-color: var(--accent-cobalt);
+  background-color: transparent;
+}
+
+.sci-chiclet--recommended {
+  border-color: var(--warning);
+}
+
+.sci-chiclet-name {
+  font-size: 26rpx;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.sci-chiclet-tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 18rpx;
+  font-weight: 600;
+  letter-spacing: 2rpx;
+  text-transform: uppercase;
+}
+
+.sci-chiclet-tag--active {
+  color: var(--accent-cobalt);
+}
+
+.sci-chiclet-tag--previewing {
+  color: var(--accent-cobalt);
+}
+
+.sci-chiclet-tag--recommended {
+  color: var(--warning);
+}
+
+// --- Recommendation hint ---
+
+.sci-rec-hint {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12rpx;
+  padding: 0 0 20rpx;
   margin-bottom: 4rpx;
 }
 
-.sci-pillar-question {
-  display: block;
+.sci-rec-hint-tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 18rpx;
+  font-weight: 600;
+  letter-spacing: 2rpx;
+  text-transform: uppercase;
+  color: var(--warning);
+}
+
+.sci-rec-hint-text {
+  flex: 1;
   font-size: 24rpx;
-  margin-bottom: 16rpx;
+  color: var(--text-muted);
   line-height: 1.5;
 }
 
-// --- Per-pillar Simple/Advanced tabs ---
-.sci-mode-tabs {
-  display: flex;
-  gap: 16rpx;
-  margin-bottom: 16rpx;
-}
-
-.sci-mode-tab {
-  flex: 0 0 auto;
-  padding: 10rpx 24rpx;
-  font-size: 24rpx;
-  border-radius: 16rpx;
-  background-color: var(--surface-subtle);
-  color: var(--text-muted);
-  border: 1rpx solid var(--border);
-}
-
-.sci-mode-tab--active {
-  background-color: var(--primary);
-  color: var(--primary-on);
-  border-color: var(--primary);
-  font-weight: 600;
-}
-
-// --- Active + alternative theory cards ---
-// Active card gets the primary-color left rail AND a tinted background
-// so the selection state reads at thumb-arm distance. Previous design
-// relied only on a tiny ACTIVE badge; the badge alone disappeared in
-// the visual scan when scrolling through alternatives below.
-.sci-active-card {
-  border-left: 4rpx solid var(--primary);
-  background-color: rgba(30, 142, 91, 0.06); // ~6% --primary
-}
-
-.sci-alt-card {
-  border-left: 4rpx solid var(--border);
-}
-
-.sci-active-header {
-  display: flex;
-  align-items: center;
-  gap: 12rpx;
-  margin-bottom: 4rpx;
-}
-
-.sci-card-name {
-  font-size: 30rpx;
-  font-weight: 600;
+.sci-rec-hint-name {
   color: var(--text);
+  font-weight: 600;
 }
 
-.sci-active-badge {
-  // Bumped 18rpx → 22rpx so the active state reads even when the user
-  // skims past the active card to compare alternatives.
-  font-size: 22rpx;
-  letter-spacing: 1rpx;
-  font-weight: 700;
-  padding: 2rpx 10rpx;
-  border-radius: 12rpx;
-  background-color: var(--surface-subtle);
+// --- Body: author/status line + description ---
+
+.sci-body {
+  padding: 4rpx 0 24rpx;
 }
 
-.sci-card-author {
-  display: block;
-  font-size: 22rpx;
+.sci-status-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 16rpx;
   margin-bottom: 12rpx;
 }
 
-.sci-card-text {
-  display: block;
-  font-size: 26rpx;
+.sci-status-author {
+  font-size: 22rpx;
+  color: var(--text-muted);
+}
+
+.sci-status-author-name {
   color: var(--text);
-  line-height: 1.6;
+}
+
+.sci-status-tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 18rpx;
+  font-weight: 600;
+  letter-spacing: 2rpx;
+  text-transform: uppercase;
+}
+
+.sci-status-tag--active {
+  color: var(--accent-cobalt);
+}
+
+.sci-status-tag--previewing {
+  color: var(--text-muted);
+}
+
+.sci-description {
+  display: block;
+  font-size: 28rpx;
+  color: var(--text);
+  line-height: 1.65;
+}
+
+// --- Switch / cancel CTAs ---
+// Primary green only when the user has staged a switch — matches web's
+// "one primary per surface" rule and the two-track palette (green = act).
+
+.sci-commit-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16rpx;
+  margin-bottom: 24rpx;
+}
+
+.sci-commit-btn {
+  flex: 1 1 60%;
+  min-width: 0;
+  font-size: 28rpx;
+}
+
+.sci-cancel-btn {
+  flex: 0 0 auto;
+  font-size: 26rpx;
+  color: var(--text-muted);
+}
+
+// --- Advanced disclosure ---
+
+.sci-disclosure {
+  margin-top: 32rpx;
+  padding-top: 24rpx;
+  border-top: 1rpx solid var(--border);
+}
+
+.sci-disclosure-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10rpx;
+  padding: 8rpx 0;
+  min-height: 64rpx;
+}
+
+.sci-disclosure-trigger--hover {
+  opacity: 0.7;
+}
+
+.sci-disclosure-chevron {
+  font-family: var(--font-mono, monospace);
+  font-size: 28rpx;
+  color: var(--accent-cobalt);
+  transition: transform 200ms ease-out;
+  display: inline-block;
+}
+
+.sci-disclosure-chevron--open {
+  transform: rotate(90deg);
+}
+
+.sci-disclosure-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 22rpx;
+  font-weight: 600;
+  letter-spacing: 2rpx;
+  text-transform: uppercase;
+  color: var(--accent-cobalt);
 }
 
 // --- Rich-text markdown rendering ---
+
 .sci-rich-text {
   display: block;
+  margin-top: 20rpx;
   font-size: 26rpx;
   color: var(--text);
-  line-height: 1.6;
-  // <rich-text> renders the inner nodes — these classes apply to the
-  // outer wrapper. The nodes themselves use default WeChat styling for
-  // <p>, <strong>, <em>, <ul>, etc., which respects the inherited
-  // font-size and color above.
+  line-height: 1.65;
 }
 
-// --- Citations / References ---
+// --- Citations ---
+
 .sci-citations {
-  margin-top: 16rpx;
-  padding-top: 16rpx;
-  border-top: 1rpx solid var(--border-subtle);
+  margin-top: 28rpx;
 }
 
 .sci-citations-label {
   display: block;
+  font-family: var(--font-mono, monospace);
   font-size: 20rpx;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 2rpx;
-  font-weight: 600;
-  margin-bottom: 8rpx;
+  color: var(--text-muted);
+  margin-bottom: 12rpx;
 }
 
 .sci-citation-row {
-  padding: 8rpx 0;
+  padding: 12rpx 0;
   border-bottom: 1rpx solid var(--border-subtle);
 }
 
@@ -172,46 +404,45 @@
   display: block;
   font-size: 20rpx;
   margin-top: 4rpx;
+  color: var(--accent-cobalt);
   text-decoration: underline;
 }
 
-// --- Recommendation hint ---
-.sci-recommendation {
-  padding: 16rpx 24rpx;
-  margin-bottom: 16rpx;
-  border-radius: 12rpx;
-  background-color: var(--surface-subtle);
-  border: 1rpx solid var(--warning);
+// --- Zone labels footer ---
+
+.sci-zone-card {
+  padding: 24rpx;
+  border: 1rpx solid var(--border);
+  border-radius: 16rpx;
+  background-color: var(--surface);
 }
 
-.sci-recommendation-text {
-  font-size: 24rpx;
-  line-height: 1.5;
+.sci-zone-label {
+  display: block;
+  font-family: var(--font-mono, monospace);
+  font-size: 20rpx;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2rpx;
+  color: var(--text-muted);
+  margin-bottom: 8rpx;
 }
 
-.sci-recommendation-name {
-  font-weight: 700;
-  color: var(--warning);
-}
-
-.sci-line {
+.sci-zone-line {
   display: block;
   font-size: 26rpx;
   color: var(--text);
   line-height: 1.6;
 }
 
-.sci-muted-line {
-  display: block;
-  font-size: 22rpx;
-  line-height: 1.5;
-  margin-top: 8rpx;
+.sci-zone-value {
+  font-weight: 600;
 }
 
-// "Use this theory" button on alternative theory cards. Compact so it
-// reads as an action affordance rather than a hero CTA.
-.sci-use-btn {
-  margin-top: 16rpx;
-  font-size: 26rpx;
-  width: 100%;
+.sci-zone-muted {
+  display: block;
+  font-size: 22rpx;
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin-top: 8rpx;
 }

--- a/miniapp/pages/science/index.ts
+++ b/miniapp/pages/science/index.ts
@@ -354,7 +354,11 @@ Page({
   },
 
   /** Commit the previewed theory: PUT /api/science, then refetch so
-   * `active[pillar]` flips. Mirrors web's preview-then-commit flow. */
+   * `active[pillar]` flips. Mirrors web's preview-then-commit flow.
+   * `refetch()` catches its own errors and surfaces them via the page-
+   * level error state, so a refetch failure after a successful PUT
+   * doesn't fall into this catch block (which would mislabel a saved
+   * write as "Failed to switch theory"). */
   async onSwitchTheory() {
     const focused = this.data.focused as SciencePillar;
     const previewing = this.data.previewing as Partial<Record<SciencePillar, string>>;

--- a/miniapp/pages/science/index.ts
+++ b/miniapp/pages/science/index.ts
@@ -11,26 +11,35 @@ import { applyThemeChrome, themeClassName } from '../../utils/theme';
 import { parseMarkdown, copyUrlToClipboard } from '../../utils/markdown';
 import { t, tFmt } from '../../utils/i18n';
 
+const ALL_PILLARS: SciencePillar[] = ['load', 'recovery', 'prediction', 'zones'];
+
+const PILLAR_NUMS: Record<SciencePillar, string> = {
+  load: '01',
+  recovery: '02',
+  prediction: '03',
+  zones: '04',
+};
+
 function buildScienceTr() {
   return {
     navTitle: t('Training science'),
-    trainingScience: t('Training Science'),
     failedToLoad: t('Failed to load'),
     retry: t('Retry'),
+    eyebrow: t('Four-pillar framework'),
     intro: t(
-      "Praxys's numbers come from published research. These are the theories currently powering your dashboard, plus the alternatives you could switch to on the web.",
+      'Each pillar runs a published theory you can read, verify, and swap. Praxys interprets your data through whichever framework you choose.',
     ),
-    simple: t('Simple'),
-    advanced: t('Advanced'),
-    active: t('Active'),
     references: t('References'),
     tapToCopy: t('tap to copy URL'),
     zoneLabels: t('Zone labels'),
     currentlyUsing: t('Currently using'),
-    suggestion: t('Based on your training, we suggest'),
-    noActiveTheory: t('No active theory configured.'),
-    useThis: t('Use this'),
-    saving: t('Saving…'),
+    showAdvanced: t('Show methodology details'),
+    hideAdvanced: t('Hide methodology details'),
+    cancelPreview: t('Cancel preview'),
+    activeTag: t('Active'),
+    previewingTag: t('Previewing'),
+    recommendedTag: t('Recommended'),
+    by: t('by'),
   };
 }
 
@@ -45,10 +54,10 @@ function pillarLabels(): Record<SciencePillar, string> {
 
 function pillarQuestions(): Record<SciencePillar, string> {
   return {
-    load: t('How does training stress become fitness?'),
-    recovery: t('How do we assess readiness to train?'),
-    prediction: t('How do we estimate race potential?'),
-    zones: t('How is intensity classified?'),
+    load: t('Translates training stress into fitness.'),
+    recovery: t("Reads readiness from the body's signals."),
+    prediction: t('Estimates race performance from current fitness.'),
+    zones: t('Defines what counts as easy, threshold, hard.'),
   };
 }
 
@@ -58,32 +67,46 @@ interface CitationRow {
   hasUrl: boolean;
 }
 
-interface TheoryCard {
+interface ChicletRow {
   id: string;
   name: string;
-  author: string;
-  simpleText: string;
-  advancedHtml: string;
+  isActive: boolean;
+  isPreviewing: boolean;
+  isRecommended: boolean;
+  /** Combined modifier string for {{ }} interpolation in WXML. */
+  modifier: string;
+}
+
+interface PillarTab {
+  pillar: SciencePillar;
+  num: string;
+  label: string;
+  isFocused: boolean;
+  recAvailable: boolean;
+}
+
+interface DetailView {
+  pillar: SciencePillar;
+  num: string;
+  label: string;
+  question: string;
+  hasActive: boolean;
+  chiclets: ChicletRow[];
+  /** Theory currently shown in the body (active or previewed). */
+  shownAuthor: string;
+  shownAuthorVisible: boolean;
+  shownDescription: string;
+  shownAdvancedHtml: string;
   hasAdvanced: boolean;
   citations: CitationRow[];
   hasCitations: boolean;
-}
-
-interface PillarRow {
-  pillar: SciencePillar;
-  label: string;
-  question: string;
-  modeIsSimple: boolean;
-  modeIsAdvanced: boolean;
-  hasActive: boolean;
-  activeName: string;
-  activeAuthor: string;
-  activeCard?: TheoryCard;
-  hasRecommendation: boolean;
-  recommendationName: string;
-  recommendationReason: string;
-  hasAlternatives: boolean;
-  alternatives: TheoryCard[];
+  /** Recommendation hint visibility + content. */
+  hasRecHint: boolean;
+  recName: string;
+  recReason: string;
+  /** Preview-commit row visibility + button label. */
+  isPreviewMode: boolean;
+  switchLabel: string;
 }
 
 interface SciState {
@@ -91,7 +114,9 @@ interface SciState {
   loading: boolean;
   errorMessage: string;
   hasResponse: boolean;
-  pillars: PillarRow[];
+  tabs: PillarTab[];
+  detail: DetailView | null;
+  showAdvanced: boolean;
   activeLabels: string;
   hasMultipleLabelSets: boolean;
   labelSetCount: number;
@@ -99,7 +124,7 @@ interface SciState {
    *  string. Computed at refetch time so the count interpolates and the
    *  whole sentence stays translatable as a single message. */
   labelSetsAvailableText: string;
-  /** Pillar currently mid-save, so the matching button can disable. */
+  /** Pillar currently mid-save, so the Switch button can disable. */
   selectingPillar: SciencePillar | '';
 }
 
@@ -108,7 +133,9 @@ const initialData: SciState = {
   loading: true,
   errorMessage: '',
   hasResponse: false,
-  pillars: [],
+  tabs: [],
+  detail: null,
+  showAdvanced: false,
   activeLabels: '',
   hasMultipleLabelSets: false,
   labelSetCount: 0,
@@ -116,15 +143,10 @@ const initialData: SciState = {
   selectingPillar: '',
 };
 
-const ALL_PILLARS: SciencePillar[] = ['load', 'recovery', 'prediction', 'zones'];
-
-/**
- * Format a citation object as a readable line. Citations come through
- * the API as `Record<string, unknown>[]` because the YAML schema is
- * loose; we narrow per-field with typeof guards. URLs are surfaced as
- * tappable copy-to-clipboard rows separately because <rich-text> <a>
- * tags don't navigate in mini programs.
- */
+/** Format a citation object as a readable line. Loose YAML schema means
+ * we narrow per-field with typeof guards. URLs surface as tappable
+ * copy-to-clipboard rows separately because <rich-text> <a> tags don't
+ * navigate in mini programs. */
 function formatCitation(c: Record<string, unknown>): string {
   const parts: string[] = [];
   const authors = typeof c.authors === 'string' ? c.authors : '';
@@ -144,78 +166,124 @@ function formatCitation(c: Record<string, unknown>): string {
   return parts.join(' ');
 }
 
-function buildTheoryCard(theory: TheorySummary): TheoryCard {
-  const advancedSrc = theory.advanced_description || theory.description || '';
-  const { html: advancedHtml } = parseMarkdown(advancedSrc);
-
-  const citations: CitationRow[] = (theory.citations ?? []).map((c) => {
+function buildCitations(theory: TheorySummary): CitationRow[] {
+  return (theory.citations ?? []).map((c) => {
     const url = typeof c.url === 'string' ? c.url : '';
+    return { display: formatCitation(c), url, hasUrl: !!url };
+  });
+}
+
+function chicletModifier(isActive: boolean, isPreviewing: boolean, isRecommended: boolean): string {
+  if (isPreviewing) return 'sci-chiclet--previewing';
+  if (isActive) return 'sci-chiclet--active';
+  if (isRecommended) return 'sci-chiclet--recommended';
+  return '';
+}
+
+function buildPillarTabs(
+  response: ScienceResponse,
+  focused: SciencePillar,
+  labels: Record<SciencePillar, string>,
+): PillarTab[] {
+  return ALL_PILLARS.map((pillar) => {
+    const active = response.active?.[pillar];
+    const rec = response.recommendations?.find((r) => r.pillar === pillar);
+    const recAvailable = !!(rec && rec.recommended_id !== active?.id);
     return {
-      display: formatCitation(c),
-      url,
-      hasUrl: !!url,
+      pillar,
+      num: PILLAR_NUMS[pillar],
+      label: labels[pillar],
+      isFocused: pillar === focused,
+      recAvailable,
+    };
+  });
+}
+
+function buildDetail(
+  pillar: SciencePillar,
+  response: ScienceResponse,
+  previewId: string | undefined,
+  labels: Record<SciencePillar, string>,
+  questions: Record<SciencePillar, string>,
+  tr: { switchToFmt: string },
+): DetailView {
+  const active = response.active?.[pillar];
+  const alternatives = response.available?.[pillar] ?? [];
+  const recommendation: PillarRecommendation | undefined =
+    response.recommendations?.find((r) => r.pillar === pillar);
+
+  const isPreviewMode = !!(previewId && previewId !== active?.id);
+  const previewedTheory = previewId ? alternatives.find((t) => t.id === previewId) : undefined;
+  const shownTheory: TheorySummary | undefined = isPreviewMode ? previewedTheory : active;
+
+  const chiclets: ChicletRow[] = alternatives.map((t) => {
+    const isActive = t.id === active?.id;
+    const isPreviewing = t.id === previewId && previewId !== active?.id;
+    const isRecommended =
+      !!recommendation && recommendation.recommended_id === t.id && t.id !== active?.id;
+    return {
+      id: t.id,
+      name: t.name,
+      isActive,
+      isPreviewing,
+      isRecommended,
+      modifier: chicletModifier(isActive, isPreviewing, isRecommended),
     };
   });
 
-  return {
-    id: theory.id,
-    name: theory.name,
-    author: theory.author,
-    simpleText: theory.simple_description || theory.description || '',
-    advancedHtml,
-    hasAdvanced: !!advancedHtml,
-    citations,
-    hasCitations: citations.length > 0,
-  };
-}
+  const recommendedDifferent =
+    !!recommendation && recommendation.recommended_id !== active?.id;
+  const recommendedTheory = recommendedDifferent
+    ? alternatives.find((t) => t.id === recommendation!.recommended_id)
+    : undefined;
+  // Hide the rec hint once the user starts previewing the recommended
+  // theory — the chiclet's amber halo plus the body's "Previewing" tag
+  // already carry the message, and a third surface would crowd the
+  // staged Switch CTA.
+  const hasRecHint =
+    !!recommendedDifferent &&
+    !!recommendedTheory &&
+    previewId !== recommendation!.recommended_id;
 
-function buildPillarRow(
-  pillar: SciencePillar,
-  response: ScienceResponse,
-  modes: Record<SciencePillar, 'simple' | 'advanced'>,
-): PillarRow {
-  const active = response.active?.[pillar];
-  const allAlternatives = response.available?.[pillar] ?? [];
-  const others = allAlternatives.filter((t: TheorySummary) => t.id !== active?.id);
-  const recommendation = response.recommendations?.find(
-    (r: PillarRecommendation) => r.pillar === pillar,
-  );
-  const recommendedName =
-    recommendation && recommendation.recommended_id !== active?.id
-      ? allAlternatives.find((t: TheorySummary) => t.id === recommendation.recommended_id)?.name ?? ''
-      : '';
+  let advancedHtml = '';
+  let hasAdvanced = false;
+  if (shownTheory) {
+    const src = shownTheory.advanced_description || shownTheory.description || '';
+    const parsed = parseMarkdown(src);
+    advancedHtml = parsed.html;
+    hasAdvanced = !!advancedHtml;
+  }
+  const citations = shownTheory ? buildCitations(shownTheory) : [];
 
-  const mode = modes[pillar];
-
-  const labels = pillarLabels();
-  const questions = pillarQuestions();
   return {
     pillar,
+    num: PILLAR_NUMS[pillar],
     label: labels[pillar],
     question: questions[pillar],
-    modeIsSimple: mode === 'simple',
-    modeIsAdvanced: mode === 'advanced',
-    hasActive: active != null,
-    activeName: active?.name ?? '',
-    activeAuthor: active?.author ?? '',
-    activeCard: active ? buildTheoryCard(active) : undefined,
-    hasRecommendation: !!recommendedName && !!recommendation?.reason,
-    recommendationName: recommendedName,
-    recommendationReason: recommendation?.reason ?? '',
-    hasAlternatives: others.length > 0,
-    alternatives: others.slice(0, 5).map(buildTheoryCard),
+    hasActive: !!active,
+    chiclets,
+    shownAuthor: shownTheory?.author ?? '',
+    shownAuthorVisible: !!shownTheory && !!shownTheory.author && shownTheory.author !== 'system',
+    shownDescription: shownTheory?.simple_description || shownTheory?.description || '',
+    shownAdvancedHtml: advancedHtml,
+    hasAdvanced,
+    citations,
+    hasCitations: citations.length > 0,
+    hasRecHint,
+    recName: recommendedTheory?.name ?? '',
+    recReason: recommendation?.reason ?? '',
+    isPreviewMode,
+    switchLabel: previewedTheory ? tFmt(tr.switchToFmt, previewedTheory.name) : '',
   };
 }
 
-const DEFAULT_MODES: Record<SciencePillar, 'simple' | 'advanced'> = {
-  load: 'simple',
-  recovery: 'simple',
-  prediction: 'simple',
-  zones: 'simple',
-};
-
 Page({
-  data: { ...initialData, pillarModes: { ...DEFAULT_MODES }, tr: buildScienceTr() },
+  data: {
+    ...initialData,
+    focused: 'load' as SciencePillar,
+    previewing: {} as Partial<Record<SciencePillar, string>>,
+    tr: buildScienceTr(),
+  },
 
   onLoad() {
     this.setData({ themeClass: themeClassName(), tr: buildScienceTr() });
@@ -225,20 +293,17 @@ Page({
   onShow() {
     // Guarded theme update: other tabs can't be reached by getCurrentPages()
     // from Settings, so if the user changed theme while on another tab,
-    // this is the first chance to apply it. Equality check prevents
-    // re-renders on normal tab switches where nothing changed.
+    // this is the first chance to apply it.
     const tc = themeClassName();
-    if (tc !== this.data.themeClass) {
-      this.setData({ themeClass: tc });
-    }
-    // Locale guard: rebuilds tr when language changed while this tab
-    // was not active (same pattern as theme — globalData stores the
-    // active locale so we detect drift without a storage read).
+    if (tc !== this.data.themeClass) this.setData({ themeClass: tc });
+    // Locale guard: rebuild tr / labels / questions when language changed
+    // while this tab was not active (same pattern as theme).
     const curLocale = getApp<IAppOption>().globalData.locale;
     const pgMut = this as unknown as Record<string, unknown>;
     if (curLocale !== pgMut._locale) {
       pgMut._locale = curLocale;
       this.setData({ tr: buildScienceTr() });
+      this.rebuildView();
     }
     applyThemeChrome();
   },
@@ -247,22 +312,40 @@ Page({
     void this.refetch();
   },
 
-  setPillarMode(e: WechatMiniprogram.TouchEvent) {
+  onSelectPillar(e: WechatMiniprogram.TouchEvent) {
     const pillar = e.currentTarget.dataset.pillar as SciencePillar | undefined;
-    const mode = e.currentTarget.dataset.mode as 'simple' | 'advanced' | undefined;
-    if (!pillar || !mode) return;
-    const modes = {
-      ...(this.data.pillarModes as Record<SciencePillar, 'simple' | 'advanced'>),
-      [pillar]: mode,
-    };
-    // Re-derive the per-pillar boolean flags so WXML doesn't have to do
-    // map lookups every render. _response is cached on data so the
-    // toggle doesn't re-fetch from the network.
+    if (!pillar || pillar === this.data.focused) return;
+    this.setData({ focused: pillar, showAdvanced: false });
+    this.rebuildView();
+  },
+
+  onChicletTap(e: WechatMiniprogram.TouchEvent) {
+    const id = e.currentTarget.dataset.id as string | undefined;
+    if (!id) return;
+    const focused = this.data.focused as SciencePillar;
     const response = (this.data as { _response?: ScienceResponse })._response;
-    const pillars = response
-      ? ALL_PILLARS.map((p) => buildPillarRow(p, response, modes))
-      : (this.data.pillars as PillarRow[]);
-    this.setData({ pillarModes: modes, pillars });
+    const active = response?.active?.[focused];
+    const previewing = { ...(this.data.previewing as Partial<Record<SciencePillar, string>>) };
+    if (id === active?.id) {
+      // Tapping the active chiclet cancels any preview.
+      delete previewing[focused];
+    } else {
+      previewing[focused] = id;
+    }
+    this.setData({ previewing, showAdvanced: false });
+    this.rebuildView();
+  },
+
+  onCancelPreview() {
+    const focused = this.data.focused as SciencePillar;
+    const previewing = { ...(this.data.previewing as Partial<Record<SciencePillar, string>>) };
+    delete previewing[focused];
+    this.setData({ previewing });
+    this.rebuildView();
+  },
+
+  onToggleAdvanced() {
+    this.setData({ showAdvanced: !this.data.showAdvanced });
   },
 
   onCopyCitation(e: WechatMiniprogram.TouchEvent) {
@@ -270,22 +353,22 @@ Page({
     if (url) copyUrlToClipboard(url);
   },
 
-  /**
-   * Switch the active theory for one of the four pillars (load /
-   * recovery / prediction / zones). Mirrors web's
-   * `updateScience({ science: { [pillar]: id } })` — same `PUT
-   * /api/science` endpoint, same body shape. We refetch on success so
-   * the activeCard / alternatives split flips, and surface the failed-
-   * theory id in a toast on error.
-   */
-  async onSelectTheory(e: WechatMiniprogram.TouchEvent) {
-    const pillar = e.currentTarget.dataset.pillar as SciencePillar | undefined;
-    const id = e.currentTarget.dataset.id as string | undefined;
-    if (!pillar || !id) return;
-    if (this.data.selectingPillar) return; // already saving
-    this.setData({ selectingPillar: pillar });
+  /** Commit the previewed theory: PUT /api/science, then refetch so
+   * `active[pillar]` flips. Mirrors web's preview-then-commit flow. */
+  async onSwitchTheory() {
+    const focused = this.data.focused as SciencePillar;
+    const previewing = this.data.previewing as Partial<Record<SciencePillar, string>>;
+    const id = previewing[focused];
+    if (!id) return;
+    if (this.data.selectingPillar) return;
+    this.setData({ selectingPillar: focused });
     try {
-      await apiPut('/api/science', { science: { [pillar]: id } });
+      await apiPut('/api/science', { science: { [focused]: id } });
+      // Clear preview before refetch so the rebuilt view shows the new
+      // active state (not lingering preview chrome).
+      const next = { ...previewing };
+      delete next[focused];
+      this.setData({ previewing: next });
       await this.refetch();
     } catch (err) {
       const e2 = err as Partial<ApiError>;
@@ -300,18 +383,39 @@ Page({
     }
   },
 
+  /** Rebuild tabs + detail from cached `_response` without refetching. */
+  rebuildView() {
+    const response = (this.data as { _response?: ScienceResponse })._response;
+    if (!response) return;
+    const focused = this.data.focused as SciencePillar;
+    const previewing = this.data.previewing as Partial<Record<SciencePillar, string>>;
+    const labels = pillarLabels();
+    const questions = pillarQuestions();
+    const tabs = buildPillarTabs(response, focused, labels);
+    const detail = buildDetail(focused, response, previewing[focused], labels, questions, {
+      switchToFmt: t('Switch to {0}'),
+    });
+    this.setData({ tabs, detail });
+  },
+
   async refetch() {
     this.setData({ loading: true, errorMessage: '' });
     try {
       const response = await apiGet<ScienceResponse>('/api/science');
-      const modes = (this.data.pillarModes as Record<SciencePillar, 'simple' | 'advanced'>)
-        ?? { ...DEFAULT_MODES };
-      const pillars = ALL_PILLARS.map((p) => buildPillarRow(p, response, modes));
+      const focused = this.data.focused as SciencePillar;
+      const previewing = this.data.previewing as Partial<Record<SciencePillar, string>>;
+      const labels = pillarLabels();
+      const questions = pillarQuestions();
+      const tabs = buildPillarTabs(response, focused, labels);
+      const detail = buildDetail(focused, response, previewing[focused], labels, questions, {
+        switchToFmt: t('Switch to {0}'),
+      });
       this.setData({
         loading: false,
         errorMessage: '',
         hasResponse: true,
-        pillars,
+        tabs,
+        detail,
         activeLabels: response.active_labels,
         hasMultipleLabelSets: response.label_sets.length > 1,
         labelSetCount: response.label_sets.length,
@@ -319,8 +423,8 @@ Page({
           '{0} label sets available — switch on the web.',
           response.label_sets.length,
         ),
-        // Cache raw response on the instance so mode-toggles can rebuild
-        // pillar rows without refetching. Underscored to mark as internal.
+        // Cache raw response so pillar/chiclet changes can rebuild the
+        // view without refetching.
         _response: response,
       } as Record<string, unknown>);
     } catch (e) {

--- a/miniapp/pages/science/index.wxml
+++ b/miniapp/pages/science/index.wxml
@@ -3,128 +3,141 @@
 
   <scroll-view scroll-y="{{true}}" class="sci-scroll">
     <view class="sci-content">
-    <block wx:if="{{loading && !hasResponse}}">
-      <state-card type="loading" />
-      <state-card type="loading" />
-    </block>
+      <block wx:if="{{loading && !hasResponse}}">
+        <state-card type="loading" />
+        <state-card type="loading" />
+      </block>
 
-    <block wx:elif="{{errorMessage}}">
-      <state-card type="error" headline="{{tr.failedToLoad}}" detail="{{errorMessage}}" show-retry bindretry="onRetry" />
-    </block>
+      <block wx:elif="{{errorMessage}}">
+        <state-card type="error" headline="{{tr.failedToLoad}}" detail="{{errorMessage}}" show-retry bindretry="onRetry" />
+      </block>
 
-    <block wx:elif="{{hasResponse}}">
-      <text class="sci-intro">{{tr.intro}}</text>
+      <block wx:elif="{{hasResponse && detail}}">
+        <!-- Header -->
+        <text class="sci-eyebrow">{{tr.eyebrow}}</text>
+        <text class="sci-intro">{{tr.intro}}</text>
 
-      <view
-        wx:for="{{pillars}}"
-        wx:key="pillar"
-        wx:for-item="row"
-        class="sci-pillar-section"
-      >
-        <text class="sci-pillar-heading">{{row.label}}</text>
-        <text class="sci-pillar-question ts-muted">{{row.question}}</text>
-
-        <view class="sci-mode-tabs">
-          <text
-            class="sci-mode-tab {{row.modeIsSimple ? 'sci-mode-tab--active' : ''}}"
-            data-pillar="{{row.pillar}}"
-            data-mode="simple"
-            bindtap="setPillarMode"
-          >{{tr.simple}}</text>
-          <text
-            class="sci-mode-tab {{row.modeIsAdvanced ? 'sci-mode-tab--active' : ''}}"
-            data-pillar="{{row.pillar}}"
-            data-mode="advanced"
-            bindtap="setPillarMode"
-          >{{tr.advanced}}</text>
-        </view>
-
-        <!-- Active theory card -->
-        <view wx:if="{{row.hasActive}}" class="ts-card sci-active-card">
-          <view class="sci-active-header">
-            <text class="sci-card-name">{{row.activeName}}</text>
-            <text class="sci-active-badge ts-primary">{{tr.active}}</text>
+        <!-- Pillar tab strip -->
+        <scroll-view scroll-x="{{true}}" enhanced="{{true}}" show-scrollbar="{{false}}" class="sci-tabs-wrap">
+          <view class="sci-tabs">
+            <view
+              wx:for="{{tabs}}"
+              wx:key="pillar"
+              wx:for-item="tab"
+              class="sci-tab {{tab.isFocused ? 'sci-tab--focused' : ''}}"
+              data-pillar="{{tab.pillar}}"
+              bindtap="onSelectPillar"
+              hover-class="sci-tab--hover"
+              hover-stay-time="80"
+            >
+              <text class="sci-tab-num">{{tab.num}}</text>
+              <text class="sci-tab-label">{{tab.label}}</text>
+              <view wx:if="{{tab.recAvailable}}" class="sci-tab-rec-dot" aria-label="{{tr.recommendedTag}}"></view>
+            </view>
           </view>
-          <text class="sci-card-author ts-muted">{{row.activeAuthor}}</text>
+        </scroll-view>
 
-          <text wx:if="{{row.modeIsSimple}}" class="sci-card-text">
-            {{row.activeCard.simpleText}}
+        <!-- Detail panel -->
+        <view class="sci-detail">
+          <text class="sci-detail-eyebrow">
+            <text class="sci-detail-num">{{detail.num}}</text>
+            <text class="sci-detail-eyebrow-sep"> · </text>
+            {{detail.label}}
           </text>
+          <text class="sci-detail-question">{{detail.question}}</text>
 
-          <block wx:if="{{row.modeIsAdvanced}}">
-            <rich-text class="sci-rich-text" nodes="{{row.activeCard.advancedHtml}}"></rich-text>
-            <view wx:if="{{row.activeCard.hasCitations}}" class="sci-citations">
-              <text class="sci-citations-label ts-muted">{{tr.references}}</text>
+          <!-- Chiclet switcher -->
+          <scroll-view scroll-x="{{true}}" enhanced="{{true}}" show-scrollbar="{{false}}" class="sci-chiclets-wrap">
+            <view class="sci-chiclets">
               <view
-                wx:for="{{row.activeCard.citations}}"
-                wx:key="display"
-                wx:for-item="cite"
-                class="sci-citation-row"
-                data-url="{{cite.url}}"
-                bindtap="onCopyCitation"
+                wx:for="{{detail.chiclets}}"
+                wx:key="id"
+                wx:for-item="chip"
+                class="sci-chiclet {{chip.modifier}}"
+                data-id="{{chip.id}}"
+                bindtap="onChicletTap"
+                hover-class="sci-chiclet--hover"
+                hover-stay-time="80"
               >
-                <text class="sci-citation-text">{{cite.display}}</text>
-                <text wx:if="{{cite.hasUrl}}" class="sci-citation-url ts-primary">{{tr.tapToCopy}}</text>
+                <text class="sci-chiclet-name">{{chip.name}}</text>
+                <text wx:if="{{chip.isActive}}" class="sci-chiclet-tag sci-chiclet-tag--active">·&#160;{{tr.activeTag}}</text>
+                <text wx:elif="{{chip.isPreviewing}}" class="sci-chiclet-tag sci-chiclet-tag--previewing">·&#160;{{tr.previewingTag}}</text>
+                <text wx:elif="{{chip.isRecommended}}" class="sci-chiclet-tag sci-chiclet-tag--recommended">·&#160;{{tr.recommendedTag}}</text>
               </view>
             </view>
-          </block>
-        </view>
+          </scroll-view>
 
-        <!-- Recommendation hint -->
-        <view wx:if="{{row.hasRecommendation}}" class="sci-recommendation">
-          <text class="sci-recommendation-text ts-warning">
-            {{tr.suggestion}} <text class="sci-recommendation-name">{{row.recommendationName}}</text> — {{row.recommendationReason}}
-          </text>
-        </view>
+          <!-- Recommendation hint -->
+          <view wx:if="{{detail.hasRecHint}}" class="sci-rec-hint">
+            <text class="sci-rec-hint-tag">{{tr.recommendedTag}}</text>
+            <text class="sci-rec-hint-text">
+              <text class="sci-rec-hint-name">{{detail.recName}}</text> — {{detail.recReason}}
+            </text>
+          </view>
 
-        <!-- Alternative theories -->
-        <view
-          wx:for="{{row.alternatives}}"
-          wx:key="id"
-          wx:for-item="alt"
-          class="ts-card sci-alt-card"
-        >
-          <text class="sci-card-name">{{alt.name}}</text>
-          <text class="sci-card-author ts-muted">{{alt.author}}</text>
-
-          <text wx:if="{{row.modeIsSimple}}" class="sci-card-text">{{alt.simpleText}}</text>
-
-          <block wx:if="{{row.modeIsAdvanced}}">
-            <rich-text class="sci-rich-text" nodes="{{alt.advancedHtml}}"></rich-text>
-            <view wx:if="{{alt.hasCitations}}" class="sci-citations">
-              <text class="sci-citations-label ts-muted">{{tr.references}}</text>
-              <view
-                wx:for="{{alt.citations}}"
-                wx:key="display"
-                wx:for-item="cite"
-                class="sci-citation-row"
-                data-url="{{cite.url}}"
-                bindtap="onCopyCitation"
-              >
-                <text class="sci-citation-text">{{cite.display}}</text>
-                <text wx:if="{{cite.hasUrl}}" class="sci-citation-url ts-primary">{{tr.tapToCopy}}</text>
-              </view>
+          <!-- Body: author/status line + description -->
+          <view class="sci-body">
+            <view class="sci-status-line">
+              <text wx:if="{{detail.shownAuthorVisible}}" class="sci-status-author">{{tr.by}} <text class="sci-status-author-name">{{detail.shownAuthor}}</text></text>
+              <text wx:if="{{detail.isPreviewMode}}" class="sci-status-tag sci-status-tag--previewing">{{tr.previewingTag}}</text>
+              <text wx:else class="sci-status-tag sci-status-tag--active">{{tr.activeTag}}</text>
             </view>
-          </block>
+            <text class="sci-description">{{detail.shownDescription}}</text>
+          </view>
 
-          <button
-            class="ts-button ts-button--secondary sci-use-btn"
-            data-pillar="{{row.pillar}}"
-            data-id="{{alt.id}}"
-            bindtap="onSelectTheory"
-            disabled="{{selectingPillar === row.pillar}}"
-          >{{tr.useThis}}</button>
+          <!-- Switch / cancel CTAs -->
+          <view wx:if="{{detail.isPreviewMode}}" class="sci-commit-row">
+            <button
+              class="ts-button ts-button--primary sci-commit-btn"
+              bindtap="onSwitchTheory"
+              disabled="{{selectingPillar === detail.pillar}}"
+            >{{detail.switchLabel}}</button>
+            <button
+              class="ts-button ts-button--ghost sci-cancel-btn"
+              bindtap="onCancelPreview"
+            >{{tr.cancelPreview}}</button>
+          </view>
+
+          <!-- Advanced disclosure -->
+          <view class="sci-disclosure">
+            <view
+              class="sci-disclosure-trigger"
+              bindtap="onToggleAdvanced"
+              hover-class="sci-disclosure-trigger--hover"
+              hover-stay-time="80"
+            >
+              <text class="sci-disclosure-chevron {{showAdvanced ? 'sci-disclosure-chevron--open' : ''}}">›</text>
+              <text class="sci-disclosure-label">{{showAdvanced ? tr.hideAdvanced : tr.showAdvanced}}</text>
+            </view>
+
+            <block wx:if="{{showAdvanced}}">
+              <rich-text wx:if="{{detail.hasAdvanced}}" class="sci-rich-text" nodes="{{detail.shownAdvancedHtml}}"></rich-text>
+
+              <view wx:if="{{detail.hasCitations}}" class="sci-citations">
+                <text class="sci-citations-label">{{tr.references}}</text>
+                <view
+                  wx:for="{{detail.citations}}"
+                  wx:key="display"
+                  wx:for-item="cite"
+                  class="sci-citation-row"
+                  data-url="{{cite.url}}"
+                  bindtap="onCopyCitation"
+                >
+                  <text class="sci-citation-text">{{cite.display}}</text>
+                  <text wx:if="{{cite.hasUrl}}" class="sci-citation-url">{{tr.tapToCopy}}</text>
+                </view>
+              </view>
+            </block>
+          </view>
         </view>
-      </view>
 
-      <view class="ts-card">
-        <text class="ts-section-label">{{tr.zoneLabels}}</text>
-        <text class="sci-line">{{tr.currentlyUsing}}: <text class="ts-value">{{activeLabels}}</text></text>
-        <text wx:if="{{hasMultipleLabelSets}}" class="sci-muted-line ts-muted">
-          {{labelSetsAvailableText}}
-        </text>
-      </view>
-    </block>
+        <!-- Zone labels footer -->
+        <view class="sci-zone-card">
+          <text class="sci-zone-label">{{tr.zoneLabels}}</text>
+          <text class="sci-zone-line">{{tr.currentlyUsing}}: <text class="sci-zone-value">{{activeLabels}}</text></text>
+          <text wx:if="{{hasMultipleLabelSets}}" class="sci-zone-muted">{{labelSetsAvailableText}}</text>
+        </view>
+      </block>
     </view>
   </scroll-view>
 </view>

--- a/miniapp/utils/i18n-extra.ts
+++ b/miniapp/utils/i18n-extra.ts
@@ -259,17 +259,6 @@ const EN_HISTORY_SCIENCE = {
   'No active theory configured.': 'No active theory configured.',
   '{0} label sets available — switch on the web.':
     '{0} label sets available — switch on the web.',
-  // Transitional fallbacks: web's Science page redesign (PR #259) replaced
-  // these strings with new copy. The miniapp Science page will be
-  // redesigned for parity in a follow-up PR; until then these keep
-  // pages/science/index.ts rendering rather than falling through to the
-  // raw English. Remove when miniapp parity ships.
-  Simple: 'Simple',
-  Advanced: 'Advanced',
-  'How does training stress become fitness?': 'How does training stress become fitness?',
-  'How do we assess readiness to train?': 'How do we assess readiness to train?',
-  'How do we estimate race potential?': 'How do we estimate race potential?',
-  'How is intensity classified?': 'How is intensity classified?',
 };
 
 const EN_SETTINGS = {
@@ -540,13 +529,6 @@ const ZH_HISTORY_SCIENCE = {
   'No active theory configured.': '尚未配置启用的理论。',
   '{0} label sets available — switch on the web.':
     '可选的区间标签集共 {0} 套——请在网页端切换。',
-  // Transitional fallbacks — see EN_HISTORY_SCIENCE comment above.
-  Simple: '简要',
-  Advanced: '详细',
-  'How does training stress become fitness?': '训练应激如何转化为体能？',
-  'How do we assess readiness to train?': '如何评估训练准备度？',
-  'How do we estimate race potential?': '如何估算比赛潜力？',
-  'How is intensity classified?': '如何分类训练强度？',
 };
 
 const ZH_SETTINGS = {


### PR DESCRIPTION
## Summary
- Mirrors web's Science page redesign (PR #259) on the WeChat Skyline surface; same feature set, mobile-native layout
- Replaces the 4 stacked card-with-rail sections + per-pillar Simple/Advanced tab pairs (8 controls) with: a horizontal pillar tab strip (cobalt focus indicator + amber rec dot) + a single detail panel + chiclet preview-then-commit + cobalt advanced disclosure
- Drops the transitional i18n fallbacks added in PR #259 (Simple, Advanced, the four "How does …?" pillar questions) since the new index.ts no longer references them

## Why
Web parity. CLAUDE.md: *"Frontend changes should reach both surfaces. … The mini program is not a desktop port — it can adapt the layout / chrome / interactions to native mobile conventions, but the feature set, data model, and write operations should match."* The chiclet preview-then-commit semantics, the recommendation indicator, the advanced disclosure, and the Zone Labels relocation all came across; the layout adapted from web's master-detail rail (no horizontal real estate on a phone) to a top tab strip + detail panel.

The previous miniapp page also carried the AI-cliché `border-left: 4rpx solid var(--primary)` rail-on-rounded-card pattern — the same one DESIGN.md retired on the web side. Gone.

## Test plan
- [ ] Open WeChat DevTools at `miniapp/`, navigate to Science page
- [ ] Tab strip scrolls horizontally; tapping a tab swaps the detail panel; cobalt bottom-edge indicator follows the focused tab
- [ ] Amber dot appears on tabs where `recommendations[pillar].recommended_id !== active.id`
- [ ] Tapping a non-active chiclet enters preview mode: cobalt outline + body swaps + primary-green Switch CTA + ghost Cancel
- [ ] Tapping the active chiclet (or Cancel) exits preview without an API call
- [ ] `Switch to {name}` calls `PUT /api/science`, refetches, the active chiclet moves
- [ ] Demo mode disables the Switch button
- [ ] Recommendation hint hides once user starts previewing the recommended theory (rec already conveyed by chiclet halo + body status)
- [ ] Show methodology details disclosure expands `<rich-text nodes>` + tappable copy-to-clipboard citation rows
- [ ] Zone Labels footer card shows currently-using + "{n} label sets available — switch on the web." line
- [ ] Light + dark theme both legible
- [ ] zh locale: tab labels, eyebrow, intro, status tags, switch CTA, disclosure label, recommendation hint all translated
- [ ] CI: miniapp `build` job (sync-types + sync-i18n + check-i18n + tsc) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)