### PR TITLE
Fix COROS test fixture: sportType 1/4 → 100/102

### DIFF
--- a/tests/test_coros_sync.py
+++ b/tests/test_coros_sync.py
@@ -21,7 +21,10 @@ RAW_ACTIVITIES = [
     {
         "labelId": "abc123",
         "date": 20260415,
-        "sportType": 1,
+        # COROS sportType 100 = outdoor run; the legacy 1/2/3/4 codes
+        # were replaced with the real API codes in #234 but this fixture
+        # was missed.
+        "sportType": 100,
         "distance": 10000,
         "duration": 3000,
         "avgHeartRate": 155,
@@ -33,7 +36,7 @@ RAW_ACTIVITIES = [
     {
         "labelId": "def456",
         "date": 20260416,
-        "sportType": 4,
+        "sportType": 102,  # 102 = trail running (was 4 in the legacy map)
         "distance": 0,
         "duration": 1800,
         "avgHeartRate": 140,


### PR DESCRIPTION
## Summary

CI's \`Deploy Backend\` job has been failing on \`tests/test_coros_sync.py::TestParseActivities::test_basic_parse\` and \`::test_zero_distance\` ever since the install step was unblocked by #267 + #268. This fixes the failing tests.

## Root cause

PR #234 (\"COROS sync: persist per-second streams to activity_samples\") rewrote \`sync/coros_sync.py::_SPORT_TYPE_MAP\` to use the **actual COROS API codes** — 100 = outdoor run, 102 = trail running, 200 = cycling, etc. — instead of the placeholder 1-9 codes the test fixture had been written against. The fixture in \`tests/test_coros_sync.py\` (last touched by #181) wasn't updated. So \`_map_sport_type(1)\` and \`_map_sport_type(4)\` now both fall through to \`\"other\"\`, blowing the two assertions:

\`\`\`
E   AssertionError: assert 'other' == 'running'
E   AssertionError: assert 'other' == 'trail_running'
\`\`\`

The failure was masked by the dependency-resolution failure that #266's squash introduced — CI never reached the \`Run tests\` step, so this regression sat undiscovered. Once #267 + #268 restored install, the test failure surfaced.

## Fix

Update \`RAW_ACTIVITIES\` in the fixture to use the real codes:
- \`sportType: 1\` → \`sportType: 100\` (outdoor run, maps to \`\"running\"\`)
- \`sportType: 4\` → \`sportType: 102\` (trail running)

Inline a brief comment explaining the original-vs-current code so a future reader who greps for \`sportType: 1\` finds the rationale.

## Test plan

- [x] \`tests/test_coros_sync.py\` — 31 passed (was 29 passed + 2 failed)
- [x] \`tests/test_coros_activity_stream.py\` — 10 passed
- [x] Full local suite remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)