### PR TITLE
miniapp Goal: cobalt the science-note triggers and citations

### DIFF
--- a/miniapp/pages/goal/index.scss
+++ b/miniapp/pages/goal/index.scss
@@ -163,15 +163,20 @@
   gap: 8rpx;
 }
 
+// Cobalt = reasoning surface, per the Reasoning Color Rule. The arrow +
+// label form the progressive-disclosure trigger ("How this is calculated"),
+// which mirrors web's ScienceNote — both signal "tap to see the
+// methodology behind a number". Body prose below stays muted because the
+// body is supporting context, not the reasoning *signal*.
 .goal-note-arrow {
   font-size: 22rpx;
-  color: var(--text-muted);
+  color: var(--accent-cobalt);
   width: 24rpx;
 }
 
 .goal-note-label {
   font-size: 22rpx;
-  color: var(--text-muted);
+  color: var(--accent-cobalt);
   text-transform: uppercase;
   letter-spacing: 1rpx;
   font-weight: 600;
@@ -195,8 +200,13 @@
   padding: 8rpx 0;
 }
 
+// Citation link — cobalt + underline matches web's ScienceNote
+// (`text-accent-cobalt underline-offset-2`). The trigger and the source
+// citation both belong to the reasoning surface, so they share the cobalt
+// signal.
 .goal-note-source {
   font-size: 24rpx;
+  color: var(--accent-cobalt);
   text-decoration: underline;
 }
 

--- a/miniapp/pages/goal/index.wxml
+++ b/miniapp/pages/goal/index.wxml
@@ -136,7 +136,7 @@
               class="goal-note-source-row"
               bindtap="onTapPredictionSource"
             >
-              <text class="goal-note-source ts-primary">{{tr.sourceTapCopy}}</text>
+              <text class="goal-note-source">{{tr.sourceTapCopy}}</text>
             </view>
           </view>
         </view>
@@ -152,7 +152,7 @@
           <view wx:if="{{noteUltraExpanded}}" class="goal-note-body">
             <text class="goal-note-text">{{noteUltraText}}</text>
             <view class="goal-note-source-row" bindtap="onTapUltraSource">
-              <text class="goal-note-source ts-primary">{{tr.discussionTapCopy}}</text>
+              <text class="goal-note-source">{{tr.discussionTapCopy}}</text>
             </view>
           </view>
         </view>


### PR DESCRIPTION
## Summary

- Switch `goal-note-arrow` / `goal-note-label` from `var(--text-muted)` to `var(--accent-cobalt)` so the "How this is calculated" / "Ultra caveat" toggles read as reasoning affordances.
- Switch the source citation links from `ts-primary` (green) to `var(--accent-cobalt)` to match web's `ScienceNote` citation behavior (`text-accent-cobalt underline-offset-2`).
- Body prose inside the expanded notes stays muted — per the Reasoning Color Rule, only the trigger + citation carry the cobalt signal; the surrounding explanation is supporting context.

Aligns the miniapp Goal page with the Reasoning Color Rule formalized in #245 and the brand-token semantic palette in CLAUDE.md.

Closes #246.

## Test plan

- [ ] Open Goal page in WeChat DevTools, both light + dark themes.
- [ ] Tap "How this is calculated" → arrow + label render in cobalt; expanded body prose stays muted; tap-to-copy "Source" link is cobalt + underlined.
- [ ] Repeat for the "Ultra caveat" note (race-mode + ultra distances).
- [ ] `npm run typecheck` in `miniapp/` passes (i18n coverage + tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)