### PR TITLE
Restore fitparse + sync backoff + CAPTCHA-gate docs lost in #266 squash

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -236,7 +236,11 @@ def _run_sync(user_id: str, source: str, creds: dict,
                 logger.exception("Activity-derived CP refresh failed for user %s", user_id)
                 db.rollback()
 
-        # Update last_sync on the connection record
+        # Update last_sync on the connection record. Clear any prior
+        # backoff state so a previously-failed connection that the user
+        # successfully synced manually (or that recovered on its own)
+        # rejoins the regular schedule immediately.
+        from db.sync_scheduler import reset_connection_backoff
         conn = db.query(UserConnection).filter(
             UserConnection.user_id == user_id,
             UserConnection.platform == source,
@@ -244,6 +248,7 @@ def _run_sync(user_id: str, source: str, creds: dict,
         if conn:
             conn.last_sync = datetime.now(timezone.utc).replace(tzinfo=None)
             conn.status = "connected"
+            reset_connection_backoff(conn)
             db.commit()
 
         logger.info("Sync %s for user %s: %s", source, user_id, counts)
@@ -277,15 +282,17 @@ def _run_sync(user_id: str, source: str, creds: dict,
                 "last_sync": None,
                 "error": str(e),
             }
-        # Update connection status to error
+        # Update connection status with classification + backoff so the
+        # background scheduler stops hammering a stuck connection.
+        # ``_record_sync_failure`` handles its own rollback and commit.
         try:
+            from db.sync_scheduler import _record_sync_failure
             conn = db.query(UserConnection).filter(
                 UserConnection.user_id == user_id,
                 UserConnection.platform == source,
             ).first()
             if conn:
-                conn.status = "error"
-                db.commit()
+                _record_sync_failure(conn, e, db)
         except Exception:
             pass
     finally:
@@ -975,7 +982,8 @@ def _sync_coros(user_id: str, creds: dict, from_date: str | None,
         fetch_daily_metrics,
         fetch_fitness_summary,
         parse_activities,
-        parse_splits,
+        parse_fit_laps,
+        parse_fit_stream,
         parse_daily_metrics as parse_daily,
         parse_fitness_summary as parse_fitness,
         mobile_login,
@@ -1032,8 +1040,11 @@ def _sync_coros(user_id: str, creds: dict, from_date: str | None,
         row.setdefault("source", "coros")
     act_count = sync_writer.write_activities(user_id, activity_rows, db)
 
-    # Splits (per-activity laps)
+    # Splits and per-second samples from the same activity detail call.
+    # parse_activity_stream() reads trackPoints when present; returns []
+    # otherwise (UNVERIFIED field names — needs real COROS data to confirm).
     all_splits = []
+    all_samples = []
     total = len(raw_activities)
     for idx, raw_act in enumerate(raw_activities):
         act_id = str(raw_act.get("labelId") or raw_act.get("activityId") or "")
@@ -1042,12 +1053,17 @@ def _sync_coros(user_id: str, creds: dict, from_date: str | None,
         with _sync_lock:
             status.setdefault("coros", {})["progress"] = f"Fetching splits: {idx + 1}/{total}"
         try:
-            detail = fetch_activity_detail(access_token, region, act_id)
-            all_splits.extend(parse_splits(act_id, detail))
+            sport_type = raw_act.get("sportType")
+            fit_bytes = fetch_activity_detail(access_token, region, act_id, sport_type)
+            if fit_bytes:
+                all_splits.extend(parse_fit_laps(act_id, fit_bytes))
+                all_samples.extend(parse_fit_stream(act_id, fit_bytes))
             time_mod.sleep(0.3)
         except Exception as e:
             logger.debug("COROS splits for %s: skipped (%s)", act_id, e)
     split_count = sync_writer.write_splits(user_id, all_splits, db)
+    sample_count = sync_writer.write_samples(user_id, all_samples, db)
+    logger.debug("COROS sync: %d splits, %d samples written", split_count, sample_count)
 
     # Daily metrics (HRV, resting HR, training load)
     # Fetch a wider window (90 days) to ensure enough HRV readings for
@@ -1145,6 +1161,7 @@ def get_sync_status(
 ) -> dict:
     """Return current sync status for this user's connected platforms."""
     from db.models import UserConnection
+    from db.sync_scheduler import ACTIVE_CONNECTION_STATUSES
 
     # Snapshot runtime status under lock to avoid reading partial updates.
     # _get_user_status acquires _sync_lock internally, so call it outside
@@ -1165,7 +1182,7 @@ def get_sync_status(
             "status": runtime.get("status", "idle"),
             "last_sync": utc_isoformat(conn.last_sync) or runtime.get("last_sync"),
             "error": runtime.get("error"),
-            "connected": conn.status in ("connected", "error"),
+            "connected": conn.status in ACTIVE_CONNECTION_STATUSES,
             "progress": runtime.get("progress"),
         }
 

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -47,6 +47,29 @@ Expect individual endpoints to 400/404 on `connectapi.garmin.cn` even when the a
 - The recovery loop has per-endpoint consecutive-failure circuit breakers (5 strikes → stop calling that endpoint for the remaining days).
 - `parse_garmin_recovery` uses `isinstance` guards + `or`-coalesce on every nested `.get()` — `dict.get(k, default)` returns `None`, not the default, for a present-but-null key, and the legacy code's crash here used to abort the whole recovery loop.
 
+### Garmin's CAPTCHA gate is time-bound, not sticky
+
+When the headless `garminconnect` flow trips Garmin/Cloudflare's bot detection, the rejection looks **permanent** but isn't. The trap is assuming you need to engineer your way around the gate when you actually just need to stop feeding it.
+
+**The failure shape.** A stuck connection's last error is a `GarminConnectConnectionError` carrying `responseStatus.type: "CAPTCHA_REQUIRED"` (when Garmin's app layer fires the gate) or `Portal login failed (non-JSON): HTTP 403` with HTML body containing `challenges.cloudflare.com` (when Cloudflare's WAF fires it before the request reaches Garmin's auth backend). Both surface the same way to users: dashboard data stops updating; the connection card shows `auth_required`.
+
+**The escalation that keeps the gate alive.** Every fresh SSO attempt from our App Service IP feeds the bot score. Without backoff, the scheduler retries every 10 min, the score never decays, and the gate stays hot indefinitely. This was the entire 2026-04-25 lockout — four users stuck for seven straight days because each scheduler tick fed the system that was rejecting them.
+
+**What actually clears it.** Stop the storm. PR #256's `_record_sync_failure` + `auth_required` terminal state is the load-bearing fix: once the scheduler stops retrying, Garmin/Cloudflare's bot scoring decays naturally over **hours to a day or two**. After that the regular headless flow works again on the same IP, same account, no code changes. Confirmed empirically with the affected users from the 2026-04-25 lockout.
+
+**What does NOT clear it (do not waste time on these).**
+
+- An interactive Playwright viewport relay so the user solves CAPTCHA in our IP context. Built and tested locally for ~4h before this conclusion. Cloudflare returns the "Just a moment…" challenge HTML on `/portal/api/login` regardless of headless-fingerprint patches (`navigator.webdriver`, `plugins`, WebGL renderer, etc.); the patches buy nothing because Cloudflare's challenge is keyed on TLS fingerprint, header order, and account history, not just JS-detectable signals. Closed PR #257 with this rationale; the worktree-only code is not in tree.
+- Switching to `camoufox` (Firefox-based stealth) is the next plausible escalation if interactive ever does become necessary, but the bar for needing it is high — it requires a stealth-vs-Cloudflare maintenance commitment we don't otherwise have.
+
+**User-facing recovery flow** (what to tell people in the `auth_required` state):
+
+1. Open `connect.garmin.com` in a real desktop browser, sign in successfully, complete any CAPTCHA shown. This clears any **account-level** flag the storm raised.
+2. Wait — overnight is usually enough; same-day works often. The gate is per-(IP, account) and decays without our intervention as long as the scheduler stays parked.
+3. Click **Reconnect** in Praxys Settings. The headless flow runs again; if it succeeds, `_upsert_connection_credentials` clears the backoff state and the scheduler resumes. If it still fails, wait another half-day and retry.
+
+The diagnostic to confirm a future "is this the same gate" is `scripts/garmin_diagnose.py login` — captured non-JSON HTML response with `challenges.cloudflare.com` references = same family. App Insights query `AppTraces | where Message has "All login strategies exhausted" or Message has "IP rate limited by Garmin"` shows the same pattern at the fleet level.
+
 ### Recovery RHR vs TRIMP threshold RHR
 
 Two different RHR values for two different purposes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,9 @@ httpx>=0.27.0
 # for FastAPI, requests, SQLAlchemy, and logging.
 azure-monitor-opentelemetry>=1.6.0
 
+# FIT file parsing for COROS activity detail (laps + trackpoints)
+fitparse>=0.6.0
+
 # Azure OpenAI client used by api/llm.py for the post-sync Coach insight
 # generator. >=1.50.0 because chat_json passes max_completion_tokens
 # (introduced in openai 1.40) and response_format={"type": "json_object"}.


### PR DESCRIPTION
## Summary

Follow-up to PR #267. CI on main passed install (the original failure that #267 set out to fix) but now hits \`ModuleNotFoundError: No module named 'fitparse'\` at test collection because PR #267 used the wrong restore target.

#267 restored the four files affected by #258 to their state at \`224dc77\` (parent of \`c223da8\`, the unmerged #258 commit). That correctly undid #258's diff — but \`224dc77\` predates three other commits that had merged to main in the meantime:

- \`b5d4a80\` (#234) — added \`fitparse>=0.6.0\` to \`requirements.txt\` for COROS FIT parsing
- \`0a5e359\` (#256) — Garmin sync exponential-backoff + auth_required state in \`api/routes/sync.py\`
- \`c3dd379\` (#264) — "Garmin CAPTCHA gate is time-bound" learning in \`docs/dev/gotchas.md\`

So #267 silently undid those three changes alongside the #258 revert. This PR restores them by taking the same three files from \`c541e00\` — the actual main state right before the botched #266 merge — so the "drop only #258's diff" intent of #267 is faithfully realised.

\`tests/test_garmin_login_fallback.py\` was already at the right state after #267, no further change needed.

## Files restored to c541e00 state

- \`requirements.txt\` — re-add \`fitparse>=0.6.0\`
- \`api/routes/sync.py\` — re-introduce \`reset_connection_backoff\` + \`_record_sync_failure\` integration
- \`docs/dev/gotchas.md\` — re-add the CAPTCHA-gate paragraph

## Test plan

- [x] \`pip install -r requirements.txt\` includes fitparse → \`tests/test_coros_*.py\` collection succeeds
- [x] \`tests/test_garmin_login_fallback.py\` (7) + \`tests/test_stryd_push_status_endpoints.py\` (7) pass on garminconnect 0.3.3 + this requirements.txt
- [ ] Pre-existing on main, **out of scope here**: \`tests/test_coros_sync.py::TestParseActivities::test_basic_parse\` and \`test_zero_distance\` fail (\`activity_type == 'running'\` but parser returns \`'other'\`). Reproduces on a clean \`origin/main\` checkout — was hidden by the install-step failure that masked CI past it. Should be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)