### PR TITLE
Reshape Training: stat strip + chart switcher + Coach receipt; window-aware Plan with sync_state

### DIFF
--- a/api/packs.py
+++ b/api/packs.py
@@ -630,18 +630,28 @@ def get_fitness_pack(ctx: RequestContext) -> dict:
     fs = ctx.fitness_series
     proj = ctx.projection
     display_days = 60
-    date_range = pd.date_range(
-        ctx.today - timedelta(days=display_days), ctx.today,
-    )
-    display_ctl = fs["ctl"].iloc[-len(date_range):]
-    display_atl = fs["atl"].iloc[-len(date_range):]
-    display_tsb = fs["tsb"].iloc[-len(date_range):]
-    ff_dates = [d.strftime("%Y-%m-%d") for d in date_range]
+    # Pair dates with values from the same source — fs["ctl"]'s own
+    # index. The previous code took dates from a synthetic
+    # ``pd.date_range(today-60d, today)`` (61 entries) and values
+    # from ``fs["ctl"].iloc[-61:]`` — fine when the user has ≥61
+    # days of data, but for users whose history is shorter the
+    # dates list is longer than the values list and they get paired
+    # off by index, dragging values 12+ days back in time. Visually
+    # that showed up as the FF lines trailing off ~12 days before
+    # today on a stale-data account.
+    cutoff = ctx.today - timedelta(days=display_days)
+    ctl_window = fs["ctl"][fs["ctl"].index >= cutoff]
+    atl_window = fs["atl"][fs["atl"].index >= cutoff]
+    tsb_window = fs["tsb"][fs["tsb"].index >= cutoff]
+    ff_dates = [
+        (d.strftime("%Y-%m-%d") if hasattr(d, "strftime") else str(d))
+        for d in ctl_window.index
+    ]
     fitness_fatigue = {
         "dates": ff_dates,
-        "ctl": [round(float(v), 1) for v in display_ctl.values],
-        "atl": [round(float(v), 1) for v in display_atl.values],
-        "tsb": [round(float(v), 1) for v in display_tsb.values],
+        "ctl": [round(float(v), 1) for v in ctl_window.values],
+        "atl": [round(float(v), 1) for v in atl_window.values],
+        "tsb": [round(float(v), 1) for v in tsb_window.values],
         "projected_dates": proj["dates"],
         "projected_ctl": proj["ctl"],
         "projected_atl": proj["atl"],

--- a/api/packs.py
+++ b/api/packs.py
@@ -742,61 +742,8 @@ def get_science_pack(ctx: RequestContext) -> dict:
     }
 
 
-def get_plan_pack(ctx: RequestContext) -> dict:
-    """Upcoming workouts + today's planned power_max for /api/plan.
-
-    Used by ``/api/plan``. Reads only the ``training_plans`` rows already
-    loaded by ``RequestContext._data`` — no fitness series, recovery,
-    diagnosis, projection, or activity-list build. The pre-pack route
-    called ``get_dashboard_data`` to extract these two fields, which paid
-    the full dashboard compute (~22 top-level steps including the
-    deduplication pass and per-second ``activity_samples`` load) just to
-    discard everything except ``plan`` and one row of ``signal``.
-
-    ``cp_current`` preserves the legacy field name even though it carries
-    today's planned ``target_power_max`` (the upper bound of today's
-    workout, not the user's current CP). Renaming would be a frontend
-    contract change for a field nothing currently reads — left as-is.
-    """
-    plan_df = ctx.plan
-    today = ctx.today
-
-    workouts: list[dict] = []
-    if not plan_df.empty:
-        upcoming = plan_df[plan_df["date"] >= today].sort_values("date")
-        for _, row in upcoming.iterrows():
-            row_date = row["date"]
-            workout: dict = {
-                "date": (
-                    row_date.isoformat()
-                    if hasattr(row_date, "isoformat")
-                    else str(row_date)
-                ),
-                "workout_type": row.get("workout_type", ""),
-            }
-            for field, csv_col in (
-                ("duration_min", "planned_duration_min"),
-                ("distance_km", "planned_distance_km"),
-                ("power_min", "target_power_min"),
-                ("power_max", "target_power_max"),
-                ("description", "workout_description"),
-            ):
-                val = row.get(csv_col)
-                if pd.notna(val) and val != "":
-                    workout[field] = (
-                        str(val) if field == "description" else float(val)
-                    )
-            workouts.append(workout)
-
-    cp_current: float | None = None
-    if not plan_df.empty:
-        today_plan = plan_df[plan_df["date"] == today]
-        if not today_plan.empty:
-            val = today_plan.iloc[0].get("target_power_max")
-            if pd.notna(val) and val != "":
-                try:
-                    cp_current = float(val)
-                except (ValueError, TypeError):
-                    pass
-
-    return {"workouts": workouts, "cp_current": cp_current}
+# NOTE: ``get_plan_pack`` was retired with the /api/plan reshape.
+# The route now does its own (window-aware, source-filtered, sync-state-
+# aware) projection of ``ctx.plan`` — see api/routes/plan.py. The pack
+# only ever served two endpoints (this one) and its ``cp_current`` field
+# was dead on the frontend, so the indirection wasn't earning its keep.

--- a/api/packs.py
+++ b/api/packs.py
@@ -563,15 +563,17 @@ def get_signal_pack(ctx: RequestContext) -> dict:
         data_dir=None, latest_cp_watts=ctx.latest_cp_watts,
     )
 
-    display_days = 60
-    date_range = pd.date_range(
-        ctx.today - timedelta(days=display_days), ctx.today,
-    )
-    display_tsb = fs["tsb"].iloc[-len(date_range):]
-    ff_dates = [d.strftime("%Y-%m-%d") for d in date_range]
+    # Sparkline uses the last 14 days of TSB. Take the tail directly
+    # off the series (no synthetic date_range) so dates and values
+    # always come from the same source — same fix as get_fitness_pack.
+    tsb_window = fs["tsb"].iloc[-14:]
+    ff_dates = [
+        (d.strftime("%Y-%m-%d") if hasattr(d, "strftime") else str(d))
+        for d in tsb_window.index
+    ]
     tsb_sparkline = {
-        "dates": ff_dates[-14:],
-        "values": [round(float(v), 1) for v in display_tsb.values][-14:],
+        "dates": ff_dates,
+        "values": [round(float(v), 1) for v in tsb_window.values],
         "projected_dates": proj["dates"][:7],
         "projected_values": proj["tsb"][:7],
     }
@@ -638,11 +640,12 @@ def get_fitness_pack(ctx: RequestContext) -> dict:
     # dates list is longer than the values list and they get paired
     # off by index, dragging values 12+ days back in time. Visually
     # that showed up as the FF lines trailing off ~12 days before
-    # today on a stale-data account.
-    cutoff = ctx.today - timedelta(days=display_days)
-    ctl_window = fs["ctl"][fs["ctl"].index >= cutoff]
-    atl_window = fs["atl"][fs["atl"].index >= cutoff]
-    tsb_window = fs["tsb"][fs["tsb"].index >= cutoff]
+    # today on a stale-data account. iloc-tail keeps the same
+    # alignment guarantee without a date-vs-Timestamp comparison
+    # that would throw on mixed-dtype indexes.
+    ctl_window = fs["ctl"].iloc[-display_days:]
+    atl_window = fs["atl"].iloc[-display_days:]
+    tsb_window = fs["tsb"].iloc[-display_days:]
     ff_dates = [
         (d.strftime("%Y-%m-%d") if hasattr(d, "strftime") else str(d))
         for d in ctl_window.index

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -47,9 +47,13 @@ def _stryd_push_status_path(user_id: str) -> str:
 # for any UI that wants a few months of plan view, tight enough that an
 # abusive ``?end=2099-12-31`` can't force the server to ship years of rows.
 _MAX_WINDOW_DAYS = 365
-# Default window when neither bound is supplied. Two weeks matches the
-# longest pill the Training page surfaces.
-_DEFAULT_WINDOW_DAYS = 14
+# Default forward offset when no ``end`` is supplied. ``end`` is
+# inclusive, so a forward offset of 14 returns 15 calendar days
+# ([today, today+14]). Frontend pills mirror this offset semantic
+# (1wk = +6, 2wk = +13, 4wk = +27 if exact 7/14/28-day inclusive
+# windows are needed; current frontend uses +N which yields N+1 days
+# inclusive — accepted for the eyebrow's "≈ N weeks" framing).
+_DEFAULT_FORWARD_DAYS = 14
 
 
 def _resolve_window(start: str | None, end: str | None) -> tuple[date, date]:
@@ -57,7 +61,7 @@ def _resolve_window(start: str | None, end: str | None) -> tuple[date, date]:
 
     Accepts ISO ``YYYY-MM-DD`` for both bounds. Either or both may be
     omitted: missing ``start`` defaults to today; missing ``end`` defaults
-    to ``start + _DEFAULT_WINDOW_DAYS``. Inverted or oversized windows
+    to ``start + _DEFAULT_FORWARD_DAYS``. Inverted or oversized windows
     raise 400 — silently clamping would mask bad client input.
     """
     today = date.today()
@@ -70,7 +74,7 @@ def _resolve_window(start: str | None, end: str | None) -> tuple[date, date]:
     try:
         end_d = (
             date.fromisoformat(end) if end
-            else start_d + timedelta(days=_DEFAULT_WINDOW_DAYS)
+            else start_d + timedelta(days=_DEFAULT_FORWARD_DAYS)
         )
     except ValueError as exc:
         raise HTTPException(
@@ -93,19 +97,31 @@ def _compute_ai_sync_state(
 ) -> str:
     """Sync state of an AI plan row against the user's Stryd calendar.
 
-    - ``synced``     — A Stryd row exists at this date and its
-                       ``external_id`` equals the ``workout_id`` we logged
-                       when the user last pushed this date.
+    - ``synced``     — Either (a) a Stryd row exists at this date and
+                       its ``external_id`` matches the ``workout_id`` we
+                       logged on push, or (b) the push log has the
+                       workout but the next Stryd sync hasn't pulled
+                       the row back in yet. Both cases mean "Praxys's
+                       version is on Stryd"; the latter is the brief
+                       window after a successful POST /plan/push-stryd
+                       and before the user's next Stryd sync, and a
+                       consumer that doesn't share the frontend's
+                       optimistic ``pushStatus`` map (mini-program,
+                       MCP) would otherwise see ``not_synced`` and
+                       offer to push again.
     - ``mismatch``   — A Stryd row exists at this date but its
                        ``external_id`` is unknown to us (user-edited on
                        Stryd, or we never pushed). The UI uses this to
                        warn before overwriting.
-    - ``not_synced`` — No Stryd row at this date.
+    - ``not_synced`` — No Stryd row, no push log entry: nothing has
+                       ever pushed to Stryd for this date.
     """
     stryd_row = stryd_by_date.get(date_str)
-    if stryd_row is None:
-        return "not_synced"
     pushed_id = (push_status.get(date_str) or {}).get("workout_id")
+
+    if stryd_row is None:
+        return "synced" if pushed_id else "not_synced"
+
     stryd_external = stryd_row.get("external_id")
     if (
         pushed_id
@@ -192,27 +208,50 @@ def get_plan(
             if has_source else windowed.iloc[0:0]
         )
 
-        stryd_by_date: dict[str, pd.Series] = {}
+        # Stryd allows multiple workouts on the same date (AM run +
+        # PM strides, race + shakeout). Group rows-per-date so the
+        # AI sync_state derivation can pick the best match by
+        # workout_type instead of arbitrarily collapsing to the
+        # last-iterated row.
+        stryd_by_date: dict[str, list[pd.Series]] = {}
         for _, srow in stryd_rows.iterrows():
             sd = srow["date"]
             key = sd.isoformat() if hasattr(sd, "isoformat") else str(sd)
-            stryd_by_date[key] = srow
+            stryd_by_date.setdefault(key, []).append(srow)
+
+        def _best_stryd_match(rows: list[pd.Series], wt: str) -> pd.Series:
+            """Pick the Stryd row whose workout_type matches ``wt``,
+            falling back to the first row when nothing matches. AI
+            plans are typically one-per-date, so a match means we're
+            comparing apples to apples."""
+            wt_lower = (wt or "").lower()
+            for r in rows:
+                if str(r.get("workout_type", "")).lower() == wt_lower:
+                    return r
+            return rows[0]
 
         ai_dates: set[str] = set()
         for _, row in ai_rows.sort_values("date").iterrows():
             workout = _row_to_workout(row, source="ai")
+            ai_wt = workout.get("workout_type", "")
+            stryd_match_by_date = {
+                d: _best_stryd_match(rows, ai_wt)
+                for d, rows in stryd_by_date.items()
+            }
             workout["sync_state"] = _compute_ai_sync_state(
-                workout["date"], push_status, stryd_by_date,
+                workout["date"], push_status, stryd_match_by_date,
             )
             ai_dates.add(workout["date"])
             workouts.append(workout)
 
-        # Stryd rows on dates the AI plan doesn't cover — show them so the
-        # user still sees their imported / coach-authored Stryd workouts.
-        for date_str, srow in stryd_by_date.items():
+        # Stryd rows on dates the AI plan doesn't cover — show them
+        # all (each as its own row) so the user still sees their
+        # imported / coach-authored Stryd workouts.
+        for date_str, srows in stryd_by_date.items():
             if date_str in ai_dates:
                 continue
-            workouts.append(_row_to_workout(srow, source="stryd"))
+            for srow in srows:
+                workouts.append(_row_to_workout(srow, source="stryd"))
 
         workouts.sort(key=lambda w: w["date"])
 

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -2,12 +2,12 @@
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pandas as pd
 import requests
 from dotenv import load_dotenv
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 from api.auth import get_data_user_id, require_write_access
 from api.deps import get_dashboard_data
-from api.etag import CACHE_CONTROL, ETagGuard, etag_guard_for_endpoint
-from api.packs import RequestContext, get_plan_pack
+from api.etag import CACHE_CONTROL, ENDPOINT_SCOPES, ETagGuard, compute_etag
+from api.packs import RequestContext
 from db.cache_revision import bump_revisions
 from db.session import get_db
 
@@ -43,34 +43,199 @@ def _stryd_push_status_path(user_id: str) -> str:
     return os.path.join(_STRYD_PUSH_STATUS_DIR, f"{user_id}.json")
 
 
+# Hard cap on how wide a window the client can request. Generous enough
+# for any UI that wants a few months of plan view, tight enough that an
+# abusive ``?end=2099-12-31`` can't force the server to ship years of rows.
+_MAX_WINDOW_DAYS = 365
+# Default window when neither bound is supplied. Two weeks matches the
+# longest pill the Training page surfaces.
+_DEFAULT_WINDOW_DAYS = 14
+
+
+def _resolve_window(start: str | None, end: str | None) -> tuple[date, date]:
+    """Parse / default the ?start=&end= query window.
+
+    Accepts ISO ``YYYY-MM-DD`` for both bounds. Either or both may be
+    omitted: missing ``start`` defaults to today; missing ``end`` defaults
+    to ``start + _DEFAULT_WINDOW_DAYS``. Inverted or oversized windows
+    raise 400 — silently clamping would mask bad client input.
+    """
+    today = date.today()
+    try:
+        start_d = date.fromisoformat(start) if start else today
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid start date: {start!r}"
+        ) from exc
+    try:
+        end_d = (
+            date.fromisoformat(end) if end
+            else start_d + timedelta(days=_DEFAULT_WINDOW_DAYS)
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid end date: {end!r}"
+        ) from exc
+    if end_d < start_d:
+        raise HTTPException(
+            status_code=400, detail="Window end must be on or after start",
+        )
+    if (end_d - start_d).days > _MAX_WINDOW_DAYS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Window cannot exceed {_MAX_WINDOW_DAYS} days",
+        )
+    return start_d, end_d
+
+
+def _compute_sync_state(
+    date_str: str, push_status: dict, stryd_by_date: dict,
+) -> str:
+    """Sync state of an AI plan row against the user's Stryd calendar.
+
+    - ``synced``     — A Stryd row exists at this date and its
+                       ``external_id`` equals the ``workout_id`` we logged
+                       when the user last pushed this date.
+    - ``mismatch``   — A Stryd row exists at this date but its
+                       ``external_id`` is unknown to us (user-edited on
+                       Stryd, or we never pushed). The UI uses this to
+                       warn before overwriting.
+    - ``not_synced`` — No Stryd row at this date.
+    """
+    stryd_row = stryd_by_date.get(date_str)
+    if stryd_row is None:
+        return "not_synced"
+    pushed_id = (push_status.get(date_str) or {}).get("workout_id")
+    stryd_external = stryd_row.get("external_id")
+    if (
+        pushed_id
+        and stryd_external is not None
+        and pd.notna(stryd_external)
+        and str(stryd_external) == str(pushed_id)
+    ):
+        return "synced"
+    return "mismatch"
+
+
+def _resolve_sync_target(ctx: RequestContext) -> str | None:
+    """Name of the platform AI plan rows get pushed to.
+
+    Today only Stryd is wired up as a write target; surfacing it as a
+    derived field (rather than free-form preference) lets the UI decide
+    whether to even render sync chrome without sniffing connections.
+    """
+    return "stryd" if "stryd" in (ctx.config.connections or []) else None
+
+
 @router.get("/plan")
 def get_plan(
-    guard: ETagGuard = Depends(etag_guard_for_endpoint("plan")),
+    request: Request,
+    response: Response,
+    start: str | None = Query(
+        None,
+        description="Window start (YYYY-MM-DD). Defaults to today.",
+    ),
+    end: str | None = Query(
+        None,
+        description="Window end (YYYY-MM-DD). Defaults to start + 14 days.",
+    ),
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ):
-    """Return all upcoming planned workouts plus the caller's Stryd push status.
+    """Return the AI plan window plus per-row Stryd sync state.
 
-    The push-status field used to be its own endpoint (GET /plan/stryd-status)
-    but every UI surface that asked for /plan also needed it, so each
-    Training-page cold load paid an extra cross-GFW round-trip. Folding it
-    into this response saves one request without measurably changing the
-    cost of /plan itself — _load_push_status is a single small JSON read.
+    Source filter is hard-coded to ``ai`` — the canonical plan is the one
+    the user (or Praxys) authored. Stryd plan rows in the same window are
+    surfaced as ``sync_state`` flags on AI rows that share a date and as
+    ``stryd_only_dates`` for Stryd entries that have no AI counterpart
+    (user-created on Stryd, or workouts we removed locally but didn't
+    delete remotely).
 
-    The body is built from L1 ``get_plan_pack`` (only the ``training_plans``
-    rows the response actually consumes) rather than the legacy
-    ``get_dashboard_data`` recompute, plus the caller-scoped Stryd push
-    status JSON file. L2 ETag/304 sits on top — push/delete handlers bump
-    the ``plans`` scope so a fresh push is never served stale via 304.
+    Window framing is mixed into the ETag salt so two clients hitting
+    different windows can't bleed cache into each other. Stryd push
+    status comes from a per-user JSON file that lives outside the DB
+    revision counters; the push/delete handlers bump ``plans`` so a fresh
+    push is never served stale via 304.
     """
+    start_d, end_d = _resolve_window(start, end)
+
+    etag = compute_etag(
+        db, user_id, ENDPOINT_SCOPES["plan"],
+        salt=f"start={start_d.isoformat()}&end={end_d.isoformat()}",
+    )
+    guard = ETagGuard(etag, request.headers.get("if-none-match"))
     if guard.is_match:
         return guard.not_modified()
+    guard.apply(response)
+
     ctx = RequestContext(user_id=user_id, db=db)
-    pack = get_plan_pack(ctx)
+    plan_df = ctx.plan
+    push_status = _load_push_status(user_id)
+    sync_target = _resolve_sync_target(ctx)
+
+    workouts: list[dict] = []
+    stryd_only_dates: list[str] = []
+
+    if not plan_df.empty and "date" in plan_df.columns:
+        windowed = plan_df[
+            (plan_df["date"] >= start_d) & (plan_df["date"] <= end_d)
+        ]
+        has_source = "source" in windowed.columns
+        ai_rows = (
+            windowed[windowed["source"] == "ai"] if has_source else windowed
+        )
+        stryd_rows = (
+            windowed[windowed["source"] == "stryd"]
+            if has_source else windowed.iloc[0:0]
+        )
+
+        stryd_by_date: dict[str, pd.Series] = {}
+        for _, srow in stryd_rows.iterrows():
+            sd = srow["date"]
+            key = sd.isoformat() if hasattr(sd, "isoformat") else str(sd)
+            stryd_by_date[key] = srow
+
+        used_stryd_dates: set[str] = set()
+        for _, row in ai_rows.sort_values("date").iterrows():
+            row_date = row["date"]
+            date_str = (
+                row_date.isoformat()
+                if hasattr(row_date, "isoformat")
+                else str(row_date)
+            )
+            workout: dict = {
+                "date": date_str,
+                "workout_type": row.get("workout_type", ""),
+            }
+            for field, csv_col in (
+                ("duration_min", "planned_duration_min"),
+                ("distance_km", "planned_distance_km"),
+                ("power_min", "target_power_min"),
+                ("power_max", "target_power_max"),
+                ("description", "workout_description"),
+            ):
+                val = row.get(csv_col)
+                if pd.notna(val) and val != "":
+                    workout[field] = (
+                        str(val) if field == "description" else float(val)
+                    )
+            workout["sync_state"] = _compute_sync_state(
+                date_str, push_status, stryd_by_date,
+            )
+            if date_str in stryd_by_date:
+                used_stryd_dates.add(date_str)
+            workouts.append(workout)
+
+        stryd_only_dates = sorted(
+            d for d in stryd_by_date if d not in used_stryd_dates
+        )
+
     body = {
-        "workouts": pack["workouts"],
-        "cp_current": pack["cp_current"],
-        "stryd_status": _load_push_status(user_id),
+        "workouts": workouts,
+        "stryd_status": push_status,
+        "sync_target": sync_target,
+        "stryd_only_dates": stryd_only_dates,
+        "window": {"start": start_d.isoformat(), "end": end_d.isoformat()},
     }
     return Response(
         content=json.dumps(body),

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -88,7 +88,7 @@ def _resolve_window(start: str | None, end: str | None) -> tuple[date, date]:
     return start_d, end_d
 
 
-def _compute_sync_state(
+def _compute_ai_sync_state(
     date_str: str, push_status: dict, stryd_by_date: dict,
 ) -> str:
     """Sync state of an AI plan row against the user's Stryd calendar.
@@ -142,14 +142,18 @@ def get_plan(
     user_id: str = Depends(get_data_user_id),
     db: Session = Depends(get_db),
 ):
-    """Return the AI plan window plus per-row Stryd sync state.
+    """Return all plan rows in a window with per-row sync state.
 
-    Source filter is hard-coded to ``ai`` — the canonical plan is the one
-    the user (or Praxys) authored. Stryd plan rows in the same window are
-    surfaced as ``sync_state`` flags on AI rows that share a date and as
-    ``stryd_only_dates`` for Stryd entries that have no AI counterpart
-    (user-created on Stryd, or workouts we removed locally but didn't
-    delete remotely).
+    Each workout carries its ``source`` (``ai`` | ``stryd``). When a date
+    has both an AI and a Stryd row, the AI row wins and the Stryd row is
+    used purely to derive ``sync_state`` (synced / mismatch / not_synced)
+    — that surfaces "did your Praxys-authored plan land on Stryd?" while
+    still showing the user every scheduled workout.
+
+    Stryd-only rows surface with ``source='stryd'`` and no ``sync_state``:
+    they live natively on Stryd, so the AI-vs-Stryd sync question doesn't
+    apply. The UI labels them by source so users who imported a coach's
+    plan from Stryd still see something here.
 
     Window framing is mixed into the ETag salt so two clients hitting
     different windows can't bleed cache into each other. Stryd push
@@ -174,7 +178,6 @@ def get_plan(
     sync_target = _resolve_sync_target(ctx)
 
     workouts: list[dict] = []
-    stryd_only_dates: list[str] = []
 
     if not plan_df.empty and "date" in plan_df.columns:
         windowed = plan_df[
@@ -195,46 +198,28 @@ def get_plan(
             key = sd.isoformat() if hasattr(sd, "isoformat") else str(sd)
             stryd_by_date[key] = srow
 
-        used_stryd_dates: set[str] = set()
+        ai_dates: set[str] = set()
         for _, row in ai_rows.sort_values("date").iterrows():
-            row_date = row["date"]
-            date_str = (
-                row_date.isoformat()
-                if hasattr(row_date, "isoformat")
-                else str(row_date)
+            workout = _row_to_workout(row, source="ai")
+            workout["sync_state"] = _compute_ai_sync_state(
+                workout["date"], push_status, stryd_by_date,
             )
-            workout: dict = {
-                "date": date_str,
-                "workout_type": row.get("workout_type", ""),
-            }
-            for field, csv_col in (
-                ("duration_min", "planned_duration_min"),
-                ("distance_km", "planned_distance_km"),
-                ("power_min", "target_power_min"),
-                ("power_max", "target_power_max"),
-                ("description", "workout_description"),
-            ):
-                val = row.get(csv_col)
-                if pd.notna(val) and val != "":
-                    workout[field] = (
-                        str(val) if field == "description" else float(val)
-                    )
-            workout["sync_state"] = _compute_sync_state(
-                date_str, push_status, stryd_by_date,
-            )
-            if date_str in stryd_by_date:
-                used_stryd_dates.add(date_str)
+            ai_dates.add(workout["date"])
             workouts.append(workout)
 
-        stryd_only_dates = sorted(
-            d for d in stryd_by_date if d not in used_stryd_dates
-        )
+        # Stryd rows on dates the AI plan doesn't cover — show them so the
+        # user still sees their imported / coach-authored Stryd workouts.
+        for date_str, srow in stryd_by_date.items():
+            if date_str in ai_dates:
+                continue
+            workouts.append(_row_to_workout(srow, source="stryd"))
+
+        workouts.sort(key=lambda w: w["date"])
 
     body = {
         "workouts": workouts,
         "stryd_status": push_status,
         "sync_target": sync_target,
-        "stryd_only_dates": stryd_only_dates,
         "window": {"start": start_d.isoformat(), "end": end_d.isoformat()},
     }
     return Response(
@@ -242,6 +227,30 @@ def get_plan(
         media_type="application/json",
         headers={"ETag": guard.etag, "Cache-Control": CACHE_CONTROL},
     )
+
+
+def _row_to_workout(row, *, source: str) -> dict:
+    """Project a single plan_df row into the JSON shape the UI consumes."""
+    row_date = row["date"]
+    date_str = (
+        row_date.isoformat() if hasattr(row_date, "isoformat") else str(row_date)
+    )
+    workout: dict = {
+        "date": date_str,
+        "source": source,
+        "workout_type": row.get("workout_type", ""),
+    }
+    for field, csv_col in (
+        ("duration_min", "planned_duration_min"),
+        ("distance_km", "planned_distance_km"),
+        ("power_min", "target_power_min"),
+        ("power_max", "target_power_max"),
+        ("description", "workout_description"),
+    ):
+        val = row.get(csv_col)
+        if pd.notna(val) and val != "":
+            workout[field] = str(val) if field == "description" else float(val)
+    return workout
 
 
 def _load_push_status(user_id: str) -> dict:

--- a/db/models.py
+++ b/db/models.py
@@ -400,6 +400,14 @@ class TrainingPlan(Base):
     target_pace_max = Column(String(20), nullable=True)
     workout_description = Column(Text, nullable=True)
     source = Column(String(20), default="stryd")  # stryd or ai
+    # External platform's identifier for this workout, when the plan
+    # row was imported from a platform calendar (e.g. Stryd's workout
+    # `id`). NULL for AI-generated rows. Lets `/api/plan` join AI rows
+    # against platform rows on date and detect mismatches: if Praxys
+    # pushed a workout, we know its external_id from the push log; if
+    # the platform has a workout with a different external_id on that
+    # date, it's user-created (mismatch).
+    external_id = Column(String(100), nullable=True)
     meta = Column(JSON, nullable=True)  # for AI plans: generated_at, cp_at_generation
 
     __table_args__ = (

--- a/db/session.py
+++ b/db/session.py
@@ -133,6 +133,7 @@ def init_db():
         ("user_connections", "consecutive_failures", "INTEGER NOT NULL DEFAULT 0"),
         ("user_connections", "next_retry_at", "DATETIME DEFAULT NULL"),
         ("user_connections", "last_error", "VARCHAR(500) DEFAULT NULL"),
+        ("training_plans", "external_id", "VARCHAR(100) DEFAULT NULL"),
     ]
     _indexes = [
         # (index_name, table, column, unique)

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -583,7 +583,15 @@ def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
 
 def write_training_plan(user_id: str, rows: list[dict], source: str,
                         db: Session) -> int:
-    """Write training plan rows to DB. Returns count of new."""
+    """Write training plan rows to DB. Returns count of new + updated.
+
+    Existing rows on the same (user, date, source, workout_type) get
+    their `external_id` refreshed if the incoming row has one — needed
+    so `/api/plan` can detect mismatches against Stryd's calendar
+    after the `external_id` column was added. Without the refresh, all
+    pre-existing Stryd rows would stay null and look like external
+    user-created workouts forever.
+    """
     if not rows:
         return 0
     count = 0
@@ -592,13 +600,18 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
         if not d:
             continue
         wt = _str(row.get("workout_type"))
-        exists = db.query(TrainingPlan.id).filter(
+        new_external_id = _str(row.get("external_id")) or None
+        existing = db.query(TrainingPlan).filter(
             TrainingPlan.user_id == user_id,
             TrainingPlan.date == d,
             TrainingPlan.source == source,
             TrainingPlan.workout_type == wt,
         ).first()
-        if exists:
+        if existing:
+            # Backfill external_id on rows that pre-date the column.
+            if new_external_id and existing.external_id != new_external_id:
+                existing.external_id = new_external_id
+                count += 1
             continue
         db.add(TrainingPlan(
             user_id=user_id, date=d, source=source,
@@ -608,6 +621,7 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
             target_power_min=_float(row.get("target_power_min")),
             target_power_max=_float(row.get("target_power_max")),
             workout_description=_str(row.get("workout_description")),
+            external_id=new_external_id,
         ))
         count += 1
     if count > 0:

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -609,6 +609,11 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
         ).first()
         if existing:
             # Backfill external_id on rows that pre-date the column.
+            # Intentionally one-way: once an ``external_id`` is set we
+            # never clear it (``new_external_id`` only overwrites when
+            # it's truthy). A future Stryd response that omits the id
+            # for the same workout — older API revision, partial
+            # response — must not drop known data on a transient gap.
             if new_external_id and existing.external_id != new_external_id:
                 existing.external_id = new_external_id
                 count += 1

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -353,11 +353,17 @@ Paginated activity history.
 
 ### GET /api/plan
 
-Upcoming planned workouts plus the caller's Stryd push history.
+The user's AI plan within a window, plus per-row Stryd sync state and the
+caller's Stryd push history.
 
-The `stryd_status` field used to be its own `GET /api/plan/stryd-status`
-endpoint; it was folded into this response so the Training page only pays
-one cross-region round-trip on cold load.
+The canonical plan is the AI-authored one (`source='ai'`); Stryd plan rows
+in the same window are surfaced as a `sync_state` flag on each AI row and
+as `stryd_only_dates` for Stryd entries with no AI counterpart.
+
+**Query params:**
+- `start` *(YYYY-MM-DD, default = today)* — window start.
+- `end` *(YYYY-MM-DD, default = `start + 14 days`)* — window end. Inverted
+  or longer-than-365-day windows return 400.
 
 **Response:**
 ```json
@@ -370,15 +376,29 @@ one cross-region round-trip on cold load.
       "distance_km": 11.0,
       "power_min": 235,
       "power_max": 255,
-      "description": "WU 10min, 2x20min @235-255W..."
+      "description": "WU 10min, 2x20min @235-255W...",
+      "sync_state": "synced"
     }
   ],
-  "cp_current": 247.8,
   "stryd_status": {
     "2026-04-11": { "workout_id": "stryd_123", "pushed_at": "...", "status": "pushed" }
-  }
+  },
+  "sync_target": "stryd",
+  "stryd_only_dates": ["2026-04-13"],
+  "window": { "start": "2026-04-11", "end": "2026-04-25" }
 }
 ```
+
+`sync_state` is one of:
+- `synced` — Stryd has a matching workout whose id equals the one we
+  logged on push (a re-push is a no-op).
+- `mismatch` — Stryd has a workout on this date but we don't recognise
+  its id (user-edited on Stryd, or never pushed). The UI confirms before
+  overwriting.
+- `not_synced` — No Stryd workout on this date.
+
+`sync_target` is `"stryd"` when the user has a Stryd connection, else
+`null` — clients can hide the entire sync column when it's `null`.
 
 ### POST /api/plan/push-stryd
 

--- a/miniapp/utils/i18n-extra.ts
+++ b/miniapp/utils/i18n-extra.ts
@@ -318,6 +318,19 @@ const EN_NAV_CHARTS = {
   'No data': 'No data',
   // Scatter chart tooltip
   'Sleep {0} · {1}': 'Sleep {0} · {1}',
+  // Mini-program-only Training-page strings — the web side has reworded
+  // these into countdowns ("Need N more days") that need the
+  // ``data_meta.data_days`` field, which the mini program's training pack
+  // doesn't surface yet. Until the mini program adopts the countdown
+  // wording, keep its existing messages here so check-i18n is happy.
+  'Weekly Load Compliance': 'Weekly Load Compliance',
+  'Not enough data for accurate fitness tracking': 'Not enough data for accurate fitness tracking',
+  'Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves.':
+    'Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves.',
+  'Not enough data to show sleep vs performance':
+    'Not enough data to show sleep vs performance',
+  'Not enough data for weekly load comparison':
+    'Not enough data for weekly load comparison',
 };
 
 // ---------------------------------------------------------------------------
@@ -589,6 +602,15 @@ const ZH_NAV_CHARTS = {
   'Not enough data': '数据不足',
   'No data': '暂无数据',
   'Sleep {0} · {1}': '睡眠 {0} · {1}',
+  // Mini-program-only Training-page strings — see EN_NAV_CHARTS for context.
+  'Weekly Load Compliance': '每周负荷合规度',
+  'Not enough data for accurate fitness tracking': '数据不足，暂无法准确跟踪体能',
+  'Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves.':
+    '请至少同步 6 周的活动数据以显示有意义的体能、疲劳和状态曲线。',
+  'Not enough data to show sleep vs performance':
+    '数据不足，暂无法显示睡眠与表现的关系',
+  'Not enough data for weekly load comparison':
+    '数据不足，暂无法对比每周负荷',
 };
 
 export const I18N_EXTRA: Record<Locale, Record<string, string>> = {

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -413,6 +413,12 @@ def fetch_training_plan_api(
 
         description = " | ".join(desc_parts) if desc_parts else title
 
+        # Stryd's workout `id` is the external identifier we persist as
+        # `external_id`. Lets the /api/plan join logic distinguish
+        # "Stryd workout we pushed" (matches our push log's workout_id)
+        # from "Stryd workout the user manually scheduled" (mismatch).
+        external_id = item.get("id") or item.get("workout_id") or ""
+
         row = {
             "date": workout_date,
             "workout_type": workout_type,
@@ -421,8 +427,9 @@ def fetch_training_plan_api(
             "target_power_min": power_min,
             "target_power_max": power_max,
             "workout_description": description,
+            "external_id": str(external_id) if external_id else "",
         }
-        logger.debug(f"    {workout_date} — {workout_type} ({duration_min}min, {distance_km}km)")
+        logger.debug(f"    {workout_date} — {workout_type} ({duration_min}min, {distance_km}km) [id={external_id}]")
         rows.append(row)
 
     return rows

--- a/tests/test_plan_sync_state.py
+++ b/tests/test_plan_sync_state.py
@@ -107,16 +107,21 @@ def _seed_rows(user_id: str, rows: list[dict]) -> None:
         db.close()
 
 
-def test_get_plan_returns_only_ai_rows_in_window(api_client):
+def test_get_plan_returns_window_with_source_tag(api_client):
+    """Both AI and Stryd plan rows in the window come back, each tagged
+    with its ``source`` so the UI can label them. Past and far-future
+    rows are clipped by the default [today, +14d] window.
+    """
     client, user_id = api_client
     today = date.today()
-    in_window = today + timedelta(days=2)
+    ai_day = today + timedelta(days=2)
+    stryd_day = today + timedelta(days=4)
     out_of_window = today + timedelta(days=30)
 
     _seed_rows(user_id, [
-        {"date": in_window, "source": "ai", "workout_type": "easy"},
-        {"date": in_window, "source": "stryd", "workout_type": "easy_stryd"},
-        # Past AI row — also out of the default forward window.
+        {"date": ai_day, "source": "ai", "workout_type": "easy"},
+        {"date": stryd_day, "source": "stryd", "workout_type": "tempo"},
+        # Past AI row — out of the default forward window.
         {"date": today - timedelta(days=2), "source": "ai", "workout_type": "rest"},
         # Future AI row beyond the default 14-day window.
         {"date": out_of_window, "source": "ai", "workout_type": "long_run"},
@@ -126,9 +131,11 @@ def test_get_plan_returns_only_ai_rows_in_window(api_client):
     assert res.status_code == 200, res.text
     body = res.json()
     workouts = body["workouts"]
-    # Only the in-window AI row survives the source + window filter.
-    assert [w["date"] for w in workouts] == [in_window.isoformat()]
-    assert workouts[0]["workout_type"] == "easy"
+    # Both in-window rows surface, sorted by date and tagged by source.
+    assert [(w["date"], w["source"]) for w in workouts] == [
+        (ai_day.isoformat(), "ai"),
+        (stryd_day.isoformat(), "stryd"),
+    ]
     # The retired ``cp_current`` field must not return.
     assert "cp_current" not in body
     # Window echo helps clients page without restating the math themselves.
@@ -136,6 +143,22 @@ def test_get_plan_returns_only_ai_rows_in_window(api_client):
         "start": today.isoformat(),
         "end": (today + timedelta(days=14)).isoformat(),
     }
+
+
+def test_ai_row_takes_precedence_when_date_collides(api_client):
+    """When both AI and Stryd schedule the same date, the AI row wins
+    as the visible workout and the Stryd row contributes only to
+    ``sync_state`` derivation."""
+    client, user_id = api_client
+    target = date.today() + timedelta(days=2)
+    _seed_rows(user_id, [
+        {"date": target, "source": "ai", "workout_type": "threshold"},
+        {"date": target, "source": "stryd", "workout_type": "tempo_stryd"},
+    ])
+    workouts = client.get("/api/plan").json()["workouts"]
+    assert len(workouts) == 1
+    assert workouts[0]["source"] == "ai"
+    assert workouts[0]["workout_type"] == "threshold"
 
 
 def test_sync_state_synced_when_external_id_matches_push_log(api_client):
@@ -157,7 +180,6 @@ def test_sync_state_synced_when_external_id_matches_push_log(api_client):
 
     body = client.get("/api/plan").json()
     assert body["workouts"][0]["sync_state"] == "synced"
-    assert body["stryd_only_dates"] == []
 
 
 def test_sync_state_mismatch_when_external_id_diverges(api_client):
@@ -195,10 +217,11 @@ def test_sync_state_not_synced_when_no_stryd_row(api_client):
     assert body["workouts"][0]["sync_state"] == "not_synced"
 
 
-def test_stryd_only_dates_lists_orphan_stryd_rows(api_client):
-    """Stryd row with no AI counterpart in the window surfaces in
-    ``stryd_only_dates`` — the UI uses this to warn that the user has
-    work scheduled on Stryd that Praxys didn't author.
+def test_stryd_only_row_surfaces_with_source_tag(api_client):
+    """A Stryd row with no AI counterpart still appears in ``workouts``
+    so the user sees their imported / coach-authored workouts. It carries
+    ``source='stryd'`` and no ``sync_state`` (it lives natively on Stryd
+    so the AI-vs-Stryd sync question doesn't apply).
     """
     client, user_id = api_client
     ai_day = date.today() + timedelta(days=2)
@@ -207,9 +230,12 @@ def test_stryd_only_dates_lists_orphan_stryd_rows(api_client):
         {"date": ai_day, "source": "ai", "workout_type": "easy"},
         {"date": orphan_day, "source": "stryd", "workout_type": "race"},
     ])
-    body = client.get("/api/plan").json()
-    assert [w["date"] for w in body["workouts"]] == [ai_day.isoformat()]
-    assert body["stryd_only_dates"] == [orphan_day.isoformat()]
+    workouts = client.get("/api/plan").json()["workouts"]
+    by_date = {w["date"]: w for w in workouts}
+    assert by_date[ai_day.isoformat()]["source"] == "ai"
+    stryd_row = by_date[orphan_day.isoformat()]
+    assert stryd_row["source"] == "stryd"
+    assert "sync_state" not in stryd_row
 
 
 def test_window_query_params_clamp_response(api_client):

--- a/tests/test_plan_sync_state.py
+++ b/tests/test_plan_sync_state.py
@@ -207,6 +207,61 @@ def test_sync_state_mismatch_when_external_id_diverges(api_client):
     assert body["workouts"][0]["sync_state"] == "mismatch"
 
 
+def test_sync_state_synced_when_pushed_but_stryd_not_yet_resynced(api_client):
+    """The brief window after a successful push but before the next
+    Stryd sync pulls the row back in: push log has the workout_id but
+    no Stryd row exists yet. Must read as ``synced`` for consumers
+    that don't share the frontend's optimistic ``pushStatus`` map
+    (mini-program, MCP). Otherwise they'd offer to push again.
+    """
+    from api.routes.plan import _save_push_status
+
+    client, user_id = api_client
+    target = date.today() + timedelta(days=6)
+    _save_push_status(user_id, {
+        target.isoformat(): {"workout_id": "stryd-just-pushed", "status": "pushed"},
+    })
+    _seed_rows(user_id, [
+        {"date": target, "source": "ai", "workout_type": "easy"},
+    ])
+    body = client.get("/api/plan").json()
+    assert body["workouts"][0]["sync_state"] == "synced"
+
+
+def test_sync_state_uses_workout_type_match_when_multiple_stryd_rows(api_client):
+    """Stryd allows multiple workouts on the same date (AM run + PM
+    strides, race + shakeout). The AI sync_state derivation must
+    pick the row whose ``workout_type`` matches the AI row, not
+    arbitrarily the last-iterated one.
+    """
+    from api.routes.plan import _save_push_status
+
+    client, user_id = api_client
+    target = date.today() + timedelta(days=2)
+    _save_push_status(user_id, {
+        target.isoformat(): {"workout_id": "stryd-threshold", "status": "pushed"},
+    })
+    _seed_rows(user_id, [
+        # AI plan: a threshold workout.
+        {"date": target, "source": "ai", "workout_type": "threshold"},
+        # Stryd has *both* the matched threshold (with our pushed id)
+        # AND an unrelated easy run added by the user. Without the
+        # workout_type-match, the easy row could collapse the threshold
+        # row in stryd_by_date and the AI row would mis-read mismatch.
+        {
+            "date": target, "source": "stryd",
+            "workout_type": "easy", "external_id": "stryd-other-easy",
+        },
+        {
+            "date": target, "source": "stryd",
+            "workout_type": "threshold", "external_id": "stryd-threshold",
+        },
+    ])
+    body = client.get("/api/plan").json()
+    ai_row = next(w for w in body["workouts"] if w["source"] == "ai")
+    assert ai_row["sync_state"] == "synced"
+
+
 def test_sync_state_not_synced_when_no_stryd_row(api_client):
     client, user_id = api_client
     target = date.today() + timedelta(days=5)
@@ -285,6 +340,19 @@ def test_invalid_window_returns_400(api_client):
 
     bad_format = client.get("/api/plan?start=not-a-date")
     assert bad_format.status_code == 400
+
+
+def test_oversized_window_returns_400(api_client):
+    """Cap is 365 days. ``?end=2099-12-31`` against today shouldn't
+    force the server to ship a multi-year payload — the cap should
+    reject it with a clear 400 instead of silently clamping."""
+    client, _ = api_client
+    today = date.today()
+    huge = client.get(
+        f"/api/plan?start={today.isoformat()}&end={(today + timedelta(days=400)).isoformat()}"
+    )
+    assert huge.status_code == 400, huge.text
+    assert "365" in huge.text
 
 
 def test_sync_target_reflects_stryd_connection(api_client, monkeypatch):

--- a/tests/test_plan_sync_state.py
+++ b/tests/test_plan_sync_state.py
@@ -1,0 +1,287 @@
+"""GET /api/plan window-framing + sync_state derivation.
+
+Covers the contract change in the Plan reshape:
+
+- The canonical plan is the AI-authored one (`source='ai'`); Stryd plan
+  rows in the same window become `sync_state` flags on AI rows that share
+  a date and `stryd_only_dates` for orphan Stryd rows.
+- ``?start=&end=`` clamps the response window and is salted into the
+  ETag so two clients on different windows can't bleed cache.
+- ``cp_current`` was retired — its presence here would mean a partial
+  revert of the reshape.
+"""
+import os
+import tempfile
+from datetime import date, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def api_client(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_SYNC_SCHEDULER", "false")
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY",
+        "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=",
+    )
+    monkeypatch.setenv("PRAXYS_JWT_SECRET", "test-secret-plan-sync-state")
+
+    from db import session as db_session
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from api.routes import plan as plan_mod
+    scratch_root = os.path.join(tmpdir.name, "ai", "stryd_push_status")
+    monkeypatch.setattr(plan_mod, "_DATA_DIR", tmpdir.name)
+    monkeypatch.setattr(plan_mod, "_STRYD_PUSH_STATUS_DIR", scratch_root)
+
+    from api.main import app
+    from api.auth import (
+        get_current_user_id, get_data_user_id, require_write_access,
+    )
+    from db.session import get_db
+
+    user_id = "test-user-plan-sync-state"
+
+    def _override_user():
+        return user_id
+
+    def _override_db():
+        db = db_session.SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_current_user_id] = _override_user
+    app.dependency_overrides[get_data_user_id] = _override_user
+    app.dependency_overrides[require_write_access] = _override_user
+    app.dependency_overrides[get_db] = _override_db
+
+    client = TestClient(app)
+    try:
+        yield client, user_id
+    finally:
+        app.dependency_overrides.clear()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _seed_rows(user_id: str, rows: list[dict]) -> None:
+    """Insert TrainingPlan rows. Each dict needs date/source/workout_type."""
+    from db import session as db_session
+    from db.models import TrainingPlan
+
+    db = db_session.SessionLocal()
+    try:
+        for r in rows:
+            db.add(TrainingPlan(
+                user_id=user_id,
+                date=r["date"],
+                source=r["source"],
+                workout_type=r.get("workout_type", ""),
+                workout_description=r.get("workout_description", ""),
+                external_id=r.get("external_id"),
+                planned_duration_min=r.get("planned_duration_min"),
+            ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_get_plan_returns_only_ai_rows_in_window(api_client):
+    client, user_id = api_client
+    today = date.today()
+    in_window = today + timedelta(days=2)
+    out_of_window = today + timedelta(days=30)
+
+    _seed_rows(user_id, [
+        {"date": in_window, "source": "ai", "workout_type": "easy"},
+        {"date": in_window, "source": "stryd", "workout_type": "easy_stryd"},
+        # Past AI row — also out of the default forward window.
+        {"date": today - timedelta(days=2), "source": "ai", "workout_type": "rest"},
+        # Future AI row beyond the default 14-day window.
+        {"date": out_of_window, "source": "ai", "workout_type": "long_run"},
+    ])
+
+    res = client.get("/api/plan")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    workouts = body["workouts"]
+    # Only the in-window AI row survives the source + window filter.
+    assert [w["date"] for w in workouts] == [in_window.isoformat()]
+    assert workouts[0]["workout_type"] == "easy"
+    # The retired ``cp_current`` field must not return.
+    assert "cp_current" not in body
+    # Window echo helps clients page without restating the math themselves.
+    assert body["window"] == {
+        "start": today.isoformat(),
+        "end": (today + timedelta(days=14)).isoformat(),
+    }
+
+
+def test_sync_state_synced_when_external_id_matches_push_log(api_client):
+    """An AI row + Stryd row at the same date with matching ids → ``synced``."""
+    from api.routes.plan import _save_push_status
+
+    client, user_id = api_client
+    target = date.today() + timedelta(days=3)
+    _save_push_status(user_id, {
+        target.isoformat(): {"workout_id": "stryd-abc", "status": "pushed"},
+    })
+    _seed_rows(user_id, [
+        {"date": target, "source": "ai", "workout_type": "threshold"},
+        {
+            "date": target, "source": "stryd",
+            "workout_type": "threshold", "external_id": "stryd-abc",
+        },
+    ])
+
+    body = client.get("/api/plan").json()
+    assert body["workouts"][0]["sync_state"] == "synced"
+    assert body["stryd_only_dates"] == []
+
+
+def test_sync_state_mismatch_when_external_id_diverges(api_client):
+    """Stryd row exists but its id doesn't match the push log → ``mismatch``.
+
+    This is the case the UI must catch before re-pushing — typically the
+    user edited the workout directly inside Stryd's calendar.
+    """
+    from api.routes.plan import _save_push_status
+
+    client, user_id = api_client
+    target = date.today() + timedelta(days=4)
+    _save_push_status(user_id, {
+        target.isoformat(): {"workout_id": "stryd-old", "status": "pushed"},
+    })
+    _seed_rows(user_id, [
+        {"date": target, "source": "ai", "workout_type": "intervals"},
+        {
+            "date": target, "source": "stryd",
+            "workout_type": "intervals", "external_id": "stryd-edited",
+        },
+    ])
+
+    body = client.get("/api/plan").json()
+    assert body["workouts"][0]["sync_state"] == "mismatch"
+
+
+def test_sync_state_not_synced_when_no_stryd_row(api_client):
+    client, user_id = api_client
+    target = date.today() + timedelta(days=5)
+    _seed_rows(user_id, [
+        {"date": target, "source": "ai", "workout_type": "easy"},
+    ])
+    body = client.get("/api/plan").json()
+    assert body["workouts"][0]["sync_state"] == "not_synced"
+
+
+def test_stryd_only_dates_lists_orphan_stryd_rows(api_client):
+    """Stryd row with no AI counterpart in the window surfaces in
+    ``stryd_only_dates`` — the UI uses this to warn that the user has
+    work scheduled on Stryd that Praxys didn't author.
+    """
+    client, user_id = api_client
+    ai_day = date.today() + timedelta(days=2)
+    orphan_day = date.today() + timedelta(days=4)
+    _seed_rows(user_id, [
+        {"date": ai_day, "source": "ai", "workout_type": "easy"},
+        {"date": orphan_day, "source": "stryd", "workout_type": "race"},
+    ])
+    body = client.get("/api/plan").json()
+    assert [w["date"] for w in body["workouts"]] == [ai_day.isoformat()]
+    assert body["stryd_only_dates"] == [orphan_day.isoformat()]
+
+
+def test_window_query_params_clamp_response(api_client):
+    client, user_id = api_client
+    today = date.today()
+    near = today + timedelta(days=2)
+    far = today + timedelta(days=20)
+    _seed_rows(user_id, [
+        {"date": near, "source": "ai", "workout_type": "easy"},
+        {"date": far, "source": "ai", "workout_type": "long_run"},
+    ])
+
+    res = client.get(
+        f"/api/plan?start={today.isoformat()}&end={(today + timedelta(days=7)).isoformat()}"
+    )
+    assert res.status_code == 200
+    near_only = res.json()
+    assert [w["date"] for w in near_only["workouts"]] == [near.isoformat()]
+
+    res = client.get(
+        f"/api/plan?start={today.isoformat()}&end={far.isoformat()}"
+    )
+    assert res.status_code == 200
+    both = res.json()
+    assert [w["date"] for w in both["workouts"]] == [
+        near.isoformat(), far.isoformat(),
+    ]
+
+
+def test_window_etag_does_not_collide_across_windows(api_client):
+    """Different windows must hash to different ETags — otherwise a 304
+    revalidation would replay the wrong window's body."""
+    client, _ = api_client
+    today = date.today()
+    a = client.get(f"/api/plan?start={today.isoformat()}&end={(today + timedelta(days=7)).isoformat()}")
+    b = client.get(f"/api/plan?start={today.isoformat()}&end={(today + timedelta(days=21)).isoformat()}")
+    assert a.headers["etag"] != b.headers["etag"]
+
+
+def test_invalid_window_returns_400(api_client):
+    client, _ = api_client
+    today = date.today()
+    inverted = client.get(
+        f"/api/plan?start={today.isoformat()}&end={(today - timedelta(days=1)).isoformat()}"
+    )
+    assert inverted.status_code == 400
+
+    bad_format = client.get("/api/plan?start=not-a-date")
+    assert bad_format.status_code == 400
+
+
+def test_sync_target_reflects_stryd_connection(api_client, monkeypatch):
+    """``sync_target`` is ``"stryd"`` only when the user is actually
+    connected to Stryd — the Plan UI hides the sync column otherwise."""
+    client, _ = api_client
+
+    # No connections → sync_target null.
+    body = client.get("/api/plan").json()
+    assert body["sync_target"] is None
+
+    # Inject a stryd connection at the config layer.
+    from analysis import config as cfg_mod
+
+    real_loader = cfg_mod.load_config_from_db
+
+    def _with_stryd(user_id, db):
+        cfg = real_loader(user_id, db)
+        cfg.connections = list({*cfg.connections, "stryd"})
+        return cfg
+
+    monkeypatch.setattr("api.packs.load_config_from_db", _with_stryd)
+    body = client.get(
+        "/api/plan", headers={"If-None-Match": '"never"'},
+    ).json()
+    assert body["sync_target"] == "stryd"

--- a/web/src/components/AiInsightsCard.tsx
+++ b/web/src/components/AiInsightsCard.tsx
@@ -1,10 +1,31 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useApi } from '@/hooks/useApi';
-import type { AiInsight } from '@/types/api';
+import type { AiInsight, AiInsightFinding } from '@/types/api';
 import { msg } from '@lingui/core/macro';
 import { Trans, Plural, useLingui } from '@lingui/react/macro';
 import { useLocale } from '@/contexts/LocaleContext';
 import { linkifyScienceTerms } from '@/lib/science-links';
+
+/**
+ * Deterministic "Praxys Coach" content rendered when no LLM insight
+ * row exists for this slot. Lets the receipt remain the single
+ * narrative-interpretation surface across pages — the user always sees
+ * Praxys Coach, with AI content when it's there and rule-based content
+ * otherwise. Without it, AiInsightsCard returns null when the LLM is
+ * silent (legacy behavior).
+ */
+export interface CoachFallback {
+  /** Lead sentence shown in the receipt body. Accepts ReactNode so
+   *  callers can embed `<strong>` highlights for numbers (Goal does
+   *  this — "<strong>14</strong> days to race day…"). */
+  headline: ReactNode;
+  summary?: string;
+  findings?: AiInsightFinding[];
+  recommendations?: string[];
+  /** Stamp shown in the cobalt banner where AI insights show timeAgo
+   *  (e.g. "6wk" lookback for a weekly diagnosis). Optional. */
+  stamp?: string;
+}
 
 interface Props {
   /**
@@ -23,6 +44,12 @@ interface Props {
    * site.
    */
   attribution?: string;
+  /**
+   * Deterministic content shown when the LLM insight slot is empty.
+   * Without it, the component returns null on no AI insight (legacy
+   * behavior used by callers that don't have a rule-based equivalent).
+   */
+  fallback?: CoachFallback;
 }
 
 const PLUGIN_URL = 'https://github.com/dddtc2005/praxys';
@@ -41,17 +68,21 @@ function timeAgo(isoDate: string, locale: string): string {
 }
 
 /**
- * Renders an LLM-generated Praxys Coach insight as the canonical
- * coach-receipt component (square-cornered, flat cobalt banner,
- * structured findings + recommendations, embedded Claude Code skill
- * hint). Replaces the prior purple-bordered card pattern that has been
- * retired (see PR #245).
+ * Renders the Praxys Coach receipt — square-cornered, flat cobalt
+ * banner, structured findings + recommendations, embedded Claude Code
+ * skill hint. The single canonical narrative-interpretation surface
+ * across pages.
  *
- * Returns null when no insight row exists yet — the rule-based
- * fallback prose lives in the calling page (e.g. Today's signal.reason
- * suppressed under hasCoachBrief).
+ * Content source ordering:
+ *   1. LLM insight at /api/insights/{insightType} when present.
+ *   2. Caller-provided `fallback` when the LLM slot is empty.
+ *   3. null (component renders nothing) when neither is available.
+ *
+ * The receipt always carries the same brand banner regardless of
+ * source — users see Praxys Coach whether the analysis was
+ * AI-generated or computed from rule-based heuristics.
  */
-export default function AiInsightsCard({ insightType, attribution }: Props) {
+export default function AiInsightsCard({ insightType, attribution, fallback }: Props) {
   const { data } = useApi<{ insight: AiInsight | null }>(`/api/insights/${insightType}`);
   const { locale } = useLocale();
   const { i18n } = useLingui();
@@ -59,34 +90,54 @@ export default function AiInsightsCard({ insightType, attribution }: Props) {
   const [detailsOpen, setDetailsOpen] = useState(false);
 
   const insight = data?.insight;
-  if (!insight) return null;
 
-  // Prefer the active-locale translation when present; fall back to the
-  // top-level English fields (Issue #103 contract).
-  const localized = (locale === 'zh' && insight.translations?.zh) || insight;
-  const headline = localized.headline;
-  const summary = localized.summary;
-  const findings = localized.findings ?? insight.findings ?? [];
-  const recommendations = localized.recommendations ?? insight.recommendations ?? [];
-  const hasDetails = findings.length > 0 || recommendations.length > 0;
+  // Prefer the active-locale translation when present; fall back to
+  // the top-level English fields (Issue #103 contract).
+  const localized = insight && ((locale === 'zh' && insight.translations?.zh) || insight);
+
+  // Resolve the actual content to render. AI takes precedence; fallback
+  // fills in when AI is silent. If neither exists the surface stays
+  // hidden — caller controls its own empty state.
+  const content = localized
+    ? {
+        headline: localized.headline as ReactNode,
+        summary: localized.summary,
+        findings: localized.findings ?? insight!.findings ?? [],
+        recommendations: localized.recommendations ?? insight!.recommendations ?? [],
+        stamp: insight!.generated_at ? timeAgo(insight!.generated_at, locale) : undefined,
+        isAi: true,
+      }
+    : fallback
+      ? {
+          headline: fallback.headline,
+          summary: fallback.summary,
+          findings: fallback.findings ?? [],
+          recommendations: fallback.recommendations ?? [],
+          stamp: fallback.stamp,
+          isAi: false,
+        }
+      : null;
+
+  if (!content) return null;
 
   // insightType -> plugin skill name mapping. The plugin's slash commands
   // use kebab-case (`/praxys:race-forecast`); insight rows in the DB use
   // snake_case (`race_forecast`). 1:1 transform.
   const skillName = insightType.replace(/_/g, '-');
+  const hasDetails = content.findings.length > 0 || content.recommendations.length > 0;
 
   return (
     <aside className="coach-receipt" aria-label={i18n._(msg`Praxys Coach insight`)}>
       <div className="coach-banner">
         <span className="coach-mark"><Trans>Praxys Coach</Trans></span>
-        {insight.generated_at && (
-          <span className="coach-stamp font-data">{timeAgo(insight.generated_at, locale)}</span>
+        {content.stamp && (
+          <span className="coach-stamp font-data">{content.stamp}</span>
         )}
       </div>
       <div className="coach-body">
-        <p className="coach-headline">{headline}</p>
-        {summary && (
-          <p className="coach-summary">{linkifyScienceTerms(summary)}</p>
+        <p className="coach-headline">{content.headline}</p>
+        {content.summary && (
+          <p className="coach-summary">{linkifyScienceTerms(content.summary)}</p>
         )}
         {hasDetails && (
           <button
@@ -100,17 +151,17 @@ export default function AiInsightsCard({ insightType, attribution }: Props) {
               <Trans>Hide details</Trans>
             ) : (
               <span>
-                {findings.length > 0 && (
+                {content.findings.length > 0 && (
                   <Plural
-                    value={findings.length}
+                    value={content.findings.length}
                     one="# finding"
                     other="# findings"
                   />
                 )}
-                {findings.length > 0 && recommendations.length > 0 && <Trans> · </Trans>}
-                {recommendations.length > 0 && (
+                {content.findings.length > 0 && content.recommendations.length > 0 && <Trans> · </Trans>}
+                {content.recommendations.length > 0 && (
                   <Plural
-                    value={recommendations.length}
+                    value={content.recommendations.length}
                     one="# recommendation"
                     other="# recommendations"
                   />
@@ -119,11 +170,11 @@ export default function AiInsightsCard({ insightType, attribution }: Props) {
             )}
           </button>
         )}
-        {detailsOpen && findings.length > 0 && (
+        {detailsOpen && content.findings.length > 0 && (
           <>
             <p className="coach-label"><Trans>Findings</Trans></p>
             <ul className="coach-list">
-              {findings.map((f, i) => (
+              {content.findings.map((f, i) => (
                 <li key={i} className={`coach-row coach-row-${f.type}`}>
                   <span className="coach-tag" aria-hidden="true">[{f.type === 'positive' ? '+' : f.type === 'warning' ? '!' : '·'}]</span>
                   <span className="coach-text">{linkifyScienceTerms(f.text)}</span>
@@ -132,12 +183,12 @@ export default function AiInsightsCard({ insightType, attribution }: Props) {
             </ul>
           </>
         )}
-        {detailsOpen && recommendations.length > 0 && (
+        {detailsOpen && content.recommendations.length > 0 && (
           <>
-            {findings.length > 0 && <hr className="coach-rule" />}
+            {content.findings.length > 0 && <hr className="coach-rule" />}
             <p className="coach-label"><Trans>Recommendations</Trans></p>
             <ol className="coach-list">
-              {recommendations.map((r, i) => (
+              {content.recommendations.map((r, i) => (
                 <li key={i} className="coach-row">
                   <span className="coach-tag coach-tag-rec" aria-hidden="true">→</span>
                   <span className="coach-text">{linkifyScienceTerms(r)}</span>

--- a/web/src/components/DistributionBar.tsx
+++ b/web/src/components/DistributionBar.tsx
@@ -6,12 +6,17 @@ interface Props {
   distribution: ZoneDistribution[];
 }
 
+// Cool→warm gradient as zone intensity climbs. Aerobic zones use
+// tinted ink at decreasing opacity; threshold/vo2 zones get the warm
+// semantic colors. No accent-blue / accent-purple — those tokens are
+// retired per DESIGN.md ("reasoning roles move to cobalt; positive
+// deltas to primary; metadata to muted-foreground").
 const ZONE_COLORS = [
-  { color: 'bg-destructive', textColor: 'text-destructive' },
-  { color: 'bg-accent-amber', textColor: 'text-accent-amber' },
-  { color: 'bg-accent-blue', textColor: 'text-accent-blue' },
-  { color: 'bg-accent-blue/50', textColor: 'text-accent-blue' },
-  { color: 'bg-muted-foreground', textColor: 'text-muted-foreground' },
+  { color: 'bg-destructive',          textColor: 'text-destructive' },
+  { color: 'bg-accent-amber',         textColor: 'text-accent-amber' },
+  { color: 'bg-muted-foreground',     textColor: 'text-foreground' },
+  { color: 'bg-muted-foreground/60',  textColor: 'text-foreground/70' },
+  { color: 'bg-muted-foreground/30',  textColor: 'text-muted-foreground' },
 ];
 
 function getZoneColor(index: number, total: number) {

--- a/web/src/components/ScienceNote.tsx
+++ b/web/src/components/ScienceNote.tsx
@@ -20,7 +20,12 @@ export default function ScienceNote({ text, sourceUrl, sourceLabel }: { text: st
   const [expanded, setExpanded] = useState(false);
   const { t } = useLingui();
   return (
-    <div className="mt-4 pt-3 border-t border-border">
+    // No own border. Page-level section hairlines do the separation
+    // work in flat-page contexts; on surfaces that still need a
+    // visual divider above the note (Goal's trajectory block), the
+    // parent provides it. Eliminates the "double-hairline" look when
+    // a flat section ends with a ScienceNote.
+    <div className="mt-4">
       <button
         onClick={() => setExpanded(!expanded)}
         className="text-[12px] text-accent-cobalt hover:text-accent-cobalt/80 transition-colors"

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -9,17 +9,23 @@ import { Trans, useLingui, Plural } from '@lingui/react/macro';
 import { useLocale } from '@/contexts/LocaleContext';
 import { useSettings } from '@/contexts/SettingsContext';
 
+// Workout-type chips lean on the semantic palette only.
+//   primary       — easy / recovery (action: go and run easy)
+//   muted         — long (steady aerobic methodology slot, restrained)
+//   accent-amber  — tempo / threshold (caution: at the line)
+//   destructive   — interval / repetition (this costs you)
+//   muted         — unknown types (no accent rather than reaching for blue/purple)
 const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
-  easy:       { bg: 'bg-primary/15', text: 'text-primary' },
-  recovery:   { bg: 'bg-primary/15', text: 'text-primary' },
-  long:       { bg: 'bg-accent-blue/15',  text: 'text-accent-blue' },
+  easy:       { bg: 'bg-primary/15',      text: 'text-primary' },
+  recovery:   { bg: 'bg-primary/15',      text: 'text-primary' },
+  long:       { bg: 'bg-muted',           text: 'text-foreground' },
   tempo:      { bg: 'bg-accent-amber/15', text: 'text-accent-amber' },
   threshold:  { bg: 'bg-accent-amber/15', text: 'text-accent-amber' },
-  interval:   { bg: 'bg-destructive/15',   text: 'text-destructive' },
-  repetition: { bg: 'bg-destructive/15',   text: 'text-destructive' },
+  interval:   { bg: 'bg-destructive/15',  text: 'text-destructive' },
+  repetition: { bg: 'bg-destructive/15',  text: 'text-destructive' },
 };
 
-const DEFAULT_COLOR = { bg: 'bg-accent-purple/15', text: 'text-accent-purple' };
+const DEFAULT_COLOR = { bg: 'bg-muted', text: 'text-muted-foreground' };
 
 function getTypeColor(type: string) {
   const key = type.toLowerCase().replace(/\s+/g, ' ');
@@ -210,7 +216,7 @@ function WorkoutRow({
     <div
       className={`group flex items-center gap-3 py-2.5 px-3 rounded-lg transition-colors ${
         isToday
-          ? 'bg-primary/5 ring-1 ring-accent-green/20'
+          ? 'bg-primary/5 ring-1 ring-primary/30'
           : 'hover:bg-muted/50'
       }`}
     >

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -1,13 +1,34 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useApi, API_BASE, getAuthHeaders } from '@/hooks/useApi';
 import type { PlanResponse, PlannedWorkout, StrydPushStatus, StrydPushResult } from '@/types/api';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Trans, useLingui, Plural } from '@lingui/react/macro';
 import { useLocale } from '@/contexts/LocaleContext';
 import { useSettings } from '@/contexts/SettingsContext';
+
+// Window pill choices for the Plan section. Days, not weeks, because
+// the API speaks day-resolution and the user reads "next 14 days" the
+// same way they read "two weeks." Persist the choice so power users
+// land on their preferred view every visit.
+const WINDOW_OPTIONS = [
+  { id: '1wk', days: 7 },
+  { id: '2wk', days: 14 },
+  { id: '4wk', days: 28 },
+] as const;
+type WindowId = typeof WINDOW_OPTIONS[number]['id'];
+const WINDOW_STORAGE_KEY = 'praxys.plan_window';
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function endIso(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
 
 // Workout-type chips lean on the semantic palette only.
 //   primary       — easy / recovery (action: go and run easy)
@@ -55,7 +76,16 @@ function formatDate(dateStr: string, locale: string): { day: string; weekday: st
   };
 }
 
-type PushState = 'none' | 'pushed' | 'pushing' | 'error';
+// Server-truth states (`pushed`, `mismatch`, `not_synced`, `native`) are
+// merged with transient local states (`pushing`, `error`) to yield a
+// single per-row badge state. The resolver in the parent picks one.
+type PushState =
+  | 'none'        // AI row, never pushed (sync_state='not_synced')
+  | 'pushed'      // AI row, server says 'synced'
+  | 'pushing'     // local optimistic — push request in flight
+  | 'error'       // local optimistic — push request failed
+  | 'mismatch'    // AI row + Stryd row exist but ids don't match
+  | 'native';     // workout originated on Stryd (source='stryd')
 
 const UploadIcon = ({ className }: { className?: string }) => (
   <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -89,6 +119,12 @@ const RefreshIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+const WarningIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 16 16" fill="currentColor">
+    <path d="M7.13 1.66a1 1 0 011.74 0l6.31 11.18A1 1 0 0114.31 14.5H1.69a1 1 0 01-.87-1.66L7.13 1.66zM7 6h2v4H7V6zm0 5h2v2H7v-2z" />
+  </svg>
+);
+
 function StrydStatusBadge({
   state,
   error,
@@ -102,6 +138,43 @@ function StrydStatusBadge({
 }) {
   const { t } = useLingui();
   if (!showStryd) return null;
+
+  if (state === 'native') {
+    // Workout came from Stryd directly — nothing to push, just show
+    // the source as a quiet label so the user knows where it lives.
+    return (
+      <span className="text-[10px] font-data uppercase tracking-wider text-muted-foreground shrink-0">
+        <Trans>From Stryd</Trans>
+      </span>
+    );
+  }
+
+  if (state === 'mismatch') {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger
+            render={(
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onPush}
+                aria-label={t`Workout differs on Stryd — re-push to overwrite`}
+                className="w-6 h-6 shrink-0 text-accent-amber hover:text-accent-amber/80"
+              >
+                <WarningIcon className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          />
+          <TooltipContent side="left">
+            <p className="text-xs">
+              <Trans>Differs on Stryd — click to re-push and overwrite.</Trans>
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   if (state === 'pushing') {
     return (
@@ -282,55 +355,64 @@ async function pushDatesToStryd(dates: string[]): Promise<{
   return resp.json();
 }
 
-function ExpandableWorkoutList({
-  workouts,
-  getPushState,
-  pushErrors,
-  hasStryd,
-  pushSingle,
+function WindowPills({
+  active,
+  onChange,
 }: {
-  workouts: PlannedWorkout[];
-  getPushState: (date: string) => PushState;
-  pushErrors: Record<string, string>;
-  hasStryd: boolean;
-  pushSingle: (date: string) => void;
+  active: WindowId;
+  onChange: (next: WindowId) => void;
 }) {
-  const [showAll, setShowAll] = useState(false);
-  const INITIAL_COUNT = 7; // Show 1 week by default
-
-  const visible = showAll ? workouts : workouts.slice(0, INITIAL_COUNT);
-  const hasMore = workouts.length > INITIAL_COUNT;
-
+  const { t } = useLingui();
+  const labels: Record<WindowId, string> = {
+    '1wk': t`1 wk`,
+    '2wk': t`2 wk`,
+    '4wk': t`4 wk`,
+  };
   return (
-    <div>
-      <div className="space-y-0.5">
-        {visible.map((w) => (
-          <WorkoutRow
-            key={w.date}
-            workout={w}
-            pushState={getPushState(w.date)}
-            pushError={pushErrors[w.date]}
-            showStryd={hasStryd}
-            onPushSingle={pushSingle}
-          />
-        ))}
-      </div>
-      {hasMore && (
-        <button
-          onClick={() => setShowAll(!showAll)}
-          className="mt-3 w-full text-center text-xs text-muted-foreground hover:text-primary transition-colors py-2"
-        >
-          {showAll
-            ? <Trans>Show less</Trans>
-            : <Trans>Show {workouts.length - INITIAL_COUNT} more workouts</Trans>}
-        </button>
-      )}
+    <div
+      role="tablist"
+      aria-label={t`Plan window`}
+      className="inline-flex items-center gap-1 rounded-full bg-muted/60 p-1 text-[11px] font-medium"
+    >
+      {WINDOW_OPTIONS.map((opt) => {
+        const isActive = opt.id === active;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(opt.id)}
+            className={`rounded-full px-3 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              isActive
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {labels[opt.id]}
+          </button>
+        );
+      })}
     </div>
   );
 }
 
 export default function UpcomingPlanCard() {
-  const { data, loading, error, refetch } = useApi<PlanResponse>('/api/plan');
+  const [windowId, setWindowId] = useState<WindowId>(() => {
+    if (typeof window === 'undefined') return '2wk';
+    const stored = window.localStorage.getItem(WINDOW_STORAGE_KEY) as WindowId | null;
+    return stored && WINDOW_OPTIONS.some((o) => o.id === stored) ? stored : '2wk';
+  });
+  const windowDays = WINDOW_OPTIONS.find((o) => o.id === windowId)?.days ?? 14;
+
+  // Window in the URL keeps queryKey-keyed cache entries distinct per
+  // window, so toggling 1wk ↔ 4wk doesn't replay the wrong cached body.
+  const planUrl = useMemo(
+    () => `/api/plan?start=${todayIso()}&end=${endIso(windowDays)}`,
+    [windowDays],
+  );
+  const { data, loading, error, refetch } = useApi<PlanResponse>(planUrl);
+
   const [pushStatus, setPushStatus] = useState<StrydPushStatus>({});
   const [pushErrors, setPushErrors] = useState<Record<string, string>>({});
   const [pushing, setPushing] = useState(false);
@@ -340,6 +422,13 @@ export default function UpcomingPlanCard() {
   // a second /api/settings request.
   const { config: settings } = useSettings();
   const hasStryd = Boolean(settings?.connections?.includes('stryd'));
+
+  const handleWindowChange = useCallback((next: WindowId) => {
+    setWindowId(next);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(WINDOW_STORAGE_KEY, next);
+    }
+  }, []);
 
   // Mirror server stryd_status into local state so push/delete handlers can
   // apply optimistic updates without waiting for a refetch; the next /api/plan
@@ -351,10 +440,18 @@ export default function UpcomingPlanCard() {
   }, [data?.stryd_status]);
 
   const getPushState = useCallback(
-    (date: string): PushState => {
+    (workout: PlannedWorkout): PushState => {
+      const date = workout.date;
       if (pushingDates.has(date)) return 'pushing';
       if (pushErrors[date]) return 'error';
-      if (pushStatus[date]) return 'pushed';
+      // Stryd-source rows have no AI/Stryd sync question — they are
+      // already on Stryd by definition.
+      if (workout.source === 'stryd') return 'native';
+      // Server-derived sync_state is the source of truth for AI rows.
+      // The local `pushStatus` map only matters for optimistic updates
+      // between a successful push and the next /api/plan refetch.
+      if (workout.sync_state === 'mismatch') return 'mismatch';
+      if (workout.sync_state === 'synced' || pushStatus[date]) return 'pushed';
       return 'none';
     },
     [pushingDates, pushErrors, pushStatus],
@@ -468,110 +565,117 @@ export default function UpcomingPlanCard() {
 
   if (loading) {
     return (
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-4 w-32" />
-        </CardHeader>
-        <CardContent className="space-y-3">
+      <section>
+        <Skeleton className="h-3 w-32 mb-5" />
+        <div className="space-y-2">
           {[...Array(4)].map((_, i) => (
             <Skeleton key={i} className="h-12 rounded-lg" />
           ))}
-        </CardContent>
-      </Card>
+        </div>
+      </section>
     );
   }
 
   if (error) {
     return (
-      <Card>
-        <CardContent className="pt-4 flex items-center justify-between">
-          <div>
-            <p className="text-sm text-destructive"><Trans>Failed to load training plan</Trans></p>
-            <p className="text-xs text-muted-foreground">{error}</p>
-          </div>
-          <Button variant="outline" size="sm" onClick={() => refetch()}><Trans>Retry</Trans></Button>
-        </CardContent>
-      </Card>
+      <section className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-destructive"><Trans>Failed to load training plan</Trans></p>
+          <p className="text-xs text-muted-foreground">{error}</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()}><Trans>Retry</Trans></Button>
+      </section>
     );
   }
 
   if (!data) return null;
+
+  // Header chrome: eyebrow + window pills (left) and Push All + count
+  // (right). Stays the same in empty / populated states so the user
+  // can switch windows without the chrome jumping around.
+  const aiPushable = data.workouts.filter(
+    (w) => w.source === 'ai'
+      && w.workout_type.toLowerCase() !== 'rest'
+      && (w.sync_state === 'not_synced' || w.sync_state === 'mismatch')
+      && !pushStatus[w.date],
+  );
+  const unpushedCount = aiPushable.length;
+  const allSynced = unpushedCount === 0
+    && data.workouts.some((w) => w.source === 'ai');
+
+  const header = (
+    <div className="flex flex-wrap items-center justify-between gap-3 mb-5">
+      <div className="flex items-center gap-3">
+        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
+          <Trans>Upcoming Plan</Trans>
+        </p>
+        <WindowPills active={windowId} onChange={handleWindowChange} />
+      </div>
+      <div className="flex items-center gap-3">
+        {data.workouts.length > 0 && (
+          <span className="text-[11px] text-muted-foreground font-data">
+            <Plural value={data.workouts.length} one="# workout" other="# workouts" />
+          </span>
+        )}
+        {hasStryd && data.workouts.length > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-3 text-[11px] gap-1.5"
+            disabled={pushing || allSynced}
+            onClick={pushAll}
+          >
+            {pushing ? (
+              <>
+                <SpinnerIcon className="h-3 w-3" />
+                <Trans>Pushing…</Trans>
+              </>
+            ) : allSynced ? (
+              <>
+                <CheckIcon className="h-3 w-3" />
+                <Trans>All synced</Trans>
+              </>
+            ) : (
+              <>
+                <UploadIcon className="h-3 w-3" />
+                <Trans>Push to Stryd</Trans>
+                {unpushedCount > 0 && (
+                  <span className="font-data ml-0.5">({unpushedCount})</span>
+                )}
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
   if (data.workouts.length === 0) {
-    // Render the empty state instead of disappearing — silent removal
-    // makes it look like the section is broken when it's just empty,
-    // and the user has no signal that they could pick a different
-    // window to find something.
     return (
-      <Card>
-        <CardHeader className="flex-row items-baseline justify-between space-y-0">
-          <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            <Trans>Upcoming Plan</Trans>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            <Trans>No workouts scheduled in the next two weeks.</Trans>
-          </p>
-        </CardContent>
-      </Card>
+      <section>
+        {header}
+        <p className="text-sm text-muted-foreground">
+          <Trans>No workouts scheduled in this window.</Trans>
+        </p>
+      </section>
     );
   }
 
-  const unpushedCount = data.workouts.filter(
-    (w) => !pushStatus[w.date] && w.workout_type.toLowerCase() !== 'rest',
-  ).length;
-  const allPushed = unpushedCount === 0;
-
   return (
-    <Card>
-      <CardHeader className="flex-row items-baseline justify-between space-y-0">
-        <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          <Trans>Upcoming Plan</Trans>
-        </CardTitle>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground font-data">
-            <Plural value={data.workouts.length} one="# workout" other="# workouts" />
-          </span>
-          {hasStryd && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-6 px-2 text-[10px] font-semibold uppercase tracking-wider gap-1"
-              disabled={pushing || allPushed}
-              onClick={pushAll}
-            >
-              {pushing ? (
-                <>
-                  <SpinnerIcon className="h-3 w-3" />
-                  <Trans>Pushing...</Trans>
-                </>
-              ) : allPushed ? (
-                <>
-                  <CheckIcon className="h-3 w-3" />
-                  <Trans>Synced</Trans>
-                </>
-              ) : (
-                <>
-                  <UploadIcon className="h-3 w-3" />
-                  <Trans>Push All</Trans>
-                  {unpushedCount > 0 && (
-                    <span className="font-data ml-0.5">({unpushedCount})</span>
-                  )}
-                </>
-              )}
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <ExpandableWorkoutList
-          workouts={data.workouts}
-          getPushState={getPushState}
-          pushErrors={pushErrors}
-          hasStryd={hasStryd}
-          pushSingle={pushSingle}
-        />
-      </CardContent>
-    </Card>
+    <section>
+      {header}
+      <div className="space-y-1">
+        {data.workouts.map((w) => (
+          <WorkoutRow
+            key={`${w.source}-${w.date}`}
+            workout={w}
+            pushState={getPushState(w)}
+            pushError={pushErrors[w.date]}
+            showStryd={hasStryd}
+            onPushSingle={pushSingle}
+          />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -495,7 +495,27 @@ export default function UpcomingPlanCard() {
     );
   }
 
-  if (!data || data.workouts.length === 0) return null;
+  if (!data) return null;
+  if (data.workouts.length === 0) {
+    // Render the empty state instead of disappearing — silent removal
+    // makes it look like the section is broken when it's just empty,
+    // and the user has no signal that they could pick a different
+    // window to find something.
+    return (
+      <Card>
+        <CardHeader className="flex-row items-baseline justify-between space-y-0">
+          <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            <Trans>Upcoming Plan</Trans>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            <Trans>No workouts scheduled in the next two weeks.</Trans>
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   const unpushedCount = data.workouts.filter(
     (w) => !pushStatus[w.date] && w.workout_type.toLowerCase() !== 'rest',

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -3,7 +3,6 @@ import { useApi, API_BASE, getAuthHeaders } from '@/hooks/useApi';
 import type { PlanResponse, PlannedWorkout, StrydPushStatus, StrydPushResult } from '@/types/api';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Trans, useLingui, Plural } from '@lingui/react/macro';
 import { useLocale } from '@/contexts/LocaleContext';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -125,6 +124,18 @@ const WarningIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
+// Always-visible labeled pill for the per-row sync state. The earlier
+// design hid action affordances behind hover (`group-hover:text-…`), so
+// users on touch devices and anyone scanning the list at a glance had
+// no way to see what to do — the only way to discover "push" was to
+// hover every row. Showing the action explicitly trades a few px of
+// horizontal space for a clearer single-click CTA.
+const PILL_BASE =
+  'inline-flex items-center gap-1.5 shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium ' +
+  'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+const PILL_CLICKABLE = 'cursor-pointer';
+const PILL_STATIC = 'cursor-default';
+
 function StrydStatusBadge({
   state,
   error,
@@ -140,123 +151,86 @@ function StrydStatusBadge({
   if (!showStryd) return null;
 
   if (state === 'native') {
-    // Workout came from Stryd directly — nothing to push, just show
-    // the source as a quiet label so the user knows where it lives.
     return (
-      <span className="text-[10px] font-data uppercase tracking-wider text-muted-foreground shrink-0">
+      <span
+        className={`${PILL_BASE} ${PILL_STATIC} bg-muted text-muted-foreground`}
+        title={t`This workout was imported from Stryd.`}
+      >
         <Trans>From Stryd</Trans>
       </span>
     );
   }
 
-  if (state === 'mismatch') {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger
-            render={(
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onPush}
-                aria-label={t`Workout differs on Stryd — re-push to overwrite`}
-                className="w-6 h-6 shrink-0 text-accent-amber hover:text-accent-amber/80"
-              >
-                <WarningIcon className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          />
-          <TooltipContent side="left">
-            <p className="text-xs">
-              <Trans>Differs on Stryd — click to re-push and overwrite.</Trans>
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-
   if (state === 'pushing') {
     return (
-      <div className="w-6 h-6 flex items-center justify-center shrink-0">
-        <SpinnerIcon className="h-3.5 w-3.5 text-muted-foreground" />
-      </div>
+      <span className={`${PILL_BASE} ${PILL_STATIC} bg-accent-cobalt/10 text-accent-cobalt`}>
+        <SpinnerIcon className="h-3 w-3" />
+        <Trans>Syncing…</Trans>
+      </span>
     );
   }
 
   if (state === 'error') {
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger
-            render={(
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onPush}
-                aria-label={t`Retry push to Stryd`}
-                className="w-6 h-6 shrink-0 text-destructive hover:text-destructive/80"
-              >
-                <ErrorIcon className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          />
-          <TooltipContent side="left">
-            <p className="text-xs">{error || <Trans>Push failed</Trans>} — <Trans>click to retry</Trans></p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <button
+        type="button"
+        onClick={onPush}
+        title={error || t`Push failed — click to retry`}
+        aria-label={t`Retry push to Stryd`}
+        className={`${PILL_BASE} ${PILL_CLICKABLE} bg-destructive/10 text-destructive hover:bg-destructive/15`}
+      >
+        <ErrorIcon className="h-3 w-3" />
+        <Trans>Retry</Trans>
+      </button>
+    );
+  }
+
+  if (state === 'mismatch') {
+    return (
+      <button
+        type="button"
+        onClick={onPush}
+        title={t`This workout differs on Stryd — click to overwrite with the Praxys version.`}
+        aria-label={t`Overwrite Stryd with Praxys version`}
+        className={`${PILL_BASE} ${PILL_CLICKABLE} bg-accent-amber/10 text-accent-amber hover:bg-accent-amber/15`}
+      >
+        <WarningIcon className="h-3 w-3" />
+        <Trans>Differs · overwrite</Trans>
+      </button>
     );
   }
 
   if (state === 'pushed') {
+    // Synced — clicking re-pushes (after deleting the prior workout
+    // server-side). Keep a soft hover state so the affordance is
+    // discoverable without screaming for attention.
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger
-            render={(
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onPush}
-                aria-label={t`Re-push to Stryd`}
-                className="w-6 h-6 shrink-0 text-primary [&>svg.check]:block [&>svg.refresh]:hidden hover:[&>svg.check]:hidden hover:[&>svg.refresh]:block hover:text-accent-amber"
-              >
-                <CheckIcon className="check h-3.5 w-3.5" />
-                <RefreshIcon className="refresh h-3.5 w-3.5" />
-              </Button>
-            )}
-          />
-          <TooltipContent side="left">
-            <p className="text-xs"><Trans>Re-push to Stryd</Trans></p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <button
+        type="button"
+        onClick={onPush}
+        title={t`Synced to Stryd. Click to re-push.`}
+        aria-label={t`Re-push to Stryd`}
+        className={`${PILL_BASE} ${PILL_CLICKABLE} bg-primary/10 text-primary hover:bg-primary/15 [&>svg.check]:inline [&>svg.refresh]:hidden hover:[&>svg.check]:hidden hover:[&>svg.refresh]:inline`}
+      >
+        <CheckIcon className="check h-3 w-3" />
+        <RefreshIcon className="refresh h-3 w-3" />
+        <Trans>Synced</Trans>
+      </button>
     );
   }
 
-  // state === 'none' — show push button on hover
+  // state === 'none' — never pushed. The clear primary CTA: click to push.
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger
-          render={(
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={onPush}
-              aria-label={t`Push to Stryd`}
-              className="w-6 h-6 shrink-0 text-muted-foreground/0 group-hover:text-muted-foreground hover:!text-primary"
-            >
-              <UploadIcon className="h-3.5 w-3.5" />
-            </Button>
-          )}
-        />
-        <TooltipContent side="left">
-          <p className="text-xs"><Trans>Push to Stryd</Trans></p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <button
+      type="button"
+      onClick={onPush}
+      title={t`Push this workout to your Stryd calendar.`}
+      aria-label={t`Push to Stryd`}
+      className={`${PILL_BASE} ${PILL_CLICKABLE} bg-accent-cobalt/10 text-accent-cobalt hover:bg-accent-cobalt/20`}
+    >
+      <UploadIcon className="h-3 w-3" />
+      <Trans>Sync to Stryd</Trans>
+    </button>
   );
 }
 

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -467,13 +467,24 @@ export default function UpcomingPlanCard() {
     [],
   );
 
-  // Push a single workout (or re-push by deleting old one first)
+  // Push a single workout (or re-push by deleting old one first).
+  //
+  // Edge case worth knowing: when re-pushing (existing workout_id), we
+  // DELETE first, then POST. If the DELETE succeeds but the POST fails,
+  // the user lands in ``error`` state with the prior workout already
+  // gone from Stryd. Re-clicking is the correct recovery — the second
+  // attempt skips the DELETE branch (pushStatus was cleared) and just
+  // creates a fresh workout. The user's intent ("overwrite the Stryd
+  // version with mine") is consistent across the failure modes; we
+  // surface the partial failure via the error pill rather than try to
+  // be clever about rolling back.
   const pushSingle = useCallback(
     async (date: string) => {
       if (pushingDates.has(date)) return;
 
       setPushingDates((prev) => new Set(prev).add(date));
 
+      let deleted = false;
       try {
         // If already pushed, delete the old workout from Stryd first
         const existing = pushStatus[date];
@@ -483,6 +494,7 @@ export default function UpcomingPlanCard() {
             const err = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }));
             throw new Error(err.detail || `HTTP ${resp.status}`);
           }
+          deleted = true;
           setPushStatus((prev) => {
             const next = { ...prev };
             delete next[date];
@@ -493,9 +505,12 @@ export default function UpcomingPlanCard() {
         const { results } = await pushDatesToStryd([date]);
         handlePushResults(results, [date]);
       } catch (e) {
+        const baseMsg = e instanceof Error ? e.message : 'Push failed';
         setPushErrors((prev) => ({
           ...prev,
-          [date]: e instanceof Error ? e.message : 'Push failed',
+          [date]: deleted
+            ? `${baseMsg} (the previous Stryd workout was deleted before the new one failed — click Sync to upload again)`
+            : baseMsg,
         }));
       } finally {
         setPushingDates((prev) => {
@@ -508,12 +523,23 @@ export default function UpcomingPlanCard() {
     [pushingDates, pushStatus, handlePushResults],
   );
 
-  // Push all unpushed workouts
+  // Push all unpushed AI workouts. Mirrors the ``aiPushable`` filter
+  // used to render the count beside the button — both must agree, or
+  // the button will offer to push N rows then push N±k after a
+  // round-trip. Specifically: must be ``source='ai'`` (Stryd-native
+  // rows would create *duplicates* on Stryd if pushed back),
+  // non-rest, and either not yet synced (``not_synced``) or diverged
+  // (``mismatch`` — re-push to overwrite).
   const pushAll = useCallback(async () => {
     if (!data) return;
 
     const datesToPush = data.workouts
-      .filter((w) => !pushStatus[w.date] && w.workout_type.toLowerCase() !== 'rest')
+      .filter(
+        (w) => w.source === 'ai'
+          && w.workout_type.toLowerCase() !== 'rest'
+          && (w.sync_state === 'not_synced' || w.sync_state === 'mismatch')
+          && !pushStatus[w.date],
+      )
       .map((w) => w.date);
 
     if (datesToPush.length === 0) return;

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -625,11 +625,15 @@ export default function UpcomingPlanCard() {
   );
 
   if (data.workouts.length === 0) {
+    const widerHint = windowId !== '4wk'
+      ? <Trans>Try a longer window above.</Trans>
+      : null;
     return (
       <section>
         {header}
         <p className="text-sm text-muted-foreground">
           <Trans>No workouts scheduled in this window.</Trans>
+          {widerHint && <span className="ml-1">{widerHint}</span>}
         </p>
       </section>
     );

--- a/web/src/components/ZoneAnalysisCard.tsx
+++ b/web/src/components/ZoneAnalysisCard.tsx
@@ -58,9 +58,12 @@ export default function ZoneAnalysisCard({ distribution, zoneRanges, theoryName,
 
   return (
     <div>
+      {/* Tab label above already says "Zone distribution" — render only
+          the theory attribution + threshold label here so the chart
+          carries its analytical context without duplicating the title. */}
       <div className="flex items-center justify-between mb-1">
-        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
-          <Trans>Zone Distribution</Trans> · {theoryName}
+        <p className="text-[11px] text-muted-foreground">
+          <Trans>vs {theoryName}</Trans>
         </p>
         {thresholdLabel && (
           <span className="text-[11px] text-muted-foreground font-data">{thresholdLabel}</span>

--- a/web/src/components/ZoneAnalysisCard.tsx
+++ b/web/src/components/ZoneAnalysisCard.tsx
@@ -1,5 +1,4 @@
 import type { ZoneDistribution, ZoneRange, DisplayConfig } from '@/types/api';
-import DistributionBar from '@/components/DistributionBar';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { tDisplay } from '@/lib/display-labels';
 
@@ -18,8 +17,15 @@ interface Props {
 // palette — no accent-blue/cobalt (cobalt is reserved for reasoning
 // surfaces), no primary green dominating the bar (primary is the action
 // signal, kept rare per the Restraint Rule). Aerobic zones stay in
-// tinted ink; caution (threshold) and high-intensity (vo2max) earn
-// warm color.
+// muted ink; threshold earns amber, high-intensity earns destructive.
+const ZONE_BAR_COLORS = [
+  'bg-muted-foreground/40',
+  'bg-muted-foreground/55',
+  'bg-foreground/65',
+  'bg-accent-amber',
+  'bg-destructive',
+];
+
 const ZONE_TEXT_COLORS = [
   'text-muted-foreground',
   'text-foreground/70',
@@ -28,22 +34,26 @@ const ZONE_TEXT_COLORS = [
   'text-destructive',
 ];
 
-function getZoneTextColor(index: number, total: number) {
-  const scaled = Math.round((index / Math.max(total - 1, 1)) * (ZONE_TEXT_COLORS.length - 1));
-  return ZONE_TEXT_COLORS[scaled] ?? ZONE_TEXT_COLORS[0];
+function scaledIndex(index: number, total: number, max: number) {
+  return Math.round((index / Math.max(total - 1, 1)) * (max - 1));
 }
 
 function formatRange(range: ZoneRange): string {
-  if (range.upper == null) return `> ${range.lower}${range.unit}`;
+  if (range.upper == null) return `≥ ${range.lower}${range.unit}`;
   if (range.lower === 0) return `< ${range.upper}${range.unit}`;
   return `${range.lower}–${range.upper}${range.unit}`;
 }
 
 /**
  * Zone distribution panel — borderless content block (no Card chrome).
- * Owns the full zone story: theory description (optional) + visual
- * proportion bar + numeric breakdown table. Used as a tab in the
- * Diagnosis chart switcher on Training; flat-by-default.
+ * One row per zone: name on the left, a horizontal "actual fills /
+ * target tick" bar in the middle, and `actual% / target%` on the right.
+ * Mirrors the WeChat Mini Program's zone-distribution layout so the
+ * two surfaces read the same.
+ *
+ * Why this and not a 4-col table: the bar makes "are you at, above,
+ * or below target?" a one-glance read. Numbers stay precise but stop
+ * being the only path to the answer.
  *
  * Note: deviation alerts that used to live here have moved into the
  * Praxys Coach receipt's rule-based fallback (single canonical
@@ -51,16 +61,18 @@ function formatRange(range: ZoneRange): string {
  */
 export default function ZoneAnalysisCard({ distribution, zoneRanges, theoryName, display, theoryDescription }: Props) {
   const { i18n } = useLingui();
-  const thresholdLabel = display ? `${display.threshold_abbrev}` : '';
-
-  const rows = [...distribution].reverse();
-  const ranges = [...zoneRanges].reverse();
+  const thresholdLabel = display ? display.threshold_abbrev : '';
+  // Zones come in ascending intensity from the API; the visual ladder
+  // reads better top-to-bottom from easiest to hardest, so keep order.
+  const rows = distribution.map((d, i) => ({
+    distribution: d,
+    range: zoneRanges[i],
+    barColor: ZONE_BAR_COLORS[scaledIndex(i, distribution.length, ZONE_BAR_COLORS.length)] ?? ZONE_BAR_COLORS[0],
+    textColor: ZONE_TEXT_COLORS[scaledIndex(i, distribution.length, ZONE_TEXT_COLORS.length)] ?? ZONE_TEXT_COLORS[0],
+  }));
 
   return (
     <div>
-      {/* Tab label above already says "Zone distribution" — render only
-          the theory attribution + threshold label here so the chart
-          carries its analytical context without duplicating the title. */}
       <div className="flex items-center justify-between mb-1">
         <p className="text-[11px] text-muted-foreground">
           <Trans>vs {theoryName}</Trans>
@@ -70,43 +82,54 @@ export default function ZoneAnalysisCard({ distribution, zoneRanges, theoryName,
         )}
       </div>
       {theoryDescription ? (
-        <p className="text-xs text-muted-foreground/80 leading-snug mb-4">
+        <p className="text-xs text-muted-foreground/80 leading-snug mb-5">
           {theoryDescription}
         </p>
       ) : (
-        <div className="mb-3" />
+        <div className="mb-4" />
       )}
 
-      {/* Visual bar above the numeric table — same dataset, two
-          presentations stacked: scan-fast bar on top, precise
-          breakdown below. */}
-      <div className="mb-5">
-        <DistributionBar distribution={distribution} />
-      </div>
-
-      <div className="grid grid-cols-[5rem_1fr_3.5rem_3.5rem] items-center pb-2 mb-2 border-b border-border">
-        <span className="text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Zone</Trans></span>
-        <span className="text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Range</Trans></span>
-        <span className="text-right text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Actual</Trans></span>
-        <span className="text-right text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Target</Trans></span>
-      </div>
-
-      <div className="space-y-1.5">
-        {rows.map((d, i) => {
-          const range = ranges[i];
-          const colorClass = getZoneTextColor(distribution.length - 1 - i, distribution.length);
+      <div className="space-y-4">
+        {rows.map(({ distribution: d, range, barColor, textColor }) => {
+          const actual = Math.max(0, Math.min(100, d.actual_pct));
+          const target = d.target_pct != null
+            ? Math.max(0, Math.min(100, d.target_pct))
+            : null;
           return (
-            <div key={d.name} className="grid grid-cols-[5rem_1fr_3.5rem_3.5rem] items-center">
-              <span className={`text-sm font-medium ${colorClass}`}>{tDisplay(d.name, i18n)}</span>
-              <span className="text-sm text-muted-foreground font-data tabular-nums truncate">
-                {range ? formatRange(range) : ''}
-              </span>
-              <span className="text-right text-sm font-semibold font-data tabular-nums text-foreground">
-                {d.actual_pct}%
-              </span>
-              <span className="text-right text-sm font-data tabular-nums text-muted-foreground">
-                {d.target_pct != null ? `${d.target_pct}%` : '—'}
-              </span>
+            <div key={d.name}>
+              <div className="flex items-baseline justify-between mb-1.5">
+                <div className="flex items-baseline gap-2">
+                  <span className={`text-sm font-medium ${textColor}`}>
+                    {tDisplay(d.name, i18n)}
+                  </span>
+                  {range && (
+                    <span className="text-[11px] text-muted-foreground/80 font-data tabular-nums">
+                      {formatRange(range)}
+                    </span>
+                  )}
+                </div>
+                <span className="text-[12px] font-data tabular-nums">
+                  <span className="text-foreground font-semibold">{d.actual_pct}%</span>
+                  <span className="text-muted-foreground/70"> / {target != null ? `${target}%` : '—'}</span>
+                </span>
+              </div>
+              {/* Track + actual fill + target tick. The track is muted,
+                  the fill is the zone's semantic color at full opacity,
+                  and the tick is a thin foreground line at `target_pct`
+                  so over/under-target becomes visible at a glance. */}
+              <div className="relative h-2 rounded-full bg-muted/70 overflow-hidden">
+                <div
+                  className={`absolute inset-y-0 left-0 ${barColor} rounded-full transition-[width]`}
+                  style={{ width: `${actual}%` }}
+                />
+                {target != null && (
+                  <div
+                    className="absolute inset-y-0 w-px bg-foreground/70"
+                    style={{ left: `${target}%` }}
+                    aria-label={`target ${target}%`}
+                  />
+                )}
+              </div>
             </div>
           );
         })}

--- a/web/src/components/ZoneAnalysisCard.tsx
+++ b/web/src/components/ZoneAnalysisCard.tsx
@@ -1,6 +1,5 @@
 import type { ZoneDistribution, ZoneRange, DisplayConfig } from '@/types/api';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import DistributionBar from '@/components/DistributionBar';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { tDisplay } from '@/lib/display-labels';
 
@@ -9,12 +8,22 @@ interface Props {
   zoneRanges: ZoneRange[];
   theoryName: string;
   display?: DisplayConfig;
+  /** Optional one-sentence theory description rendered as a muted
+   *  caption beneath the eyebrow. Used to inline-explain theory names
+   *  ("Seiler Polarized 3-Zone") that mean nothing to first-timers. */
+  theoryDescription?: string;
 }
 
+// Zone gradient runs cool→warm with intensity. Uses only the semantic
+// palette — no accent-blue/cobalt (cobalt is reserved for reasoning
+// surfaces), no primary green dominating the bar (primary is the action
+// signal, kept rare per the Restraint Rule). Aerobic zones stay in
+// tinted ink; caution (threshold) and high-intensity (vo2max) earn
+// warm color.
 const ZONE_TEXT_COLORS = [
   'text-muted-foreground',
-  'text-accent-blue/70',
-  'text-accent-blue',
+  'text-foreground/70',
+  'text-foreground',
   'text-accent-amber',
   'text-destructive',
 ];
@@ -30,70 +39,75 @@ function formatRange(range: ZoneRange): string {
   return `${range.lower}–${range.upper}${range.unit}`;
 }
 
-export default function ZoneAnalysisCard({ distribution, zoneRanges, theoryName, display }: Props) {
-  const { t, i18n } = useLingui();
+/**
+ * Zone distribution panel — borderless content block (no Card chrome).
+ * Owns the full zone story: theory description (optional) + visual
+ * proportion bar + numeric breakdown table. Used as a tab in the
+ * Diagnosis chart switcher on Training; flat-by-default.
+ *
+ * Note: deviation alerts that used to live here have moved into the
+ * Praxys Coach receipt's rule-based fallback (single canonical
+ * interpretation surface). Don't re-introduce the standalone Alert.
+ */
+export default function ZoneAnalysisCard({ distribution, zoneRanges, theoryName, display, theoryDescription }: Props) {
+  const { i18n } = useLingui();
   const thresholdLabel = display ? `${display.threshold_abbrev}` : '';
 
   const rows = [...distribution].reverse();
   const ranges = [...zoneRanges].reverse();
 
-  const alerts = distribution
-    .filter((d) => d.target_pct != null && Math.abs(d.actual_pct - d.target_pct!) > 5)
-    .map((d) => {
-      const diff = d.actual_pct - d.target_pct!;
-      const direction = diff > 0 ? t`above` : t`below`;
-      return `${tDisplay(d.name, i18n)}: ${d.actual_pct}% (${Math.abs(diff)}pp ${direction} ${d.target_pct}% ${t`target`})`;
-    });
-
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            <Trans>Zone Analysis</Trans> · {theoryName}
-          </CardTitle>
-          {thresholdLabel && (
-            <span className="text-xs text-muted-foreground font-data">{thresholdLabel}</span>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center pb-2 mb-2 border-b border-border">
-          <span className="w-20 text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Zone</Trans></span>
-          <span className="flex-1 text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Range</Trans></span>
-          <span className="w-14 text-right text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Actual</Trans></span>
-          <span className="w-14 text-right text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Target</Trans></span>
-        </div>
-
-        <div className="space-y-1.5">
-          {rows.map((d, i) => {
-            const range = ranges[i];
-            const colorClass = getZoneTextColor(distribution.length - 1 - i, distribution.length);
-            return (
-              <div key={d.name} className="flex items-center">
-                <span className={`w-20 text-sm font-medium ${colorClass}`}>{tDisplay(d.name, i18n)}</span>
-                <span className="flex-1 text-sm text-muted-foreground font-data">
-                  {range ? formatRange(range) : ''}
-                </span>
-                <span className="w-14 text-right text-sm font-semibold font-data text-foreground">
-                  {d.actual_pct}%
-                </span>
-                <span className="w-14 text-right text-sm font-data text-muted-foreground">
-                  {d.target_pct != null ? `${d.target_pct}%` : '—'}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-
-        {alerts.length > 0 && (
-          <Alert className="mt-4 border-accent-amber/30 bg-accent-amber/5">
-            <AlertDescription className="text-sm text-accent-amber">
-              <Trans>Distribution deviates from target</Trans>: {alerts.join('; ')}
-            </AlertDescription>
-          </Alert>
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
+          <Trans>Zone Distribution</Trans> · {theoryName}
+        </p>
+        {thresholdLabel && (
+          <span className="text-[11px] text-muted-foreground font-data">{thresholdLabel}</span>
         )}
-      </CardContent>
-    </Card>
+      </div>
+      {theoryDescription ? (
+        <p className="text-xs text-muted-foreground/80 leading-snug mb-4">
+          {theoryDescription}
+        </p>
+      ) : (
+        <div className="mb-3" />
+      )}
+
+      {/* Visual bar above the numeric table — same dataset, two
+          presentations stacked: scan-fast bar on top, precise
+          breakdown below. */}
+      <div className="mb-5">
+        <DistributionBar distribution={distribution} />
+      </div>
+
+      <div className="grid grid-cols-[5rem_1fr_3.5rem_3.5rem] items-center pb-2 mb-2 border-b border-border">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Zone</Trans></span>
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Range</Trans></span>
+        <span className="text-right text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Actual</Trans></span>
+        <span className="text-right text-[10px] uppercase tracking-wider text-muted-foreground"><Trans>Target</Trans></span>
+      </div>
+
+      <div className="space-y-1.5">
+        {rows.map((d, i) => {
+          const range = ranges[i];
+          const colorClass = getZoneTextColor(distribution.length - 1 - i, distribution.length);
+          return (
+            <div key={d.name} className="grid grid-cols-[5rem_1fr_3.5rem_3.5rem] items-center">
+              <span className={`text-sm font-medium ${colorClass}`}>{tDisplay(d.name, i18n)}</span>
+              <span className="text-sm text-muted-foreground font-data tabular-nums truncate">
+                {range ? formatRange(range) : ''}
+              </span>
+              <span className="text-right text-sm font-semibold font-data tabular-nums text-foreground">
+                {d.actual_pct}%
+              </span>
+              <span className="text-right text-sm font-data tabular-nums text-muted-foreground">
+                {d.target_pct != null ? `${d.target_pct}%` : '—'}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/web/src/components/charts/ComplianceChart.tsx
+++ b/web/src/components/charts/ComplianceChart.tsx
@@ -6,12 +6,11 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  Legend,
-  Cell,
+  LabelList,
 } from 'recharts';
 import type { WeeklyReview } from '@/types/api';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/useChartColors';
+import ScienceNote from '@/components/ScienceNote';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 interface Props {
@@ -19,6 +18,29 @@ interface Props {
   loadLabel?: string;
 }
 
+interface BarLabelProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  index?: number;
+}
+
+/**
+ * Weekly load compliance — borderless content block (no Card chrome).
+ * Used inside the Diagnosis chart switcher tab.
+ *
+ * Design choices:
+ * - Single primary color for the actual bar regardless of compliance
+ *   state. The under/on/over signal lives in a small mono % label
+ *   above each bar (semantic color: amber under, primary on,
+ *   destructive over). Replaces the prior cell-by-cell green/amber/red
+ *   bar fill which broke the brand's restraint rule.
+ * - Both bars same width (24px) with `barGap={-24}`, so they overlap
+ *   concentrically around a shared x-center. Taller bar shows above
+ *   the shorter; no off-center artifact.
+ * - Planned bar is a muted ghost (no diagonal pattern, no border).
+ *   Opacity contrast with the primary actual bar is the affordance.
+ */
 export default function ComplianceChart({ data, loadLabel }: Props) {
   const chartColors = useChartColors();
   const { t } = useLingui();
@@ -31,79 +53,124 @@ export default function ComplianceChart({ data, loadLabel }: Props) {
     return { week, planned, actual, compliance };
   });
 
+  // RSS = Running Stress Score, the load metric Praxys uses when no
+  // power-band targets exist. Inline-expand on first appearance per
+  // the design system's "right word, explained inline once" rule.
+  const labelExpansion = label === 'RSS'
+    ? <Trans>load (Running Stress Score)</Trans>
+    : <Trans>load ({label})</Trans>;
+
+  // Compliance % rendered above each actual bar. Single-color bars +
+  // a small mono percentage with semantic color carry the
+  // under/on/over signal — replaces the prior cell-coloring.
+  const ComplianceLabel = (props: BarLabelProps) => {
+    const { x, y, width, index } = props;
+    if (index == null || x == null || y == null || width == null) return null;
+    const entry = chartData[index];
+    const pct = entry?.compliance;
+    if (pct == null) return null;
+    const color =
+      pct < 80
+        ? 'var(--accent-amber-val)'
+        : pct > 120
+          ? 'var(--destructive)'
+          : 'var(--primary)';
+    return (
+      <text
+        x={x + width / 2}
+        y={y - 6}
+        fill={color}
+        fontSize={10}
+        fontFamily="var(--font-mono)"
+        textAnchor="middle"
+        fontWeight={600}
+      >
+        {pct}%
+      </text>
+    );
+  };
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+    <section>
+      <div className="flex flex-row items-baseline justify-between mb-4">
+        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
           <Trans>Weekly Load Compliance</Trans>
-        </CardTitle>
-        {data.planned_estimated && (
-          <p className="text-[11px] text-muted-foreground mt-1">
-            <Trans>
-              Planned bars are estimated — your plan has no {label} targets
-              for the current training base.
-            </Trans>
-          </p>
-        )}
-      </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }} barGap={-30}>
-            <defs>
-              <pattern id="planned-pattern" patternUnits="userSpaceOnUse" width="6" height="6">
-                <path d="M0 6L6 0" stroke={chartColors.tick} strokeWidth="1" strokeOpacity="0.4" />
-              </pattern>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} />
-            <XAxis
-              dataKey="week"
-              tick={{ fill: chartColors.tickLight, fontSize: 11 }}
-              tickFormatter={(v: string) => v.slice(5)}
-            />
-            <YAxis tick={{ fill: chartColors.tickLight, fontSize: 11 }} />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: chartColors.tooltipBg,
-                border: `1px solid ${chartColors.tooltipBorder}`,
-                borderRadius: 8,
-              }}
-              labelStyle={{ color: chartColors.tickLight }}
-              formatter={(value, name) => {
-                return [Math.round(Number(value)), String(name)];
-              }}
-            />
-            <Legend wrapperStyle={{ fontSize: 12, color: chartColors.tickLight }} />
-            {/* Planned bar — wider, behind, with diagonal pattern fill */}
-            <Bar
-              dataKey="planned"
-              name={`${t`Planned`} ${label}`}
-              fill="url(#planned-pattern)"
-              stroke={chartColors.tick}
-              strokeWidth={1}
-              strokeOpacity={0.3}
-              radius={[3, 3, 0, 0]}
-              barSize={32}
-            />
-            {/* Actual bar — narrower, in front, solid fill with compliance coloring */}
-            <Bar
-              dataKey="actual"
-              name={`${t`Actual`} ${label}`}
-              radius={[3, 3, 0, 0]}
-              barSize={22}
-            >
-              {chartData.map((entry, i) => {
-                const pct = entry.compliance;
-                let fill = chartColors.fitness; // green = on target
-                if (pct != null) {
-                  if (pct < 80) fill = chartColors.warning; // amber = under
-                  else if (pct > 120) fill = chartColors.negative; // red = over
-                }
-                return <Cell key={i} fill={fill} fillOpacity={0.85} />;
-              })}
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
-      </CardContent>
-    </Card>
+          <span className="normal-case tracking-normal text-muted-foreground/70 ml-2">
+            {labelExpansion}
+          </span>
+        </p>
+        {/* Inline two-step legend replaces the prior Recharts Legend
+            chrome; ghost bar + solid bar are the visual key, the
+            labels describe what each represents. */}
+        <div className="flex items-center gap-4 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-2 rounded-sm bg-muted-foreground/25" />
+            <Trans>Planned</Trans>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-2 rounded-sm bg-primary/85" />
+            <Trans>Actual</Trans>
+          </span>
+        </div>
+      </div>
+
+      {data.planned_estimated && (
+        <p className="text-[11px] text-muted-foreground mb-2">
+          <Trans>
+            Planned bars are estimated — your plan has no {label} targets
+            for the current training base.
+          </Trans>
+        </p>
+      )}
+
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart data={chartData} margin={{ top: 18, right: 10, left: 0, bottom: 5 }} barGap={-24}>
+          <CartesianGrid strokeDasharray="3 3" stroke={chartColors.grid} vertical={false} />
+          <XAxis
+            dataKey="week"
+            tick={{ fill: chartColors.tick, fontSize: 10, fontFamily: 'JetBrains Mono Variable, monospace' }}
+            tickLine={false}
+            axisLine={{ stroke: chartColors.grid }}
+            tickFormatter={(v: string) => v.slice(5)}
+          />
+          <YAxis
+            tick={{ fill: chartColors.tick, fontSize: 10, fontFamily: 'JetBrains Mono Variable, monospace' }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: chartColors.tooltipBg,
+              border: `1px solid ${chartColors.tooltipBorder}`,
+              borderRadius: 8,
+            }}
+            labelStyle={{ color: chartColors.tickLight }}
+            formatter={(value, name) => [Math.round(Number(value)), String(name)]}
+          />
+          <Bar
+            dataKey="planned"
+            name={`${t`Planned`} ${label}`}
+            fill="var(--muted-foreground)"
+            fillOpacity={0.22}
+            radius={[3, 3, 0, 0]}
+            barSize={24}
+          />
+          <Bar
+            dataKey="actual"
+            name={`${t`Actual`} ${label}`}
+            fill="var(--primary)"
+            fillOpacity={0.85}
+            radius={[3, 3, 0, 0]}
+            barSize={24}
+          >
+            <LabelList dataKey="compliance" content={ComplianceLabel as never} />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <ScienceNote
+        text={t`Compliance compares the load you actually accumulated each week (Actual) against the load your plan called for (Planned). The percentage above each bar shows how close you came: green for 80–120% (on target), amber under 80%, red over 120%. The load metric (RSS or W-equivalent) is set by your training base.`}
+      />
+    </section>
   );
 }

--- a/web/src/components/charts/ComplianceChart.tsx
+++ b/web/src/components/charts/ComplianceChart.tsx
@@ -93,11 +93,10 @@ export default function ComplianceChart({ data, loadLabel }: Props) {
   return (
     <section>
       <div className="flex flex-row items-baseline justify-between mb-4">
-        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
-          <Trans>Weekly Load Compliance</Trans>
-          <span className="normal-case tracking-normal text-muted-foreground/70 ml-2">
-            {labelExpansion}
-          </span>
+        {/* Tab label above already says "Load compliance" — keep just
+            the unit hint here (e.g. "Running Stress Score"). */}
+        <p className="text-[11px] text-muted-foreground">
+          {labelExpansion}
         </p>
         {/* Inline two-step legend replaces the prior Recharts Legend
             chrome; ghost bar + solid bar are the visual key, the

--- a/web/src/components/charts/FitnessFatigueChart.tsx
+++ b/web/src/components/charts/FitnessFatigueChart.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Line,
   XAxis,
@@ -11,9 +10,8 @@ import {
   ComposedChart,
   ReferenceArea,
   ReferenceLine,
-  ReferenceDot,
 } from 'recharts';
-import type { TimeSeriesData, WorkoutFlag } from '@/types/api';
+import type { TimeSeriesData } from '@/types/api';
 import ScienceNote from '@/components/ScienceNote';
 import ZoneLegend from '@/components/charts/ZoneLegend';
 import { useScience, tsbZoneFromConfig } from '@/contexts/ScienceContext';
@@ -25,9 +23,6 @@ import type { ScienceNoteInfo } from '@/types/api';
 interface Props {
   data: TimeSeriesData;
   scienceNote?: ScienceNoteInfo;
-  /** Flagged workouts (good / bad). Rendered as small dots above the
-   *  bottom axis, clickable to drill through to /activities. Optional. */
-  workoutFlags?: WorkoutFlag[];
 }
 
 const ZONE_OPACITIES = [0.04, 0.07, 0.06, 0.04, 0.05];
@@ -85,18 +80,10 @@ function CustomTooltip({ active, payload, label, tsbZones, chartColors }: any) {
   );
 }
 
-export default function FitnessFatigueChart({ data, scienceNote, workoutFlags }: Props) {
+export default function FitnessFatigueChart({ data, scienceNote }: Props) {
   const chartColors = useChartColors();
   const { t } = useLingui();
   const { tsbZones } = useScience();
-  const navigate = useNavigate();
-  // Limit overlay dots to dates actually rendered on the chart so a
-  // "bad" flag from before the visible window doesn't render off-axis.
-  const visibleDates = useMemo(() => new Set(data.dates), [data.dates]);
-  const flags = useMemo(
-    () => (workoutFlags ?? []).filter((f) => visibleDates.has(f.date)),
-    [workoutFlags, visibleDates],
-  );
   const { chartData, yMin, yMax, hasProjection } = useMemo(() => {
     const hasProjData = !!(data.projected_dates?.length && data.projected_ctl?.length);
 
@@ -159,7 +146,31 @@ export default function FitnessFatigueChart({ data, scienceNote, workoutFlags }:
     };
   }, [data]);
 
-  const projectionStartDate = data.dates[data.dates.length - 1];
+  // Anchor the "today" reference line to actual today, not the last
+  // data point — those drift apart when the user hasn't trained recently
+  // (or hasn't synced), and the label "today" sitting on a 10-day-old
+  // date is misleading. We snap to the nearest categorical x in
+  // chartData because Recharts ReferenceLine requires a category match.
+  const todayMarkerDate = useMemo(() => {
+    if (!chartData.length) return undefined;
+    const todayIso = new Date().toISOString().slice(0, 10);
+    const exact = chartData.find((d) => d.date === todayIso);
+    if (exact) return exact.date;
+    const todayMs = new Date(todayIso).getTime();
+    let nearest = chartData[0];
+    let nearestGap = Math.abs(new Date(nearest.date).getTime() - todayMs);
+    for (const row of chartData) {
+      const gap = Math.abs(new Date(row.date).getTime() - todayMs);
+      if (gap < nearestGap) {
+        nearest = row;
+        nearestGap = gap;
+      }
+    }
+    // If the nearest point is more than ~10 days off, the chart's
+    // window doesn't actually include today — drop the marker rather
+    // than pinning it to the edge with a misleading "today" label.
+    return nearestGap <= 10 * 24 * 60 * 60 * 1000 ? nearest.date : undefined;
+  }, [chartData]);
 
   return (
     // Borderless content block (no Card chrome) — used inside the
@@ -222,13 +233,20 @@ export default function FitnessFatigueChart({ data, scienceNote, workoutFlags }:
 
             <ReferenceLine y={0} stroke={chartColors.tick} strokeWidth={1} strokeDasharray="4 3" />
 
-            {hasProjection && (
+            {todayMarkerDate && (
               <ReferenceLine
-                x={projectionStartDate}
+                x={todayMarkerDate}
                 stroke={chartColors.projection}
                 strokeWidth={1}
                 strokeDasharray="3 3"
-                label={{ value: t`Today`, position: 'top', fill: chartColors.projection, fontSize: 10 }}
+                label={{
+                  value: t`Today`,
+                  position: 'insideTop',
+                  offset: 6,
+                  fill: chartColors.projection,
+                  fontSize: 10,
+                  fontFamily: 'JetBrains Mono Variable, monospace',
+                }}
               />
             )}
 
@@ -266,58 +284,8 @@ export default function FitnessFatigueChart({ data, scienceNote, workoutFlags }:
               </>
             )}
 
-            {flags.map((flag) => {
-              const tooltipText = `${flag.type === 'good' ? t`Good workout` : t`Bad workout`} \u00b7 ${flag.date}${flag.description ? `\n${flag.description}` : ''}`;
-              return (
-                <ReferenceDot
-                  key={`${flag.type}-${flag.date}`}
-                  x={flag.date}
-                  /* Sit ~6% above the chart floor so dots land on the
-                     visible plot area instead of crowding axis ticks. */
-                  y={yMin + (yMax - yMin) * 0.06}
-                  r={4}
-                  fill={flag.type === 'good' ? 'var(--primary)' : 'var(--destructive)'}
-                  stroke="var(--card)"
-                  strokeWidth={1.5}
-                  ifOverflow="hidden"
-                  shape={(props) => {
-                    const { cx, cy, fill, stroke, strokeWidth, r } = props as { cx: number; cy: number; fill: string; stroke: string; strokeWidth: number; r: number };
-                    return (
-                      <g
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => navigate('/activities')}
-                        role="button"
-                        aria-label={tooltipText}
-                      >
-                        <circle cx={cx} cy={cy} r={r} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
-                        {/* Larger transparent hit target so the small
-                            visual dot doesn't require pixel-precise aim. */}
-                        <circle cx={cx} cy={cy} r={r + 4} fill="transparent" />
-                        <title>{tooltipText}</title>
-                      </g>
-                    );
-                  }}
-                />
-              );
-            })}
           </ComposedChart>
         </ResponsiveContainer>
-
-        {flags.length > 0 && (
-          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px]">
-            <span className="font-data uppercase tracking-wider text-muted-foreground">
-              <Trans>Flagged</Trans>
-            </span>
-            <span className="flex items-center gap-1.5 text-muted-foreground">
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
-              <Trans>good \u00b7 {flags.filter((f) => f.type === 'good').length}</Trans>
-            </span>
-            <span className="flex items-center gap-1.5 text-muted-foreground">
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-destructive" />
-              <Trans>bad \u00b7 {flags.filter((f) => f.type === 'bad').length}</Trans>
-            </span>
-          </div>
-        )}
 
         <ZoneLegend zones={tsbZones} />
 

--- a/web/src/components/charts/FitnessFatigueChart.tsx
+++ b/web/src/components/charts/FitnessFatigueChart.tsx
@@ -151,16 +151,23 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
   // (or hasn't synced), and the label "today" sitting on a 10-day-old
   // date is misleading. We snap to the nearest categorical x in
   // chartData because Recharts ReferenceLine requires a category match.
+  //
+  // ISO dates parsed with explicit ``T00:00:00`` for consistency with
+  // the rest of the codebase (UpcomingPlanCard.formatDate). Bare
+  // ``YYYY-MM-DD`` parses as UTC in modern V8 but as local on some
+  // older runtimes — pinning the time avoids the gap calculation
+  // wandering across a midnight boundary on a slow machine clock.
   const todayMarkerDate = useMemo(() => {
     if (!chartData.length) return undefined;
+    const parseIso = (s: string) => new Date(`${s}T00:00:00`).getTime();
     const todayIso = new Date().toISOString().slice(0, 10);
     const exact = chartData.find((d) => d.date === todayIso);
     if (exact) return exact.date;
-    const todayMs = new Date(todayIso).getTime();
+    const todayMs = parseIso(todayIso);
     let nearest = chartData[0];
-    let nearestGap = Math.abs(new Date(nearest.date).getTime() - todayMs);
+    let nearestGap = Math.abs(parseIso(nearest.date) - todayMs);
     for (const row of chartData) {
-      const gap = Math.abs(new Date(row.date).getTime() - todayMs);
+      const gap = Math.abs(parseIso(row.date) - todayMs);
       if (gap < nearestGap) {
         nearest = row;
         nearestGap = gap;

--- a/web/src/components/charts/FitnessFatigueChart.tsx
+++ b/web/src/components/charts/FitnessFatigueChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Line,
   XAxis,
@@ -10,12 +11,12 @@ import {
   ComposedChart,
   ReferenceArea,
   ReferenceLine,
+  ReferenceDot,
 } from 'recharts';
-import type { TimeSeriesData } from '@/types/api';
+import type { TimeSeriesData, WorkoutFlag } from '@/types/api';
 import ScienceNote from '@/components/ScienceNote';
 import ZoneLegend from '@/components/charts/ZoneLegend';
 import { useScience, tsbZoneFromConfig } from '@/contexts/ScienceContext';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useChartColors } from '@/hooks/useChartColors';
 import { Trans, useLingui } from '@lingui/react/macro';
 
@@ -24,6 +25,9 @@ import type { ScienceNoteInfo } from '@/types/api';
 interface Props {
   data: TimeSeriesData;
   scienceNote?: ScienceNoteInfo;
+  /** Flagged workouts (good / bad). Rendered as small dots above the
+   *  bottom axis, clickable to drill through to /activities. Optional. */
+  workoutFlags?: WorkoutFlag[];
 }
 
 const ZONE_OPACITIES = [0.04, 0.07, 0.06, 0.04, 0.05];
@@ -42,7 +46,7 @@ function CustomTooltip({ active, payload, label, tsbZones, chartColors }: any) {
       <div className="flex items-center gap-2 mb-2">
         <span className="text-[11px] text-muted-foreground font-data">{label}</span>
         {isProjected && (
-          <span className="text-[9px] uppercase tracking-wider text-accent-purple font-semibold px-1.5 py-0.5 rounded bg-accent-purple/10">
+          <span className="text-[9px] uppercase tracking-wider text-accent-cobalt font-semibold px-1.5 py-0.5 rounded bg-accent-cobalt/10">
             <Trans>Projected</Trans>
           </span>
         )}
@@ -81,10 +85,18 @@ function CustomTooltip({ active, payload, label, tsbZones, chartColors }: any) {
   );
 }
 
-export default function FitnessFatigueChart({ data, scienceNote }: Props) {
+export default function FitnessFatigueChart({ data, scienceNote, workoutFlags }: Props) {
   const chartColors = useChartColors();
   const { t } = useLingui();
   const { tsbZones } = useScience();
+  const navigate = useNavigate();
+  // Limit overlay dots to dates actually rendered on the chart so a
+  // "bad" flag from before the visible window doesn't render off-axis.
+  const visibleDates = useMemo(() => new Set(data.dates), [data.dates]);
+  const flags = useMemo(
+    () => (workoutFlags ?? []).filter((f) => visibleDates.has(f.date)),
+    [workoutFlags, visibleDates],
+  );
   const { chartData, yMin, yMax, hasProjection } = useMemo(() => {
     const hasProjData = !!(data.projected_dates?.length && data.projected_ctl?.length);
 
@@ -150,23 +162,29 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
   const projectionStartDate = data.dates[data.dates.length - 1];
 
   return (
-    <Card>
-      <CardHeader className="flex-row items-center justify-between space-y-0">
-        <CardTitle className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+    // Borderless content block (no Card chrome) — used inside the
+    // Diagnosis chart switcher tab. Section identity comes from the
+    // switcher tab label above; no own header eyebrow needed.
+    <section>
+      <div className="flex flex-row items-center justify-between mb-4">
+        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
           <Trans>Fitness / Fatigue / Form</Trans>
-        </CardTitle>
-        <div className="flex items-center gap-4 text-[11px]">
+        </p>
+        {/* Legend pairs each acronym with its plain-English meaning.
+            Power users keep CTL/ATL/TSB anchors; first-timers get
+            meaning. */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
           <span className="flex items-center gap-1.5">
             <span className="inline-block w-3 h-0.5 rounded-full" style={{ backgroundColor: chartColors.fitness }} />
-            <span className="text-muted-foreground">CTL</span>
+            <span className="text-muted-foreground"><Trans>Fitness</Trans> <span className="font-data">CTL</span></span>
           </span>
           <span className="flex items-center gap-1.5">
             <span className="inline-block w-3 h-0.5 rounded-full" style={{ backgroundColor: chartColors.fatigue }} />
-            <span className="text-muted-foreground">ATL</span>
+            <span className="text-muted-foreground"><Trans>Fatigue</Trans> <span className="font-data">ATL</span></span>
           </span>
           <span className="flex items-center gap-1.5">
             <span className="inline-block w-3 h-0.5 rounded-full" style={{ backgroundColor: chartColors.form }} />
-            <span className="text-muted-foreground">TSB</span>
+            <span className="text-muted-foreground"><Trans>Form</Trans> <span className="font-data">TSB</span></span>
           </span>
           {hasProjection && (
             <span className="flex items-center gap-1.5">
@@ -175,8 +193,8 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
             </span>
           )}
         </div>
-      </CardHeader>
-      <CardContent>
+      </div>
+      <div>
         <ResponsiveContainer width="100%" height={380}>
           <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: -5, bottom: 5 }}>
             <defs>
@@ -250,8 +268,59 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
                 <Line type="monotone" dataKey="proj_tsb" stroke={chartColors.projection} strokeWidth={2} strokeDasharray="6 4" dot={false} connectNulls={false} isAnimationActive={false} />
               </>
             )}
+
+            {flags.map((flag) => {
+              const tooltipText = `${flag.type === 'good' ? t`Good workout` : t`Bad workout`} \u00b7 ${flag.date}${flag.description ? `\n${flag.description}` : ''}`;
+              return (
+                <ReferenceDot
+                  key={`${flag.type}-${flag.date}`}
+                  x={flag.date}
+                  /* Sit ~6% above the chart floor so dots land on the
+                     visible plot area instead of crowding axis ticks. */
+                  y={yMin + (yMax - yMin) * 0.06}
+                  r={4}
+                  fill={flag.type === 'good' ? 'var(--primary)' : 'var(--destructive)'}
+                  stroke="var(--card)"
+                  strokeWidth={1.5}
+                  ifOverflow="hidden"
+                  shape={(props) => {
+                    const { cx, cy, fill, stroke, strokeWidth, r } = props as { cx: number; cy: number; fill: string; stroke: string; strokeWidth: number; r: number };
+                    return (
+                      <g
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => navigate('/activities')}
+                        role="button"
+                        aria-label={tooltipText}
+                      >
+                        <circle cx={cx} cy={cy} r={r} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
+                        {/* Larger transparent hit target so the small
+                            visual dot doesn't require pixel-precise aim. */}
+                        <circle cx={cx} cy={cy} r={r + 4} fill="transparent" />
+                        <title>{tooltipText}</title>
+                      </g>
+                    );
+                  }}
+                />
+              );
+            })}
           </ComposedChart>
         </ResponsiveContainer>
+
+        {flags.length > 0 && (
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px]">
+            <span className="font-data uppercase tracking-wider text-muted-foreground">
+              <Trans>Flagged</Trans>
+            </span>
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
+              <Trans>good \u00b7 {flags.filter((f) => f.type === 'good').length}</Trans>
+            </span>
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-destructive" />
+              <Trans>bad \u00b7 {flags.filter((f) => f.type === 'bad').length}</Trans>
+            </span>
+          </div>
+        )}
 
         <ZoneLegend zones={tsbZones} />
 
@@ -261,7 +330,7 @@ export default function FitnessFatigueChart({ data, scienceNote }: Props) {
           sourceUrl={scienceNote?.citations?.[0]?.url || "https://help.trainingpeaks.com/hc/en-us/articles/204071944"}
           sourceLabel={scienceNote?.citations?.[0]?.label || "TrainingPeaks PMC"}
         />
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   );
 }

--- a/web/src/components/charts/FitnessFatigueChart.tsx
+++ b/web/src/components/charts/FitnessFatigueChart.tsx
@@ -166,10 +166,7 @@ export default function FitnessFatigueChart({ data, scienceNote, workoutFlags }:
     // Diagnosis chart switcher tab. Section identity comes from the
     // switcher tab label above; no own header eyebrow needed.
     <section>
-      <div className="flex flex-row items-center justify-between mb-4">
-        <p className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
-          <Trans>Fitness / Fatigue / Form</Trans>
-        </p>
+      <div className="flex flex-row items-center justify-end mb-4">
         {/* Legend pairs each acronym with its plain-English meaning.
             Power users keep CTL/ATL/TSB anchors; first-timers get
             meaning. */}

--- a/web/src/lib/display-labels.ts
+++ b/web/src/lib/display-labels.ts
@@ -44,6 +44,12 @@ const DISPLAY_LABEL_MAP: Record<string, MessageDescriptor> = {
   Tempo: msg`Tempo`,
   Threshold: msg`Threshold`,
   VO2max: msg`VO2max`,
+  // Polarized 3-zone names (Seiler) — surfaced by the zone-distribution
+  // chart on Training. The English labels come from the active science
+  // theory's zone_labels block; zh users get translated copies here.
+  'Zone 1 (Easy)': msg`Zone 1 (Easy)`,
+  'Zone 2 (Moderate)': msg`Zone 2 (Moderate)`,
+  'Zone 3 (Hard)': msg`Zone 3 (Hard)`,
   // Intensity metric labels
   Power: msg`Power`,
   'Heart Rate': msg`Heart Rate`,

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -41,7 +41,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:617
+#: src/components/UpcomingPlanCard.tsx:591
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -115,7 +115,7 @@ msgstr "~{estimatedActivities} activities, ~{estimatedMinutes} min"
 msgid "1 month"
 msgstr "1 month"
 
-#: src/components/UpcomingPlanCard.tsx:367
+#: src/components/UpcomingPlanCard.tsx:341
 msgid "1 wk"
 msgstr "1 wk"
 
@@ -148,7 +148,7 @@ msgstr "10K"
 msgid "1Y"
 msgstr "1Y"
 
-#: src/components/UpcomingPlanCard.tsx:368
+#: src/components/UpcomingPlanCard.tsx:342
 msgid "2 wk"
 msgstr "2 wk"
 
@@ -160,7 +160,7 @@ msgstr "3 months"
 msgid "3M"
 msgstr "3M"
 
-#: src/components/UpcomingPlanCard.tsx:369
+#: src/components/UpcomingPlanCard.tsx:343
 msgid "4 wk"
 msgstr "4 wk"
 
@@ -273,7 +273,7 @@ msgstr "Aerobic"
 msgid "All"
 msgstr "All"
 
-#: src/components/UpcomingPlanCard.tsx:636
+#: src/components/UpcomingPlanCard.tsx:610
 msgid "All synced"
 msgstr "All synced"
 
@@ -446,8 +446,8 @@ msgid "Click to copy"
 msgstr "Click to copy"
 
 #: src/components/UpcomingPlanCard.tsx:205
-msgid "click to retry"
-msgstr "click to retry"
+#~ msgid "click to retry"
+#~ msgstr "click to retry"
 
 #: src/pages/Admin.tsx:371
 msgid "Code"
@@ -688,9 +688,13 @@ msgstr "Demote to User"
 msgid "Diagnosis"
 msgstr "Diagnosis"
 
+#: src/components/UpcomingPlanCard.tsx:198
+msgid "Differs · overwrite"
+msgstr "Differs · overwrite"
+
 #: src/components/UpcomingPlanCard.tsx:171
-msgid "Differs on Stryd — click to re-push and overwrite."
-msgstr "Differs on Stryd — click to re-push and overwrite."
+#~ msgid "Differs on Stryd — click to re-push and overwrite."
+#~ msgstr "Differs on Stryd — click to re-push and overwrite."
 
 #: src/pages/Goal.tsx:294
 msgid "Direction"
@@ -867,7 +871,7 @@ msgstr "Failed to load settings"
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:583
+#: src/components/UpcomingPlanCard.tsx:557
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -970,7 +974,7 @@ msgstr "From {dataAsOfLabel}"
 msgid "From activities"
 msgstr "From activities"
 
-#: src/components/UpcomingPlanCard.tsx:147
+#: src/components/UpcomingPlanCard.tsx:159
 msgid "From Stryd"
 msgstr "From Stryd"
 
@@ -1408,7 +1412,7 @@ msgstr "No split data available."
 msgid "No Workout"
 msgstr "No Workout"
 
-#: src/components/UpcomingPlanCard.tsx:658
+#: src/components/UpcomingPlanCard.tsx:632
 msgid "No workouts scheduled in this window."
 msgstr "No workouts scheduled in this window."
 
@@ -1489,6 +1493,10 @@ msgstr "Other Signals"
 msgid "overnight score"
 msgstr "overnight score"
 
+#: src/components/UpcomingPlanCard.tsx:194
+msgid "Overwrite Stryd with Praxys version"
+msgstr "Overwrite Stryd with Praxys version"
+
 #: src/components/ActivityCard.tsx:121
 #: src/components/SplitBreakdown.tsx:50
 #: src/lib/display-labels.ts:56
@@ -1521,7 +1529,7 @@ msgstr "Plan"
 msgid "Plan sync target"
 msgstr "Plan sync target"
 
-#: src/components/UpcomingPlanCard.tsx:374
+#: src/components/UpcomingPlanCard.tsx:348
 msgid "Plan window"
 msgstr "Plan window"
 
@@ -1637,12 +1645,19 @@ msgstr "Pull your latest activities, power data, and recovery metrics"
 #~ msgstr "Push All"
 
 #: src/components/UpcomingPlanCard.tsx:205
-msgid "Push failed"
-msgstr "Push failed"
+#~ msgid "Push failed"
+#~ msgstr "Push failed"
 
-#: src/components/UpcomingPlanCard.tsx:248
-#: src/components/UpcomingPlanCard.tsx:256
-#: src/components/UpcomingPlanCard.tsx:641
+#: src/components/UpcomingPlanCard.tsx:178
+msgid "Push failed — click to retry"
+msgstr "Push failed — click to retry"
+
+#: src/components/UpcomingPlanCard.tsx:227
+msgid "Push this workout to your Stryd calendar."
+msgstr "Push this workout to your Stryd calendar."
+
+#: src/components/UpcomingPlanCard.tsx:228
+#: src/components/UpcomingPlanCard.tsx:615
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
@@ -1650,7 +1665,7 @@ msgstr "Push to Stryd"
 #~ msgid "Pushing..."
 #~ msgstr "Pushing..."
 
-#: src/components/UpcomingPlanCard.tsx:631
+#: src/components/UpcomingPlanCard.tsx:605
 msgid "Pushing…"
 msgstr "Pushing…"
 
@@ -1686,8 +1701,7 @@ msgstr "Race Prediction"
 #~ msgid "Range"
 #~ msgstr "Range"
 
-#: src/components/UpcomingPlanCard.tsx:222
-#: src/components/UpcomingPlanCard.tsx:231
+#: src/components/UpcomingPlanCard.tsx:212
 msgid "Re-push to Stryd"
 msgstr "Re-push to Stryd"
 
@@ -1813,7 +1827,8 @@ msgstr "Rest day. No workout scheduled."
 msgid "Resting HR"
 msgstr "Resting HR"
 
-#: src/components/UpcomingPlanCard.tsx:586
+#: src/components/UpcomingPlanCard.tsx:183
+#: src/components/UpcomingPlanCard.tsx:560
 #: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:319
@@ -1822,7 +1837,7 @@ msgstr "Resting HR"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/UpcomingPlanCard.tsx:197
+#: src/components/UpcomingPlanCard.tsx:179
 msgid "Retry push to Stryd"
 msgstr "Retry push to Stryd"
 
@@ -2071,14 +2086,23 @@ msgstr "Sync history"
 msgid "Sync now"
 msgstr "Sync now"
 
+#: src/components/UpcomingPlanCard.tsx:232
+msgid "Sync to Stryd"
+msgstr "Sync to Stryd"
+
 #: src/components/SetupChecklist.tsx:55
 #: src/pages/Setup.tsx:566
 msgid "Sync your data"
 msgstr "Sync your data"
 
+#: src/components/UpcomingPlanCard.tsx:217
 #: src/pages/Settings.tsx:808
 msgid "Synced"
 msgstr "Synced"
+
+#: src/components/UpcomingPlanCard.tsx:211
+msgid "Synced to Stryd. Click to re-push."
+msgstr "Synced to Stryd. Click to re-push."
 
 #: src/pages/Settings.tsx:805
 msgid "Syncing"
@@ -2088,6 +2112,7 @@ msgstr "Syncing"
 msgid "Syncing..."
 msgstr "Syncing..."
 
+#: src/components/UpcomingPlanCard.tsx:168
 #: src/pages/Today.tsx:367
 #: src/pages/Today.tsx:389
 msgid "Syncing…"
@@ -2139,6 +2164,14 @@ msgstr "Theme"
 msgid "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 msgstr "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 
+#: src/components/UpcomingPlanCard.tsx:193
+msgid "This workout differs on Stryd — click to overwrite with the Praxys version."
+msgstr "This workout differs on Stryd — click to overwrite with the Praxys version."
+
+#: src/components/UpcomingPlanCard.tsx:157
+msgid "This workout was imported from Stryd."
+msgstr "This workout was imported from Stryd."
+
 #: src/lib/display-labels.ts:45
 #: src/lib/phase-label.ts:15
 msgid "Threshold"
@@ -2177,7 +2210,7 @@ msgstr "To target"
 msgid "Today"
 msgstr "Today"
 
-#: src/components/UpcomingPlanCard.tsx:301
+#: src/components/UpcomingPlanCard.tsx:275
 msgid "TODAY"
 msgstr "TODAY"
 
@@ -2250,7 +2283,7 @@ msgstr "Ultra distance power fractions (50K+) are estimates with limited researc
 msgid "Units"
 msgstr "Units"
 
-#: src/components/UpcomingPlanCard.tsx:610
+#: src/components/UpcomingPlanCard.tsx:584
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 
@@ -2369,8 +2402,8 @@ msgid "Will sync:"
 msgstr "Will sync:"
 
 #: src/components/UpcomingPlanCard.tsx:162
-msgid "Workout differs on Stryd — re-push to overwrite"
-msgstr "Workout differs on Stryd — re-push to overwrite"
+#~ msgid "Workout differs on Stryd — re-push to overwrite"
+#~ msgstr "Workout differs on Stryd — re-push to overwrite"
 
 #: src/pages/Admin.tsx:268
 msgid "you"

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -107,6 +107,22 @@ msgstr "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>
 msgid "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>."
 msgstr "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>."
 
+#: src/pages/Login.tsx:200
+msgid "<0>Cited science.</0> No hype."
+msgstr "<0>Cited science.</0> No hype."
+
+#: src/pages/Login.tsx:192
+msgid "<0>Diagnosis & forecast</0> you can verify."
+msgstr "<0>Diagnosis & forecast</0> you can verify."
+
+#: src/pages/Login.tsx:184
+msgid "<0>Today's signal</0> · go, modify, or rest."
+msgstr "<0>Today's signal</0> · go, modify, or rest."
+
+#: src/pages/Login.tsx:407
+msgid "<0>You're on the list.</0> We'll reach out from <1>{SUPPORT_EMAIL}</1> when a slot opens."
+msgstr "<0>You're on the list.</0> We'll reach out from <1>{SUPPORT_EMAIL}</1> when a slot opens."
+
 #: src/pages/Setup.tsx:605
 msgid "~{estimatedActivities} activities, ~{estimatedMinutes} min"
 msgstr "~{estimatedActivities} activities, ~{estimatedMinutes} min"
@@ -277,7 +293,12 @@ msgstr "All"
 msgid "All synced"
 msgstr "All synced"
 
-#: src/pages/Login.tsx:60
+#: src/pages/Login.tsx:390
+#: src/pages/Login.tsx:415
+msgid "Already have an invitation code?"
+msgstr "Already have an invitation code?"
+
+#: src/pages/Login.tsx:72
 msgid "An unexpected error occurred."
 msgstr "An unexpected error occurred."
 
@@ -288,6 +309,10 @@ msgstr "Asia/CN"
 #: src/components/charts/FitnessFatigueChart.tsx:275
 msgid "ATL (Fatigue)"
 msgstr "ATL (Fatigue)"
+
+#: src/pages/Login.tsx:254
+msgid "Authentication mode"
+msgstr "Authentication mode"
 
 #: src/pages/Setup.tsx:198
 msgid "Authorize Praxys with Strava in your browser. Praxys only syncs activities from Strava."
@@ -542,6 +567,10 @@ msgstr "Cooldown"
 #~ msgid "Cosmetic — changes names and colors without affecting calculations"
 #~ msgstr "Cosmetic — changes names and colors without affecting calculations"
 
+#: src/pages/Login.tsx:112
+msgid "Could not save your email. Please email us instead."
+msgstr "Could not save your email. Please email us instead."
+
 #: src/components/charts/CpTrendChart.tsx:59
 #: src/lib/display-labels.ts:62
 msgid "CP Trend"
@@ -552,7 +581,7 @@ msgstr "CP Trend"
 msgid "Create"
 msgstr "Create"
 
-#: src/pages/Login.tsx:164
+#: src/pages/Login.tsx:488
 msgid "Create account"
 msgstr "Create account"
 
@@ -561,8 +590,12 @@ msgid "Created"
 msgstr "Created"
 
 #: src/pages/Login.tsx:164
-msgid "Creating account..."
-msgstr "Creating account..."
+#~ msgid "Creating account..."
+#~ msgstr "Creating account..."
+
+#: src/pages/Login.tsx:488
+msgid "Creating account…"
+msgstr "Creating account…"
 
 #: src/pages/Admin.tsx:475
 #: src/pages/Admin.tsx:594
@@ -607,6 +640,10 @@ msgstr "daily score"
 #: src/components/AppSidebar.tsx:29
 msgid "Dark"
 msgstr "Dark"
+
+#: src/pages/Login.tsx:537
+msgid "Dark theme (click for system)"
+msgstr "Dark theme (click for system)"
 
 #: src/pages/Settings.tsx:1107
 msgid "Data Preferences"
@@ -712,6 +749,10 @@ msgstr "Discussion"
 msgid "Dismissible banners shown to all users"
 msgstr "Dismissible banners shown to all users"
 
+#: src/pages/Login.tsx:509
+msgid "Display preferences"
+msgstr "Display preferences"
+
 #: src/components/SplitBreakdown.tsx:46
 msgid "Dist"
 msgstr "Dist"
@@ -803,15 +844,20 @@ msgstr "Elevated"
 
 #: src/pages/Admin.tsx:256
 #: src/pages/Admin.tsx:450
-#: src/pages/Login.tsx:90
-#: src/pages/Login.tsx:126
+#: src/pages/Login.tsx:285
+#: src/pages/Login.tsx:353
+#: src/pages/Login.tsx:439
 #: src/pages/Setup.tsx:206
 msgid "Email"
 msgstr "Email"
 
-#: src/pages/Login.tsx:37
+#: src/pages/Login.tsx:48
 msgid "Email and password are required."
 msgstr "Email and password are required."
+
+#: src/pages/Login.tsx:81
+msgid "Email is required."
+msgstr "Email is required."
 
 #: src/lib/display-labels.ts:43
 msgid "Endurance"
@@ -1003,6 +1049,10 @@ msgstr "Generate"
 msgid "Generate a token at cloud.ouraring.com/personal-access-tokens."
 msgstr "Generate a token at cloud.ouraring.com/personal-access-tokens."
 
+#: src/pages/Login.tsx:242
+msgid "Get access"
+msgstr "Get access"
+
 #: src/components/SetupChecklist.tsx:94
 msgid "Get started with Praxys"
 msgstr "Get started with Praxys"
@@ -1152,13 +1202,23 @@ msgstr "International"
 msgid "Invalid time format. Use H:MM:SS or H:MM"
 msgstr "Invalid time format. Use H:MM:SS or H:MM"
 
+#: src/pages/Login.tsx:472
+msgid "Invitation code"
+msgstr "Invitation code"
+
 #: src/pages/Login.tsx:149
-msgid "Invitation Code"
-msgstr "Invitation Code"
+#~ msgid "Invitation Code"
+#~ msgstr "Invitation Code"
 
 #: src/pages/Admin.tsx:334
 msgid "Invitation Codes"
 msgstr "Invitation Codes"
+
+#: src/pages/Login.tsx:339
+#: src/pages/Login.tsx:386
+#: src/pages/Login.tsx:498
+msgid "Join the waitlist"
+msgstr "Join the waitlist"
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
 #: src/pages/Training.tsx:381
@@ -1192,8 +1252,8 @@ msgid "Last synced {0}"
 msgstr "Last synced {0}"
 
 #: src/pages/Login.tsx:160
-msgid "Leave blank for the first account. Required after that."
-msgstr "Leave blank for the first account. Required after that."
+#~ msgid "Leave blank for the first account. Required after that."
+#~ msgstr "Leave blank for the first account. Required after that."
 
 #: src/components/GoalEditor.tsx:164
 msgid "Leave blank to track predicted time only"
@@ -1202,6 +1262,10 @@ msgstr "Leave blank to track predicted time only"
 #: src/components/AppSidebar.tsx:30
 msgid "Light"
 msgstr "Light"
+
+#: src/pages/Login.tsx:535
+msgid "Light theme (click for dark)"
+msgstr "Light theme (click for dark)"
 
 #: src/pages/Setup.tsx:514
 msgid "Link at least one data source to start"
@@ -1245,8 +1309,8 @@ msgid "Load compliance"
 msgstr "Load compliance"
 
 #: src/pages/Login.tsx:71
-msgid "Log in to connect your CLI plugin"
-msgstr "Log in to connect your CLI plugin"
+#~ msgid "Log in to connect your CLI plugin"
+#~ msgstr "Log in to connect your CLI plugin"
 
 #: src/components/AppSidebar.tsx:193
 #: src/components/AppSidebar.tsx:195
@@ -1254,8 +1318,8 @@ msgid "Log out"
 msgstr "Log out"
 
 #: src/pages/Login.tsx:78
-msgid "Login"
-msgstr "Login"
+#~ msgid "Login"
+#~ msgstr "Login"
 
 #: src/pages/Today.tsx:124
 msgid "low"
@@ -1345,6 +1409,10 @@ msgstr "Need 2 weeks of synced activity to compare planned vs actual. {daysToCom
 msgid "Need at least 3 activities with power data."
 msgstr "Need at least 3 activities with power data."
 
+#: src/pages/Login.tsx:507
+msgid "Need help? {SUPPORT_EMAIL}"
+msgstr "Need help? {SUPPORT_EMAIL}"
+
 #: src/pages/Goal.tsx:255
 msgid "Needed {abbrev}"
 msgstr "Needed {abbrev}"
@@ -1353,6 +1421,10 @@ msgstr "Needed {abbrev}"
 msgid "Network error. Is the server running?"
 msgstr "Network error. Is the server running?"
 
+#: src/pages/Login.tsx:118
+msgid "Network error. Please email {SUPPORT_EMAIL} directly."
+msgstr "Network error. Please email {SUPPORT_EMAIL} directly."
+
 #: src/pages/Admin.tsx:559
 msgid "New announcement"
 msgstr "New announcement"
@@ -1360,6 +1432,10 @@ msgstr "New announcement"
 #: src/pages/Admin.tsx:359
 msgid "New invitation code:"
 msgstr "New invitation code:"
+
+#: src/pages/Login.tsx:322
+msgid "New to Praxys?"
+msgstr "New to Praxys?"
 
 #: src/pages/History.tsx:96
 msgid "Next"
@@ -1376,6 +1452,10 @@ msgstr "No activities found."
 #: src/pages/Admin.tsx:600
 msgid "No announcements yet"
 msgstr "No announcements yet"
+
+#: src/pages/Login.tsx:492
+msgid "No code yet?"
+msgstr "No code yet?"
 
 #: src/pages/Today.tsx:269
 #: src/pages/Today.tsx:431
@@ -1506,8 +1586,8 @@ msgid "Pace"
 msgstr "Pace"
 
 #: src/pages/Admin.tsx:460
-#: src/pages/Login.tsx:102
-#: src/pages/Login.tsx:138
+#: src/pages/Login.tsx:302
+#: src/pages/Login.tsx:456
 #: src/pages/Setup.tsx:207
 msgid "Password"
 msgstr "Password"
@@ -1550,6 +1630,10 @@ msgstr "Planned bars are estimated — your plan has no {label} targets for the 
 msgid "Planned Workout"
 msgstr "Planned Workout"
 
+#: src/pages/Login.tsx:104
+msgid "Please check your email format and try again."
+msgstr "Please check your email format and try again."
+
 #: src/pages/Today.tsx:278
 msgid "positive"
 msgstr "positive"
@@ -1566,8 +1650,8 @@ msgid "Power metrics, Critical Power, training plans"
 msgstr "Power metrics, Critical Power, training plans"
 
 #: src/pages/Login.tsx:72
-msgid "Power-based training dashboard"
-msgstr "Power-based training dashboard"
+#~ msgid "Power-based training dashboard"
+#~ msgstr "Power-based training dashboard"
 
 #: src/components/AiInsightsCard.tsx:132
 msgid "Praxys Coach"
@@ -1576,6 +1660,10 @@ msgstr "Praxys Coach"
 #: src/components/AiInsightsCard.tsx:130
 msgid "Praxys Coach insight"
 msgstr "Praxys Coach insight"
+
+#: src/pages/Login.tsx:247
+msgid "Praxys is in private alpha."
+msgstr "Praxys is in private alpha."
 
 #: src/pages/Goal.tsx:241
 #: src/pages/Goal.tsx:278
@@ -1608,6 +1696,10 @@ msgstr "Primary for {0}"
 #: src/pages/Settings.tsx:60
 msgid "Primary source for workout data"
 msgstr "Primary source for workout data"
+
+#: src/pages/Login.tsx:136
+msgid "Private alpha · Invitation only"
+msgstr "Private alpha · Invitation only"
 
 #: src/pages/Training.tsx:335
 msgid "productive load"
@@ -1795,8 +1887,8 @@ msgid "Region"
 msgstr "Region"
 
 #: src/pages/Login.tsx:79
-msgid "Register"
-msgstr "Register"
+#~ msgid "Register"
+#~ msgstr "Register"
 
 #: src/pages/Admin.tsx:258
 msgid "Registered"
@@ -1809,6 +1901,14 @@ msgstr "Registered accounts"
 #: src/lib/phase-label.ts:18
 msgid "Rep"
 msgstr "Rep"
+
+#: src/pages/Login.tsx:328
+msgid "Request an invite"
+msgstr "Request an invite"
+
+#: src/pages/Login.tsx:272
+msgid "Request invite"
+msgstr "Request invite"
 
 #: src/lib/phase-label.ts:17
 msgid "Rest"
@@ -1881,6 +1981,10 @@ msgstr "Save Goal"
 msgid "Saving..."
 msgstr "Saving..."
 
+#: src/pages/Login.tsx:386
+msgid "Saving…"
+msgstr "Saving…"
+
 #: src/components/AppSidebar.tsx:115
 msgid "Science"
 msgstr "Science"
@@ -1950,13 +2054,23 @@ msgstr "Showing"
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 
-#: src/pages/Login.tsx:113
+#: src/pages/Login.tsx:241
+#: src/pages/Login.tsx:263
+#: src/pages/Login.tsx:318
 msgid "Sign in"
 msgstr "Sign in"
 
+#: src/pages/Login.tsx:234
+msgid "Sign in to connect your CLI plugin."
+msgstr "Sign in to connect your CLI plugin."
+
 #: src/pages/Login.tsx:113
-msgid "Signing in..."
-msgstr "Signing in..."
+#~ msgid "Signing in..."
+#~ msgstr "Signing in..."
+
+#: src/pages/Login.tsx:318
+msgid "Signing in…"
+msgstr "Signing in…"
 
 #: src/pages/Science.tsx:132
 #~ msgid "Simple"
@@ -1993,6 +2107,10 @@ msgstr "Sleep, HRV, readiness"
 #: src/pages/Goal.tsx:382
 msgid "Source"
 msgstr "Source"
+
+#: src/pages/Login.tsx:175
+msgid "Sports science that <0>meets you</0> where you are."
+msgstr "Sports science that <0>meets you</0> where you are."
 
 #: src/pages/Today.tsx:111
 #: src/pages/Today.tsx:122
@@ -2035,6 +2153,10 @@ msgstr "Stretch"
 msgid "strongly positive"
 msgstr "strongly positive"
 
+#: src/pages/Login.tsx:376
+msgid "Sub-3 marathon · 100K · stay healthy…"
+msgstr "Sub-3 marathon · 100K · stay healthy…"
+
 #: src/components/DiagnosisCard.tsx:87
 msgid "Suggestions"
 msgstr "Suggestions"
@@ -2043,10 +2165,27 @@ msgstr "Suggestions"
 msgid "Swimming"
 msgstr "Swimming"
 
+#: src/pages/Login.tsx:514
+#: src/pages/Login.tsx:515
+msgid "Switch language"
+msgstr "Switch language"
+
 #. placeholder {0}: previewedTheory.name
 #: src/pages/Science.tsx:428
 msgid "Switch to {0}"
 msgstr "Switch to {0}"
+
+#: src/pages/Login.tsx:528
+msgid "Switch to dark theme"
+msgstr "Switch to dark theme"
+
+#: src/pages/Login.tsx:531
+msgid "Switch to light theme"
+msgstr "Switch to light theme"
+
+#: src/pages/Login.tsx:530
+msgid "Switch to system theme"
+msgstr "Switch to system theme"
 
 #: src/components/SetupChecklist.tsx:59
 #: src/pages/Settings.tsx:812
@@ -2125,6 +2264,10 @@ msgstr "System"
 #: src/pages/Admin.tsx:551
 msgid "System Announcements"
 msgstr "System Announcements"
+
+#: src/pages/Login.tsx:538
+msgid "System theme (click for light)"
+msgstr "System theme (click for light)"
 
 #: src/components/ZoneAnalysisCard.tsx:45
 #~ msgid "target"
@@ -2226,6 +2369,10 @@ msgstr "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is
 msgid "Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}."
 msgstr "Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}."
 
+#: src/pages/Login.tsx:98
+msgid "Too many attempts from this network. Please email us instead."
+msgstr "Too many attempts from this network. Please email us instead."
+
 #: src/pages/Goal.tsx:141
 msgid "Tracking"
 msgstr "Tracking"
@@ -2294,6 +2441,11 @@ msgstr "Updating..."
 #: src/pages/Settings.tsx:963
 msgid "US"
 msgstr "US"
+
+#: src/pages/Login.tsx:396
+#: src/pages/Login.tsx:425
+msgid "Use it"
+msgstr "Use it"
 
 #: src/pages/Science.tsx:175
 #~ msgid "Use this"
@@ -2369,6 +2521,10 @@ msgstr "Walking"
 msgid "Warmup"
 msgstr "Warmup"
 
+#: src/pages/Login.tsx:341
+msgid "We're inviting runners in waves while we tighten the science. Drop your email and we'll reach back when a slot opens."
+msgstr "We're inviting runners in waves while we tighten the science. Drop your email and we'll reach back when a slot opens."
+
 #: src/pages/Training.tsx:209
 msgid "Weekly diagnosis ready."
 msgstr "Weekly diagnosis ready."
@@ -2389,9 +2545,17 @@ msgstr "Weekly Load"
 msgid "Weekly Volume"
 msgstr "Weekly Volume"
 
+#: src/pages/Login.tsx:246
+msgid "Welcome back."
+msgstr "Welcome back."
+
 #: src/components/GoalEditor.tsx:165
 msgid "What time are you working toward? Leave blank to track trend only"
 msgstr "What time are you working toward? Leave blank to track trend only"
+
+#: src/pages/Login.tsx:370
+msgid "What's your training goal? (optional)"
+msgstr "What's your training goal? (optional)"
 
 #: src/pages/Settings.tsx:65
 msgid "Where Praxys pushes your plan. Per-workout sync state shows in Training."
@@ -2409,8 +2573,9 @@ msgstr "Will sync:"
 msgid "you"
 msgstr "you"
 
-#: src/pages/Login.tsx:94
-#: src/pages/Login.tsx:130
+#: src/pages/Login.tsx:291
+#: src/pages/Login.tsx:359
+#: src/pages/Login.tsx:445
 msgid "you@example.com"
 msgstr "you@example.com"
 

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -41,7 +41,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:591
+#: src/components/UpcomingPlanCard.tsx:617
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -289,7 +289,7 @@ msgstr "Aerobic"
 msgid "All"
 msgstr "All"
 
-#: src/components/UpcomingPlanCard.tsx:610
+#: src/components/UpcomingPlanCard.tsx:636
 msgid "All synced"
 msgstr "All synced"
 
@@ -306,7 +306,7 @@ msgstr "An unexpected error occurred."
 msgid "Asia/CN"
 msgstr "Asia/CN"
 
-#: src/components/charts/FitnessFatigueChart.tsx:275
+#: src/components/charts/FitnessFatigueChart.tsx:282
 msgid "ATL (Fatigue)"
 msgstr "ATL (Fatigue)"
 
@@ -326,7 +326,7 @@ msgstr "Auto"
 msgid "Auto sync frequency"
 msgstr "Auto sync frequency"
 
-#: src/pages/Settings.tsx:1188
+#: src/pages/Settings.tsx:1196
 msgid "Auto-merged"
 msgstr "Auto-merged"
 
@@ -515,7 +515,7 @@ msgid "Connect {0}"
 msgstr "Connect {0}"
 
 #: src/components/SetupChecklist.tsx:47
-#: src/pages/Settings.tsx:1134
+#: src/pages/Settings.tsx:1142
 #: src/pages/Setup.tsx:513
 msgid "Connect a platform"
 msgstr "Connect a platform"
@@ -551,7 +551,7 @@ msgstr "Continue to Strava"
 msgid "Continuous"
 msgstr "Continuous"
 
-#: src/pages/Settings.tsx:1217
+#: src/pages/Settings.tsx:1225
 msgid "Continuous Improvement"
 msgstr "Continuous Improvement"
 
@@ -611,7 +611,7 @@ msgstr "Critical Power"
 msgid "Cross-training activities affect your overall training load and recovery"
 msgstr "Cross-training activities affect your overall training load and recovery"
 
-#: src/components/charts/FitnessFatigueChart.tsx:274
+#: src/components/charts/FitnessFatigueChart.tsx:281
 msgid "CTL (Fitness)"
 msgstr "CTL (Fitness)"
 
@@ -759,7 +759,7 @@ msgstr "Dist"
 
 #: src/components/ActivityCard.tsx:75
 #: src/components/GoalEditor.tsx:122
-#: src/pages/Settings.tsx:1221
+#: src/pages/Settings.tsx:1229
 msgid "Distance"
 msgstr "Distance"
 
@@ -771,7 +771,7 @@ msgstr "Distance"
 msgid "Distribution match"
 msgstr "Distribution match"
 
-#: src/pages/Settings.tsx:1273
+#: src/pages/Settings.tsx:1281
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 msgstr "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 
@@ -825,7 +825,7 @@ msgstr "EASY"
 msgid "Easy Run"
 msgstr "Easy Run"
 
-#: src/pages/Settings.tsx:1207
+#: src/pages/Settings.tsx:1215
 #: src/pages/Setup.tsx:755
 msgid "Edit"
 msgstr "Edit"
@@ -917,7 +917,7 @@ msgstr "Failed to load settings"
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:557
+#: src/components/UpcomingPlanCard.tsx:583
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -930,7 +930,7 @@ msgid "Falling"
 msgstr "Falling"
 
 #: src/components/charts/FitnessFatigueChart.tsx:58
-#: src/components/charts/FitnessFatigueChart.tsx:191
+#: src/components/charts/FitnessFatigueChart.tsx:198
 msgid "Fatigue"
 msgstr "Fatigue"
 
@@ -955,9 +955,9 @@ msgid "Findings"
 msgstr "Findings"
 
 #: src/components/charts/FitnessFatigueChart.tsx:52
-#: src/components/charts/FitnessFatigueChart.tsx:187
+#: src/components/charts/FitnessFatigueChart.tsx:194
 #: src/pages/Settings.tsx:55
-#: src/pages/Settings.tsx:1185
+#: src/pages/Settings.tsx:1193
 #: src/pages/Setup.tsx:217
 msgid "Fitness"
 msgstr "Fitness"
@@ -980,7 +980,7 @@ msgid "Follow Plan"
 msgstr "Follow Plan"
 
 #: src/components/charts/FitnessFatigueChart.tsx:64
-#: src/components/charts/FitnessFatigueChart.tsx:195
+#: src/components/charts/FitnessFatigueChart.tsx:202
 msgid "Form"
 msgstr "Form"
 
@@ -1073,7 +1073,7 @@ msgstr "Go to dashboard"
 
 #: src/components/AppSidebar.tsx:110
 #: src/pages/Goal.tsx:135
-#: src/pages/Settings.tsx:1202
+#: src/pages/Settings.tsx:1210
 msgid "Goal"
 msgstr "Goal"
 
@@ -1348,7 +1348,7 @@ msgstr "Manage users and invitation codes"
 #: src/components/GoalEditor.tsx:54
 #: src/lib/display-labels.ts:66
 #: src/pages/Settings.tsx:182
-#: src/pages/Settings.tsx:1223
+#: src/pages/Settings.tsx:1231
 msgid "Marathon"
 msgstr "Marathon"
 
@@ -1365,7 +1365,7 @@ msgstr "mild fatigue"
 msgid "mirrors {0}"
 msgstr "mirrors {0}"
 
-#: src/pages/Settings.tsx:1215
+#: src/pages/Settings.tsx:1223
 msgid "Mode"
 msgstr "Mode"
 
@@ -1468,7 +1468,7 @@ msgstr "no data"
 msgid "No Data"
 msgstr "No Data"
 
-#: src/pages/Settings.tsx:1243
+#: src/pages/Settings.tsx:1251
 msgid "No goal set. Set a race target or distance goal to unlock predictions and countdown."
 msgstr "No goal set. Set a race target or distance goal to unlock predictions and countdown."
 
@@ -1492,7 +1492,7 @@ msgstr "No split data available."
 msgid "No Workout"
 msgstr "No Workout"
 
-#: src/components/UpcomingPlanCard.tsx:632
+#: src/components/UpcomingPlanCard.tsx:661
 msgid "No workouts scheduled in this window."
 msgstr "No workouts scheduled in this window."
 
@@ -1533,7 +1533,7 @@ msgstr "Not enough data yet for accurate fitness tracking"
 msgid "Not enough data yet for weekly load comparison"
 msgstr "Not enough data yet for weekly load comparison"
 
-#: src/pages/Settings.tsx:1306
+#: src/pages/Settings.tsx:1314
 msgid "Not set"
 msgstr "Not set"
 
@@ -1714,7 +1714,7 @@ msgid "Proj"
 msgstr "Proj"
 
 #: src/components/charts/FitnessFatigueChart.tsx:45
-#: src/components/charts/FitnessFatigueChart.tsx:200
+#: src/components/charts/FitnessFatigueChart.tsx:207
 msgid "Projected"
 msgstr "Projected"
 
@@ -1749,7 +1749,7 @@ msgid "Push this workout to your Stryd calendar."
 msgstr "Push this workout to your Stryd calendar."
 
 #: src/components/UpcomingPlanCard.tsx:228
-#: src/components/UpcomingPlanCard.tsx:615
+#: src/components/UpcomingPlanCard.tsx:641
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
@@ -1757,7 +1757,7 @@ msgstr "Push to Stryd"
 #~ msgid "Pushing..."
 #~ msgstr "Pushing..."
 
-#: src/components/UpcomingPlanCard.tsx:605
+#: src/components/UpcomingPlanCard.tsx:631
 msgid "Pushing…"
 msgstr "Pushing…"
 
@@ -1768,7 +1768,7 @@ msgid "Race"
 msgstr "Race"
 
 #: src/components/GoalEditor.tsx:139
-#: src/pages/Settings.tsx:1228
+#: src/pages/Settings.tsx:1236
 msgid "Race Date"
 msgstr "Race Date"
 
@@ -1777,7 +1777,7 @@ msgid "Race date is required"
 msgstr "Race date is required"
 
 #: src/components/GoalEditor.tsx:111
-#: src/pages/Settings.tsx:1217
+#: src/pages/Settings.tsx:1225
 msgid "Race Goal"
 msgstr "Race Goal"
 
@@ -1928,7 +1928,7 @@ msgid "Resting HR"
 msgstr "Resting HR"
 
 #: src/components/UpcomingPlanCard.tsx:183
-#: src/components/UpcomingPlanCard.tsx:560
+#: src/components/UpcomingPlanCard.tsx:586
 #: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:319
@@ -2003,7 +2003,7 @@ msgid "Set a goal"
 msgstr "Set a goal"
 
 #: src/components/SetupChecklist.tsx:75
-#: src/pages/Settings.tsx:1207
+#: src/pages/Settings.tsx:1215
 #: src/pages/Setup.tsx:764
 msgid "Set goal"
 msgstr "Set goal"
@@ -2283,13 +2283,13 @@ msgid "Target {metricName}"
 msgstr "Target {metricName}"
 
 #: src/components/SetupChecklist.tsx:72
-#: src/pages/Settings.tsx:1203
+#: src/pages/Settings.tsx:1211
 #: src/pages/Setup.tsx:744
 msgid "Target a race or track continuous improvement"
 msgstr "Target a race or track continuous improvement"
 
 #: src/components/GoalEditor.tsx:152
-#: src/pages/Settings.tsx:1234
+#: src/pages/Settings.tsx:1242
 msgid "Target Time"
 msgstr "Target Time"
 
@@ -2329,7 +2329,7 @@ msgstr "Threshold Pace"
 msgid "Threshold Pace Trend"
 msgstr "Threshold Pace Trend"
 
-#: src/pages/Settings.tsx:1271
+#: src/pages/Settings.tsx:1279
 msgid "Thresholds"
 msgstr "Thresholds"
 
@@ -2346,7 +2346,7 @@ msgid "To target"
 msgstr "To target"
 
 #: src/components/AppSidebar.tsx:108
-#: src/components/charts/FitnessFatigueChart.tsx:243
+#: src/components/charts/FitnessFatigueChart.tsx:250
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
 #: src/pages/Today.tsx:350
@@ -2414,11 +2414,15 @@ msgstr "Training Zones"
 msgid "Translates training stress into fitness."
 msgstr "Translates training stress into fitness."
 
+#: src/components/UpcomingPlanCard.tsx:655
+msgid "Try a longer window above."
+msgstr "Try a longer window above."
+
 #: src/pages/Training.tsx:320
 msgid "TSB"
 msgstr "TSB"
 
-#: src/components/charts/FitnessFatigueChart.tsx:276
+#: src/components/charts/FitnessFatigueChart.tsx:283
 msgid "TSB (Form)"
 msgstr "TSB (Form)"
 
@@ -2430,7 +2434,7 @@ msgstr "Ultra distance power fractions (50K+) are estimates with limited researc
 msgid "Units"
 msgstr "Units"
 
-#: src/components/UpcomingPlanCard.tsx:584
+#: src/components/UpcomingPlanCard.tsx:610
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 
@@ -2487,7 +2491,7 @@ msgstr "Viewing configuration (read-only demo)"
 msgid "VO2max"
 msgstr "VO2max"
 
-#: src/pages/Settings.tsx:1186
+#: src/pages/Settings.tsx:1194
 msgid "VO2max, CP, LTHR, training status"
 msgstr "VO2max, CP, LTHR, training status"
 

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -13,9 +13,14 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/AiInsightsCard.tsx:110
+#: src/components/AiInsightsCard.tsx:161
 msgid " · "
 msgstr " · "
+
+#. placeholder {0}: data.diagnosis.lookback_weeks
+#: src/pages/Training.tsx:310
+msgid "· last {0} weeks"
+msgstr "· last {0} weeks"
 
 #: src/pages/Setup.tsx:606
 msgid "(Garmin rate limits apply)"
@@ -25,18 +30,18 @@ msgstr "(Garmin rate limits apply)"
 msgid "(optional)"
 msgstr "(optional)"
 
-#. placeholder {0}: findings.length
-#: src/components/AiInsightsCard.tsx:104
+#. placeholder {0}: content.findings.length
+#: src/components/AiInsightsCard.tsx:155
 msgid "{0, plural, one {# finding} other {# findings}}"
 msgstr "{0, plural, one {# finding} other {# findings}}"
 
-#. placeholder {0}: recommendations.length
-#: src/components/AiInsightsCard.tsx:112
+#. placeholder {0}: content.recommendations.length
+#: src/components/AiInsightsCard.tsx:163
 msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:507
+#: src/components/UpcomingPlanCard.tsx:617
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -45,6 +50,15 @@ msgstr "{0, plural, one {# workout} other {# workouts}}"
 #: src/pages/Setup.tsx:491
 msgid "{0} of {1} steps complete"
 msgstr "{0} of {1} steps complete"
+
+#. placeholder {0}: tDisplay(d.name, i18n)
+#. placeholder {1}: d.actual
+#. placeholder {2}: d.absDiff
+#. placeholder {3}: d.diff > 0 ? t`above` : t`below`
+#. placeholder {4}: d.target
+#: src/pages/Training.tsx:184
+msgid "{0}: {1}% ({2}pp {3} {4}% target)"
+msgstr "{0}: {1}% ({2}pp {3} {4}% target)"
 
 #: src/pages/Goal.tsx:214
 msgid "{abbrev} is <0>{dirLabel}</0>. Add more activities for a race-time prediction."
@@ -93,22 +107,6 @@ msgstr "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>
 msgid "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>."
 msgstr "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>."
 
-#: src/pages/Login.tsx:200
-msgid "<0>Cited science.</0> No hype."
-msgstr "<0>Cited science.</0> No hype."
-
-#: src/pages/Login.tsx:192
-msgid "<0>Diagnosis & forecast</0> you can verify."
-msgstr "<0>Diagnosis & forecast</0> you can verify."
-
-#: src/pages/Login.tsx:184
-msgid "<0>Today's signal</0> · go, modify, or rest."
-msgstr "<0>Today's signal</0> · go, modify, or rest."
-
-#: src/pages/Login.tsx:407
-msgid "<0>You're on the list.</0> We'll reach out from <1>{SUPPORT_EMAIL}</1> when a slot opens."
-msgstr "<0>You're on the list.</0> We'll reach out from <1>{SUPPORT_EMAIL}</1> when a slot opens."
-
 #: src/pages/Setup.tsx:605
 msgid "~{estimatedActivities} activities, ~{estimatedMinutes} min"
 msgstr "~{estimatedActivities} activities, ~{estimatedMinutes} min"
@@ -116,6 +114,10 @@ msgstr "~{estimatedActivities} activities, ~{estimatedMinutes} min"
 #: src/pages/Setup.tsx:179
 msgid "1 month"
 msgstr "1 month"
+
+#: src/components/UpcomingPlanCard.tsx:367
+msgid "1 wk"
+msgstr "1 wk"
 
 #: src/pages/Setup.tsx:182
 msgid "1 year"
@@ -125,26 +127,30 @@ msgstr "1 year"
 msgid "100 Mi"
 msgstr "100 Mi"
 
-#: src/lib/display-labels.ts:67
-#: src/pages/Settings.tsx:183
+#: src/lib/display-labels.ts:73
+#: src/pages/Settings.tsx:186
 msgid "100 Mile"
 msgstr "100 Mile"
 
 #: src/components/GoalEditor.tsx:57
-#: src/lib/display-labels.ts:66
-#: src/pages/Settings.tsx:182
+#: src/lib/display-labels.ts:72
+#: src/pages/Settings.tsx:185
 msgid "100K"
 msgstr "100K"
 
 #: src/components/GoalEditor.tsx:52
-#: src/lib/display-labels.ts:63
-#: src/pages/Settings.tsx:177
+#: src/lib/display-labels.ts:69
+#: src/pages/Settings.tsx:180
 msgid "10K"
 msgstr "10K"
 
 #: src/components/charts/CpTrendChart.tsx:55
 msgid "1Y"
 msgstr "1Y"
+
+#: src/components/UpcomingPlanCard.tsx:368
+msgid "2 wk"
+msgstr "2 wk"
 
 #: src/pages/Setup.tsx:180
 msgid "3 months"
@@ -154,24 +160,28 @@ msgstr "3 months"
 msgid "3M"
 msgstr "3M"
 
+#: src/components/UpcomingPlanCard.tsx:369
+msgid "4 wk"
+msgstr "4 wk"
+
 #: src/components/GoalEditor.tsx:56
 msgid "50 Mi"
 msgstr "50 Mi"
 
-#: src/lib/display-labels.ts:65
-#: src/pages/Settings.tsx:181
+#: src/lib/display-labels.ts:71
+#: src/pages/Settings.tsx:184
 msgid "50 Mile"
 msgstr "50 Mile"
 
 #: src/components/GoalEditor.tsx:55
-#: src/lib/display-labels.ts:64
-#: src/pages/Settings.tsx:180
+#: src/lib/display-labels.ts:70
+#: src/pages/Settings.tsx:183
 msgid "50K"
 msgstr "50K"
 
 #: src/components/GoalEditor.tsx:51
-#: src/lib/display-labels.ts:62
-#: src/pages/Settings.tsx:176
+#: src/lib/display-labels.ts:68
+#: src/pages/Settings.tsx:179
 msgid "5K"
 msgstr "5K"
 
@@ -184,15 +194,11 @@ msgid "6M"
 msgstr "6M"
 
 #: src/components/RecoveryPanel.tsx:141
-#: src/pages/Today.tsx:427
+#: src/pages/Today.tsx:431
 msgid "7d Trend"
 msgstr "7d Trend"
 
-#: src/pages/Login.tsx:162
-#~ msgid "A scientific training system that takes a position."
-#~ msgstr "A scientific training system that takes a position."
-
-#: src/components/ZoneAnalysisCard.tsx:44
+#: src/pages/Training.tsx:184
 msgid "above"
 msgstr "above"
 
@@ -225,7 +231,7 @@ msgstr "Activities"
 msgid "Activities only: runs, rides, pace, heart rate, route data"
 msgstr "Activities only: runs, rides, pace, heart rate, route data"
 
-#: src/pages/Settings.tsx:994
+#: src/pages/Settings.tsx:997
 #: src/pages/Setup.tsx:940
 msgid "Activities-only connection"
 msgstr "Activities-only connection"
@@ -234,10 +240,14 @@ msgstr "Activities-only connection"
 msgid "Activity types to sync"
 msgstr "Activity types to sync"
 
-#: src/components/charts/ComplianceChart.tsx:90
-#: src/components/ZoneAnalysisCard.tsx:64
+#: src/components/charts/ComplianceChart.tsx:111
+#: src/components/charts/ComplianceChart.tsx:159
 msgid "Actual"
 msgstr "Actual"
+
+#: src/pages/Training.tsx:368
+msgid "actual vs planned, avg"
+msgstr "actual vs planned, avg"
 
 #: src/components/SignalHero.tsx:22
 #: src/pages/Today.tsx:69
@@ -263,40 +273,35 @@ msgstr "Aerobic"
 msgid "All"
 msgstr "All"
 
-#: src/pages/Login.tsx:390
-#: src/pages/Login.tsx:415
-msgid "Already have an invitation code?"
-msgstr "Already have an invitation code?"
+#: src/components/UpcomingPlanCard.tsx:636
+msgid "All synced"
+msgstr "All synced"
 
-#: src/pages/Login.tsx:72
+#: src/pages/Login.tsx:60
 msgid "An unexpected error occurred."
 msgstr "An unexpected error occurred."
 
-#: src/pages/Settings.tsx:960
+#: src/pages/Settings.tsx:963
 msgid "Asia/CN"
 msgstr "Asia/CN"
 
-#: src/components/charts/FitnessFatigueChart.tsx:242
+#: src/components/charts/FitnessFatigueChart.tsx:275
 msgid "ATL (Fatigue)"
 msgstr "ATL (Fatigue)"
-
-#: src/pages/Login.tsx:254
-msgid "Authentication mode"
-msgstr "Authentication mode"
 
 #: src/pages/Setup.tsx:198
 msgid "Authorize Praxys with Strava in your browser. Praxys only syncs activities from Strava."
 msgstr "Authorize Praxys with Strava in your browser. Praxys only syncs activities from Strava."
 
-#: src/pages/Settings.tsx:664
+#: src/pages/Settings.tsx:667
 msgid "Auto"
 msgstr "Auto"
 
-#: src/pages/Settings.tsx:722
+#: src/pages/Settings.tsx:725
 msgid "Auto sync frequency"
 msgstr "Auto sync frequency"
 
-#: src/pages/Settings.tsx:1144
+#: src/pages/Settings.tsx:1188
 msgid "Auto-merged"
 msgstr "Auto-merged"
 
@@ -316,13 +321,21 @@ msgstr "Avg Power"
 msgid "Avg Work {intensityLabel}"
 msgstr "Avg Work {intensityLabel}"
 
-#: src/pages/Settings.tsx:705
+#: src/pages/Settings.tsx:708
 msgid "Backfill All"
 msgstr "Backfill All"
 
-#: src/pages/Settings.tsx:684
+#: src/pages/Settings.tsx:687
 msgid "Backfill..."
 msgstr "Backfill..."
+
+#: src/pages/Training.tsx:333
+msgid "balanced"
+msgstr "balanced"
+
+#: src/pages/Training.tsx:406
+msgid "Banister PMC stabilises after about 42 days of activity. Need {daysToPmc} more days."
+msgstr "Banister PMC stabilises after about 42 days of activity. Need {daysToPmc} more days."
 
 #. placeholder {0}: recommendedTheory.name
 #. placeholder {1}: recommendation!.reason
@@ -338,7 +351,7 @@ msgstr "Based on your training, <0>{0}</0> may fit better — {1}"
 msgid "Baseline"
 msgstr "Baseline"
 
-#: src/components/ZoneAnalysisCard.tsx:44
+#: src/pages/Training.tsx:184
 msgid "below"
 msgstr "below"
 
@@ -370,8 +383,8 @@ msgstr "by"
 #: src/components/GoalEditor.tsx:174
 #: src/pages/Admin.tsx:511
 #: src/pages/Admin.tsx:534
-#: src/pages/Settings.tsx:983
-#: src/pages/Settings.tsx:1020
+#: src/pages/Settings.tsx:986
+#: src/pages/Settings.tsx:1023
 #: src/pages/Setup.tsx:928
 #: src/pages/Setup.tsx:948
 msgid "Cancel"
@@ -390,7 +403,7 @@ msgstr "CAUTION"
 msgid "Change"
 msgstr "Change"
 
-#: src/pages/Goal.tsx:432
+#: src/pages/Goal.tsx:433
 msgid "Change Goal"
 msgstr "Change Goal"
 
@@ -398,8 +411,8 @@ msgstr "Change Goal"
 msgid "Check your credentials in the connection step, then try again."
 msgstr "Check your credentials in the connection step, then try again."
 
-#: src/pages/Settings.tsx:869
-#: src/pages/Settings.tsx:935
+#: src/pages/Settings.tsx:872
+#: src/pages/Settings.tsx:938
 msgid "China"
 msgstr "China"
 
@@ -420,11 +433,11 @@ msgstr "Choose primary source"
 msgid "Choose training base"
 msgstr "Choose training base"
 
-#: src/pages/Settings.tsx:1105
+#: src/pages/Settings.tsx:1108
 msgid "Choose which platform to use for each data type"
 msgstr "Choose which platform to use for each data type"
 
-#: src/pages/Settings.tsx:708
+#: src/pages/Settings.tsx:711
 msgid "Clear"
 msgstr "Clear"
 
@@ -432,7 +445,7 @@ msgstr "Clear"
 msgid "Click to copy"
 msgstr "Click to copy"
 
-#: src/components/UpcomingPlanCard.tsx:126
+#: src/components/UpcomingPlanCard.tsx:205
 msgid "click to retry"
 msgstr "click to retry"
 
@@ -440,7 +453,7 @@ msgstr "click to retry"
 msgid "Code"
 msgstr "Code"
 
-#: src/pages/Goal.tsx:361
+#: src/pages/Goal.tsx:371
 msgid "Comfortable"
 msgstr "Comfortable"
 
@@ -453,13 +466,17 @@ msgstr "Coming Up"
 msgid "Complete these steps to unlock your training insights"
 msgstr "Complete these steps to unlock your training insights"
 
-#: src/pages/Settings.tsx:555
+#: src/components/charts/ComplianceChart.tsx:171
+msgid "Compliance compares the load you actually accumulated each week (Actual) against the load your plan called for (Planned). The percentage above each bar shows how close you came: green for 80–120% (on target), amber under 80%, red over 120%. The load metric (RSS or W-equivalent) is set by your training base."
+msgstr "Compliance compares the load you actually accumulated each week (Actual) against the load your plan called for (Planned). The percentage above each bar shows how close you came: green for 80–120% (on target), amber under 80%, red over 120%. The load metric (RSS or W-equivalent) is set by your training base."
+
+#: src/pages/Settings.tsx:558
 msgid "Configure your training system"
 msgstr "Configure your training system"
 
 #: src/components/SetupChecklist.tsx:51
-#: src/pages/Settings.tsx:825
-#: src/pages/Settings.tsx:986
+#: src/pages/Settings.tsx:828
+#: src/pages/Settings.tsx:989
 #: src/pages/Setup.tsx:555
 #: src/pages/Setup.tsx:931
 msgid "Connect"
@@ -467,12 +484,13 @@ msgstr "Connect"
 
 #. placeholder {0}: connectPlatform ? (PLATFORM_META[connectPlatform]?.label || connectPlatform) : ''
 #. placeholder {0}: connectPlatform ? PLATFORM_META[connectPlatform]?.label : ''
-#: src/pages/Settings.tsx:903
+#: src/pages/Settings.tsx:906
 #: src/pages/Setup.tsx:790
 msgid "Connect {0}"
 msgstr "Connect {0}"
 
 #: src/components/SetupChecklist.tsx:47
+#: src/pages/Settings.tsx:1134
 #: src/pages/Setup.tsx:513
 msgid "Connect a platform"
 msgstr "Connect a platform"
@@ -481,25 +499,25 @@ msgstr "Connect a platform"
 msgid "Connect a platform first"
 msgstr "Connect a platform first"
 
-#: src/pages/Settings.tsx:784
+#: src/pages/Settings.tsx:787
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Settings.tsx:679
+#: src/pages/Settings.tsx:682
 msgid "Connected Platforms"
 msgstr "Connected Platforms"
 
-#: src/pages/Settings.tsx:986
+#: src/pages/Settings.tsx:989
 #: src/pages/Setup.tsx:931
 msgid "Connecting..."
 msgstr "Connecting..."
 
-#: src/pages/Settings.tsx:996
+#: src/pages/Settings.tsx:999
 #: src/pages/Setup.tsx:942
 msgid "Continue in your browser to authorize Strava. Praxys imports activities from Strava, while recovery, fitness, and plans come from your other connected platforms."
 msgstr "Continue in your browser to authorize Strava. Praxys imports activities from Strava, while recovery, fitness, and plans come from your other connected platforms."
 
-#: src/pages/Settings.tsx:1027
+#: src/pages/Settings.tsx:1030
 #: src/pages/Setup.tsx:951
 msgid "Continue to Strava"
 msgstr "Continue to Strava"
@@ -508,7 +526,7 @@ msgstr "Continue to Strava"
 msgid "Continuous"
 msgstr "Continuous"
 
-#: src/pages/Settings.tsx:1173
+#: src/pages/Settings.tsx:1217
 msgid "Continuous Improvement"
 msgstr "Continuous Improvement"
 
@@ -524,12 +542,8 @@ msgstr "Cooldown"
 #~ msgid "Cosmetic — changes names and colors without affecting calculations"
 #~ msgstr "Cosmetic — changes names and colors without affecting calculations"
 
-#: src/pages/Login.tsx:112
-msgid "Could not save your email. Please email us instead."
-msgstr "Could not save your email. Please email us instead."
-
 #: src/components/charts/CpTrendChart.tsx:59
-#: src/lib/display-labels.ts:56
+#: src/lib/display-labels.ts:62
 msgid "CP Trend"
 msgstr "CP Trend"
 
@@ -538,7 +552,7 @@ msgstr "CP Trend"
 msgid "Create"
 msgstr "Create"
 
-#: src/pages/Login.tsx:488
+#: src/pages/Login.tsx:164
 msgid "Create account"
 msgstr "Create account"
 
@@ -547,20 +561,16 @@ msgid "Created"
 msgstr "Created"
 
 #: src/pages/Login.tsx:164
-#~ msgid "Creating account..."
-#~ msgstr "Creating account..."
-
-#: src/pages/Login.tsx:488
-msgid "Creating account…"
-msgstr "Creating account…"
+msgid "Creating account..."
+msgstr "Creating account..."
 
 #: src/pages/Admin.tsx:475
 #: src/pages/Admin.tsx:594
 msgid "Creating..."
 msgstr "Creating..."
 
-#: src/lib/display-labels.ts:52
-#: src/pages/Settings.tsx:96
+#: src/lib/display-labels.ts:58
+#: src/pages/Settings.tsx:99
 msgid "Critical Power"
 msgstr "Critical Power"
 
@@ -568,7 +578,7 @@ msgstr "Critical Power"
 msgid "Cross-training activities affect your overall training load and recovery"
 msgstr "Cross-training activities affect your overall training load and recovery"
 
-#: src/components/charts/FitnessFatigueChart.tsx:241
+#: src/components/charts/FitnessFatigueChart.tsx:274
 msgid "CTL (Fitness)"
 msgstr "CTL (Fitness)"
 
@@ -590,7 +600,7 @@ msgstr "Currently set to {0}-based training"
 msgid "Cycling"
 msgstr "Cycling"
 
-#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:435
 msgid "daily score"
 msgstr "daily score"
 
@@ -598,11 +608,7 @@ msgstr "daily score"
 msgid "Dark"
 msgstr "Dark"
 
-#: src/pages/Login.tsx:537
-msgid "Dark theme (click for system)"
-msgstr "Dark theme (click for system)"
-
-#: src/pages/Settings.tsx:1104
+#: src/pages/Settings.tsx:1107
 msgid "Data Preferences"
 msgstr "Data Preferences"
 
@@ -677,15 +683,24 @@ msgstr "Demote"
 msgid "Demote to User"
 msgstr "Demote to User"
 
+#: src/pages/Training.tsx:305
+#: src/pages/Training.tsx:308
+msgid "Diagnosis"
+msgstr "Diagnosis"
+
+#: src/components/UpcomingPlanCard.tsx:171
+msgid "Differs on Stryd — click to re-push and overwrite."
+msgstr "Differs on Stryd — click to re-push and overwrite."
+
 #: src/pages/Goal.tsx:294
 msgid "Direction"
 msgstr "Direction"
 
-#: src/pages/Settings.tsx:888
+#: src/pages/Settings.tsx:891
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: src/pages/Goal.tsx:377
+#: src/pages/Goal.tsx:383
 msgid "Discussion"
 msgstr "Discussion"
 
@@ -693,25 +708,25 @@ msgstr "Discussion"
 msgid "Dismissible banners shown to all users"
 msgstr "Dismissible banners shown to all users"
 
-#: src/pages/Login.tsx:509
-msgid "Display preferences"
-msgstr "Display preferences"
-
 #: src/components/SplitBreakdown.tsx:46
 msgid "Dist"
 msgstr "Dist"
 
 #: src/components/ActivityCard.tsx:75
 #: src/components/GoalEditor.tsx:122
-#: src/pages/Settings.tsx:1177
+#: src/pages/Settings.tsx:1221
 msgid "Distance"
 msgstr "Distance"
 
 #: src/components/ZoneAnalysisCard.tsx:92
-msgid "Distribution deviates from target"
-msgstr "Distribution deviates from target"
+#~ msgid "Distribution deviates from target"
+#~ msgstr "Distribution deviates from target"
 
-#: src/pages/Settings.tsx:1229
+#: src/pages/Training.tsx:341
+msgid "Distribution match"
+msgstr "Distribution match"
+
+#: src/pages/Settings.tsx:1273
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 msgstr "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 
@@ -765,7 +780,7 @@ msgstr "EASY"
 msgid "Easy Run"
 msgstr "Easy Run"
 
-#: src/pages/Settings.tsx:1163
+#: src/pages/Settings.tsx:1207
 #: src/pages/Setup.tsx:755
 msgid "Edit"
 msgstr "Edit"
@@ -784,26 +799,21 @@ msgstr "Elevated"
 
 #: src/pages/Admin.tsx:256
 #: src/pages/Admin.tsx:450
-#: src/pages/Login.tsx:285
-#: src/pages/Login.tsx:353
-#: src/pages/Login.tsx:439
+#: src/pages/Login.tsx:90
+#: src/pages/Login.tsx:126
 #: src/pages/Setup.tsx:206
 msgid "Email"
 msgstr "Email"
 
-#: src/pages/Login.tsx:48
+#: src/pages/Login.tsx:37
 msgid "Email and password are required."
 msgstr "Email and password are required."
-
-#: src/pages/Login.tsx:81
-msgid "Email is required."
-msgstr "Email is required."
 
 #: src/lib/display-labels.ts:43
 msgid "Endurance"
 msgstr "Endurance"
 
-#: src/pages/Settings.tsx:807
+#: src/pages/Settings.tsx:810
 msgid "Error"
 msgstr "Error"
 
@@ -811,12 +821,12 @@ msgstr "Error"
 msgid "Estimates race performance from current fitness."
 msgstr "Estimates race performance from current fitness."
 
-#: src/pages/Settings.tsx:960
+#: src/pages/Settings.tsx:963
 msgid "EU"
 msgstr "EU"
 
 #. placeholder {0}: option.hours
-#: src/pages/Settings.tsx:746
+#: src/pages/Settings.tsx:749
 msgid "Every <0>{0}</0> hours"
 msgstr "Every <0>{0}</0> hours"
 
@@ -829,7 +839,7 @@ msgstr "Extended rest period. Fitness declining."
 msgid "Failed (HTTP {0})"
 msgstr "Failed (HTTP {0})"
 
-#: src/pages/Today.tsx:225
+#: src/pages/Today.tsx:223
 msgid "Failed to load"
 msgstr "Failed to load"
 
@@ -837,7 +847,7 @@ msgstr "Failed to load"
 msgid "Failed to load activities"
 msgstr "Failed to load activities"
 
-#: src/pages/Goal.tsx:439
+#: src/pages/Goal.tsx:440
 msgid "Failed to load goal data"
 msgstr "Failed to load goal data"
 
@@ -849,15 +859,15 @@ msgstr "Failed to load goal data"
 msgid "Failed to load science data."
 msgstr "Failed to load science data."
 
-#: src/pages/Settings.tsx:314
+#: src/pages/Settings.tsx:317
 msgid "Failed to load settings"
 msgstr "Failed to load settings"
 
-#: src/pages/Training.tsx:51
+#: src/pages/Training.tsx:142
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:483
+#: src/components/UpcomingPlanCard.tsx:583
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -869,15 +879,20 @@ msgstr "Failed to save goal"
 msgid "Falling"
 msgstr "Falling"
 
-#: src/components/charts/FitnessFatigueChart.tsx:59
+#: src/components/charts/FitnessFatigueChart.tsx:58
+#: src/components/charts/FitnessFatigueChart.tsx:191
 msgid "Fatigue"
 msgstr "Fatigue"
+
+#: src/pages/Training.tsx:336
+msgid "fatigue accumulating"
+msgstr "fatigue accumulating"
 
 #: src/components/charts/FormSparkline.tsx:30
 msgid "Fatigue is climbing — watch recovery before adding load."
 msgstr "Fatigue is climbing — watch recovery before adding load."
 
-#: src/pages/Today.tsx:287
+#: src/pages/Today.tsx:280
 msgid "fatigued"
 msgstr "fatigued"
 
@@ -885,18 +900,19 @@ msgstr "fatigued"
 msgid "Fatigued"
 msgstr "Fatigued"
 
-#: src/components/AiInsightsCard.tsx:124
+#: src/components/AiInsightsCard.tsx:175
 msgid "Findings"
 msgstr "Findings"
 
-#: src/components/charts/FitnessFatigueChart.tsx:53
+#: src/components/charts/FitnessFatigueChart.tsx:52
+#: src/components/charts/FitnessFatigueChart.tsx:187
 #: src/pages/Settings.tsx:55
-#: src/pages/Settings.tsx:1141
+#: src/pages/Settings.tsx:1185
 #: src/pages/Setup.tsx:217
 msgid "Fitness"
 msgstr "Fitness"
 
-#: src/components/charts/FitnessFatigueChart.tsx:156
+#: src/pages/Training.tsx:394
 msgid "Fitness / Fatigue / Form"
 msgstr "Fitness / Fatigue / Form"
 
@@ -913,9 +929,14 @@ msgstr "Flat"
 msgid "Follow Plan"
 msgstr "Follow Plan"
 
-#: src/components/charts/FitnessFatigueChart.tsx:65
+#: src/components/charts/FitnessFatigueChart.tsx:64
+#: src/components/charts/FitnessFatigueChart.tsx:195
 msgid "Form"
 msgstr "Form"
+
+#: src/pages/Training.tsx:329
+msgid "form (CTL−ATL)"
+msgstr "form (CTL−ATL)"
 
 #: src/components/charts/FormSparkline.tsx:119
 msgid "Form (TSB)"
@@ -933,32 +954,40 @@ msgstr "Four-pillar framework"
 msgid "Fresh"
 msgstr "Fresh"
 
+#: src/pages/Training.tsx:331
+msgid "fresh, primed"
+msgstr "fresh, primed"
+
 #: src/components/charts/FormSparkline.tsx:26
 msgid "Freshened up — good window for racing or testing."
 msgstr "Freshened up — good window for racing or testing."
 
-#: src/pages/Today.tsx:389
+#: src/pages/Today.tsx:382
 msgid "From {dataAsOfLabel}"
 msgstr "From {dataAsOfLabel}"
 
-#: src/pages/Settings.tsx:112
+#: src/pages/Settings.tsx:115
 msgid "From activities"
 msgstr "From activities"
+
+#: src/components/UpcomingPlanCard.tsx:147
+msgid "From Stryd"
+msgstr "From Stryd"
 
 #: src/pages/Goal.tsx:262
 #: src/pages/Goal.tsx:272
 msgid "Gap"
 msgstr "Gap"
 
-#: src/pages/Settings.tsx:952
+#: src/pages/Settings.tsx:955
 msgid "Garmin International and Garmin China are separate account systems. Pick the one your credentials belong to."
 msgstr "Garmin International and Garmin China are separate account systems. Pick the one your credentials belong to."
 
-#: src/pages/Settings.tsx:874
+#: src/pages/Settings.tsx:877
 msgid "Garmin International and Garmin China are separate accounts. To switch, disconnect and reconnect with the other account."
 msgstr "Garmin International and Garmin China are separate accounts. To switch, disconnect and reconnect with the other account."
 
-#: src/pages/Settings.tsx:1082
+#: src/pages/Settings.tsx:1085
 msgid "Garmin native running power reads ~30% higher than Stryd for the same athlete — they measure different things. Zones and benchmarks calibrated on Stryd (most coach references, most training literature) will not directly transfer. Your power data will still be internally consistent for tracking progress, but don't compare CP values across the two systems."
 msgstr "Garmin native running power reads ~30% higher than Stryd for the same athlete — they measure different things. Zones and benchmarks calibrated on Stryd (most coach references, most training literature) will not directly transfer. Your power data will still be internally consistent for tracking progress, but don't compare CP values across the two systems."
 
@@ -969,10 +998,6 @@ msgstr "Generate"
 #: src/pages/Setup.tsx:200
 msgid "Generate a token at cloud.ouraring.com/personal-access-tokens."
 msgstr "Generate a token at cloud.ouraring.com/personal-access-tokens."
-
-#: src/pages/Login.tsx:242
-msgid "Get access"
-msgstr "Get access"
 
 #: src/components/SetupChecklist.tsx:94
 msgid "Get started with Praxys"
@@ -994,11 +1019,11 @@ msgstr "Go to dashboard"
 
 #: src/components/AppSidebar.tsx:110
 #: src/pages/Goal.tsx:135
-#: src/pages/Settings.tsx:1158
+#: src/pages/Settings.tsx:1202
 msgid "Goal"
 msgstr "Goal"
 
-#: src/pages/Goal.tsx:429
+#: src/pages/Goal.tsx:430
 msgid "Goal Tracker"
 msgstr "Goal Tracker"
 
@@ -1010,22 +1035,22 @@ msgstr "Good balance of fitness and recovery. Ready for quality work."
 msgid "Half"
 msgstr "Half"
 
-#: src/lib/display-labels.ts:61
-#: src/pages/Settings.tsx:178
+#: src/lib/display-labels.ts:67
+#: src/pages/Settings.tsx:181
 msgid "Half Marathon"
 msgstr "Half Marathon"
 
-#: src/lib/display-labels.ts:49
-#: src/pages/Settings.tsx:76
+#: src/lib/display-labels.ts:55
+#: src/pages/Settings.tsx:79
 #: src/pages/Setup.tsx:172
 msgid "Heart Rate"
 msgstr "Heart Rate"
 
-#: src/pages/Settings.tsx:684
+#: src/pages/Settings.tsx:687
 msgid "Hide backfill"
 msgstr "Hide backfill"
 
-#: src/components/AiInsightsCard.tsx:100
+#: src/components/AiInsightsCard.tsx:151
 msgid "Hide details"
 msgstr "Hide details"
 
@@ -1045,7 +1070,7 @@ msgstr "High variability"
 msgid "Hiking"
 msgstr "Hiking"
 
-#: src/pages/Settings.tsx:710
+#: src/pages/Settings.tsx:713
 msgid "Historical sync may take several minutes"
 msgstr "Historical sync may take several minutes"
 
@@ -1065,15 +1090,15 @@ msgstr "Historical sync may take several minutes"
 #~ msgid "How is intensity classified?"
 #~ msgstr "How is intensity classified?"
 
-#: src/pages/Settings.tsx:724
+#: src/pages/Settings.tsx:727
 msgid "How often Praxys pulls new data in the background. Lower frequency uses less network and respects platform rate limits."
 msgstr "How often Praxys pulls new data in the background. Lower frequency uses less network and respects platform rate limits."
 
-#: src/components/ScienceNote.tsx:28
+#: src/components/ScienceNote.tsx:33
 msgid "How this is calculated"
 msgstr "How this is calculated"
 
-#: src/pages/Settings.tsx:1044
+#: src/pages/Settings.tsx:1047
 #: src/pages/Setup.tsx:705
 msgid "How your zones and training load are calculated"
 msgstr "How your zones and training load are calculated"
@@ -1114,8 +1139,8 @@ msgstr "Improving"
 msgid "Insufficient HRV data for analysis"
 msgstr "Insufficient HRV data for analysis"
 
-#: src/pages/Settings.tsx:870
-#: src/pages/Settings.tsx:935
+#: src/pages/Settings.tsx:873
+#: src/pages/Settings.tsx:938
 msgid "International"
 msgstr "International"
 
@@ -1123,29 +1148,24 @@ msgstr "International"
 msgid "Invalid time format. Use H:MM:SS or H:MM"
 msgstr "Invalid time format. Use H:MM:SS or H:MM"
 
-#: src/pages/Login.tsx:472
-msgid "Invitation code"
-msgstr "Invitation code"
-
 #: src/pages/Login.tsx:149
-#~ msgid "Invitation Code"
-#~ msgstr "Invitation Code"
+msgid "Invitation Code"
+msgstr "Invitation Code"
 
 #: src/pages/Admin.tsx:334
 msgid "Invitation Codes"
 msgstr "Invitation Codes"
 
-#: src/pages/Login.tsx:339
-#: src/pages/Login.tsx:386
-#: src/pages/Login.tsx:498
-msgid "Join the waitlist"
-msgstr "Join the waitlist"
+#. placeholder {0}: data.diagnosis.lookback_weeks
+#: src/pages/Training.tsx:381
+msgid "km / week, {0}wk avg"
+msgstr "km / week, {0}wk avg"
 
-#: src/lib/display-labels.ts:53
+#: src/lib/display-labels.ts:59
 msgid "Lactate Threshold HR"
 msgstr "Lactate Threshold HR"
 
-#: src/pages/Settings.tsx:647
+#: src/pages/Settings.tsx:650
 msgid "Language"
 msgstr "Language"
 
@@ -1158,22 +1178,18 @@ msgid "Last Activity"
 msgstr "Last Activity"
 
 #. placeholder {0}: status.error
-#: src/pages/Settings.tsx:858
+#: src/pages/Settings.tsx:861
 msgid "Last sync failed: {0}"
 msgstr "Last sync failed: {0}"
 
 #. placeholder {0}: new Date(status.last_sync).toLocaleString()
-#: src/pages/Settings.tsx:852
+#: src/pages/Settings.tsx:855
 msgid "Last synced {0}"
 msgstr "Last synced {0}"
 
 #: src/pages/Login.tsx:160
-#~ msgid "Leave blank for the first account. Required after that."
-#~ msgstr "Leave blank for the first account. Required after that."
-
-#: src/pages/Login.tsx:489
-#~ msgid "Leave blank if this is the first account on a fresh install."
-#~ msgstr "Leave blank if this is the first account on a fresh install."
+msgid "Leave blank for the first account. Required after that."
+msgstr "Leave blank for the first account. Required after that."
 
 #: src/components/GoalEditor.tsx:164
 msgid "Leave blank to track predicted time only"
@@ -1182,10 +1198,6 @@ msgstr "Leave blank to track predicted time only"
 #: src/components/AppSidebar.tsx:30
 msgid "Light"
 msgstr "Light"
-
-#: src/pages/Login.tsx:535
-msgid "Light theme (click for dark)"
-msgstr "Light theme (click for dark)"
 
 #: src/pages/Setup.tsx:514
 msgid "Link at least one data source to start"
@@ -1203,7 +1215,7 @@ msgstr "Link text (optional)"
 msgid "Link URL (optional)"
 msgstr "Link URL (optional)"
 
-#: src/pages/Settings.tsx:680
+#: src/pages/Settings.tsx:683
 msgid "Link your training devices and services"
 msgstr "Link your training devices and services"
 
@@ -1211,13 +1223,26 @@ msgstr "Link your training devices and services"
 msgid "Live demo — real training data, read-only"
 msgstr "Live demo — real training data, read-only"
 
+#: src/components/charts/ComplianceChart.tsx:61
+msgid "load ({label})"
+msgstr "load ({label})"
+
+#: src/components/charts/ComplianceChart.tsx:60
+msgid "load (Running Stress Score)"
+msgstr "load (Running Stress Score)"
+
 #: src/pages/Science.tsx:25
 msgid "Load & Fitness"
 msgstr "Load & Fitness"
 
+#: src/pages/Training.tsx:359
+#: src/pages/Training.tsx:433
+msgid "Load compliance"
+msgstr "Load compliance"
+
 #: src/pages/Login.tsx:71
-#~ msgid "Log in to connect your CLI plugin"
-#~ msgstr "Log in to connect your CLI plugin"
+msgid "Log in to connect your CLI plugin"
+msgstr "Log in to connect your CLI plugin"
 
 #: src/components/AppSidebar.tsx:193
 #: src/components/AppSidebar.tsx:195
@@ -1225,8 +1250,8 @@ msgid "Log out"
 msgstr "Log out"
 
 #: src/pages/Login.tsx:78
-#~ msgid "Login"
-#~ msgstr "Login"
+msgid "Login"
+msgstr "Login"
 
 #: src/pages/Today.tsx:124
 msgid "low"
@@ -1236,11 +1261,11 @@ msgstr "low"
 msgid "Low"
 msgstr "Low"
 
-#: src/pages/Settings.tsx:97
+#: src/pages/Settings.tsx:100
 msgid "LTHR"
 msgstr "LTHR"
 
-#: src/lib/display-labels.ts:57
+#: src/lib/display-labels.ts:63
 msgid "LTHR Trend"
 msgstr "LTHR Trend"
 
@@ -1253,17 +1278,17 @@ msgid "Manage users and invitation codes"
 msgstr "Manage users and invitation codes"
 
 #: src/components/GoalEditor.tsx:54
-#: src/lib/display-labels.ts:60
-#: src/pages/Settings.tsx:179
-#: src/pages/Settings.tsx:1179
+#: src/lib/display-labels.ts:66
+#: src/pages/Settings.tsx:182
+#: src/pages/Settings.tsx:1223
 msgid "Marathon"
 msgstr "Marathon"
 
-#: src/pages/Settings.tsx:99
+#: src/pages/Settings.tsx:102
 msgid "Max HR"
 msgstr "Max HR"
 
-#: src/pages/Today.tsx:286
+#: src/pages/Today.tsx:279
 msgid "mild fatigue"
 msgstr "mild fatigue"
 
@@ -1272,7 +1297,7 @@ msgstr "mild fatigue"
 msgid "mirrors {0}"
 msgstr "mirrors {0}"
 
-#: src/pages/Settings.tsx:1171
+#: src/pages/Settings.tsx:1215
 msgid "Mode"
 msgstr "Mode"
 
@@ -1285,22 +1310,36 @@ msgstr "MODIFY"
 msgid "months"
 msgstr "months"
 
+#. placeholder {0}: tDisplay(worstDeviation.name, i18n)
+#. placeholder {1}: worstDeviation.actual
+#. placeholder {2}: worstDeviation.target
+#: src/pages/Training.tsx:190
+msgid "Most over-target: {0} at {1}% (target {2}%). Shift 1-2 sessions next week toward an under-target zone."
+msgstr "Most over-target: {0} at {1}% (target {2}%). Shift 1-2 sessions next week toward an under-target zone."
+
+#. placeholder {0}: tDisplay(worstDeviation.name, i18n)
+#. placeholder {1}: worstDeviation.actual
+#. placeholder {2}: worstDeviation.target
+#: src/pages/Training.tsx:193
+msgid "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
+msgstr "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
+
 #. placeholder {0}: primaryPrompt?.category
 #: src/pages/Setup.tsx:976
 msgid "Multiple platforms provide <0>{0}</0> data. Which should be the primary source?"
 msgstr "Multiple platforms provide <0>{0}</0> data. Which should be the primary source?"
 
+#: src/pages/Training.tsx:441
+msgid "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
+msgstr "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
+
 #: src/pages/Training.tsx:112
-msgid "Need at least 3 activities with power data to plot a meaningful trend."
-msgstr "Need at least 3 activities with power data to plot a meaningful trend."
+#~ msgid "Need at least 3 activities with power data to plot a meaningful trend."
+#~ msgstr "Need at least 3 activities with power data to plot a meaningful trend."
 
 #: src/pages/Goal.tsx:224
 msgid "Need at least 3 activities with power data."
 msgstr "Need at least 3 activities with power data."
-
-#: src/pages/Login.tsx:507
-msgid "Need help? {SUPPORT_EMAIL}"
-msgstr "Need help? {SUPPORT_EMAIL}"
 
 #: src/pages/Goal.tsx:255
 msgid "Needed {abbrev}"
@@ -1310,10 +1349,6 @@ msgstr "Needed {abbrev}"
 msgid "Network error. Is the server running?"
 msgstr "Network error. Is the server running?"
 
-#: src/pages/Login.tsx:118
-msgid "Network error. Please email {SUPPORT_EMAIL} directly."
-msgstr "Network error. Please email {SUPPORT_EMAIL} directly."
-
 #: src/pages/Admin.tsx:559
 msgid "New announcement"
 msgstr "New announcement"
@@ -1322,15 +1357,11 @@ msgstr "New announcement"
 msgid "New invitation code:"
 msgstr "New invitation code:"
 
-#: src/pages/Login.tsx:322
-msgid "New to Praxys?"
-msgstr "New to Praxys?"
-
 #: src/pages/History.tsx:96
 msgid "Next"
 msgstr "Next"
 
-#: src/pages/Settings.tsx:728
+#: src/pages/Settings.tsx:731
 msgid "Next sync"
 msgstr "Next sync"
 
@@ -1342,14 +1373,10 @@ msgstr "No activities found."
 msgid "No announcements yet"
 msgstr "No announcements yet"
 
-#: src/pages/Login.tsx:492
-msgid "No code yet?"
-msgstr "No code yet?"
-
-#: src/pages/Today.tsx:276
-#: src/pages/Today.tsx:427
-#: src/pages/Today.tsx:428
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:269
+#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:432
+#: src/pages/Today.tsx:433
 msgid "no data"
 msgstr "no data"
 
@@ -1357,7 +1384,7 @@ msgstr "no data"
 msgid "No Data"
 msgstr "No Data"
 
-#: src/pages/Settings.tsx:1199
+#: src/pages/Settings.tsx:1243
 msgid "No goal set. Set a race target or distance goal to unlock predictions and countdown."
 msgstr "No goal set. Set a race target or distance goal to unlock predictions and countdown."
 
@@ -1365,7 +1392,7 @@ msgstr "No goal set. Set a race target or distance goal to unlock predictions an
 msgid "No invitation codes yet. Generate one to invite a user."
 msgstr "No invitation codes yet. Generate one to invite a user."
 
-#: src/pages/Today.tsx:365
+#: src/pages/Today.tsx:358
 msgid "No new HRV, sleep, or activity since."
 msgstr "No new HRV, sleep, or activity since."
 
@@ -1381,6 +1408,10 @@ msgstr "No split data available."
 msgid "No Workout"
 msgstr "No Workout"
 
+#: src/components/UpcomingPlanCard.tsx:658
+msgid "No workouts scheduled in this window."
+msgstr "No workouts scheduled in this window."
+
 #: src/pages/Today.tsx:125
 msgid "normal"
 msgstr "normal"
@@ -1390,28 +1421,35 @@ msgstr "normal"
 msgid "Normal"
 msgstr "Normal"
 
-#: src/pages/Settings.tsx:787
+#: src/pages/Settings.tsx:790
 msgid "Not connected"
 msgstr "Not connected"
 
 #: src/pages/Training.tsx:102
-msgid "Not enough data for accurate fitness tracking"
-msgstr "Not enough data for accurate fitness tracking"
+#~ msgid "Not enough data for accurate fitness tracking"
+#~ msgstr "Not enough data for accurate fitness tracking"
 
 #: src/pages/Training.tsx:119
-msgid "Not enough data for weekly load comparison"
-msgstr "Not enough data for weekly load comparison"
+#~ msgid "Not enough data for weekly load comparison"
+#~ msgstr "Not enough data for weekly load comparison"
 
 #: src/pages/Goal.tsx:223
-#: src/pages/Training.tsx:111
 msgid "Not enough data to show CP trend"
 msgstr "Not enough data to show CP trend"
 
 #: src/pages/Training.tsx:126
-msgid "Not enough data to show sleep vs performance"
-msgstr "Not enough data to show sleep vs performance"
+#~ msgid "Not enough data to show sleep vs performance"
+#~ msgstr "Not enough data to show sleep vs performance"
 
-#: src/pages/Settings.tsx:1262
+#: src/pages/Training.tsx:405
+msgid "Not enough data yet for accurate fitness tracking"
+msgstr "Not enough data yet for accurate fitness tracking"
+
+#: src/pages/Training.tsx:440
+msgid "Not enough data yet for weekly load comparison"
+msgstr "Not enough data yet for weekly load comparison"
+
+#: src/pages/Settings.tsx:1306
 msgid "Not set"
 msgstr "Not set"
 
@@ -1423,7 +1461,7 @@ msgstr "Note"
 msgid "Note (optional)"
 msgstr "Note (optional)"
 
-#: src/pages/Settings.tsx:1079
+#: src/pages/Settings.tsx:1082
 msgid "Note on Garmin native power"
 msgstr "Note on Garmin native power"
 
@@ -1447,21 +1485,21 @@ msgstr "Options"
 msgid "Other Signals"
 msgstr "Other Signals"
 
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:433
 msgid "overnight score"
 msgstr "overnight score"
 
 #: src/components/ActivityCard.tsx:121
 #: src/components/SplitBreakdown.tsx:50
-#: src/lib/display-labels.ts:50
-#: src/pages/Settings.tsx:85
+#: src/lib/display-labels.ts:56
+#: src/pages/Settings.tsx:88
 #: src/pages/Setup.tsx:174
 msgid "Pace"
 msgstr "Pace"
 
 #: src/pages/Admin.tsx:460
-#: src/pages/Login.tsx:302
-#: src/pages/Login.tsx:456
+#: src/pages/Login.tsx:102
+#: src/pages/Login.tsx:138
 #: src/pages/Setup.tsx:207
 msgid "Password"
 msgstr "Password"
@@ -1475,20 +1513,28 @@ msgid "Personal Access Token"
 msgstr "Personal Access Token"
 
 #: src/pages/Settings.tsx:56
-#: src/pages/Settings.tsx:62
 #: src/pages/Setup.tsx:218
 msgid "Plan"
 msgstr "Plan"
 
-#: src/components/charts/ComplianceChart.tsx:79
+#: src/pages/Settings.tsx:65
+msgid "Plan sync target"
+msgstr "Plan sync target"
+
+#: src/components/UpcomingPlanCard.tsx:374
+msgid "Plan window"
+msgstr "Plan window"
+
+#: src/components/charts/ComplianceChart.tsx:107
+#: src/components/charts/ComplianceChart.tsx:151
 msgid "Planned"
 msgstr "Planned"
 
-#: src/pages/Today.tsx:435
+#: src/pages/Today.tsx:439
 msgid "Planned · Today"
 msgstr "Planned · Today"
 
-#: src/components/charts/ComplianceChart.tsx:42
+#: src/components/charts/ComplianceChart.tsx:118
 msgid "Planned bars are estimated — your plan has no {label} targets for the current training base."
 msgstr "Planned bars are estimated — your plan has no {label} targets for the current training base."
 
@@ -1496,17 +1542,13 @@ msgstr "Planned bars are estimated — your plan has no {label} targets for the 
 msgid "Planned Workout"
 msgstr "Planned Workout"
 
-#: src/pages/Login.tsx:104
-msgid "Please check your email format and try again."
-msgstr "Please check your email format and try again."
-
-#: src/pages/Today.tsx:285
+#: src/pages/Today.tsx:278
 msgid "positive"
 msgstr "positive"
 
 #: src/components/SplitBreakdown.tsx:48
-#: src/lib/display-labels.ts:48
-#: src/pages/Settings.tsx:67
+#: src/lib/display-labels.ts:54
+#: src/pages/Settings.tsx:70
 #: src/pages/Setup.tsx:170
 msgid "Power"
 msgstr "Power"
@@ -1516,24 +1558,16 @@ msgid "Power metrics, Critical Power, training plans"
 msgstr "Power metrics, Critical Power, training plans"
 
 #: src/pages/Login.tsx:72
-#~ msgid "Power-based training dashboard"
-#~ msgstr "Power-based training dashboard"
+msgid "Power-based training dashboard"
+msgstr "Power-based training dashboard"
 
-#: src/components/AiInsightsCard.tsx:81
+#: src/components/AiInsightsCard.tsx:132
 msgid "Praxys Coach"
 msgstr "Praxys Coach"
 
-#: src/components/AiInsightsCard.tsx:79
+#: src/components/AiInsightsCard.tsx:130
 msgid "Praxys Coach insight"
 msgstr "Praxys Coach insight"
-
-#: src/pages/Login.tsx:247
-msgid "Praxys is in private alpha."
-msgstr "Praxys is in private alpha."
-
-#: src/pages/Login.tsx:134
-#~ msgid "Praxys race-flag mark"
-#~ msgstr "Praxys race-flag mark"
 
 #: src/pages/Goal.tsx:241
 #: src/pages/Goal.tsx:278
@@ -1559,7 +1593,7 @@ msgid "Previous"
 msgstr "Previous"
 
 #. placeholder {0}: CAPABILITY_LABELS[cat] ? i18n._(CAPABILITY_LABELS[cat]) : cat
-#: src/pages/Settings.tsx:844
+#: src/pages/Settings.tsx:847
 msgid "Primary for {0}"
 msgstr "Primary for {0}"
 
@@ -1567,11 +1601,11 @@ msgstr "Primary for {0}"
 msgid "Primary source for workout data"
 msgstr "Primary source for workout data"
 
-#: src/pages/Login.tsx:136
-msgid "Private alpha · Invitation only"
-msgstr "Private alpha · Invitation only"
+#: src/pages/Training.tsx:335
+msgid "productive load"
+msgstr "productive load"
 
-#: src/pages/Settings.tsx:580
+#: src/pages/Settings.tsx:583
 msgid "Profile"
 msgstr "Profile"
 
@@ -1579,8 +1613,8 @@ msgstr "Profile"
 msgid "Proj"
 msgstr "Proj"
 
-#: src/components/charts/FitnessFatigueChart.tsx:46
-#: src/components/charts/FitnessFatigueChart.tsx:174
+#: src/components/charts/FitnessFatigueChart.tsx:45
+#: src/components/charts/FitnessFatigueChart.tsx:200
 msgid "Projected"
 msgstr "Projected"
 
@@ -1599,30 +1633,35 @@ msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "Pull your latest activities, power data, and recovery metrics"
 
 #: src/components/UpcomingPlanCard.tsx:530
-msgid "Push All"
-msgstr "Push All"
+#~ msgid "Push All"
+#~ msgstr "Push All"
 
-#: src/components/UpcomingPlanCard.tsx:126
+#: src/components/UpcomingPlanCard.tsx:205
 msgid "Push failed"
 msgstr "Push failed"
 
-#: src/components/UpcomingPlanCard.tsx:169
-#: src/components/UpcomingPlanCard.tsx:177
+#: src/components/UpcomingPlanCard.tsx:248
+#: src/components/UpcomingPlanCard.tsx:256
+#: src/components/UpcomingPlanCard.tsx:641
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
 #: src/components/UpcomingPlanCard.tsx:520
-msgid "Pushing..."
-msgstr "Pushing..."
+#~ msgid "Pushing..."
+#~ msgstr "Pushing..."
 
-#: src/lib/display-labels.ts:68
+#: src/components/UpcomingPlanCard.tsx:631
+msgid "Pushing…"
+msgstr "Pushing…"
+
+#: src/lib/display-labels.ts:74
 #: src/pages/Goal.tsx:109
 #: src/pages/Goal.tsx:127
 msgid "Race"
 msgstr "Race"
 
 #: src/components/GoalEditor.tsx:139
-#: src/pages/Settings.tsx:1184
+#: src/pages/Settings.tsx:1228
 msgid "Race Date"
 msgstr "Race Date"
 
@@ -1631,7 +1670,7 @@ msgid "Race date is required"
 msgstr "Race date is required"
 
 #: src/components/GoalEditor.tsx:111
-#: src/pages/Settings.tsx:1173
+#: src/pages/Settings.tsx:1217
 msgid "Race Goal"
 msgstr "Race Goal"
 
@@ -1644,11 +1683,11 @@ msgid "Race Prediction"
 msgstr "Race Prediction"
 
 #: src/components/ZoneAnalysisCard.tsx:63
-msgid "Range"
-msgstr "Range"
+#~ msgid "Range"
+#~ msgstr "Range"
 
-#: src/components/UpcomingPlanCard.tsx:143
-#: src/components/UpcomingPlanCard.tsx:152
+#: src/components/UpcomingPlanCard.tsx:222
+#: src/components/UpcomingPlanCard.tsx:231
 msgid "Re-push to Stryd"
 msgstr "Re-push to Stryd"
 
@@ -1656,7 +1695,7 @@ msgstr "Re-push to Stryd"
 msgid "Read-only accounts that mirror your dashboard data"
 msgstr "Read-only accounts that mirror your dashboard data"
 
-#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:435
 msgid "Readiness"
 msgstr "Readiness"
 
@@ -1664,7 +1703,7 @@ msgstr "Readiness"
 msgid "Reads readiness from the body's signals."
 msgstr "Reads readiness from the body's signals."
 
-#: src/pages/Goal.tsx:358
+#: src/pages/Goal.tsx:368
 msgid "Realistic alternative targets"
 msgstr "Realistic alternative targets"
 
@@ -1672,11 +1711,11 @@ msgstr "Realistic alternative targets"
 msgid "Recommendation available"
 msgstr "Recommendation available"
 
-#: src/components/AiInsightsCard.tsx:138
+#: src/components/AiInsightsCard.tsx:189
 msgid "Recommendations"
 msgstr "Recommendations"
 
-#: src/pages/Settings.tsx:750
+#: src/pages/Settings.tsx:753
 msgid "recommended"
 msgstr "recommended"
 
@@ -1698,7 +1737,7 @@ msgstr "Recommended"
 msgid "Recovery"
 msgstr "Recovery"
 
-#: src/pages/Today.tsx:406
+#: src/pages/Today.tsx:399
 msgid "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 msgstr "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 
@@ -1719,7 +1758,7 @@ msgstr "Recovery Status"
 msgid "Recovery status uses ln(RMSSD) compared to your personal baseline. 'Fatigued' = below baseline mean minus 1 SD (Kiviniemi et al, 2007 threshold). 'Fresh' = above baseline mean plus 0.5 SD (Plews et al, 2012 smallest worthwhile change). The 7-day trend and CV are monitored per Plews — declining trend or CV above 10% signals autonomic disturbance. Sleep, RHR, and TSB are shown as informational context when HRV is available."
 msgstr "Recovery status uses ln(RMSSD) compared to your personal baseline. 'Fatigued' = below baseline mean minus 1 SD (Kiviniemi et al, 2007 threshold). 'Fresh' = above baseline mean plus 0.5 SD (Plews et al, 2012 smallest worthwhile change). The 7-day trend and CV are monitored per Plews — declining trend or CV above 10% signals autonomic disturbance. Sleep, RHR, and TSB are shown as informational context when HRV is available."
 
-#: src/pages/Settings.tsx:1027
+#: src/pages/Settings.tsx:1030
 #: src/pages/Setup.tsx:951
 msgid "Redirecting..."
 msgstr "Redirecting..."
@@ -1733,17 +1772,17 @@ msgstr "Reduce Intensity"
 msgid "References"
 msgstr "References"
 
-#: src/pages/Settings.tsx:866
-#: src/pages/Settings.tsx:933
-#: src/pages/Settings.tsx:958
+#: src/pages/Settings.tsx:869
+#: src/pages/Settings.tsx:936
+#: src/pages/Settings.tsx:961
 #: src/pages/Setup.tsx:836
 #: src/pages/Setup.tsx:857
 msgid "Region"
 msgstr "Region"
 
 #: src/pages/Login.tsx:79
-#~ msgid "Register"
-#~ msgstr "Register"
+msgid "Register"
+msgstr "Register"
 
 #: src/pages/Admin.tsx:258
 msgid "Registered"
@@ -1757,14 +1796,6 @@ msgstr "Registered accounts"
 msgid "Rep"
 msgstr "Rep"
 
-#: src/pages/Login.tsx:328
-msgid "Request an invite"
-msgstr "Request an invite"
-
-#: src/pages/Login.tsx:272
-msgid "Request invite"
-msgstr "Request invite"
-
 #: src/lib/phase-label.ts:17
 msgid "Rest"
 msgstr "Rest"
@@ -1774,24 +1805,24 @@ msgstr "Rest"
 msgid "REST"
 msgstr "REST"
 
-#: src/pages/Today.tsx:289
+#: src/pages/Today.tsx:282
 msgid "Rest day. No workout scheduled."
 msgstr "Rest day. No workout scheduled."
 
-#: src/pages/Settings.tsx:100
+#: src/pages/Settings.tsx:103
 msgid "Resting HR"
 msgstr "Resting HR"
 
-#: src/components/UpcomingPlanCard.tsx:486
-#: src/pages/Goal.tsx:442
+#: src/components/UpcomingPlanCard.tsx:586
+#: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
-#: src/pages/Settings.tsx:316
-#: src/pages/Today.tsx:228
-#: src/pages/Training.tsx:54
+#: src/pages/Settings.tsx:319
+#: src/pages/Today.tsx:226
+#: src/pages/Training.tsx:145
 msgid "Retry"
 msgstr "Retry"
 
-#: src/components/UpcomingPlanCard.tsx:118
+#: src/components/UpcomingPlanCard.tsx:197
 msgid "Retry push to Stryd"
 msgstr "Retry push to Stryd"
 
@@ -1803,7 +1834,7 @@ msgstr "Revoke"
 msgid "Revoked"
 msgstr "Revoked"
 
-#: src/pages/Today.tsx:428
+#: src/pages/Today.tsx:432
 msgid "RHR"
 msgstr "RHR"
 
@@ -1819,7 +1850,7 @@ msgstr "Role"
 msgid "Run"
 msgstr "Run"
 
-#: src/components/AiInsightsCard.tsx:153
+#: src/components/AiInsightsCard.tsx:204
 msgid "Run <0>/praxys:{skillName}</0> in Claude Code for deeper analysis"
 msgstr "Run <0>/praxys:{skillName}</0> in Claude Code for deeper analysis"
 
@@ -1835,10 +1866,6 @@ msgstr "Save Goal"
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/pages/Login.tsx:386
-msgid "Saving…"
-msgstr "Saving…"
-
 #: src/components/AppSidebar.tsx:115
 msgid "Science"
 msgstr "Science"
@@ -1847,7 +1874,7 @@ msgstr "Science"
 msgid "Science pillars"
 msgstr "Science pillars"
 
-#: src/pages/Settings.tsx:977
+#: src/pages/Settings.tsx:980
 msgid "Select the region matching your COROS account."
 msgstr "Select the region matching your COROS account."
 
@@ -1857,7 +1884,7 @@ msgid "Set a goal"
 msgstr "Set a goal"
 
 #: src/components/SetupChecklist.tsx:75
-#: src/pages/Settings.tsx:1163
+#: src/pages/Settings.tsx:1207
 #: src/pages/Setup.tsx:764
 msgid "Set goal"
 msgstr "Set goal"
@@ -1870,12 +1897,12 @@ msgstr "Set up Praxys"
 msgid "Set Your Goal"
 msgstr "Set Your Goal"
 
-#: src/pages/Settings.tsx:621
+#: src/pages/Settings.tsx:624
 msgid "Set your name"
 msgstr "Set your name"
 
 #: src/components/AppSidebar.tsx:119
-#: src/pages/Settings.tsx:553
+#: src/pages/Settings.tsx:556
 msgid "Settings"
 msgstr "Settings"
 
@@ -1884,18 +1911,17 @@ msgstr "Settings"
 msgid "Setup"
 msgstr "Setup"
 
-#. placeholder {0}: workouts.length - INITIAL_COUNT
 #: src/components/UpcomingPlanCard.tsx:319
-msgid "Show {0} more workouts"
-msgstr "Show {0} more workouts"
+#~ msgid "Show {0} more workouts"
+#~ msgstr "Show {0} more workouts"
 
-#: src/pages/Today.tsx:381
+#: src/pages/Today.tsx:374
 msgid "Show anyway"
 msgstr "Show anyway"
 
 #: src/components/UpcomingPlanCard.tsx:318
-msgid "Show less"
-msgstr "Show less"
+#~ msgid "Show less"
+#~ msgstr "Show less"
 
 #: src/pages/Science.tsx:465
 msgid "Show methodology details"
@@ -1905,27 +1931,17 @@ msgstr "Show methodology details"
 msgid "Showing"
 msgstr "Showing"
 
-#: src/pages/Today.tsx:362
+#: src/pages/Today.tsx:355
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 
-#: src/pages/Login.tsx:241
-#: src/pages/Login.tsx:263
-#: src/pages/Login.tsx:318
+#: src/pages/Login.tsx:113
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/pages/Login.tsx:234
-msgid "Sign in to connect your CLI plugin."
-msgstr "Sign in to connect your CLI plugin."
-
 #: src/pages/Login.tsx:113
-#~ msgid "Signing in..."
-#~ msgstr "Signing in..."
-
-#: src/pages/Login.tsx:318
-msgid "Signing in…"
-msgstr "Signing in…"
+msgid "Signing in..."
+msgstr "Signing in..."
 
 #: src/pages/Science.tsx:132
 #~ msgid "Simple"
@@ -1936,7 +1952,7 @@ msgid "Skip for now"
 msgstr "Skip for now"
 
 #: src/components/RecoveryPanel.tsx:174
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:433
 msgid "Sleep"
 msgstr "Sleep"
 
@@ -1958,14 +1974,10 @@ msgstr "Sleep score, HRV, readiness"
 msgid "Sleep, HRV, readiness"
 msgstr "Sleep, HRV, readiness"
 
-#: src/components/ScienceNote.tsx:40
-#: src/pages/Goal.tsx:376
+#: src/components/ScienceNote.tsx:45
+#: src/pages/Goal.tsx:382
 msgid "Source"
 msgstr "Source"
-
-#: src/pages/Login.tsx:175
-msgid "Sports science that <0>meets you</0> where you are."
-msgstr "Sports science that <0>meets you</0> where you are."
 
 #: src/pages/Today.tsx:111
 #: src/pages/Today.tsx:122
@@ -1988,11 +2000,11 @@ msgstr "Status"
 msgid "Steady"
 msgstr "Steady"
 
-#: src/pages/Settings.tsx:1000
+#: src/pages/Settings.tsx:1003
 msgid "Strava Client ID"
 msgstr "Strava Client ID"
 
-#: src/pages/Settings.tsx:1009
+#: src/pages/Settings.tsx:1012
 msgid "Strava Client Secret"
 msgstr "Strava Client Secret"
 
@@ -2000,17 +2012,13 @@ msgstr "Strava Client Secret"
 msgid "Strength"
 msgstr "Strength"
 
-#: src/pages/Goal.tsx:365
+#: src/pages/Goal.tsx:375
 msgid "Stretch"
 msgstr "Stretch"
 
-#: src/pages/Today.tsx:284
+#: src/pages/Today.tsx:277
 msgid "strongly positive"
 msgstr "strongly positive"
-
-#: src/pages/Login.tsx:376
-msgid "Sub-3 marathon · 100K · stay healthy…"
-msgstr "Sub-3 marathon · 100K · stay healthy…"
 
 #: src/components/DiagnosisCard.tsx:87
 msgid "Suggestions"
@@ -2020,54 +2028,37 @@ msgstr "Suggestions"
 msgid "Swimming"
 msgstr "Swimming"
 
-#: src/pages/Login.tsx:514
-#: src/pages/Login.tsx:515
-msgid "Switch language"
-msgstr "Switch language"
-
 #. placeholder {0}: previewedTheory.name
 #: src/pages/Science.tsx:428
 msgid "Switch to {0}"
 msgstr "Switch to {0}"
 
-#: src/pages/Login.tsx:528
-msgid "Switch to dark theme"
-msgstr "Switch to dark theme"
-
-#: src/pages/Login.tsx:531
-msgid "Switch to light theme"
-msgstr "Switch to light theme"
-
-#: src/pages/Login.tsx:530
-msgid "Switch to system theme"
-msgstr "Switch to system theme"
-
 #: src/components/SetupChecklist.tsx:59
-#: src/pages/Settings.tsx:809
+#: src/pages/Settings.tsx:812
 msgid "Sync"
 msgstr "Sync"
 
 #: src/pages/Training.tsx:127
-msgid "Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date."
-msgstr "Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date."
+#~ msgid "Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date."
+#~ msgstr "Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date."
 
-#: src/pages/Settings.tsx:687
+#: src/pages/Settings.tsx:690
 msgid "Sync All"
 msgstr "Sync All"
 
 #: src/pages/Training.tsx:120
-msgid "Sync at least 2 weeks of data to compare planned vs actual training load."
-msgstr "Sync at least 2 weeks of data to compare planned vs actual training load."
+#~ msgid "Sync at least 2 weeks of data to compare planned vs actual training load."
+#~ msgstr "Sync at least 2 weeks of data to compare planned vs actual training load."
 
 #: src/pages/Training.tsx:103
-msgid "Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves."
-msgstr "Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves."
+#~ msgid "Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves."
+#~ msgstr "Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves."
 
 #: src/pages/Setup.tsx:689
 msgid "Sync complete! Your data is ready."
 msgstr "Sync complete! Your data is ready."
 
-#: src/pages/Settings.tsx:695
+#: src/pages/Settings.tsx:698
 msgid "Sync from:"
 msgstr "Sync from:"
 
@@ -2075,8 +2066,8 @@ msgstr "Sync from:"
 msgid "Sync history"
 msgstr "Sync history"
 
-#: src/pages/Today.tsx:374
-#: src/pages/Today.tsx:396
+#: src/pages/Today.tsx:367
+#: src/pages/Today.tsx:389
 msgid "Sync now"
 msgstr "Sync now"
 
@@ -2085,12 +2076,11 @@ msgstr "Sync now"
 msgid "Sync your data"
 msgstr "Sync your data"
 
-#: src/components/UpcomingPlanCard.tsx:525
-#: src/pages/Settings.tsx:805
+#: src/pages/Settings.tsx:808
 msgid "Synced"
 msgstr "Synced"
 
-#: src/pages/Settings.tsx:802
+#: src/pages/Settings.tsx:805
 msgid "Syncing"
 msgstr "Syncing"
 
@@ -2098,8 +2088,8 @@ msgstr "Syncing"
 msgid "Syncing..."
 msgstr "Syncing..."
 
-#: src/pages/Today.tsx:374
-#: src/pages/Today.tsx:396
+#: src/pages/Today.tsx:367
+#: src/pages/Today.tsx:389
 msgid "Syncing…"
 msgstr "Syncing…"
 
@@ -2111,16 +2101,11 @@ msgstr "System"
 msgid "System Announcements"
 msgstr "System Announcements"
 
-#: src/pages/Login.tsx:538
-msgid "System theme (click for light)"
-msgstr "System theme (click for light)"
-
 #: src/components/ZoneAnalysisCard.tsx:45
-msgid "target"
-msgstr "target"
+#~ msgid "target"
+#~ msgstr "target"
 
 #: src/components/WorkoutTimeline.tsx:41
-#: src/components/ZoneAnalysisCard.tsx:65
 #: src/pages/Goal.tsx:246
 msgid "Target"
 msgstr "Target"
@@ -2130,13 +2115,13 @@ msgid "Target {metricName}"
 msgstr "Target {metricName}"
 
 #: src/components/SetupChecklist.tsx:72
-#: src/pages/Settings.tsx:1159
+#: src/pages/Settings.tsx:1203
 #: src/pages/Setup.tsx:744
 msgid "Target a race or track continuous improvement"
 msgstr "Target a race or track continuous improvement"
 
 #: src/components/GoalEditor.tsx:152
-#: src/pages/Settings.tsx:1190
+#: src/pages/Settings.tsx:1234
 msgid "Target Time"
 msgstr "Target Time"
 
@@ -2159,16 +2144,16 @@ msgstr "This will permanently delete <0>{0}</0> and all their data (activities, 
 msgid "Threshold"
 msgstr "Threshold"
 
-#: src/lib/display-labels.ts:54
-#: src/pages/Settings.tsx:98
+#: src/lib/display-labels.ts:60
+#: src/pages/Settings.tsx:101
 msgid "Threshold Pace"
 msgstr "Threshold Pace"
 
-#: src/lib/display-labels.ts:58
+#: src/lib/display-labels.ts:64
 msgid "Threshold Pace Trend"
 msgstr "Threshold Pace Trend"
 
-#: src/pages/Settings.tsx:1227
+#: src/pages/Settings.tsx:1271
 msgid "Thresholds"
 msgstr "Thresholds"
 
@@ -2185,14 +2170,14 @@ msgid "To target"
 msgstr "To target"
 
 #: src/components/AppSidebar.tsx:108
-#: src/components/charts/FitnessFatigueChart.tsx:216
+#: src/components/charts/FitnessFatigueChart.tsx:243
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
-#: src/pages/Today.tsx:357
+#: src/pages/Today.tsx:350
 msgid "Today"
 msgstr "Today"
 
-#: src/components/UpcomingPlanCard.tsx:222
+#: src/components/UpcomingPlanCard.tsx:301
 msgid "TODAY"
 msgstr "TODAY"
 
@@ -2208,15 +2193,6 @@ msgstr "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is
 msgid "Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}."
 msgstr "Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}."
 
-#: src/pages/Login.tsx:533
-#: src/pages/Login.tsx:534
-#~ msgid "Toggle theme"
-#~ msgstr "Toggle theme"
-
-#: src/pages/Login.tsx:98
-msgid "Too many attempts from this network. Please email us instead."
-msgstr "Too many attempts from this network. Please email us instead."
-
 #: src/pages/Goal.tsx:141
 msgid "Tracking"
 msgstr "Tracking"
@@ -2226,10 +2202,11 @@ msgid "Train toward a specific race date"
 msgstr "Train toward a specific race date"
 
 #: src/components/AppSidebar.tsx:109
+#: src/pages/Training.tsx:289
 msgid "Training"
 msgstr "Training"
 
-#: src/pages/Settings.tsx:1043
+#: src/pages/Settings.tsx:1046
 msgid "Training Base"
 msgstr "Training Base"
 
@@ -2238,12 +2215,12 @@ msgid "Training Diagnosis"
 msgstr "Training Diagnosis"
 
 #: src/pages/Training.tsx:66
-msgid "Training Insights"
-msgstr "Training Insights"
+#~ msgid "Training Insights"
+#~ msgstr "Training Insights"
 
 #: src/pages/Settings.tsx:62
-msgid "Training plan & targets"
-msgstr "Training plan & targets"
+#~ msgid "Training plan & targets"
+#~ msgstr "Training plan & targets"
 
 #: src/pages/Science.tsx:173
 msgid "Training Science"
@@ -2257,7 +2234,11 @@ msgstr "Training Zones"
 msgid "Translates training stress into fitness."
 msgstr "Translates training stress into fitness."
 
-#: src/components/charts/FitnessFatigueChart.tsx:243
+#: src/pages/Training.tsx:320
+msgid "TSB"
+msgstr "TSB"
+
+#: src/components/charts/FitnessFatigueChart.tsx:276
 msgid "TSB (Form)"
 msgstr "TSB (Form)"
 
@@ -2265,11 +2246,11 @@ msgstr "TSB (Form)"
 msgid "Ultra distance power fractions (50K+) are estimates with limited research backing. Riegel's exponent is validated only up to marathon distance. Predictions beyond marathon carry significantly higher uncertainty due to factors like fueling, terrain, heat, and pacing strategy that dominate ultra performance but are not captured by power/pace models."
 msgstr "Ultra distance power fractions (50K+) are estimates with limited research backing. Riegel's exponent is validated only up to marathon distance. Predictions beyond marathon carry significantly higher uncertainty due to factors like fueling, terrain, heat, and pacing strategy that dominate ultra performance but are not captured by power/pace models."
 
-#: src/pages/Settings.tsx:633
+#: src/pages/Settings.tsx:636
 msgid "Units"
 msgstr "Units"
 
-#: src/components/UpcomingPlanCard.tsx:503
+#: src/components/UpcomingPlanCard.tsx:610
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 
@@ -2277,14 +2258,9 @@ msgstr "Upcoming Plan"
 msgid "Updating..."
 msgstr "Updating..."
 
-#: src/pages/Settings.tsx:960
+#: src/pages/Settings.tsx:963
 msgid "US"
 msgstr "US"
-
-#: src/pages/Login.tsx:396
-#: src/pages/Login.tsx:425
-msgid "Use it"
-msgstr "Use it"
 
 #: src/pages/Science.tsx:175
 #~ msgid "Use this"
@@ -2318,7 +2294,7 @@ msgstr "Users"
 msgid "view"
 msgstr "view"
 
-#: src/pages/Settings.tsx:555
+#: src/pages/Settings.tsx:558
 msgid "Viewing configuration (read-only demo)"
 msgstr "Viewing configuration (read-only demo)"
 
@@ -2326,14 +2302,31 @@ msgstr "Viewing configuration (read-only demo)"
 msgid "VO2max"
 msgstr "VO2max"
 
-#: src/pages/Settings.tsx:1142
+#: src/pages/Settings.tsx:1186
 msgid "VO2max, CP, LTHR, training status"
 msgstr "VO2max, CP, LTHR, training status"
 
+#: src/pages/Training.tsx:373
+msgid "Volume"
+msgstr "Volume"
+
+#. placeholder {0}: data.diagnosis.theory_name
+#: src/pages/Training.tsx:351
+msgid "vs {0}"
+msgstr "vs {0}"
+
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
-#: src/pages/Today.tsx:276
+#: src/pages/Today.tsx:269
 msgid "vs {0} baseline"
 msgstr "vs {0} baseline"
+
+#: src/components/ZoneAnalysisCard.tsx:78
+msgid "vs {theoryName}"
+msgstr "vs {theoryName}"
+
+#: src/pages/Training.tsx:353
+msgid "vs target zones"
+msgstr "vs target zones"
 
 #: src/pages/Setup.tsx:162
 msgid "Walking"
@@ -2343,75 +2336,90 @@ msgstr "Walking"
 msgid "Warmup"
 msgstr "Warmup"
 
-#: src/pages/Login.tsx:341
-msgid "We're inviting runners in waves while we tighten the science. Drop your email and we'll reach back when a slot opens."
-msgstr "We're inviting runners in waves while we tighten the science. Drop your email and we'll reach back when a slot opens."
+#: src/pages/Training.tsx:209
+msgid "Weekly diagnosis ready."
+msgstr "Weekly diagnosis ready."
 
 #: src/components/WeeklyLoadMini.tsx:30
 msgid "Weekly Load"
 msgstr "Weekly Load"
 
 #: src/components/charts/ComplianceChart.tsx:38
-msgid "Weekly Load Compliance"
-msgstr "Weekly Load Compliance"
+#~ msgid "Weekly Load Compliance"
+#~ msgstr "Weekly Load Compliance"
 
 #: src/pages/Training.tsx:67
-msgid "Weekly Review"
-msgstr "Weekly Review"
+#~ msgid "Weekly Review"
+#~ msgstr "Weekly Review"
 
 #: src/components/DiagnosisCard.tsx:41
 msgid "Weekly Volume"
 msgstr "Weekly Volume"
 
-#: src/pages/Login.tsx:246
-msgid "Welcome back."
-msgstr "Welcome back."
-
 #: src/components/GoalEditor.tsx:165
 msgid "What time are you working toward? Leave blank to track trend only"
 msgstr "What time are you working toward? Leave blank to track trend only"
 
-#: src/pages/Login.tsx:370
-msgid "What's your training goal? (optional)"
-msgstr "What's your training goal? (optional)"
+#: src/pages/Settings.tsx:65
+msgid "Where Praxys pushes your plan. Per-workout sync state shows in Training."
+msgstr "Where Praxys pushes your plan. Per-workout sync state shows in Training."
 
 #: src/pages/Setup.tsx:800
 msgid "Will sync:"
 msgstr "Will sync:"
 
+#: src/components/UpcomingPlanCard.tsx:162
+msgid "Workout differs on Stryd — re-push to overwrite"
+msgstr "Workout differs on Stryd — re-push to overwrite"
+
 #: src/pages/Admin.tsx:268
 msgid "you"
 msgstr "you"
 
-#: src/pages/Login.tsx:291
-#: src/pages/Login.tsx:359
-#: src/pages/Login.tsx:445
+#: src/pages/Login.tsx:94
+#: src/pages/Login.tsx:130
 msgid "you@example.com"
 msgstr "you@example.com"
 
-#: src/pages/Settings.tsx:581
+#: src/pages/Settings.tsx:584
 msgid "Your identity in Praxys"
 msgstr "Your identity in Praxys"
 
-#: src/pages/Settings.tsx:607
+#: src/pages/Settings.tsx:610
 msgid "Your name"
 msgstr "Your name"
 
-#: src/pages/Settings.tsx:1002
+#: src/pages/Settings.tsx:1005
 msgid "Your Strava API Client ID"
 msgstr "Your Strava API Client ID"
 
-#: src/pages/Settings.tsx:1012
+#: src/pages/Settings.tsx:1015
 msgid "Your Strava API Client Secret"
 msgstr "Your Strava API Client Secret"
 
 #: src/components/ZoneAnalysisCard.tsx:62
-msgid "Zone"
-msgstr "Zone"
+#~ msgid "Zone"
+#~ msgstr "Zone"
+
+#: src/lib/display-labels.ts:50
+msgid "Zone 1 (Easy)"
+msgstr "Zone 1 (Easy)"
+
+#: src/lib/display-labels.ts:51
+msgid "Zone 2 (Moderate)"
+msgstr "Zone 2 (Moderate)"
+
+#: src/lib/display-labels.ts:52
+msgid "Zone 3 (Hard)"
+msgstr "Zone 3 (Hard)"
 
 #: src/components/ZoneAnalysisCard.tsx:53
-msgid "Zone Analysis"
-msgstr "Zone Analysis"
+#~ msgid "Zone Analysis"
+#~ msgstr "Zone Analysis"
+
+#: src/pages/Training.tsx:419
+msgid "Zone distribution"
+msgstr "Zone distribution"
 
 #: src/pages/Science.tsx:186
 msgid "Zone labels"
@@ -2421,7 +2429,7 @@ msgstr "Zone labels"
 #~ msgid "Zone Labels"
 #~ msgstr "Zone Labels"
 
-#: src/pages/Settings.tsx:68
+#: src/pages/Settings.tsx:71
 msgid "Zones & load from Critical Power"
 msgstr "Zones & load from Critical Power"
 
@@ -2429,12 +2437,12 @@ msgstr "Zones & load from Critical Power"
 msgid "Zones & load from Critical Power (best with Stryd)"
 msgstr "Zones & load from Critical Power (best with Stryd)"
 
-#: src/pages/Settings.tsx:77
+#: src/pages/Settings.tsx:80
 #: src/pages/Setup.tsx:172
 msgid "Zones & load from Lactate Threshold HR"
 msgstr "Zones & load from Lactate Threshold HR"
 
-#: src/pages/Settings.tsx:86
+#: src/pages/Settings.tsx:89
 #: src/pages/Setup.tsx:174
 msgid "Zones & load from Threshold Pace"
 msgstr "Zones & load from Threshold Pace"

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -20,7 +20,7 @@ msgstr " · "
 #. placeholder {0}: data.diagnosis.lookback_weeks
 #: src/pages/Training.tsx:310
 msgid "· last {0} weeks"
-msgstr ""
+msgstr "· 最近 {0} 周"
 
 #: src/pages/Setup.tsx:606
 msgid "(Garmin rate limits apply)"
@@ -41,7 +41,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:617
+#: src/components/UpcomingPlanCard.tsx:591
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -58,7 +58,7 @@ msgstr "第 {0} 步，共 {1} 步"
 #. placeholder {4}: d.target
 #: src/pages/Training.tsx:184
 msgid "{0}: {1}% ({2}pp {3} {4}% target)"
-msgstr ""
+msgstr "{0}：{1}%（{2}pp {3} 目标 {4}%）"
 
 #: src/pages/Goal.tsx:214
 msgid "{abbrev} is <0>{dirLabel}</0>. Add more activities for a race-time prediction."
@@ -115,9 +115,9 @@ msgstr "约 {estimatedActivities} 项活动，约 {estimatedMinutes} 分钟"
 msgid "1 month"
 msgstr "1 个月"
 
-#: src/components/UpcomingPlanCard.tsx:367
+#: src/components/UpcomingPlanCard.tsx:341
 msgid "1 wk"
-msgstr ""
+msgstr "1 周"
 
 #: src/pages/Setup.tsx:182
 msgid "1 year"
@@ -148,9 +148,9 @@ msgstr "10公里"
 msgid "1Y"
 msgstr "1年"
 
-#: src/components/UpcomingPlanCard.tsx:368
+#: src/components/UpcomingPlanCard.tsx:342
 msgid "2 wk"
-msgstr ""
+msgstr "2 周"
 
 #: src/pages/Setup.tsx:180
 msgid "3 months"
@@ -160,9 +160,9 @@ msgstr "3 个月"
 msgid "3M"
 msgstr "3月"
 
-#: src/components/UpcomingPlanCard.tsx:369
+#: src/components/UpcomingPlanCard.tsx:343
 msgid "4 wk"
-msgstr ""
+msgstr "4 周"
 
 #: src/components/GoalEditor.tsx:56
 msgid "50 Mi"
@@ -247,7 +247,7 @@ msgstr "实际"
 
 #: src/pages/Training.tsx:368
 msgid "actual vs planned, avg"
-msgstr ""
+msgstr "实际 vs 计划，平均"
 
 #: src/components/SignalHero.tsx:22
 #: src/pages/Today.tsx:69
@@ -273,9 +273,9 @@ msgstr "有氧"
 msgid "All"
 msgstr "全部"
 
-#: src/components/UpcomingPlanCard.tsx:636
+#: src/components/UpcomingPlanCard.tsx:610
 msgid "All synced"
-msgstr ""
+msgstr "全部已同步"
 
 #: src/pages/Login.tsx:60
 msgid "An unexpected error occurred."
@@ -331,11 +331,11 @@ msgstr "同步历史数据..."
 
 #: src/pages/Training.tsx:333
 msgid "balanced"
-msgstr ""
+msgstr "均衡"
 
 #: src/pages/Training.tsx:406
 msgid "Banister PMC stabilises after about 42 days of activity. Need {daysToPmc} more days."
-msgstr ""
+msgstr "Banister PMC 模型大约需要 42 天活动数据才能稳定。还需 {daysToPmc} 天。"
 
 #. placeholder {0}: recommendedTheory.name
 #. placeholder {1}: recommendation!.reason
@@ -446,8 +446,8 @@ msgid "Click to copy"
 msgstr "点击复制"
 
 #: src/components/UpcomingPlanCard.tsx:205
-msgid "click to retry"
-msgstr "点击重试"
+#~ msgid "click to retry"
+#~ msgstr "点击重试"
 
 #: src/pages/Admin.tsx:371
 msgid "Code"
@@ -468,7 +468,7 @@ msgstr "完成这些步骤以解锁您的训练解读"
 
 #: src/components/charts/ComplianceChart.tsx:171
 msgid "Compliance compares the load you actually accumulated each week (Actual) against the load your plan called for (Planned). The percentage above each bar shows how close you came: green for 80–120% (on target), amber under 80%, red over 120%. The load metric (RSS or W-equivalent) is set by your training base."
-msgstr ""
+msgstr "合规度对比您每周实际累积的负荷（实际）与计划要求的负荷（计划）。每根柱子上方的百分比显示完成程度：80–120% 为绿色（达标）、低于 80% 为琥珀色、高于 120% 为红色。负荷指标（RSS 或当量瓦特）由您的训练基准决定。"
 
 #: src/pages/Settings.tsx:558
 msgid "Configure your training system"
@@ -686,11 +686,15 @@ msgstr "降级为普通用户"
 #: src/pages/Training.tsx:305
 #: src/pages/Training.tsx:308
 msgid "Diagnosis"
-msgstr ""
+msgstr "诊断"
+
+#: src/components/UpcomingPlanCard.tsx:198
+msgid "Differs · overwrite"
+msgstr "存在差异 · 覆盖"
 
 #: src/components/UpcomingPlanCard.tsx:171
-msgid "Differs on Stryd — click to re-push and overwrite."
-msgstr ""
+#~ msgid "Differs on Stryd — click to re-push and overwrite."
+#~ msgstr ""
 
 #: src/pages/Goal.tsx:294
 msgid "Direction"
@@ -724,7 +728,7 @@ msgstr "距离"
 
 #: src/pages/Training.tsx:341
 msgid "Distribution match"
-msgstr ""
+msgstr "分布匹配度"
 
 #: src/pages/Settings.tsx:1273
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
@@ -867,7 +871,7 @@ msgstr "加载设置失败"
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:583
+#: src/components/UpcomingPlanCard.tsx:557
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -886,7 +890,7 @@ msgstr "疲劳"
 
 #: src/pages/Training.tsx:336
 msgid "fatigue accumulating"
-msgstr ""
+msgstr "疲劳累积中"
 
 #: src/components/charts/FormSparkline.tsx:30
 msgid "Fatigue is climbing — watch recovery before adding load."
@@ -936,7 +940,7 @@ msgstr "竞技状态"
 
 #: src/pages/Training.tsx:329
 msgid "form (CTL−ATL)"
-msgstr ""
+msgstr "状态（CTL−ATL）"
 
 #: src/components/charts/FormSparkline.tsx:119
 msgid "Form (TSB)"
@@ -956,7 +960,7 @@ msgstr "充分恢复"
 
 #: src/pages/Training.tsx:331
 msgid "fresh, primed"
-msgstr ""
+msgstr "状态良好"
 
 #: src/components/charts/FormSparkline.tsx:26
 msgid "Freshened up — good window for racing or testing."
@@ -970,9 +974,9 @@ msgstr "数据自 {dataAsOfLabel}"
 msgid "From activities"
 msgstr "来自活动"
 
-#: src/components/UpcomingPlanCard.tsx:147
+#: src/components/UpcomingPlanCard.tsx:159
 msgid "From Stryd"
-msgstr ""
+msgstr "来自 Stryd"
 
 #: src/pages/Goal.tsx:262
 #: src/pages/Goal.tsx:272
@@ -1159,7 +1163,7 @@ msgstr "邀请码"
 #. placeholder {0}: data.diagnosis.lookback_weeks
 #: src/pages/Training.tsx:381
 msgid "km / week, {0}wk avg"
-msgstr ""
+msgstr "公里 / 周，{0} 周均值"
 
 #: src/lib/display-labels.ts:59
 msgid "Lactate Threshold HR"
@@ -1225,11 +1229,11 @@ msgstr "直播演示 — 真实训练数据，只读"
 
 #: src/components/charts/ComplianceChart.tsx:61
 msgid "load ({label})"
-msgstr ""
+msgstr "负荷（{label}）"
 
 #: src/components/charts/ComplianceChart.tsx:60
 msgid "load (Running Stress Score)"
-msgstr ""
+msgstr "负荷（跑步压力分 RSS）"
 
 #: src/pages/Science.tsx:25
 msgid "Load & Fitness"
@@ -1238,7 +1242,7 @@ msgstr "负荷与体能"
 #: src/pages/Training.tsx:359
 #: src/pages/Training.tsx:433
 msgid "Load compliance"
-msgstr ""
+msgstr "负荷合规度"
 
 #: src/pages/Login.tsx:71
 msgid "Log in to connect your CLI plugin"
@@ -1315,14 +1319,14 @@ msgstr "月"
 #. placeholder {2}: worstDeviation.target
 #: src/pages/Training.tsx:190
 msgid "Most over-target: {0} at {1}% (target {2}%). Shift 1-2 sessions next week toward an under-target zone."
-msgstr ""
+msgstr "最超标区间：{0} 为 {1}%（目标 {2}%）。下周将 1-2 次训练转向欠达标区间。"
 
 #. placeholder {0}: tDisplay(worstDeviation.name, i18n)
 #. placeholder {1}: worstDeviation.actual
 #. placeholder {2}: worstDeviation.target
 #: src/pages/Training.tsx:193
 msgid "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
-msgstr ""
+msgstr "最欠达标区间：{0} 为 {1}%（目标 {2}%）。下周在此区间增加 1-2 次训练。"
 
 #. placeholder {0}: primaryPrompt?.category
 #: src/pages/Setup.tsx:976
@@ -1331,7 +1335,7 @@ msgstr "多个平台提供 <0>{0}</0> 数据。应将哪个作为主要来源？
 
 #: src/pages/Training.tsx:441
 msgid "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
-msgstr ""
+msgstr "需要 2 周已同步的活动数据才能对比计划与实际。还差 {daysToCompare} 天。"
 
 #: src/pages/Training.tsx:112
 #~ msgid "Need at least 3 activities with power data to plot a meaningful trend."
@@ -1408,9 +1412,9 @@ msgstr "没有可用的分段数据。"
 msgid "No Workout"
 msgstr "无训练"
 
-#: src/components/UpcomingPlanCard.tsx:658
+#: src/components/UpcomingPlanCard.tsx:632
 msgid "No workouts scheduled in this window."
-msgstr ""
+msgstr "此窗口内暂无安排的训练。"
 
 #: src/pages/Today.tsx:125
 msgid "normal"
@@ -1443,11 +1447,11 @@ msgstr "数据不足以显示 CP 趋势"
 
 #: src/pages/Training.tsx:405
 msgid "Not enough data yet for accurate fitness tracking"
-msgstr ""
+msgstr "数据不足，暂无法准确跟踪体能"
 
 #: src/pages/Training.tsx:440
 msgid "Not enough data yet for weekly load comparison"
-msgstr ""
+msgstr "数据不足，暂无法对比每周负荷"
 
 #: src/pages/Settings.tsx:1306
 msgid "Not set"
@@ -1489,6 +1493,10 @@ msgstr "其他信号"
 msgid "overnight score"
 msgstr "夜间评分"
 
+#: src/components/UpcomingPlanCard.tsx:194
+msgid "Overwrite Stryd with Praxys version"
+msgstr "用 Praxys 版本覆盖 Stryd"
+
 #: src/components/ActivityCard.tsx:121
 #: src/components/SplitBreakdown.tsx:50
 #: src/lib/display-labels.ts:56
@@ -1519,11 +1527,11 @@ msgstr "计划"
 
 #: src/pages/Settings.tsx:65
 msgid "Plan sync target"
-msgstr ""
+msgstr "计划同步目标"
 
-#: src/components/UpcomingPlanCard.tsx:374
+#: src/components/UpcomingPlanCard.tsx:348
 msgid "Plan window"
-msgstr ""
+msgstr "计划时间窗口"
 
 #: src/components/charts/ComplianceChart.tsx:107
 #: src/components/charts/ComplianceChart.tsx:151
@@ -1603,7 +1611,7 @@ msgstr "训练数据的主要来源"
 
 #: src/pages/Training.tsx:335
 msgid "productive load"
-msgstr ""
+msgstr "负荷富有成效"
 
 #: src/pages/Settings.tsx:583
 msgid "Profile"
@@ -1637,12 +1645,19 @@ msgstr "拉取您最近的活动、功率数据和恢复指标"
 #~ msgstr "全部推送"
 
 #: src/components/UpcomingPlanCard.tsx:205
-msgid "Push failed"
-msgstr "推送失败"
+#~ msgid "Push failed"
+#~ msgstr "推送失败"
 
-#: src/components/UpcomingPlanCard.tsx:248
-#: src/components/UpcomingPlanCard.tsx:256
-#: src/components/UpcomingPlanCard.tsx:641
+#: src/components/UpcomingPlanCard.tsx:178
+msgid "Push failed — click to retry"
+msgstr "推送失败 — 点击重试"
+
+#: src/components/UpcomingPlanCard.tsx:227
+msgid "Push this workout to your Stryd calendar."
+msgstr "将此训练推送至您的 Stryd 日历。"
+
+#: src/components/UpcomingPlanCard.tsx:228
+#: src/components/UpcomingPlanCard.tsx:615
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
@@ -1650,9 +1665,9 @@ msgstr "推送到 Stryd"
 #~ msgid "Pushing..."
 #~ msgstr "正在推送..."
 
-#: src/components/UpcomingPlanCard.tsx:631
+#: src/components/UpcomingPlanCard.tsx:605
 msgid "Pushing…"
-msgstr ""
+msgstr "推送中…"
 
 #: src/lib/display-labels.ts:74
 #: src/pages/Goal.tsx:109
@@ -1686,8 +1701,7 @@ msgstr "比赛预测"
 #~ msgid "Range"
 #~ msgstr "范围"
 
-#: src/components/UpcomingPlanCard.tsx:222
-#: src/components/UpcomingPlanCard.tsx:231
+#: src/components/UpcomingPlanCard.tsx:212
 msgid "Re-push to Stryd"
 msgstr "重新推送到 Stryd"
 
@@ -1813,7 +1827,8 @@ msgstr "休息日。今日无训练安排。"
 msgid "Resting HR"
 msgstr "静息心率"
 
-#: src/components/UpcomingPlanCard.tsx:586
+#: src/components/UpcomingPlanCard.tsx:183
+#: src/components/UpcomingPlanCard.tsx:560
 #: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:319
@@ -1822,7 +1837,7 @@ msgstr "静息心率"
 msgid "Retry"
 msgstr "重试"
 
-#: src/components/UpcomingPlanCard.tsx:197
+#: src/components/UpcomingPlanCard.tsx:179
 msgid "Retry push to Stryd"
 msgstr "重试推送到 Stryd"
 
@@ -2071,14 +2086,23 @@ msgstr "同步历史"
 msgid "Sync now"
 msgstr "立即同步"
 
+#: src/components/UpcomingPlanCard.tsx:232
+msgid "Sync to Stryd"
+msgstr "同步至 Stryd"
+
 #: src/components/SetupChecklist.tsx:55
 #: src/pages/Setup.tsx:566
 msgid "Sync your data"
 msgstr "同步数据"
 
+#: src/components/UpcomingPlanCard.tsx:217
 #: src/pages/Settings.tsx:808
 msgid "Synced"
 msgstr "已同步"
+
+#: src/components/UpcomingPlanCard.tsx:211
+msgid "Synced to Stryd. Click to re-push."
+msgstr "已同步至 Stryd。点击重新推送。"
 
 #: src/pages/Settings.tsx:805
 msgid "Syncing"
@@ -2088,6 +2112,7 @@ msgstr "同步中"
 msgid "Syncing..."
 msgstr "同步中..."
 
+#: src/components/UpcomingPlanCard.tsx:168
 #: src/pages/Today.tsx:367
 #: src/pages/Today.tsx:389
 msgid "Syncing…"
@@ -2139,6 +2164,14 @@ msgstr "主题"
 msgid "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 msgstr "这将永久删除 <0>{0}</0> 及其所有数据（活动、配置、连接、计划）。此操作无法撤销。"
 
+#: src/components/UpcomingPlanCard.tsx:193
+msgid "This workout differs on Stryd — click to overwrite with the Praxys version."
+msgstr "Stryd 上的此训练有差异 — 点击用 Praxys 版本覆盖。"
+
+#: src/components/UpcomingPlanCard.tsx:157
+msgid "This workout was imported from Stryd."
+msgstr "此训练来自 Stryd 导入。"
+
 #: src/lib/display-labels.ts:45
 #: src/lib/phase-label.ts:15
 msgid "Threshold"
@@ -2177,7 +2210,7 @@ msgstr "距目标"
 msgid "Today"
 msgstr "今日"
 
-#: src/components/UpcomingPlanCard.tsx:301
+#: src/components/UpcomingPlanCard.tsx:275
 msgid "TODAY"
 msgstr "今日"
 
@@ -2236,7 +2269,7 @@ msgstr "将训练应激转化为体能。"
 
 #: src/pages/Training.tsx:320
 msgid "TSB"
-msgstr ""
+msgstr "TSB"
 
 #: src/components/charts/FitnessFatigueChart.tsx:276
 msgid "TSB (Form)"
@@ -2250,7 +2283,7 @@ msgstr "超长距离功率分数（50K+）为估算值，研究支持有限。Ri
 msgid "Units"
 msgstr "单位"
 
-#: src/components/UpcomingPlanCard.tsx:610
+#: src/components/UpcomingPlanCard.tsx:584
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 
@@ -2308,12 +2341,12 @@ msgstr "VO2max、CP、LTHR、训练状态"
 
 #: src/pages/Training.tsx:373
 msgid "Volume"
-msgstr ""
+msgstr "里程"
 
 #. placeholder {0}: data.diagnosis.theory_name
 #: src/pages/Training.tsx:351
 msgid "vs {0}"
-msgstr ""
+msgstr "vs {0}"
 
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
 #: src/pages/Today.tsx:269
@@ -2322,11 +2355,11 @@ msgstr "对比基准 {0}"
 
 #: src/components/ZoneAnalysisCard.tsx:78
 msgid "vs {theoryName}"
-msgstr ""
+msgstr "vs {theoryName}"
 
 #: src/pages/Training.tsx:353
 msgid "vs target zones"
-msgstr ""
+msgstr "vs 目标区间"
 
 #: src/pages/Setup.tsx:162
 msgid "Walking"
@@ -2338,7 +2371,7 @@ msgstr "热身"
 
 #: src/pages/Training.tsx:209
 msgid "Weekly diagnosis ready."
-msgstr ""
+msgstr "周度诊断已就绪。"
 
 #: src/components/WeeklyLoadMini.tsx:30
 msgid "Weekly Load"
@@ -2362,15 +2395,15 @@ msgstr "您的目标时间是多少？留空则仅追踪趋势"
 
 #: src/pages/Settings.tsx:65
 msgid "Where Praxys pushes your plan. Per-workout sync state shows in Training."
-msgstr ""
+msgstr "Praxys 将计划推送到的目标平台。每个训练的同步状态显示在训练页。"
 
 #: src/pages/Setup.tsx:800
 msgid "Will sync:"
 msgstr "将同步："
 
 #: src/components/UpcomingPlanCard.tsx:162
-msgid "Workout differs on Stryd — re-push to overwrite"
-msgstr ""
+#~ msgid "Workout differs on Stryd — re-push to overwrite"
+#~ msgstr ""
 
 #: src/pages/Admin.tsx:268
 msgid "you"
@@ -2403,15 +2436,15 @@ msgstr "你的 Strava API 客户端密钥"
 
 #: src/lib/display-labels.ts:50
 msgid "Zone 1 (Easy)"
-msgstr ""
+msgstr "第 1 区（轻松）"
 
 #: src/lib/display-labels.ts:51
 msgid "Zone 2 (Moderate)"
-msgstr ""
+msgstr "第 2 区（中等）"
 
 #: src/lib/display-labels.ts:52
 msgid "Zone 3 (Hard)"
-msgstr ""
+msgstr "第 3 区（高强度）"
 
 #: src/components/ZoneAnalysisCard.tsx:53
 #~ msgid "Zone Analysis"
@@ -2419,7 +2452,7 @@ msgstr ""
 
 #: src/pages/Training.tsx:419
 msgid "Zone distribution"
-msgstr ""
+msgstr "区间分布"
 
 #: src/pages/Science.tsx:186
 msgid "Zone labels"

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -107,6 +107,22 @@ msgstr "距比赛日还有 <0>{days}</0> 天。当前预测 <1>{predicted}</1>�
 msgid "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>."
 msgstr "距比赛日还有 <0>{days}</0> 天。当前预测 <1>{predicted}</1>。"
 
+#: src/pages/Login.tsx:200
+msgid "<0>Cited science.</0> No hype."
+msgstr ""
+
+#: src/pages/Login.tsx:192
+msgid "<0>Diagnosis & forecast</0> you can verify."
+msgstr ""
+
+#: src/pages/Login.tsx:184
+msgid "<0>Today's signal</0> · go, modify, or rest."
+msgstr ""
+
+#: src/pages/Login.tsx:407
+msgid "<0>You're on the list.</0> We'll reach out from <1>{SUPPORT_EMAIL}</1> when a slot opens."
+msgstr ""
+
 #: src/pages/Setup.tsx:605
 msgid "~{estimatedActivities} activities, ~{estimatedMinutes} min"
 msgstr "约 {estimatedActivities} 项活动，约 {estimatedMinutes} 分钟"
@@ -277,7 +293,12 @@ msgstr "全部"
 msgid "All synced"
 msgstr "全部已同步"
 
-#: src/pages/Login.tsx:60
+#: src/pages/Login.tsx:390
+#: src/pages/Login.tsx:415
+msgid "Already have an invitation code?"
+msgstr ""
+
+#: src/pages/Login.tsx:72
 msgid "An unexpected error occurred."
 msgstr "发生了意外错误。"
 
@@ -288,6 +309,10 @@ msgstr "亚洲/中国"
 #: src/components/charts/FitnessFatigueChart.tsx:275
 msgid "ATL (Fatigue)"
 msgstr "ATL（疲劳）"
+
+#: src/pages/Login.tsx:254
+msgid "Authentication mode"
+msgstr ""
 
 #: src/pages/Setup.tsx:198
 msgid "Authorize Praxys with Strava in your browser. Praxys only syncs activities from Strava."
@@ -542,6 +567,10 @@ msgstr "放松"
 #~ msgid "Cosmetic — changes names and colors without affecting calculations"
 #~ msgstr "仅外观——更改名称与颜色，不影响计算"
 
+#: src/pages/Login.tsx:112
+msgid "Could not save your email. Please email us instead."
+msgstr ""
+
 #: src/components/charts/CpTrendChart.tsx:59
 #: src/lib/display-labels.ts:62
 msgid "CP Trend"
@@ -552,7 +581,7 @@ msgstr "CP 趋势"
 msgid "Create"
 msgstr "创建"
 
-#: src/pages/Login.tsx:164
+#: src/pages/Login.tsx:488
 msgid "Create account"
 msgstr "创建账号"
 
@@ -561,8 +590,12 @@ msgid "Created"
 msgstr "创建时间"
 
 #: src/pages/Login.tsx:164
-msgid "Creating account..."
-msgstr "创建中..."
+#~ msgid "Creating account..."
+#~ msgstr "创建中..."
+
+#: src/pages/Login.tsx:488
+msgid "Creating account…"
+msgstr ""
 
 #: src/pages/Admin.tsx:475
 #: src/pages/Admin.tsx:594
@@ -607,6 +640,10 @@ msgstr "每日评分"
 #: src/components/AppSidebar.tsx:29
 msgid "Dark"
 msgstr "深色"
+
+#: src/pages/Login.tsx:537
+msgid "Dark theme (click for system)"
+msgstr ""
 
 #: src/pages/Settings.tsx:1107
 msgid "Data Preferences"
@@ -712,6 +749,10 @@ msgstr "讨论"
 msgid "Dismissible banners shown to all users"
 msgstr "向所有用户显示的可关闭横幅"
 
+#: src/pages/Login.tsx:509
+msgid "Display preferences"
+msgstr ""
+
 #: src/components/SplitBreakdown.tsx:46
 msgid "Dist"
 msgstr "距离"
@@ -803,15 +844,20 @@ msgstr "升高"
 
 #: src/pages/Admin.tsx:256
 #: src/pages/Admin.tsx:450
-#: src/pages/Login.tsx:90
-#: src/pages/Login.tsx:126
+#: src/pages/Login.tsx:285
+#: src/pages/Login.tsx:353
+#: src/pages/Login.tsx:439
 #: src/pages/Setup.tsx:206
 msgid "Email"
 msgstr "邮箱"
 
-#: src/pages/Login.tsx:37
+#: src/pages/Login.tsx:48
 msgid "Email and password are required."
 msgstr "请输入邮箱和密码。"
+
+#: src/pages/Login.tsx:81
+msgid "Email is required."
+msgstr ""
 
 #: src/lib/display-labels.ts:43
 msgid "Endurance"
@@ -1003,6 +1049,10 @@ msgstr "生成"
 msgid "Generate a token at cloud.ouraring.com/personal-access-tokens."
 msgstr "请在 cloud.ouraring.com/personal-access-tokens 生成一个令牌。"
 
+#: src/pages/Login.tsx:242
+msgid "Get access"
+msgstr ""
+
 #: src/components/SetupChecklist.tsx:94
 msgid "Get started with Praxys"
 msgstr "开始使用 Praxys"
@@ -1152,13 +1202,23 @@ msgstr "国际"
 msgid "Invalid time format. Use H:MM:SS or H:MM"
 msgstr "时间格式无效。请使用 H:MM:SS 或 H:MM"
 
+#: src/pages/Login.tsx:472
+msgid "Invitation code"
+msgstr ""
+
 #: src/pages/Login.tsx:149
-msgid "Invitation Code"
-msgstr "邀请码"
+#~ msgid "Invitation Code"
+#~ msgstr "邀请码"
 
 #: src/pages/Admin.tsx:334
 msgid "Invitation Codes"
 msgstr "邀请码"
+
+#: src/pages/Login.tsx:339
+#: src/pages/Login.tsx:386
+#: src/pages/Login.tsx:498
+msgid "Join the waitlist"
+msgstr ""
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
 #: src/pages/Training.tsx:381
@@ -1192,8 +1252,8 @@ msgid "Last synced {0}"
 msgstr "上次同步 {0}"
 
 #: src/pages/Login.tsx:160
-msgid "Leave blank for the first account. Required after that."
-msgstr "首个账号可留空，之后必填。"
+#~ msgid "Leave blank for the first account. Required after that."
+#~ msgstr "首个账号可留空，之后必填。"
 
 #: src/components/GoalEditor.tsx:164
 msgid "Leave blank to track predicted time only"
@@ -1202,6 +1262,10 @@ msgstr "留空则仅追踪预测时间"
 #: src/components/AppSidebar.tsx:30
 msgid "Light"
 msgstr "浅色"
+
+#: src/pages/Login.tsx:535
+msgid "Light theme (click for dark)"
+msgstr ""
 
 #: src/pages/Setup.tsx:514
 msgid "Link at least one data source to start"
@@ -1245,8 +1309,8 @@ msgid "Load compliance"
 msgstr "负荷合规度"
 
 #: src/pages/Login.tsx:71
-msgid "Log in to connect your CLI plugin"
-msgstr "登录以连接 CLI 插件"
+#~ msgid "Log in to connect your CLI plugin"
+#~ msgstr "登录以连接 CLI 插件"
 
 #: src/components/AppSidebar.tsx:193
 #: src/components/AppSidebar.tsx:195
@@ -1254,8 +1318,8 @@ msgid "Log out"
 msgstr "退出登录"
 
 #: src/pages/Login.tsx:78
-msgid "Login"
-msgstr "登录"
+#~ msgid "Login"
+#~ msgstr "登录"
 
 #: src/pages/Today.tsx:124
 msgid "low"
@@ -1345,6 +1409,10 @@ msgstr "需要 2 周已同步的活动数据才能对比计划与实际。还差
 msgid "Need at least 3 activities with power data."
 msgstr "需要至少 3 次带功率数据的活动。"
 
+#: src/pages/Login.tsx:507
+msgid "Need help? {SUPPORT_EMAIL}"
+msgstr ""
+
 #: src/pages/Goal.tsx:255
 msgid "Needed {abbrev}"
 msgstr "所需 {abbrev}"
@@ -1353,6 +1421,10 @@ msgstr "所需 {abbrev}"
 msgid "Network error. Is the server running?"
 msgstr "网络错误。服务器在运行吗？"
 
+#: src/pages/Login.tsx:118
+msgid "Network error. Please email {SUPPORT_EMAIL} directly."
+msgstr ""
+
 #: src/pages/Admin.tsx:559
 msgid "New announcement"
 msgstr "新公告"
@@ -1360,6 +1432,10 @@ msgstr "新公告"
 #: src/pages/Admin.tsx:359
 msgid "New invitation code:"
 msgstr "新邀请码："
+
+#: src/pages/Login.tsx:322
+msgid "New to Praxys?"
+msgstr ""
 
 #: src/pages/History.tsx:96
 msgid "Next"
@@ -1376,6 +1452,10 @@ msgstr "未找到活动。"
 #: src/pages/Admin.tsx:600
 msgid "No announcements yet"
 msgstr "还没有公告"
+
+#: src/pages/Login.tsx:492
+msgid "No code yet?"
+msgstr ""
 
 #: src/pages/Today.tsx:269
 #: src/pages/Today.tsx:431
@@ -1506,8 +1586,8 @@ msgid "Pace"
 msgstr "配速"
 
 #: src/pages/Admin.tsx:460
-#: src/pages/Login.tsx:102
-#: src/pages/Login.tsx:138
+#: src/pages/Login.tsx:302
+#: src/pages/Login.tsx:456
 #: src/pages/Setup.tsx:207
 msgid "Password"
 msgstr "密码"
@@ -1550,6 +1630,10 @@ msgstr "计划中的条形为估算值 — 您的计划在当前训练基础下�
 msgid "Planned Workout"
 msgstr "计划训练"
 
+#: src/pages/Login.tsx:104
+msgid "Please check your email format and try again."
+msgstr ""
+
 #: src/pages/Today.tsx:278
 msgid "positive"
 msgstr "状态良好"
@@ -1566,8 +1650,8 @@ msgid "Power metrics, Critical Power, training plans"
 msgstr "功率指标、阈值功率、训练计划"
 
 #: src/pages/Login.tsx:72
-msgid "Power-based training dashboard"
-msgstr "功率训练仪表盘"
+#~ msgid "Power-based training dashboard"
+#~ msgstr "功率训练仪表盘"
 
 #: src/components/AiInsightsCard.tsx:132
 msgid "Praxys Coach"
@@ -1576,6 +1660,10 @@ msgstr "Praxys 教练"
 #: src/components/AiInsightsCard.tsx:130
 msgid "Praxys Coach insight"
 msgstr "Praxys 教练分析"
+
+#: src/pages/Login.tsx:247
+msgid "Praxys is in private alpha."
+msgstr ""
 
 #: src/pages/Goal.tsx:241
 #: src/pages/Goal.tsx:278
@@ -1608,6 +1696,10 @@ msgstr "作为 {0} 的主要来源"
 #: src/pages/Settings.tsx:60
 msgid "Primary source for workout data"
 msgstr "训练数据的主要来源"
+
+#: src/pages/Login.tsx:136
+msgid "Private alpha · Invitation only"
+msgstr ""
 
 #: src/pages/Training.tsx:335
 msgid "productive load"
@@ -1795,8 +1887,8 @@ msgid "Region"
 msgstr "地区"
 
 #: src/pages/Login.tsx:79
-msgid "Register"
-msgstr "注册"
+#~ msgid "Register"
+#~ msgstr "注册"
 
 #: src/pages/Admin.tsx:258
 msgid "Registered"
@@ -1809,6 +1901,14 @@ msgstr "注册账号"
 #: src/lib/phase-label.ts:18
 msgid "Rep"
 msgstr "组"
+
+#: src/pages/Login.tsx:328
+msgid "Request an invite"
+msgstr ""
+
+#: src/pages/Login.tsx:272
+msgid "Request invite"
+msgstr ""
 
 #: src/lib/phase-label.ts:17
 msgid "Rest"
@@ -1881,6 +1981,10 @@ msgstr "保存目标"
 msgid "Saving..."
 msgstr "保存中..."
 
+#: src/pages/Login.tsx:386
+msgid "Saving…"
+msgstr ""
+
 #: src/components/AppSidebar.tsx:115
 msgid "Science"
 msgstr "科学"
@@ -1950,13 +2054,23 @@ msgstr "显示"
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "显示的是昨天的快照。最近一次读数 {dataAsOfLabel}。"
 
-#: src/pages/Login.tsx:113
+#: src/pages/Login.tsx:241
+#: src/pages/Login.tsx:263
+#: src/pages/Login.tsx:318
 msgid "Sign in"
 msgstr "登录"
 
+#: src/pages/Login.tsx:234
+msgid "Sign in to connect your CLI plugin."
+msgstr ""
+
 #: src/pages/Login.tsx:113
-msgid "Signing in..."
-msgstr "登录中..."
+#~ msgid "Signing in..."
+#~ msgstr "登录中..."
+
+#: src/pages/Login.tsx:318
+msgid "Signing in…"
+msgstr ""
 
 #: src/pages/Science.tsx:132
 #~ msgid "Simple"
@@ -1993,6 +2107,10 @@ msgstr "睡眠、HRV、恢复度"
 #: src/pages/Goal.tsx:382
 msgid "Source"
 msgstr "来源"
+
+#: src/pages/Login.tsx:175
+msgid "Sports science that <0>meets you</0> where you are."
+msgstr ""
 
 #: src/pages/Today.tsx:111
 #: src/pages/Today.tsx:122
@@ -2035,6 +2153,10 @@ msgstr "挑战目标"
 msgid "strongly positive"
 msgstr "状态极佳"
 
+#: src/pages/Login.tsx:376
+msgid "Sub-3 marathon · 100K · stay healthy…"
+msgstr ""
+
 #: src/components/DiagnosisCard.tsx:87
 msgid "Suggestions"
 msgstr "建议"
@@ -2043,10 +2165,27 @@ msgstr "建议"
 msgid "Swimming"
 msgstr "游泳"
 
+#: src/pages/Login.tsx:514
+#: src/pages/Login.tsx:515
+msgid "Switch language"
+msgstr ""
+
 #. placeholder {0}: previewedTheory.name
 #: src/pages/Science.tsx:428
 msgid "Switch to {0}"
 msgstr "切换为 {0}"
+
+#: src/pages/Login.tsx:528
+msgid "Switch to dark theme"
+msgstr ""
+
+#: src/pages/Login.tsx:531
+msgid "Switch to light theme"
+msgstr ""
+
+#: src/pages/Login.tsx:530
+msgid "Switch to system theme"
+msgstr ""
 
 #: src/components/SetupChecklist.tsx:59
 #: src/pages/Settings.tsx:812
@@ -2125,6 +2264,10 @@ msgstr "跟随系统"
 #: src/pages/Admin.tsx:551
 msgid "System Announcements"
 msgstr "系统公告"
+
+#: src/pages/Login.tsx:538
+msgid "System theme (click for light)"
+msgstr ""
 
 #: src/components/ZoneAnalysisCard.tsx:45
 #~ msgid "target"
@@ -2226,6 +2369,10 @@ msgstr "当前 <0>{distLabel}</0> 预测 <1>{predicted}</1>。{abbrev} 趋势 <2
 msgid "Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}."
 msgstr "今日的恢复尚未同步。显示 {latestDateLabel} 的最新读数。"
 
+#: src/pages/Login.tsx:98
+msgid "Too many attempts from this network. Please email us instead."
+msgstr ""
+
 #: src/pages/Goal.tsx:141
 msgid "Tracking"
 msgstr "跟踪"
@@ -2294,6 +2441,11 @@ msgstr "更新中..."
 #: src/pages/Settings.tsx:963
 msgid "US"
 msgstr "美国"
+
+#: src/pages/Login.tsx:396
+#: src/pages/Login.tsx:425
+msgid "Use it"
+msgstr ""
 
 #: src/pages/Science.tsx:175
 #~ msgid "Use this"
@@ -2369,6 +2521,10 @@ msgstr "步行"
 msgid "Warmup"
 msgstr "热身"
 
+#: src/pages/Login.tsx:341
+msgid "We're inviting runners in waves while we tighten the science. Drop your email and we'll reach back when a slot opens."
+msgstr ""
+
 #: src/pages/Training.tsx:209
 msgid "Weekly diagnosis ready."
 msgstr "周度诊断已就绪。"
@@ -2389,9 +2545,17 @@ msgstr "周训练负荷"
 msgid "Weekly Volume"
 msgstr "周里程"
 
+#: src/pages/Login.tsx:246
+msgid "Welcome back."
+msgstr ""
+
 #: src/components/GoalEditor.tsx:165
 msgid "What time are you working toward? Leave blank to track trend only"
 msgstr "您的目标时间是多少？留空则仅追踪趋势"
+
+#: src/pages/Login.tsx:370
+msgid "What's your training goal? (optional)"
+msgstr ""
 
 #: src/pages/Settings.tsx:65
 msgid "Where Praxys pushes your plan. Per-workout sync state shows in Training."
@@ -2409,8 +2573,9 @@ msgstr "将同步："
 msgid "you"
 msgstr "您"
 
-#: src/pages/Login.tsx:94
-#: src/pages/Login.tsx:130
+#: src/pages/Login.tsx:291
+#: src/pages/Login.tsx:359
+#: src/pages/Login.tsx:445
 msgid "you@example.com"
 msgstr "you@example.com"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -13,9 +13,14 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/AiInsightsCard.tsx:110
+#: src/components/AiInsightsCard.tsx:161
 msgid " · "
 msgstr " · "
+
+#. placeholder {0}: data.diagnosis.lookback_weeks
+#: src/pages/Training.tsx:310
+msgid "· last {0} weeks"
+msgstr ""
 
 #: src/pages/Setup.tsx:606
 msgid "(Garmin rate limits apply)"
@@ -25,18 +30,18 @@ msgstr "（受 Garmin 速率限制影响）"
 msgid "(optional)"
 msgstr "（可选）"
 
-#. placeholder {0}: findings.length
-#: src/components/AiInsightsCard.tsx:104
+#. placeholder {0}: content.findings.length
+#: src/components/AiInsightsCard.tsx:155
 msgid "{0, plural, one {# finding} other {# findings}}"
 msgstr "{0, plural, other {# 条发现}}"
 
-#. placeholder {0}: recommendations.length
-#: src/components/AiInsightsCard.tsx:112
+#. placeholder {0}: content.recommendations.length
+#: src/components/AiInsightsCard.tsx:163
 msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:507
+#: src/components/UpcomingPlanCard.tsx:617
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -45,6 +50,15 @@ msgstr "{0, plural, other {# 次训练}}"
 #: src/pages/Setup.tsx:491
 msgid "{0} of {1} steps complete"
 msgstr "第 {0} 步，共 {1} 步"
+
+#. placeholder {0}: tDisplay(d.name, i18n)
+#. placeholder {1}: d.actual
+#. placeholder {2}: d.absDiff
+#. placeholder {3}: d.diff > 0 ? t`above` : t`below`
+#. placeholder {4}: d.target
+#: src/pages/Training.tsx:184
+msgid "{0}: {1}% ({2}pp {3} {4}% target)"
+msgstr ""
 
 #: src/pages/Goal.tsx:214
 msgid "{abbrev} is <0>{dirLabel}</0>. Add more activities for a race-time prediction."
@@ -93,22 +107,6 @@ msgstr "距比赛日还有 <0>{days}</0> 天。当前预测 <1>{predicted}</1>�
 msgid "<0>{days}</0> days to race day. Today's prediction is <1>{predicted}</1>."
 msgstr "距比赛日还有 <0>{days}</0> 天。当前预测 <1>{predicted}</1>。"
 
-#: src/pages/Login.tsx:200
-msgid "<0>Cited science.</0> No hype."
-msgstr "<0>有据可查的科学。</0>不浮夸。"
-
-#: src/pages/Login.tsx:192
-msgid "<0>Diagnosis & forecast</0> you can verify."
-msgstr "<0>可验证的</0>诊断与预测。"
-
-#: src/pages/Login.tsx:184
-msgid "<0>Today's signal</0> · go, modify, or rest."
-msgstr "<0>今日信号</0> · 训练、调整或休息。"
-
-#: src/pages/Login.tsx:407
-msgid "<0>You're on the list.</0> We'll reach out from <1>{SUPPORT_EMAIL}</1> when a slot opens."
-msgstr "<0>已加入候补名单。</0>有空位时，我们会从 <1>{SUPPORT_EMAIL}</1> 与您联系。"
-
 #: src/pages/Setup.tsx:605
 msgid "~{estimatedActivities} activities, ~{estimatedMinutes} min"
 msgstr "约 {estimatedActivities} 项活动，约 {estimatedMinutes} 分钟"
@@ -116,6 +114,10 @@ msgstr "约 {estimatedActivities} 项活动，约 {estimatedMinutes} 分钟"
 #: src/pages/Setup.tsx:179
 msgid "1 month"
 msgstr "1 个月"
+
+#: src/components/UpcomingPlanCard.tsx:367
+msgid "1 wk"
+msgstr ""
 
 #: src/pages/Setup.tsx:182
 msgid "1 year"
@@ -125,26 +127,30 @@ msgstr "1 年"
 msgid "100 Mi"
 msgstr "100 英里"
 
-#: src/lib/display-labels.ts:67
-#: src/pages/Settings.tsx:183
+#: src/lib/display-labels.ts:73
+#: src/pages/Settings.tsx:186
 msgid "100 Mile"
 msgstr "100英里"
 
 #: src/components/GoalEditor.tsx:57
-#: src/lib/display-labels.ts:66
-#: src/pages/Settings.tsx:182
+#: src/lib/display-labels.ts:72
+#: src/pages/Settings.tsx:185
 msgid "100K"
 msgstr "100公里"
 
 #: src/components/GoalEditor.tsx:52
-#: src/lib/display-labels.ts:63
-#: src/pages/Settings.tsx:177
+#: src/lib/display-labels.ts:69
+#: src/pages/Settings.tsx:180
 msgid "10K"
 msgstr "10公里"
 
 #: src/components/charts/CpTrendChart.tsx:55
 msgid "1Y"
 msgstr "1年"
+
+#: src/components/UpcomingPlanCard.tsx:368
+msgid "2 wk"
+msgstr ""
 
 #: src/pages/Setup.tsx:180
 msgid "3 months"
@@ -154,24 +160,28 @@ msgstr "3 个月"
 msgid "3M"
 msgstr "3月"
 
+#: src/components/UpcomingPlanCard.tsx:369
+msgid "4 wk"
+msgstr ""
+
 #: src/components/GoalEditor.tsx:56
 msgid "50 Mi"
 msgstr "50 英里"
 
-#: src/lib/display-labels.ts:65
-#: src/pages/Settings.tsx:181
+#: src/lib/display-labels.ts:71
+#: src/pages/Settings.tsx:184
 msgid "50 Mile"
 msgstr "50英里"
 
 #: src/components/GoalEditor.tsx:55
-#: src/lib/display-labels.ts:64
-#: src/pages/Settings.tsx:180
+#: src/lib/display-labels.ts:70
+#: src/pages/Settings.tsx:183
 msgid "50K"
 msgstr "50公里"
 
 #: src/components/GoalEditor.tsx:51
-#: src/lib/display-labels.ts:62
-#: src/pages/Settings.tsx:176
+#: src/lib/display-labels.ts:68
+#: src/pages/Settings.tsx:179
 msgid "5K"
 msgstr "5公里"
 
@@ -184,12 +194,11 @@ msgid "6M"
 msgstr "6月"
 
 #: src/components/RecoveryPanel.tsx:141
-#: src/pages/Today.tsx:427
+#: src/pages/Today.tsx:431
 msgid "7d Trend"
 msgstr "7天趋势"
 
-
-#: src/components/ZoneAnalysisCard.tsx:44
+#: src/pages/Training.tsx:184
 msgid "above"
 msgstr "高于"
 
@@ -222,7 +231,7 @@ msgstr "活动"
 msgid "Activities only: runs, rides, pace, heart rate, route data"
 msgstr "仅活动数据：跑步、骑行、配速、心率、路线数据"
 
-#: src/pages/Settings.tsx:994
+#: src/pages/Settings.tsx:997
 #: src/pages/Setup.tsx:940
 msgid "Activities-only connection"
 msgstr "仅限活动连接"
@@ -231,10 +240,14 @@ msgstr "仅限活动连接"
 msgid "Activity types to sync"
 msgstr "要同步的活动类型"
 
-#: src/components/charts/ComplianceChart.tsx:90
-#: src/components/ZoneAnalysisCard.tsx:64
+#: src/components/charts/ComplianceChart.tsx:111
+#: src/components/charts/ComplianceChart.tsx:159
 msgid "Actual"
 msgstr "实际"
+
+#: src/pages/Training.tsx:368
+msgid "actual vs planned, avg"
+msgstr ""
 
 #: src/components/SignalHero.tsx:22
 #: src/pages/Today.tsx:69
@@ -247,6 +260,9 @@ msgstr "调整训练"
 msgid "Admin"
 msgstr "管理"
 
+#: src/pages/Science.tsx:133
+#~ msgid "Advanced"
+#~ msgstr "详细"
 
 #: src/lib/phase-label.ts:13
 msgid "Aerobic"
@@ -257,40 +273,35 @@ msgstr "有氧"
 msgid "All"
 msgstr "全部"
 
-#: src/pages/Login.tsx:390
-#: src/pages/Login.tsx:415
-msgid "Already have an invitation code?"
-msgstr "已有邀请码？"
+#: src/components/UpcomingPlanCard.tsx:636
+msgid "All synced"
+msgstr ""
 
-#: src/pages/Login.tsx:72
+#: src/pages/Login.tsx:60
 msgid "An unexpected error occurred."
 msgstr "发生了意外错误。"
 
-#: src/pages/Settings.tsx:960
+#: src/pages/Settings.tsx:963
 msgid "Asia/CN"
 msgstr "亚洲/中国"
 
-#: src/components/charts/FitnessFatigueChart.tsx:242
+#: src/components/charts/FitnessFatigueChart.tsx:275
 msgid "ATL (Fatigue)"
 msgstr "ATL（疲劳）"
-
-#: src/pages/Login.tsx:254
-msgid "Authentication mode"
-msgstr "登录方式"
 
 #: src/pages/Setup.tsx:198
 msgid "Authorize Praxys with Strava in your browser. Praxys only syncs activities from Strava."
 msgstr "请在浏览器中为 Praxys 授权 Strava。Praxys 仅从 Strava 同步活动数据。"
 
-#: src/pages/Settings.tsx:664
+#: src/pages/Settings.tsx:667
 msgid "Auto"
 msgstr "自动"
 
-#: src/pages/Settings.tsx:722
+#: src/pages/Settings.tsx:725
 msgid "Auto sync frequency"
 msgstr "自动同步频率"
 
-#: src/pages/Settings.tsx:1144
+#: src/pages/Settings.tsx:1188
 msgid "Auto-merged"
 msgstr "自动合并"
 
@@ -310,13 +321,21 @@ msgstr "平均功率"
 msgid "Avg Work {intensityLabel}"
 msgstr "平均工作 {intensityLabel}"
 
-#: src/pages/Settings.tsx:705
+#: src/pages/Settings.tsx:708
 msgid "Backfill All"
 msgstr "同步全部历史数据"
 
-#: src/pages/Settings.tsx:684
+#: src/pages/Settings.tsx:687
 msgid "Backfill..."
 msgstr "同步历史数据..."
+
+#: src/pages/Training.tsx:333
+msgid "balanced"
+msgstr ""
+
+#: src/pages/Training.tsx:406
+msgid "Banister PMC stabilises after about 42 days of activity. Need {daysToPmc} more days."
+msgstr ""
 
 #. placeholder {0}: recommendedTheory.name
 #. placeholder {1}: recommendation!.reason
@@ -324,12 +343,15 @@ msgstr "同步历史数据..."
 msgid "Based on your training, <0>{0}</0> may fit better — {1}"
 msgstr "根据您的训练，<0>{0}</0> 可能更合适 — {1}"
 
+#: src/pages/Science.tsx:156
+#~ msgid "Based on your training, we suggest <0>{0}</0> — {1}"
+#~ msgstr "根据您的训练，我们建议 <0>{0}</0> — {1}"
 
 #: src/components/RecoveryPanel.tsx:131
 msgid "Baseline"
 msgstr "基准"
 
-#: src/components/ZoneAnalysisCard.tsx:44
+#: src/pages/Training.tsx:184
 msgid "below"
 msgstr "低于"
 
@@ -361,8 +383,8 @@ msgstr "作者"
 #: src/components/GoalEditor.tsx:174
 #: src/pages/Admin.tsx:511
 #: src/pages/Admin.tsx:534
-#: src/pages/Settings.tsx:983
-#: src/pages/Settings.tsx:1020
+#: src/pages/Settings.tsx:986
+#: src/pages/Settings.tsx:1023
 #: src/pages/Setup.tsx:928
 #: src/pages/Setup.tsx:948
 msgid "Cancel"
@@ -381,7 +403,7 @@ msgstr "注意"
 msgid "Change"
 msgstr "更改"
 
-#: src/pages/Goal.tsx:432
+#: src/pages/Goal.tsx:433
 msgid "Change Goal"
 msgstr "修改目标"
 
@@ -389,8 +411,8 @@ msgstr "修改目标"
 msgid "Check your credentials in the connection step, then try again."
 msgstr "请在连接步骤中检查您的凭据，然后重试。"
 
-#: src/pages/Settings.tsx:869
-#: src/pages/Settings.tsx:935
+#: src/pages/Settings.tsx:872
+#: src/pages/Settings.tsx:938
 msgid "China"
 msgstr "中国"
 
@@ -411,11 +433,11 @@ msgstr "选择主要数据源"
 msgid "Choose training base"
 msgstr "选择训练基准"
 
-#: src/pages/Settings.tsx:1105
+#: src/pages/Settings.tsx:1108
 msgid "Choose which platform to use for each data type"
 msgstr "为每种数据类型选择使用的平台"
 
-#: src/pages/Settings.tsx:708
+#: src/pages/Settings.tsx:711
 msgid "Clear"
 msgstr "清除"
 
@@ -423,7 +445,7 @@ msgstr "清除"
 msgid "Click to copy"
 msgstr "点击复制"
 
-#: src/components/UpcomingPlanCard.tsx:126
+#: src/components/UpcomingPlanCard.tsx:205
 msgid "click to retry"
 msgstr "点击重试"
 
@@ -431,7 +453,7 @@ msgstr "点击重试"
 msgid "Code"
 msgstr "代码"
 
-#: src/pages/Goal.tsx:361
+#: src/pages/Goal.tsx:371
 msgid "Comfortable"
 msgstr "轻松目标"
 
@@ -444,13 +466,17 @@ msgstr "即将到来"
 msgid "Complete these steps to unlock your training insights"
 msgstr "完成这些步骤以解锁您的训练解读"
 
-#: src/pages/Settings.tsx:555
+#: src/components/charts/ComplianceChart.tsx:171
+msgid "Compliance compares the load you actually accumulated each week (Actual) against the load your plan called for (Planned). The percentage above each bar shows how close you came: green for 80–120% (on target), amber under 80%, red over 120%. The load metric (RSS or W-equivalent) is set by your training base."
+msgstr ""
+
+#: src/pages/Settings.tsx:558
 msgid "Configure your training system"
 msgstr "配置您的训练系统"
 
 #: src/components/SetupChecklist.tsx:51
-#: src/pages/Settings.tsx:825
-#: src/pages/Settings.tsx:986
+#: src/pages/Settings.tsx:828
+#: src/pages/Settings.tsx:989
 #: src/pages/Setup.tsx:555
 #: src/pages/Setup.tsx:931
 msgid "Connect"
@@ -458,12 +484,13 @@ msgstr "连接"
 
 #. placeholder {0}: connectPlatform ? (PLATFORM_META[connectPlatform]?.label || connectPlatform) : ''
 #. placeholder {0}: connectPlatform ? PLATFORM_META[connectPlatform]?.label : ''
-#: src/pages/Settings.tsx:903
+#: src/pages/Settings.tsx:906
 #: src/pages/Setup.tsx:790
 msgid "Connect {0}"
 msgstr "连接 {0}"
 
 #: src/components/SetupChecklist.tsx:47
+#: src/pages/Settings.tsx:1134
 #: src/pages/Setup.tsx:513
 msgid "Connect a platform"
 msgstr "连接平台"
@@ -472,25 +499,25 @@ msgstr "连接平台"
 msgid "Connect a platform first"
 msgstr "请先连接一个平台"
 
-#: src/pages/Settings.tsx:784
+#: src/pages/Settings.tsx:787
 msgid "Connected"
 msgstr "已连接"
 
-#: src/pages/Settings.tsx:679
+#: src/pages/Settings.tsx:682
 msgid "Connected Platforms"
 msgstr "已连接平台"
 
-#: src/pages/Settings.tsx:986
+#: src/pages/Settings.tsx:989
 #: src/pages/Setup.tsx:931
 msgid "Connecting..."
 msgstr "连接中..."
 
-#: src/pages/Settings.tsx:996
+#: src/pages/Settings.tsx:999
 #: src/pages/Setup.tsx:942
 msgid "Continue in your browser to authorize Strava. Praxys imports activities from Strava, while recovery, fitness, and plans come from your other connected platforms."
 msgstr "继续在浏览器中授权 Strava。Praxys 会从 Strava 导入活动，而恢复、体能和计划则来自您连接的其他平台。"
 
-#: src/pages/Settings.tsx:1027
+#: src/pages/Settings.tsx:1030
 #: src/pages/Setup.tsx:951
 msgid "Continue to Strava"
 msgstr "继续前往 Strava"
@@ -499,7 +526,7 @@ msgstr "继续前往 Strava"
 msgid "Continuous"
 msgstr "持续提升"
 
-#: src/pages/Settings.tsx:1173
+#: src/pages/Settings.tsx:1217
 msgid "Continuous Improvement"
 msgstr "持续提升"
 
@@ -511,13 +538,12 @@ msgstr "已配置持续提升"
 msgid "Cooldown"
 msgstr "放松"
 
-
-#: src/pages/Login.tsx:112
-msgid "Could not save your email. Please email us instead."
-msgstr "无法保存您的邮箱，请直接发邮件联系我们。"
+#: src/pages/Science.tsx:255
+#~ msgid "Cosmetic — changes names and colors without affecting calculations"
+#~ msgstr "仅外观——更改名称与颜色，不影响计算"
 
 #: src/components/charts/CpTrendChart.tsx:59
-#: src/lib/display-labels.ts:56
+#: src/lib/display-labels.ts:62
 msgid "CP Trend"
 msgstr "CP 趋势"
 
@@ -526,7 +552,7 @@ msgstr "CP 趋势"
 msgid "Create"
 msgstr "创建"
 
-#: src/pages/Login.tsx:488
+#: src/pages/Login.tsx:164
 msgid "Create account"
 msgstr "创建账号"
 
@@ -534,18 +560,17 @@ msgstr "创建账号"
 msgid "Created"
 msgstr "创建时间"
 
-
-#: src/pages/Login.tsx:488
-msgid "Creating account…"
-msgstr "正在创建账户……"
+#: src/pages/Login.tsx:164
+msgid "Creating account..."
+msgstr "创建中..."
 
 #: src/pages/Admin.tsx:475
 #: src/pages/Admin.tsx:594
 msgid "Creating..."
 msgstr "创建中..."
 
-#: src/lib/display-labels.ts:52
-#: src/pages/Settings.tsx:96
+#: src/lib/display-labels.ts:58
+#: src/pages/Settings.tsx:99
 msgid "Critical Power"
 msgstr "阈值功率"
 
@@ -553,7 +578,7 @@ msgstr "阈值功率"
 msgid "Cross-training activities affect your overall training load and recovery"
 msgstr "交叉训练活动会影响您的整体训练负荷与恢复"
 
-#: src/components/charts/FitnessFatigueChart.tsx:241
+#: src/components/charts/FitnessFatigueChart.tsx:274
 msgid "CTL (Fitness)"
 msgstr "CTL（体能）"
 
@@ -575,7 +600,7 @@ msgstr "当前设置为基于 {0} 的训练"
 msgid "Cycling"
 msgstr "骑行"
 
-#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:435
 msgid "daily score"
 msgstr "每日评分"
 
@@ -583,11 +608,7 @@ msgstr "每日评分"
 msgid "Dark"
 msgstr "深色"
 
-#: src/pages/Login.tsx:537
-msgid "Dark theme (click for system)"
-msgstr "深色主题（点击切换为跟随系统）"
-
-#: src/pages/Settings.tsx:1104
+#: src/pages/Settings.tsx:1107
 msgid "Data Preferences"
 msgstr "数据偏好"
 
@@ -662,15 +683,24 @@ msgstr "降级"
 msgid "Demote to User"
 msgstr "降级为普通用户"
 
+#: src/pages/Training.tsx:305
+#: src/pages/Training.tsx:308
+msgid "Diagnosis"
+msgstr ""
+
+#: src/components/UpcomingPlanCard.tsx:171
+msgid "Differs on Stryd — click to re-push and overwrite."
+msgstr ""
+
 #: src/pages/Goal.tsx:294
 msgid "Direction"
 msgstr "趋势"
 
-#: src/pages/Settings.tsx:888
+#: src/pages/Settings.tsx:891
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: src/pages/Goal.tsx:377
+#: src/pages/Goal.tsx:383
 msgid "Discussion"
 msgstr "讨论"
 
@@ -678,25 +708,25 @@ msgstr "讨论"
 msgid "Dismissible banners shown to all users"
 msgstr "向所有用户显示的可关闭横幅"
 
-#: src/pages/Login.tsx:509
-msgid "Display preferences"
-msgstr "显示偏好"
-
 #: src/components/SplitBreakdown.tsx:46
 msgid "Dist"
 msgstr "距离"
 
 #: src/components/ActivityCard.tsx:75
 #: src/components/GoalEditor.tsx:122
-#: src/pages/Settings.tsx:1177
+#: src/pages/Settings.tsx:1221
 msgid "Distance"
 msgstr "距离"
 
 #: src/components/ZoneAnalysisCard.tsx:92
-msgid "Distribution deviates from target"
-msgstr "分布偏离目标"
+#~ msgid "Distribution deviates from target"
+#~ msgstr "分布偏离目标"
 
-#: src/pages/Settings.tsx:1229
+#: src/pages/Training.tsx:341
+msgid "Distribution match"
+msgstr ""
+
+#: src/pages/Settings.tsx:1273
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 msgstr "驱动您的区间计算和训练负荷。数值来自已连接的数据源；当有多个数据源时，请选择要使用的来源。"
 
@@ -750,7 +780,7 @@ msgstr "轻松"
 msgid "Easy Run"
 msgstr "轻松跑"
 
-#: src/pages/Settings.tsx:1163
+#: src/pages/Settings.tsx:1207
 #: src/pages/Setup.tsx:755
 msgid "Edit"
 msgstr "编辑"
@@ -769,26 +799,21 @@ msgstr "升高"
 
 #: src/pages/Admin.tsx:256
 #: src/pages/Admin.tsx:450
-#: src/pages/Login.tsx:285
-#: src/pages/Login.tsx:353
-#: src/pages/Login.tsx:439
+#: src/pages/Login.tsx:90
+#: src/pages/Login.tsx:126
 #: src/pages/Setup.tsx:206
 msgid "Email"
 msgstr "邮箱"
 
-#: src/pages/Login.tsx:48
+#: src/pages/Login.tsx:37
 msgid "Email and password are required."
 msgstr "请输入邮箱和密码。"
-
-#: src/pages/Login.tsx:81
-msgid "Email is required."
-msgstr "请输入邮箱。"
 
 #: src/lib/display-labels.ts:43
 msgid "Endurance"
 msgstr "耐力"
 
-#: src/pages/Settings.tsx:807
+#: src/pages/Settings.tsx:810
 msgid "Error"
 msgstr "错误"
 
@@ -796,12 +821,12 @@ msgstr "错误"
 msgid "Estimates race performance from current fitness."
 msgstr "基于当前体能估算比赛表现。"
 
-#: src/pages/Settings.tsx:960
+#: src/pages/Settings.tsx:963
 msgid "EU"
 msgstr "欧盟"
 
 #. placeholder {0}: option.hours
-#: src/pages/Settings.tsx:746
+#: src/pages/Settings.tsx:749
 msgid "Every <0>{0}</0> hours"
 msgstr "每 <0>{0}</0> 小时"
 
@@ -814,7 +839,7 @@ msgstr "长时间休息期。体能在下降。"
 msgid "Failed (HTTP {0})"
 msgstr "失败（HTTP {0}）"
 
-#: src/pages/Today.tsx:225
+#: src/pages/Today.tsx:223
 msgid "Failed to load"
 msgstr "加载失败"
 
@@ -822,24 +847,27 @@ msgstr "加载失败"
 msgid "Failed to load activities"
 msgstr "加载活动失败"
 
-#: src/pages/Goal.tsx:439
+#: src/pages/Goal.tsx:440
 msgid "Failed to load goal data"
 msgstr "目标数据加载失败"
 
+#: src/pages/Science.tsx:216
+#~ msgid "Failed to load science data"
+#~ msgstr "加载科学数据失败"
 
 #: src/pages/Science.tsx:83
 msgid "Failed to load science data."
 msgstr "加载科学数据失败。"
 
-#: src/pages/Settings.tsx:314
+#: src/pages/Settings.tsx:317
 msgid "Failed to load settings"
 msgstr "加载设置失败"
 
-#: src/pages/Training.tsx:51
+#: src/pages/Training.tsx:142
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:483
+#: src/components/UpcomingPlanCard.tsx:583
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -851,15 +879,20 @@ msgstr "保存目标失败"
 msgid "Falling"
 msgstr "下降"
 
-#: src/components/charts/FitnessFatigueChart.tsx:59
+#: src/components/charts/FitnessFatigueChart.tsx:58
+#: src/components/charts/FitnessFatigueChart.tsx:191
 msgid "Fatigue"
 msgstr "疲劳"
+
+#: src/pages/Training.tsx:336
+msgid "fatigue accumulating"
+msgstr ""
 
 #: src/components/charts/FormSparkline.tsx:30
 msgid "Fatigue is climbing — watch recovery before adding load."
 msgstr "疲劳正在上升——在增加负荷前先关注恢复。"
 
-#: src/pages/Today.tsx:287
+#: src/pages/Today.tsx:280
 msgid "fatigued"
 msgstr "疲劳"
 
@@ -867,18 +900,19 @@ msgstr "疲劳"
 msgid "Fatigued"
 msgstr "疲劳"
 
-#: src/components/AiInsightsCard.tsx:124
+#: src/components/AiInsightsCard.tsx:175
 msgid "Findings"
 msgstr "发现"
 
-#: src/components/charts/FitnessFatigueChart.tsx:53
+#: src/components/charts/FitnessFatigueChart.tsx:52
+#: src/components/charts/FitnessFatigueChart.tsx:187
 #: src/pages/Settings.tsx:55
-#: src/pages/Settings.tsx:1141
+#: src/pages/Settings.tsx:1185
 #: src/pages/Setup.tsx:217
 msgid "Fitness"
 msgstr "体能"
 
-#: src/components/charts/FitnessFatigueChart.tsx:156
+#: src/pages/Training.tsx:394
 msgid "Fitness / Fatigue / Form"
 msgstr "体能 / 疲劳 / 状态"
 
@@ -895,14 +929,22 @@ msgstr "持平"
 msgid "Follow Plan"
 msgstr "按计划进行"
 
-#: src/components/charts/FitnessFatigueChart.tsx:65
+#: src/components/charts/FitnessFatigueChart.tsx:64
+#: src/components/charts/FitnessFatigueChart.tsx:195
 msgid "Form"
 msgstr "竞技状态"
+
+#: src/pages/Training.tsx:329
+msgid "form (CTL−ATL)"
+msgstr ""
 
 #: src/components/charts/FormSparkline.tsx:119
 msgid "Form (TSB)"
 msgstr "竞技状态 (TSB)"
 
+#: src/pages/Science.tsx:229
+#~ msgid "Four pillars power your analysis. Each uses a published theory you can understand, verify, and change."
+#~ msgstr "四大支柱驱动您的分析。每一支柱都采用可理解、可验证、可更改的已发表理论。"
 
 #: src/pages/Science.tsx:170
 msgid "Four-pillar framework"
@@ -912,32 +954,40 @@ msgstr "四大支柱框架"
 msgid "Fresh"
 msgstr "充分恢复"
 
+#: src/pages/Training.tsx:331
+msgid "fresh, primed"
+msgstr ""
+
 #: src/components/charts/FormSparkline.tsx:26
 msgid "Freshened up — good window for racing or testing."
 msgstr "充分恢复——适合比赛或测试的好时机。"
 
-#: src/pages/Today.tsx:389
+#: src/pages/Today.tsx:382
 msgid "From {dataAsOfLabel}"
 msgstr "数据自 {dataAsOfLabel}"
 
-#: src/pages/Settings.tsx:112
+#: src/pages/Settings.tsx:115
 msgid "From activities"
 msgstr "来自活动"
+
+#: src/components/UpcomingPlanCard.tsx:147
+msgid "From Stryd"
+msgstr ""
 
 #: src/pages/Goal.tsx:262
 #: src/pages/Goal.tsx:272
 msgid "Gap"
 msgstr "差距"
 
-#: src/pages/Settings.tsx:952
+#: src/pages/Settings.tsx:955
 msgid "Garmin International and Garmin China are separate account systems. Pick the one your credentials belong to."
 msgstr "Garmin International 和 Garmin China 是两个独立的账号系统。请选择您的凭据所属的系统。"
 
-#: src/pages/Settings.tsx:874
+#: src/pages/Settings.tsx:877
 msgid "Garmin International and Garmin China are separate accounts. To switch, disconnect and reconnect with the other account."
 msgstr "Garmin International 和 Garmin China 是两个独立的账号。要切换，请断开连接并使用另一个账号重新连接。"
 
-#: src/pages/Settings.tsx:1082
+#: src/pages/Settings.tsx:1085
 msgid "Garmin native running power reads ~30% higher than Stryd for the same athlete — they measure different things. Zones and benchmarks calibrated on Stryd (most coach references, most training literature) will not directly transfer. Your power data will still be internally consistent for tracking progress, but don't compare CP values across the two systems."
 msgstr "Garmin 原生跑步功率同一位运动员读取值通常比 Stryd 高约 30%——它们测量的是不同的东西。基于 Stryd 校准的功率区间和基准值（大多数教练参考、大多数训练文献）不能直接套用。您的功率数据在跟踪进展时仍会保持内部一致性，但不要跨这两个系统比较 CP 值。"
 
@@ -948,10 +998,6 @@ msgstr "生成"
 #: src/pages/Setup.tsx:200
 msgid "Generate a token at cloud.ouraring.com/personal-access-tokens."
 msgstr "请在 cloud.ouraring.com/personal-access-tokens 生成一个令牌。"
-
-#: src/pages/Login.tsx:242
-msgid "Get access"
-msgstr "申请加入"
 
 #: src/components/SetupChecklist.tsx:94
 msgid "Get started with Praxys"
@@ -973,11 +1019,11 @@ msgstr "前往仪表盘"
 
 #: src/components/AppSidebar.tsx:110
 #: src/pages/Goal.tsx:135
-#: src/pages/Settings.tsx:1158
+#: src/pages/Settings.tsx:1202
 msgid "Goal"
 msgstr "目标"
 
-#: src/pages/Goal.tsx:429
+#: src/pages/Goal.tsx:430
 msgid "Goal Tracker"
 msgstr "目标追踪"
 
@@ -989,22 +1035,22 @@ msgstr "体能与恢复平衡良好。已准备好进行高质量训练。"
 msgid "Half"
 msgstr "半程"
 
-#: src/lib/display-labels.ts:61
-#: src/pages/Settings.tsx:178
+#: src/lib/display-labels.ts:67
+#: src/pages/Settings.tsx:181
 msgid "Half Marathon"
 msgstr "半程马拉松"
 
-#: src/lib/display-labels.ts:49
-#: src/pages/Settings.tsx:76
+#: src/lib/display-labels.ts:55
+#: src/pages/Settings.tsx:79
 #: src/pages/Setup.tsx:172
 msgid "Heart Rate"
 msgstr "心率"
 
-#: src/pages/Settings.tsx:684
+#: src/pages/Settings.tsx:687
 msgid "Hide backfill"
 msgstr "隐藏历史同步"
 
-#: src/components/AiInsightsCard.tsx:100
+#: src/components/AiInsightsCard.tsx:151
 msgid "Hide details"
 msgstr "隐藏详情"
 
@@ -1024,23 +1070,35 @@ msgstr "变异性偏高"
 msgid "Hiking"
 msgstr "徒步"
 
-#: src/pages/Settings.tsx:710
+#: src/pages/Settings.tsx:713
 msgid "Historical sync may take several minutes"
 msgstr "历史同步可能需要几分钟"
 
+#: src/pages/Science.tsx:26
+#~ msgid "How do we assess readiness to train?"
+#~ msgstr "如何评估训练准备度？"
 
+#: src/pages/Science.tsx:27
+#~ msgid "How do we estimate race potential?"
+#~ msgstr "如何估算比赛潜力？"
 
+#: src/pages/Science.tsx:25
+#~ msgid "How does training stress become fitness?"
+#~ msgstr "训练应激如何转化为体能？"
 
+#: src/pages/Science.tsx:28
+#~ msgid "How is intensity classified?"
+#~ msgstr "如何分类训练强度？"
 
-#: src/pages/Settings.tsx:724
+#: src/pages/Settings.tsx:727
 msgid "How often Praxys pulls new data in the background. Lower frequency uses less network and respects platform rate limits."
 msgstr "Praxys 后台拉取新数据的频率。较低频率占用更少网络流量，并尊重平台的速率限制。"
 
-#: src/components/ScienceNote.tsx:28
+#: src/components/ScienceNote.tsx:33
 msgid "How this is calculated"
 msgstr "计算方法"
 
-#: src/pages/Settings.tsx:1044
+#: src/pages/Settings.tsx:1047
 #: src/pages/Setup.tsx:705
 msgid "How your zones and training load are calculated"
 msgstr "如何计算您的区间与训练负荷"
@@ -1081,8 +1139,8 @@ msgstr "改善中"
 msgid "Insufficient HRV data for analysis"
 msgstr "用于分析的 HRV 数据不足"
 
-#: src/pages/Settings.tsx:870
-#: src/pages/Settings.tsx:935
+#: src/pages/Settings.tsx:873
+#: src/pages/Settings.tsx:938
 msgid "International"
 msgstr "国际"
 
@@ -1090,26 +1148,24 @@ msgstr "国际"
 msgid "Invalid time format. Use H:MM:SS or H:MM"
 msgstr "时间格式无效。请使用 H:MM:SS 或 H:MM"
 
-#: src/pages/Login.tsx:472
-msgid "Invitation code"
+#: src/pages/Login.tsx:149
+msgid "Invitation Code"
 msgstr "邀请码"
-
 
 #: src/pages/Admin.tsx:334
 msgid "Invitation Codes"
 msgstr "邀请码"
 
-#: src/pages/Login.tsx:339
-#: src/pages/Login.tsx:386
-#: src/pages/Login.tsx:498
-msgid "Join the waitlist"
-msgstr "加入候补名单"
+#. placeholder {0}: data.diagnosis.lookback_weeks
+#: src/pages/Training.tsx:381
+msgid "km / week, {0}wk avg"
+msgstr ""
 
-#: src/lib/display-labels.ts:53
+#: src/lib/display-labels.ts:59
 msgid "Lactate Threshold HR"
 msgstr "乳酸阈值心率"
 
-#: src/pages/Settings.tsx:647
+#: src/pages/Settings.tsx:650
 msgid "Language"
 msgstr "语言"
 
@@ -1122,16 +1178,18 @@ msgid "Last Activity"
 msgstr "上次活动"
 
 #. placeholder {0}: status.error
-#: src/pages/Settings.tsx:858
+#: src/pages/Settings.tsx:861
 msgid "Last sync failed: {0}"
 msgstr "上次同步失败：{0}"
 
 #. placeholder {0}: new Date(status.last_sync).toLocaleString()
-#: src/pages/Settings.tsx:852
+#: src/pages/Settings.tsx:855
 msgid "Last synced {0}"
 msgstr "上次同步 {0}"
 
-
+#: src/pages/Login.tsx:160
+msgid "Leave blank for the first account. Required after that."
+msgstr "首个账号可留空，之后必填。"
 
 #: src/components/GoalEditor.tsx:164
 msgid "Leave blank to track predicted time only"
@@ -1140,10 +1198,6 @@ msgstr "留空则仅追踪预测时间"
 #: src/components/AppSidebar.tsx:30
 msgid "Light"
 msgstr "浅色"
-
-#: src/pages/Login.tsx:535
-msgid "Light theme (click for dark)"
-msgstr "浅色主题（点击切换为深色）"
 
 #: src/pages/Setup.tsx:514
 msgid "Link at least one data source to start"
@@ -1161,7 +1215,7 @@ msgstr "链接文本（可选）"
 msgid "Link URL (optional)"
 msgstr "链接 URL（可选）"
 
-#: src/pages/Settings.tsx:680
+#: src/pages/Settings.tsx:683
 msgid "Link your training devices and services"
 msgstr "关联您的训练设备与服务"
 
@@ -1169,16 +1223,35 @@ msgstr "关联您的训练设备与服务"
 msgid "Live demo — real training data, read-only"
 msgstr "直播演示 — 真实训练数据，只读"
 
+#: src/components/charts/ComplianceChart.tsx:61
+msgid "load ({label})"
+msgstr ""
+
+#: src/components/charts/ComplianceChart.tsx:60
+msgid "load (Running Stress Score)"
+msgstr ""
+
 #: src/pages/Science.tsx:25
 msgid "Load & Fitness"
 msgstr "负荷与体能"
 
+#: src/pages/Training.tsx:359
+#: src/pages/Training.tsx:433
+msgid "Load compliance"
+msgstr ""
+
+#: src/pages/Login.tsx:71
+msgid "Log in to connect your CLI plugin"
+msgstr "登录以连接 CLI 插件"
 
 #: src/components/AppSidebar.tsx:193
 #: src/components/AppSidebar.tsx:195
 msgid "Log out"
 msgstr "退出登录"
 
+#: src/pages/Login.tsx:78
+msgid "Login"
+msgstr "登录"
 
 #: src/pages/Today.tsx:124
 msgid "low"
@@ -1188,11 +1261,11 @@ msgstr "偏低"
 msgid "Low"
 msgstr "偏低"
 
-#: src/pages/Settings.tsx:97
+#: src/pages/Settings.tsx:100
 msgid "LTHR"
 msgstr "乳酸阈值心率"
 
-#: src/lib/display-labels.ts:57
+#: src/lib/display-labels.ts:63
 msgid "LTHR Trend"
 msgstr "LTHR 趋势"
 
@@ -1205,17 +1278,17 @@ msgid "Manage users and invitation codes"
 msgstr "管理用户和邀请码"
 
 #: src/components/GoalEditor.tsx:54
-#: src/lib/display-labels.ts:60
-#: src/pages/Settings.tsx:179
-#: src/pages/Settings.tsx:1179
+#: src/lib/display-labels.ts:66
+#: src/pages/Settings.tsx:182
+#: src/pages/Settings.tsx:1223
 msgid "Marathon"
 msgstr "马拉松"
 
-#: src/pages/Settings.tsx:99
+#: src/pages/Settings.tsx:102
 msgid "Max HR"
 msgstr "最大心率"
 
-#: src/pages/Today.tsx:286
+#: src/pages/Today.tsx:279
 msgid "mild fatigue"
 msgstr "轻度疲劳"
 
@@ -1224,7 +1297,7 @@ msgstr "轻度疲劳"
 msgid "mirrors {0}"
 msgstr "镜像 {0}"
 
-#: src/pages/Settings.tsx:1171
+#: src/pages/Settings.tsx:1215
 msgid "Mode"
 msgstr "模式"
 
@@ -1237,22 +1310,36 @@ msgstr "调整"
 msgid "months"
 msgstr "月"
 
+#. placeholder {0}: tDisplay(worstDeviation.name, i18n)
+#. placeholder {1}: worstDeviation.actual
+#. placeholder {2}: worstDeviation.target
+#: src/pages/Training.tsx:190
+msgid "Most over-target: {0} at {1}% (target {2}%). Shift 1-2 sessions next week toward an under-target zone."
+msgstr ""
+
+#. placeholder {0}: tDisplay(worstDeviation.name, i18n)
+#. placeholder {1}: worstDeviation.actual
+#. placeholder {2}: worstDeviation.target
+#: src/pages/Training.tsx:193
+msgid "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
+msgstr ""
+
 #. placeholder {0}: primaryPrompt?.category
 #: src/pages/Setup.tsx:976
 msgid "Multiple platforms provide <0>{0}</0> data. Which should be the primary source?"
 msgstr "多个平台提供 <0>{0}</0> 数据。应将哪个作为主要来源？"
 
+#: src/pages/Training.tsx:441
+msgid "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
+msgstr ""
+
 #: src/pages/Training.tsx:112
-msgid "Need at least 3 activities with power data to plot a meaningful trend."
-msgstr "需要至少 3 次带功率数据的活动才能绘制有意义的趋势。"
+#~ msgid "Need at least 3 activities with power data to plot a meaningful trend."
+#~ msgstr "需要至少 3 次带功率数据的活动才能绘制有意义的趋势。"
 
 #: src/pages/Goal.tsx:224
 msgid "Need at least 3 activities with power data."
 msgstr "需要至少 3 次带功率数据的活动。"
-
-#: src/pages/Login.tsx:507
-msgid "Need help? {SUPPORT_EMAIL}"
-msgstr "需要帮助？{SUPPORT_EMAIL}"
 
 #: src/pages/Goal.tsx:255
 msgid "Needed {abbrev}"
@@ -1262,10 +1349,6 @@ msgstr "所需 {abbrev}"
 msgid "Network error. Is the server running?"
 msgstr "网络错误。服务器在运行吗？"
 
-#: src/pages/Login.tsx:118
-msgid "Network error. Please email {SUPPORT_EMAIL} directly."
-msgstr "网络错误，请直接发邮件至 {SUPPORT_EMAIL}。"
-
 #: src/pages/Admin.tsx:559
 msgid "New announcement"
 msgstr "新公告"
@@ -1274,15 +1357,11 @@ msgstr "新公告"
 msgid "New invitation code:"
 msgstr "新邀请码："
 
-#: src/pages/Login.tsx:322
-msgid "New to Praxys?"
-msgstr "第一次使用 Praxys？"
-
 #: src/pages/History.tsx:96
 msgid "Next"
 msgstr "下一页"
 
-#: src/pages/Settings.tsx:728
+#: src/pages/Settings.tsx:731
 msgid "Next sync"
 msgstr "下次同步"
 
@@ -1294,14 +1373,10 @@ msgstr "未找到活动。"
 msgid "No announcements yet"
 msgstr "还没有公告"
 
-#: src/pages/Login.tsx:492
-msgid "No code yet?"
-msgstr "还没有邀请码？"
-
-#: src/pages/Today.tsx:276
-#: src/pages/Today.tsx:427
-#: src/pages/Today.tsx:428
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:269
+#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:432
+#: src/pages/Today.tsx:433
 msgid "no data"
 msgstr "无数据"
 
@@ -1309,7 +1384,7 @@ msgstr "无数据"
 msgid "No Data"
 msgstr "无数据"
 
-#: src/pages/Settings.tsx:1199
+#: src/pages/Settings.tsx:1243
 msgid "No goal set. Set a race target or distance goal to unlock predictions and countdown."
 msgstr "尚未设定目标。设定比赛目标或距离目标以解锁预测与倒计时。"
 
@@ -1317,7 +1392,7 @@ msgstr "尚未设定目标。设定比赛目标或距离目标以解锁预测与
 msgid "No invitation codes yet. Generate one to invite a user."
 msgstr "尚无邀请码。生成一个以邀请用户。"
 
-#: src/pages/Today.tsx:365
+#: src/pages/Today.tsx:358
 msgid "No new HRV, sleep, or activity since."
 msgstr "此后无新的 HRV、睡眠或活动数据。"
 
@@ -1333,6 +1408,10 @@ msgstr "没有可用的分段数据。"
 msgid "No Workout"
 msgstr "无训练"
 
+#: src/components/UpcomingPlanCard.tsx:658
+msgid "No workouts scheduled in this window."
+msgstr ""
+
 #: src/pages/Today.tsx:125
 msgid "normal"
 msgstr "正常"
@@ -1342,28 +1421,35 @@ msgstr "正常"
 msgid "Normal"
 msgstr "正常"
 
-#: src/pages/Settings.tsx:787
+#: src/pages/Settings.tsx:790
 msgid "Not connected"
 msgstr "未连接"
 
 #: src/pages/Training.tsx:102
-msgid "Not enough data for accurate fitness tracking"
-msgstr "数据不足以准确追踪体能"
+#~ msgid "Not enough data for accurate fitness tracking"
+#~ msgstr "数据不足以准确追踪体能"
 
 #: src/pages/Training.tsx:119
-msgid "Not enough data for weekly load comparison"
-msgstr "数据不足以进行周负荷对比"
+#~ msgid "Not enough data for weekly load comparison"
+#~ msgstr "数据不足以进行周负荷对比"
 
 #: src/pages/Goal.tsx:223
-#: src/pages/Training.tsx:111
 msgid "Not enough data to show CP trend"
 msgstr "数据不足以显示 CP 趋势"
 
 #: src/pages/Training.tsx:126
-msgid "Not enough data to show sleep vs performance"
-msgstr "数据不足以显示睡眠与表现对比"
+#~ msgid "Not enough data to show sleep vs performance"
+#~ msgstr "数据不足以显示睡眠与表现对比"
 
-#: src/pages/Settings.tsx:1262
+#: src/pages/Training.tsx:405
+msgid "Not enough data yet for accurate fitness tracking"
+msgstr ""
+
+#: src/pages/Training.tsx:440
+msgid "Not enough data yet for weekly load comparison"
+msgstr ""
+
+#: src/pages/Settings.tsx:1306
 msgid "Not set"
 msgstr "未设置"
 
@@ -1375,7 +1461,7 @@ msgstr "备注"
 msgid "Note (optional)"
 msgstr "备注（可选）"
 
-#: src/pages/Settings.tsx:1079
+#: src/pages/Settings.tsx:1082
 msgid "Note on Garmin native power"
 msgstr "关于 Garmin 原生功率的说明"
 
@@ -1399,21 +1485,21 @@ msgstr "选项"
 msgid "Other Signals"
 msgstr "其他信号"
 
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:433
 msgid "overnight score"
 msgstr "夜间评分"
 
 #: src/components/ActivityCard.tsx:121
 #: src/components/SplitBreakdown.tsx:50
-#: src/lib/display-labels.ts:50
-#: src/pages/Settings.tsx:85
+#: src/lib/display-labels.ts:56
+#: src/pages/Settings.tsx:88
 #: src/pages/Setup.tsx:174
 msgid "Pace"
 msgstr "配速"
 
 #: src/pages/Admin.tsx:460
-#: src/pages/Login.tsx:302
-#: src/pages/Login.tsx:456
+#: src/pages/Login.tsx:102
+#: src/pages/Login.tsx:138
 #: src/pages/Setup.tsx:207
 msgid "Password"
 msgstr "密码"
@@ -1427,20 +1513,28 @@ msgid "Personal Access Token"
 msgstr "个人访问令牌"
 
 #: src/pages/Settings.tsx:56
-#: src/pages/Settings.tsx:62
 #: src/pages/Setup.tsx:218
 msgid "Plan"
 msgstr "计划"
 
-#: src/components/charts/ComplianceChart.tsx:79
+#: src/pages/Settings.tsx:65
+msgid "Plan sync target"
+msgstr ""
+
+#: src/components/UpcomingPlanCard.tsx:374
+msgid "Plan window"
+msgstr ""
+
+#: src/components/charts/ComplianceChart.tsx:107
+#: src/components/charts/ComplianceChart.tsx:151
 msgid "Planned"
 msgstr "计划"
 
-#: src/pages/Today.tsx:435
+#: src/pages/Today.tsx:439
 msgid "Planned · Today"
 msgstr "今日计划"
 
-#: src/components/charts/ComplianceChart.tsx:42
+#: src/components/charts/ComplianceChart.tsx:118
 msgid "Planned bars are estimated — your plan has no {label} targets for the current training base."
 msgstr "计划中的条形为估算值 — 您的计划在当前训练基础下没有 {label} 目标。"
 
@@ -1448,17 +1542,13 @@ msgstr "计划中的条形为估算值 — 您的计划在当前训练基础下�
 msgid "Planned Workout"
 msgstr "计划训练"
 
-#: src/pages/Login.tsx:104
-msgid "Please check your email format and try again."
-msgstr "请检查邮箱格式后重试。"
-
-#: src/pages/Today.tsx:285
+#: src/pages/Today.tsx:278
 msgid "positive"
 msgstr "状态良好"
 
 #: src/components/SplitBreakdown.tsx:48
-#: src/lib/display-labels.ts:48
-#: src/pages/Settings.tsx:67
+#: src/lib/display-labels.ts:54
+#: src/pages/Settings.tsx:70
 #: src/pages/Setup.tsx:170
 msgid "Power"
 msgstr "功率"
@@ -1467,19 +1557,17 @@ msgstr "功率"
 msgid "Power metrics, Critical Power, training plans"
 msgstr "功率指标、阈值功率、训练计划"
 
+#: src/pages/Login.tsx:72
+msgid "Power-based training dashboard"
+msgstr "功率训练仪表盘"
 
-#: src/components/AiInsightsCard.tsx:81
+#: src/components/AiInsightsCard.tsx:132
 msgid "Praxys Coach"
 msgstr "Praxys 教练"
 
-#: src/components/AiInsightsCard.tsx:79
+#: src/components/AiInsightsCard.tsx:130
 msgid "Praxys Coach insight"
 msgstr "Praxys 教练分析"
-
-#: src/pages/Login.tsx:247
-msgid "Praxys is in private alpha."
-msgstr "Praxys 正处于内测阶段。"
-
 
 #: src/pages/Goal.tsx:241
 #: src/pages/Goal.tsx:278
@@ -1505,7 +1593,7 @@ msgid "Previous"
 msgstr "上一页"
 
 #. placeholder {0}: CAPABILITY_LABELS[cat] ? i18n._(CAPABILITY_LABELS[cat]) : cat
-#: src/pages/Settings.tsx:844
+#: src/pages/Settings.tsx:847
 msgid "Primary for {0}"
 msgstr "作为 {0} 的主要来源"
 
@@ -1513,11 +1601,11 @@ msgstr "作为 {0} 的主要来源"
 msgid "Primary source for workout data"
 msgstr "训练数据的主要来源"
 
-#: src/pages/Login.tsx:136
-msgid "Private alpha · Invitation only"
-msgstr "内测中 · 仅限邀请"
+#: src/pages/Training.tsx:335
+msgid "productive load"
+msgstr ""
 
-#: src/pages/Settings.tsx:580
+#: src/pages/Settings.tsx:583
 msgid "Profile"
 msgstr "个人资料"
 
@@ -1525,8 +1613,8 @@ msgstr "个人资料"
 msgid "Proj"
 msgstr "预测"
 
-#: src/components/charts/FitnessFatigueChart.tsx:46
-#: src/components/charts/FitnessFatigueChart.tsx:174
+#: src/components/charts/FitnessFatigueChart.tsx:45
+#: src/components/charts/FitnessFatigueChart.tsx:200
 msgid "Projected"
 msgstr "预测"
 
@@ -1545,30 +1633,35 @@ msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "拉取您最近的活动、功率数据和恢复指标"
 
 #: src/components/UpcomingPlanCard.tsx:530
-msgid "Push All"
-msgstr "全部推送"
+#~ msgid "Push All"
+#~ msgstr "全部推送"
 
-#: src/components/UpcomingPlanCard.tsx:126
+#: src/components/UpcomingPlanCard.tsx:205
 msgid "Push failed"
 msgstr "推送失败"
 
-#: src/components/UpcomingPlanCard.tsx:169
-#: src/components/UpcomingPlanCard.tsx:177
+#: src/components/UpcomingPlanCard.tsx:248
+#: src/components/UpcomingPlanCard.tsx:256
+#: src/components/UpcomingPlanCard.tsx:641
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
 #: src/components/UpcomingPlanCard.tsx:520
-msgid "Pushing..."
-msgstr "正在推送..."
+#~ msgid "Pushing..."
+#~ msgstr "正在推送..."
 
-#: src/lib/display-labels.ts:68
+#: src/components/UpcomingPlanCard.tsx:631
+msgid "Pushing…"
+msgstr ""
+
+#: src/lib/display-labels.ts:74
 #: src/pages/Goal.tsx:109
 #: src/pages/Goal.tsx:127
 msgid "Race"
 msgstr "比赛"
 
 #: src/components/GoalEditor.tsx:139
-#: src/pages/Settings.tsx:1184
+#: src/pages/Settings.tsx:1228
 msgid "Race Date"
 msgstr "比赛日期"
 
@@ -1577,7 +1670,7 @@ msgid "Race date is required"
 msgstr "请填写比赛日期"
 
 #: src/components/GoalEditor.tsx:111
-#: src/pages/Settings.tsx:1173
+#: src/pages/Settings.tsx:1217
 msgid "Race Goal"
 msgstr "比赛目标"
 
@@ -1590,11 +1683,11 @@ msgid "Race Prediction"
 msgstr "比赛预测"
 
 #: src/components/ZoneAnalysisCard.tsx:63
-msgid "Range"
-msgstr "范围"
+#~ msgid "Range"
+#~ msgstr "范围"
 
-#: src/components/UpcomingPlanCard.tsx:143
-#: src/components/UpcomingPlanCard.tsx:152
+#: src/components/UpcomingPlanCard.tsx:222
+#: src/components/UpcomingPlanCard.tsx:231
 msgid "Re-push to Stryd"
 msgstr "重新推送到 Stryd"
 
@@ -1602,7 +1695,7 @@ msgstr "重新推送到 Stryd"
 msgid "Read-only accounts that mirror your dashboard data"
 msgstr "镜像您仪表盘数据的只读账号"
 
-#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:435
 msgid "Readiness"
 msgstr "准备度"
 
@@ -1610,7 +1703,7 @@ msgstr "准备度"
 msgid "Reads readiness from the body's signals."
 msgstr "通过身体信号读取训练准备度。"
 
-#: src/pages/Goal.tsx:358
+#: src/pages/Goal.tsx:368
 msgid "Realistic alternative targets"
 msgstr "可行的替代目标"
 
@@ -1618,11 +1711,11 @@ msgstr "可行的替代目标"
 msgid "Recommendation available"
 msgstr "有可用推荐"
 
-#: src/components/AiInsightsCard.tsx:138
+#: src/components/AiInsightsCard.tsx:189
 msgid "Recommendations"
 msgstr "建议"
 
-#: src/pages/Settings.tsx:750
+#: src/pages/Settings.tsx:753
 msgid "recommended"
 msgstr "推荐"
 
@@ -1644,7 +1737,7 @@ msgstr "推荐"
 msgid "Recovery"
 msgstr "恢复"
 
-#: src/pages/Today.tsx:406
+#: src/pages/Today.tsx:399
 msgid "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 msgstr "今日恢复数据尚未同步，显示的是 {recoveryLatestLabel} 的最近读数。"
 
@@ -1665,7 +1758,7 @@ msgstr "恢复状态"
 msgid "Recovery status uses ln(RMSSD) compared to your personal baseline. 'Fatigued' = below baseline mean minus 1 SD (Kiviniemi et al, 2007 threshold). 'Fresh' = above baseline mean plus 0.5 SD (Plews et al, 2012 smallest worthwhile change). The 7-day trend and CV are monitored per Plews — declining trend or CV above 10% signals autonomic disturbance. Sleep, RHR, and TSB are shown as informational context when HRV is available."
 msgstr "恢复状态使用 ln(RMSSD) 与您的个人基准进行比较。‘疲劳’ = 低于基准均值减去 1 个标准差（Kiviniemi 等，2007 阈值）。‘充分恢复’ = 高于基准均值加上 0.5 个标准差（Plews 等，2012 最小有意义变化）。7 天趋势和 CV 会按 Plews 监测 — 趋势下降或 CV 高于 10% 表明自主神经失调。当有 HRV 数据时，睡眠、静息心率 和 TSB 仅作为信息性上下文显示。"
 
-#: src/pages/Settings.tsx:1027
+#: src/pages/Settings.tsx:1030
 #: src/pages/Setup.tsx:951
 msgid "Redirecting..."
 msgstr "正在重定向..."
@@ -1679,14 +1772,17 @@ msgstr "降低强度"
 msgid "References"
 msgstr "参考文献"
 
-#: src/pages/Settings.tsx:866
-#: src/pages/Settings.tsx:933
-#: src/pages/Settings.tsx:958
+#: src/pages/Settings.tsx:869
+#: src/pages/Settings.tsx:936
+#: src/pages/Settings.tsx:961
 #: src/pages/Setup.tsx:836
 #: src/pages/Setup.tsx:857
 msgid "Region"
 msgstr "地区"
 
+#: src/pages/Login.tsx:79
+msgid "Register"
+msgstr "注册"
 
 #: src/pages/Admin.tsx:258
 msgid "Registered"
@@ -1700,14 +1796,6 @@ msgstr "注册账号"
 msgid "Rep"
 msgstr "组"
 
-#: src/pages/Login.tsx:328
-msgid "Request an invite"
-msgstr "申请邀请"
-
-#: src/pages/Login.tsx:272
-msgid "Request invite"
-msgstr "申请邀请"
-
 #: src/lib/phase-label.ts:17
 msgid "Rest"
 msgstr "休息"
@@ -1717,24 +1805,24 @@ msgstr "休息"
 msgid "REST"
 msgstr "休息"
 
-#: src/pages/Today.tsx:289
+#: src/pages/Today.tsx:282
 msgid "Rest day. No workout scheduled."
 msgstr "休息日。今日无训练安排。"
 
-#: src/pages/Settings.tsx:100
+#: src/pages/Settings.tsx:103
 msgid "Resting HR"
 msgstr "静息心率"
 
-#: src/components/UpcomingPlanCard.tsx:486
-#: src/pages/Goal.tsx:442
+#: src/components/UpcomingPlanCard.tsx:586
+#: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
-#: src/pages/Settings.tsx:316
-#: src/pages/Today.tsx:228
-#: src/pages/Training.tsx:54
+#: src/pages/Settings.tsx:319
+#: src/pages/Today.tsx:226
+#: src/pages/Training.tsx:145
 msgid "Retry"
 msgstr "重试"
 
-#: src/components/UpcomingPlanCard.tsx:118
+#: src/components/UpcomingPlanCard.tsx:197
 msgid "Retry push to Stryd"
 msgstr "重试推送到 Stryd"
 
@@ -1746,7 +1834,7 @@ msgstr "撤销"
 msgid "Revoked"
 msgstr "已撤销"
 
-#: src/pages/Today.tsx:428
+#: src/pages/Today.tsx:432
 msgid "RHR"
 msgstr "静息心率"
 
@@ -1762,7 +1850,7 @@ msgstr "角色"
 msgid "Run"
 msgstr "跑步"
 
-#: src/components/AiInsightsCard.tsx:153
+#: src/components/AiInsightsCard.tsx:204
 msgid "Run <0>/praxys:{skillName}</0> in Claude Code for deeper analysis"
 msgstr "在 Claude Code 中运行 <0>/praxys:{skillName}</0> 获取深入分析"
 
@@ -1778,10 +1866,6 @@ msgstr "保存目标"
 msgid "Saving..."
 msgstr "保存中..."
 
-#: src/pages/Login.tsx:386
-msgid "Saving…"
-msgstr "正在保存……"
-
 #: src/components/AppSidebar.tsx:115
 msgid "Science"
 msgstr "科学"
@@ -1790,7 +1874,7 @@ msgstr "科学"
 msgid "Science pillars"
 msgstr "科学支柱"
 
-#: src/pages/Settings.tsx:977
+#: src/pages/Settings.tsx:980
 msgid "Select the region matching your COROS account."
 msgstr "选择与您的 COROS 账户匹配的地区。"
 
@@ -1800,7 +1884,7 @@ msgid "Set a goal"
 msgstr "设定目标"
 
 #: src/components/SetupChecklist.tsx:75
-#: src/pages/Settings.tsx:1163
+#: src/pages/Settings.tsx:1207
 #: src/pages/Setup.tsx:764
 msgid "Set goal"
 msgstr "设定目标"
@@ -1813,12 +1897,12 @@ msgstr "设置 Praxys"
 msgid "Set Your Goal"
 msgstr "设置您的目标"
 
-#: src/pages/Settings.tsx:621
+#: src/pages/Settings.tsx:624
 msgid "Set your name"
 msgstr "设置您的名字"
 
 #: src/components/AppSidebar.tsx:119
-#: src/pages/Settings.tsx:553
+#: src/pages/Settings.tsx:556
 msgid "Settings"
 msgstr "设置"
 
@@ -1827,18 +1911,17 @@ msgstr "设置"
 msgid "Setup"
 msgstr "设置向导"
 
-#. placeholder {0}: workouts.length - INITIAL_COUNT
 #: src/components/UpcomingPlanCard.tsx:319
-msgid "Show {0} more workouts"
-msgstr "显示另外 {0} 项训练"
+#~ msgid "Show {0} more workouts"
+#~ msgstr "显示另外 {0} 项训练"
 
-#: src/pages/Today.tsx:381
+#: src/pages/Today.tsx:374
 msgid "Show anyway"
 msgstr "仍要查看"
 
 #: src/components/UpcomingPlanCard.tsx:318
-msgid "Show less"
-msgstr "显示更少"
+#~ msgid "Show less"
+#~ msgstr "显示更少"
 
 #: src/pages/Science.tsx:465
 msgid "Show methodology details"
@@ -1848,32 +1931,28 @@ msgstr "展开方法论详情"
 msgid "Showing"
 msgstr "显示"
 
-#: src/pages/Today.tsx:362
+#: src/pages/Today.tsx:355
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "显示的是昨天的快照。最近一次读数 {dataAsOfLabel}。"
 
-#: src/pages/Login.tsx:241
-#: src/pages/Login.tsx:263
-#: src/pages/Login.tsx:318
+#: src/pages/Login.tsx:113
 msgid "Sign in"
 msgstr "登录"
 
-#: src/pages/Login.tsx:234
-msgid "Sign in to connect your CLI plugin."
-msgstr "登录以连接 CLI 插件。"
+#: src/pages/Login.tsx:113
+msgid "Signing in..."
+msgstr "登录中..."
 
-
-#: src/pages/Login.tsx:318
-msgid "Signing in…"
-msgstr "正在登录……"
-
+#: src/pages/Science.tsx:132
+#~ msgid "Simple"
+#~ msgstr "简要"
 
 #: src/pages/Setup.tsx:779
 msgid "Skip for now"
 msgstr "暂时跳过"
 
 #: src/components/RecoveryPanel.tsx:174
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:433
 msgid "Sleep"
 msgstr "睡眠"
 
@@ -1895,14 +1974,10 @@ msgstr "睡眠得分、HRV、准备度"
 msgid "Sleep, HRV, readiness"
 msgstr "睡眠、HRV、恢复度"
 
-#: src/components/ScienceNote.tsx:40
-#: src/pages/Goal.tsx:376
+#: src/components/ScienceNote.tsx:45
+#: src/pages/Goal.tsx:382
 msgid "Source"
 msgstr "来源"
-
-#: src/pages/Login.tsx:175
-msgid "Sports science that <0>meets you</0> where you are."
-msgstr "运动科学，<0>知行合一</0>。"
 
 #: src/pages/Today.tsx:111
 #: src/pages/Today.tsx:122
@@ -1925,11 +2000,11 @@ msgstr "状态"
 msgid "Steady"
 msgstr "匀速"
 
-#: src/pages/Settings.tsx:1000
+#: src/pages/Settings.tsx:1003
 msgid "Strava Client ID"
 msgstr "Strava 客户端 ID"
 
-#: src/pages/Settings.tsx:1009
+#: src/pages/Settings.tsx:1012
 msgid "Strava Client Secret"
 msgstr "Strava 客户端密钥"
 
@@ -1937,17 +2012,13 @@ msgstr "Strava 客户端密钥"
 msgid "Strength"
 msgstr "力量训练"
 
-#: src/pages/Goal.tsx:365
+#: src/pages/Goal.tsx:375
 msgid "Stretch"
 msgstr "挑战目标"
 
-#: src/pages/Today.tsx:284
+#: src/pages/Today.tsx:277
 msgid "strongly positive"
 msgstr "状态极佳"
-
-#: src/pages/Login.tsx:376
-msgid "Sub-3 marathon · 100K · stay healthy…"
-msgstr "破三 · 百公里 · 保持健康……"
 
 #: src/components/DiagnosisCard.tsx:87
 msgid "Suggestions"
@@ -1957,54 +2028,37 @@ msgstr "建议"
 msgid "Swimming"
 msgstr "游泳"
 
-#: src/pages/Login.tsx:514
-#: src/pages/Login.tsx:515
-msgid "Switch language"
-msgstr "切换语言"
-
 #. placeholder {0}: previewedTheory.name
 #: src/pages/Science.tsx:428
 msgid "Switch to {0}"
 msgstr "切换为 {0}"
 
-#: src/pages/Login.tsx:528
-msgid "Switch to dark theme"
-msgstr "切换到深色主题"
-
-#: src/pages/Login.tsx:531
-msgid "Switch to light theme"
-msgstr "切换到浅色主题"
-
-#: src/pages/Login.tsx:530
-msgid "Switch to system theme"
-msgstr "切换为跟随系统"
-
 #: src/components/SetupChecklist.tsx:59
-#: src/pages/Settings.tsx:809
+#: src/pages/Settings.tsx:812
 msgid "Sync"
 msgstr "同步"
 
 #: src/pages/Training.tsx:127
-msgid "Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date."
-msgstr "将活动与睡眠数据（Garmin、Oura 或类似设备）同步，以便我们按日期配对。"
+#~ msgid "Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date."
+#~ msgstr "将活动与睡眠数据（Garmin、Oura 或类似设备）同步，以便我们按日期配对。"
 
-#: src/pages/Settings.tsx:687
+#: src/pages/Settings.tsx:690
 msgid "Sync All"
 msgstr "全部同步"
 
 #: src/pages/Training.tsx:120
-msgid "Sync at least 2 weeks of data to compare planned vs actual training load."
-msgstr "同步至少 2 周的数据后，才能对比计划与实际训练负荷。"
+#~ msgid "Sync at least 2 weeks of data to compare planned vs actual training load."
+#~ msgstr "同步至少 2 周的数据后，才能对比计划与实际训练负荷。"
 
 #: src/pages/Training.tsx:103
-msgid "Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves."
-msgstr "同步至少 6 周的活动数据后，才能看到有意义的体能、疲劳和竞技状态曲线。"
+#~ msgid "Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves."
+#~ msgstr "同步至少 6 周的活动数据后，才能看到有意义的体能、疲劳和竞技状态曲线。"
 
 #: src/pages/Setup.tsx:689
 msgid "Sync complete! Your data is ready."
 msgstr "同步完成！数据已就绪。"
 
-#: src/pages/Settings.tsx:695
+#: src/pages/Settings.tsx:698
 msgid "Sync from:"
 msgstr "同步起始日期："
 
@@ -2012,8 +2066,8 @@ msgstr "同步起始日期："
 msgid "Sync history"
 msgstr "同步历史"
 
-#: src/pages/Today.tsx:374
-#: src/pages/Today.tsx:396
+#: src/pages/Today.tsx:367
+#: src/pages/Today.tsx:389
 msgid "Sync now"
 msgstr "立即同步"
 
@@ -2022,12 +2076,11 @@ msgstr "立即同步"
 msgid "Sync your data"
 msgstr "同步数据"
 
-#: src/components/UpcomingPlanCard.tsx:525
-#: src/pages/Settings.tsx:805
+#: src/pages/Settings.tsx:808
 msgid "Synced"
 msgstr "已同步"
 
-#: src/pages/Settings.tsx:802
+#: src/pages/Settings.tsx:805
 msgid "Syncing"
 msgstr "同步中"
 
@@ -2035,8 +2088,8 @@ msgstr "同步中"
 msgid "Syncing..."
 msgstr "同步中..."
 
-#: src/pages/Today.tsx:374
-#: src/pages/Today.tsx:396
+#: src/pages/Today.tsx:367
+#: src/pages/Today.tsx:389
 msgid "Syncing…"
 msgstr "正在同步…"
 
@@ -2048,16 +2101,11 @@ msgstr "跟随系统"
 msgid "System Announcements"
 msgstr "系统公告"
 
-#: src/pages/Login.tsx:538
-msgid "System theme (click for light)"
-msgstr "跟随系统（点击切换为浅色）"
-
 #: src/components/ZoneAnalysisCard.tsx:45
-msgid "target"
-msgstr "目标"
+#~ msgid "target"
+#~ msgstr "目标"
 
 #: src/components/WorkoutTimeline.tsx:41
-#: src/components/ZoneAnalysisCard.tsx:65
 #: src/pages/Goal.tsx:246
 msgid "Target"
 msgstr "目标"
@@ -2067,13 +2115,13 @@ msgid "Target {metricName}"
 msgstr "目标 {metricName}"
 
 #: src/components/SetupChecklist.tsx:72
-#: src/pages/Settings.tsx:1159
+#: src/pages/Settings.tsx:1203
 #: src/pages/Setup.tsx:744
 msgid "Target a race or track continuous improvement"
 msgstr "瞄准一场比赛或追踪持续提升"
 
 #: src/components/GoalEditor.tsx:152
-#: src/pages/Settings.tsx:1190
+#: src/pages/Settings.tsx:1234
 msgid "Target Time"
 msgstr "目标时间"
 
@@ -2096,16 +2144,16 @@ msgstr "这将永久删除 <0>{0}</0> 及其所有数据（活动、配置、连
 msgid "Threshold"
 msgstr "乳酸阈"
 
-#: src/lib/display-labels.ts:54
-#: src/pages/Settings.tsx:98
+#: src/lib/display-labels.ts:60
+#: src/pages/Settings.tsx:101
 msgid "Threshold Pace"
 msgstr "阈值配速"
 
-#: src/lib/display-labels.ts:58
+#: src/lib/display-labels.ts:64
 msgid "Threshold Pace Trend"
 msgstr "阈值配速趋势"
 
-#: src/pages/Settings.tsx:1227
+#: src/pages/Settings.tsx:1271
 msgid "Thresholds"
 msgstr "阈值"
 
@@ -2122,14 +2170,14 @@ msgid "To target"
 msgstr "距目标"
 
 #: src/components/AppSidebar.tsx:108
-#: src/components/charts/FitnessFatigueChart.tsx:216
+#: src/components/charts/FitnessFatigueChart.tsx:243
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
-#: src/pages/Today.tsx:357
+#: src/pages/Today.tsx:350
 msgid "Today"
 msgstr "今日"
 
-#: src/components/UpcomingPlanCard.tsx:222
+#: src/components/UpcomingPlanCard.tsx:301
 msgid "TODAY"
 msgstr "今日"
 
@@ -2145,11 +2193,6 @@ msgstr "当前 <0>{distLabel}</0> 预测 <1>{predicted}</1>。{abbrev} 趋势 <2
 msgid "Today's recovery hasn't synced yet. Showing the latest reading from {latestDateLabel}."
 msgstr "今日的恢复尚未同步。显示 {latestDateLabel} 的最新读数。"
 
-
-#: src/pages/Login.tsx:98
-msgid "Too many attempts from this network. Please email us instead."
-msgstr "当前网络请求次数过多，请直接发邮件联系我们。"
-
 #: src/pages/Goal.tsx:141
 msgid "Tracking"
 msgstr "跟踪"
@@ -2159,10 +2202,11 @@ msgid "Train toward a specific race date"
 msgstr "围绕特定比赛日期进行训练"
 
 #: src/components/AppSidebar.tsx:109
+#: src/pages/Training.tsx:289
 msgid "Training"
 msgstr "训练"
 
-#: src/pages/Settings.tsx:1043
+#: src/pages/Settings.tsx:1046
 msgid "Training Base"
 msgstr "训练基准"
 
@@ -2171,12 +2215,12 @@ msgid "Training Diagnosis"
 msgstr "训练诊断"
 
 #: src/pages/Training.tsx:66
-msgid "Training Insights"
-msgstr "训练解读"
+#~ msgid "Training Insights"
+#~ msgstr "训练解读"
 
 #: src/pages/Settings.tsx:62
-msgid "Training plan & targets"
-msgstr "训练计划与目标"
+#~ msgid "Training plan & targets"
+#~ msgstr "训练计划与目标"
 
 #: src/pages/Science.tsx:173
 msgid "Training Science"
@@ -2190,7 +2234,11 @@ msgstr "训练区间"
 msgid "Translates training stress into fitness."
 msgstr "将训练应激转化为体能。"
 
-#: src/components/charts/FitnessFatigueChart.tsx:243
+#: src/pages/Training.tsx:320
+msgid "TSB"
+msgstr ""
+
+#: src/components/charts/FitnessFatigueChart.tsx:276
 msgid "TSB (Form)"
 msgstr "TSB（状态）"
 
@@ -2198,11 +2246,11 @@ msgstr "TSB（状态）"
 msgid "Ultra distance power fractions (50K+) are estimates with limited research backing. Riegel's exponent is validated only up to marathon distance. Predictions beyond marathon carry significantly higher uncertainty due to factors like fueling, terrain, heat, and pacing strategy that dominate ultra performance but are not captured by power/pace models."
 msgstr "超长距离功率分数（50K+）为估算值，研究支持有限。Riegel 指数仅在马拉松距离内得到验证。超过马拉松的预测因补给、地形、气温和配速策略等因素而具有更高不确定性，这些因素主导超马表现，但不在功率/配速模型的覆盖范围内。"
 
-#: src/pages/Settings.tsx:633
+#: src/pages/Settings.tsx:636
 msgid "Units"
 msgstr "单位"
 
-#: src/components/UpcomingPlanCard.tsx:503
+#: src/components/UpcomingPlanCard.tsx:610
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 
@@ -2210,15 +2258,13 @@ msgstr "即将到来的计划"
 msgid "Updating..."
 msgstr "更新中..."
 
-#: src/pages/Settings.tsx:960
+#: src/pages/Settings.tsx:963
 msgid "US"
 msgstr "美国"
 
-#: src/pages/Login.tsx:396
-#: src/pages/Login.tsx:425
-msgid "Use it"
-msgstr "使用邀请码"
-
+#: src/pages/Science.tsx:175
+#~ msgid "Use this"
+#~ msgstr "使用此项"
 
 #: src/pages/Setup.tsx:197
 msgid "Use your Garmin Connect credentials."
@@ -2248,7 +2294,7 @@ msgstr "用户"
 msgid "view"
 msgstr "查看"
 
-#: src/pages/Settings.tsx:555
+#: src/pages/Settings.tsx:558
 msgid "Viewing configuration (read-only demo)"
 msgstr "查看配置（只读演示）"
 
@@ -2256,14 +2302,31 @@ msgstr "查看配置（只读演示）"
 msgid "VO2max"
 msgstr "VO2max"
 
-#: src/pages/Settings.tsx:1142
+#: src/pages/Settings.tsx:1186
 msgid "VO2max, CP, LTHR, training status"
 msgstr "VO2max、CP、LTHR、训练状态"
 
+#: src/pages/Training.tsx:373
+msgid "Volume"
+msgstr ""
+
+#. placeholder {0}: data.diagnosis.theory_name
+#: src/pages/Training.tsx:351
+msgid "vs {0}"
+msgstr ""
+
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
-#: src/pages/Today.tsx:276
+#: src/pages/Today.tsx:269
 msgid "vs {0} baseline"
 msgstr "对比基准 {0}"
+
+#: src/components/ZoneAnalysisCard.tsx:78
+msgid "vs {theoryName}"
+msgstr ""
+
+#: src/pages/Training.tsx:353
+msgid "vs target zones"
+msgstr ""
 
 #: src/pages/Setup.tsx:162
 msgid "Walking"
@@ -2273,82 +2336,100 @@ msgstr "步行"
 msgid "Warmup"
 msgstr "热身"
 
-#: src/pages/Login.tsx:341
-msgid "We're inviting runners in waves while we tighten the science. Drop your email and we'll reach back when a slot opens."
-msgstr "我们正在分批邀请跑者，期间会持续打磨科学方法。留下邮箱，有空位时我们会与您联系。"
+#: src/pages/Training.tsx:209
+msgid "Weekly diagnosis ready."
+msgstr ""
 
 #: src/components/WeeklyLoadMini.tsx:30
 msgid "Weekly Load"
 msgstr "周训练负荷"
 
 #: src/components/charts/ComplianceChart.tsx:38
-msgid "Weekly Load Compliance"
-msgstr "周负荷对比"
+#~ msgid "Weekly Load Compliance"
+#~ msgstr "周负荷对比"
 
 #: src/pages/Training.tsx:67
-msgid "Weekly Review"
-msgstr "周度回顾"
+#~ msgid "Weekly Review"
+#~ msgstr "周度回顾"
 
 #: src/components/DiagnosisCard.tsx:41
 msgid "Weekly Volume"
 msgstr "周里程"
 
-#: src/pages/Login.tsx:246
-msgid "Welcome back."
-msgstr "欢迎回来。"
-
 #: src/components/GoalEditor.tsx:165
 msgid "What time are you working toward? Leave blank to track trend only"
 msgstr "您的目标时间是多少？留空则仅追踪趋势"
 
-#: src/pages/Login.tsx:370
-msgid "What's your training goal? (optional)"
-msgstr "您的训练目标是？（选填）"
+#: src/pages/Settings.tsx:65
+msgid "Where Praxys pushes your plan. Per-workout sync state shows in Training."
+msgstr ""
 
 #: src/pages/Setup.tsx:800
 msgid "Will sync:"
 msgstr "将同步："
 
+#: src/components/UpcomingPlanCard.tsx:162
+msgid "Workout differs on Stryd — re-push to overwrite"
+msgstr ""
+
 #: src/pages/Admin.tsx:268
 msgid "you"
 msgstr "您"
 
-#: src/pages/Login.tsx:291
-#: src/pages/Login.tsx:359
-#: src/pages/Login.tsx:445
+#: src/pages/Login.tsx:94
+#: src/pages/Login.tsx:130
 msgid "you@example.com"
 msgstr "you@example.com"
 
-#: src/pages/Settings.tsx:581
+#: src/pages/Settings.tsx:584
 msgid "Your identity in Praxys"
 msgstr "您在 Praxys 的身份"
 
-#: src/pages/Settings.tsx:607
+#: src/pages/Settings.tsx:610
 msgid "Your name"
 msgstr "您的名字"
 
-#: src/pages/Settings.tsx:1002
+#: src/pages/Settings.tsx:1005
 msgid "Your Strava API Client ID"
 msgstr "你的 Strava API 客户端 ID"
 
-#: src/pages/Settings.tsx:1012
+#: src/pages/Settings.tsx:1015
 msgid "Your Strava API Client Secret"
 msgstr "你的 Strava API 客户端密钥"
 
 #: src/components/ZoneAnalysisCard.tsx:62
-msgid "Zone"
-msgstr "区间"
+#~ msgid "Zone"
+#~ msgstr "区间"
+
+#: src/lib/display-labels.ts:50
+msgid "Zone 1 (Easy)"
+msgstr ""
+
+#: src/lib/display-labels.ts:51
+msgid "Zone 2 (Moderate)"
+msgstr ""
+
+#: src/lib/display-labels.ts:52
+msgid "Zone 3 (Hard)"
+msgstr ""
 
 #: src/components/ZoneAnalysisCard.tsx:53
-msgid "Zone Analysis"
-msgstr "区间分析"
+#~ msgid "Zone Analysis"
+#~ msgstr "区间分析"
+
+#: src/pages/Training.tsx:419
+msgid "Zone distribution"
+msgstr ""
 
 #: src/pages/Science.tsx:186
 msgid "Zone labels"
 msgstr "区间标签"
 
+#: src/pages/Science.tsx:253
+#~ msgid "Zone Labels"
+#~ msgstr "区间标签"
 
-#: src/pages/Settings.tsx:68
+#: src/pages/Settings.tsx:71
 msgid "Zones & load from Critical Power"
 msgstr "基于阈值功率的区间与负荷"
 
@@ -2356,108 +2437,12 @@ msgstr "基于阈值功率的区间与负荷"
 msgid "Zones & load from Critical Power (best with Stryd)"
 msgstr "基于阈值功率的区间与负荷（搭配 Stryd 效果最佳）"
 
-#: src/pages/Settings.tsx:77
+#: src/pages/Settings.tsx:80
 #: src/pages/Setup.tsx:172
 msgid "Zones & load from Lactate Threshold HR"
 msgstr "基于乳酸阈值心率的区间与负荷"
 
-#: src/pages/Settings.tsx:86
+#: src/pages/Settings.tsx:89
 #: src/pages/Setup.tsx:174
 msgid "Zones & load from Threshold Pace"
 msgstr "基于阈值配速的区间与负荷"
-#: src/pages/Login.tsx:162
-#~ msgid "A scientific training system that takes a position."
-#~ msgstr "有立场的科学训练系统。"
-
-#: src/pages/Science.tsx:133
-#~ msgid "Advanced"
-#~ msgstr "详细"
-
-#: src/pages/Science.tsx:156
-#~ msgid "Based on your training, we suggest <0>{0}</0> — {1}"
-#~ msgstr "根据您的训练，我们建议 <0>{0}</0> — {1}"
-
-#: src/pages/Science.tsx:255
-#~ msgid "Cosmetic — changes names and colors without affecting calculations"
-#~ msgstr "仅外观——更改名称与颜色，不影响计算"
-
-#: src/pages/Login.tsx:164
-#~ msgid "Creating account..."
-#~ msgstr "创建中..."
-
-#: src/pages/Science.tsx:216
-#~ msgid "Failed to load science data"
-#~ msgstr "加载科学数据失败"
-
-#: src/pages/Science.tsx:229
-#~ msgid "Four pillars power your analysis. Each uses a published theory you can understand, verify, and change."
-#~ msgstr "四大支柱驱动您的分析。每一支柱都采用可理解、可验证、可更改的已发表理论。"
-
-#: src/pages/Science.tsx:26
-#~ msgid "How do we assess readiness to train?"
-#~ msgstr "如何评估训练准备度？"
-
-#: src/pages/Science.tsx:27
-#~ msgid "How do we estimate race potential?"
-#~ msgstr "如何估算比赛潜力？"
-
-#: src/pages/Science.tsx:25
-#~ msgid "How does training stress become fitness?"
-#~ msgstr "训练应激如何转化为体能？"
-
-#: src/pages/Science.tsx:28
-#~ msgid "How is intensity classified?"
-#~ msgstr "如何分类训练强度？"
-
-#: src/pages/Login.tsx:149
-#~ msgid "Invitation Code"
-#~ msgstr "邀请码"
-
-#: src/pages/Login.tsx:160
-#~ msgid "Leave blank for the first account. Required after that."
-#~ msgstr "首个账号可留空，之后必填。"
-
-#: src/pages/Login.tsx:489
-#~ msgid "Leave blank if this is the first account on a fresh install."
-#~ msgstr "若是全新部署的首位用户，可留空。"
-
-#: src/pages/Login.tsx:71
-#~ msgid "Log in to connect your CLI plugin"
-#~ msgstr "登录以连接 CLI 插件"
-
-#: src/pages/Login.tsx:78
-#~ msgid "Login"
-#~ msgstr "登录"
-
-#: src/pages/Login.tsx:72
-#~ msgid "Power-based training dashboard"
-#~ msgstr "功率训练仪表盘"
-
-#: src/pages/Login.tsx:134
-#~ msgid "Praxys race-flag mark"
-#~ msgstr "Praxys 赛旗标识"
-
-#: src/pages/Login.tsx:79
-#~ msgid "Register"
-#~ msgstr "注册"
-
-#: src/pages/Login.tsx:113
-#~ msgid "Signing in..."
-#~ msgstr "登录中..."
-
-#: src/pages/Science.tsx:132
-#~ msgid "Simple"
-#~ msgstr "简要"
-
-#: src/pages/Login.tsx:533
-#: src/pages/Login.tsx:534
-#~ msgid "Toggle theme"
-#~ msgstr "切换主题"
-
-#: src/pages/Science.tsx:175
-#~ msgid "Use this"
-#~ msgstr "使用此项"
-
-#: src/pages/Science.tsx:253
-#~ msgid "Zone Labels"
-#~ msgstr "区间标签"

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -41,7 +41,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:591
+#: src/components/UpcomingPlanCard.tsx:617
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -289,7 +289,7 @@ msgstr "有氧"
 msgid "All"
 msgstr "全部"
 
-#: src/components/UpcomingPlanCard.tsx:610
+#: src/components/UpcomingPlanCard.tsx:636
 msgid "All synced"
 msgstr "全部已同步"
 
@@ -306,7 +306,7 @@ msgstr "发生了意外错误。"
 msgid "Asia/CN"
 msgstr "亚洲/中国"
 
-#: src/components/charts/FitnessFatigueChart.tsx:275
+#: src/components/charts/FitnessFatigueChart.tsx:282
 msgid "ATL (Fatigue)"
 msgstr "ATL（疲劳）"
 
@@ -326,7 +326,7 @@ msgstr "自动"
 msgid "Auto sync frequency"
 msgstr "自动同步频率"
 
-#: src/pages/Settings.tsx:1188
+#: src/pages/Settings.tsx:1196
 msgid "Auto-merged"
 msgstr "自动合并"
 
@@ -515,7 +515,7 @@ msgid "Connect {0}"
 msgstr "连接 {0}"
 
 #: src/components/SetupChecklist.tsx:47
-#: src/pages/Settings.tsx:1134
+#: src/pages/Settings.tsx:1142
 #: src/pages/Setup.tsx:513
 msgid "Connect a platform"
 msgstr "连接平台"
@@ -551,7 +551,7 @@ msgstr "继续前往 Strava"
 msgid "Continuous"
 msgstr "持续提升"
 
-#: src/pages/Settings.tsx:1217
+#: src/pages/Settings.tsx:1225
 msgid "Continuous Improvement"
 msgstr "持续提升"
 
@@ -611,7 +611,7 @@ msgstr "阈值功率"
 msgid "Cross-training activities affect your overall training load and recovery"
 msgstr "交叉训练活动会影响您的整体训练负荷与恢复"
 
-#: src/components/charts/FitnessFatigueChart.tsx:274
+#: src/components/charts/FitnessFatigueChart.tsx:281
 msgid "CTL (Fitness)"
 msgstr "CTL（体能）"
 
@@ -759,7 +759,7 @@ msgstr "距离"
 
 #: src/components/ActivityCard.tsx:75
 #: src/components/GoalEditor.tsx:122
-#: src/pages/Settings.tsx:1221
+#: src/pages/Settings.tsx:1229
 msgid "Distance"
 msgstr "距离"
 
@@ -771,7 +771,7 @@ msgstr "距离"
 msgid "Distribution match"
 msgstr "分布匹配度"
 
-#: src/pages/Settings.tsx:1273
+#: src/pages/Settings.tsx:1281
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 msgstr "驱动您的区间计算和训练负荷。数值来自已连接的数据源；当有多个数据源时，请选择要使用的来源。"
 
@@ -825,7 +825,7 @@ msgstr "轻松"
 msgid "Easy Run"
 msgstr "轻松跑"
 
-#: src/pages/Settings.tsx:1207
+#: src/pages/Settings.tsx:1215
 #: src/pages/Setup.tsx:755
 msgid "Edit"
 msgstr "编辑"
@@ -917,7 +917,7 @@ msgstr "加载设置失败"
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:557
+#: src/components/UpcomingPlanCard.tsx:583
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -930,7 +930,7 @@ msgid "Falling"
 msgstr "下降"
 
 #: src/components/charts/FitnessFatigueChart.tsx:58
-#: src/components/charts/FitnessFatigueChart.tsx:191
+#: src/components/charts/FitnessFatigueChart.tsx:198
 msgid "Fatigue"
 msgstr "疲劳"
 
@@ -955,9 +955,9 @@ msgid "Findings"
 msgstr "发现"
 
 #: src/components/charts/FitnessFatigueChart.tsx:52
-#: src/components/charts/FitnessFatigueChart.tsx:187
+#: src/components/charts/FitnessFatigueChart.tsx:194
 #: src/pages/Settings.tsx:55
-#: src/pages/Settings.tsx:1185
+#: src/pages/Settings.tsx:1193
 #: src/pages/Setup.tsx:217
 msgid "Fitness"
 msgstr "体能"
@@ -980,7 +980,7 @@ msgid "Follow Plan"
 msgstr "按计划进行"
 
 #: src/components/charts/FitnessFatigueChart.tsx:64
-#: src/components/charts/FitnessFatigueChart.tsx:195
+#: src/components/charts/FitnessFatigueChart.tsx:202
 msgid "Form"
 msgstr "竞技状态"
 
@@ -1073,7 +1073,7 @@ msgstr "前往仪表盘"
 
 #: src/components/AppSidebar.tsx:110
 #: src/pages/Goal.tsx:135
-#: src/pages/Settings.tsx:1202
+#: src/pages/Settings.tsx:1210
 msgid "Goal"
 msgstr "目标"
 
@@ -1348,7 +1348,7 @@ msgstr "管理用户和邀请码"
 #: src/components/GoalEditor.tsx:54
 #: src/lib/display-labels.ts:66
 #: src/pages/Settings.tsx:182
-#: src/pages/Settings.tsx:1223
+#: src/pages/Settings.tsx:1231
 msgid "Marathon"
 msgstr "马拉松"
 
@@ -1365,7 +1365,7 @@ msgstr "轻度疲劳"
 msgid "mirrors {0}"
 msgstr "镜像 {0}"
 
-#: src/pages/Settings.tsx:1215
+#: src/pages/Settings.tsx:1223
 msgid "Mode"
 msgstr "模式"
 
@@ -1468,7 +1468,7 @@ msgstr "无数据"
 msgid "No Data"
 msgstr "无数据"
 
-#: src/pages/Settings.tsx:1243
+#: src/pages/Settings.tsx:1251
 msgid "No goal set. Set a race target or distance goal to unlock predictions and countdown."
 msgstr "尚未设定目标。设定比赛目标或距离目标以解锁预测与倒计时。"
 
@@ -1492,7 +1492,7 @@ msgstr "没有可用的分段数据。"
 msgid "No Workout"
 msgstr "无训练"
 
-#: src/components/UpcomingPlanCard.tsx:632
+#: src/components/UpcomingPlanCard.tsx:661
 msgid "No workouts scheduled in this window."
 msgstr "此窗口内暂无安排的训练。"
 
@@ -1533,7 +1533,7 @@ msgstr "数据不足，暂无法准确跟踪体能"
 msgid "Not enough data yet for weekly load comparison"
 msgstr "数据不足，暂无法对比每周负荷"
 
-#: src/pages/Settings.tsx:1306
+#: src/pages/Settings.tsx:1314
 msgid "Not set"
 msgstr "未设置"
 
@@ -1714,7 +1714,7 @@ msgid "Proj"
 msgstr "预测"
 
 #: src/components/charts/FitnessFatigueChart.tsx:45
-#: src/components/charts/FitnessFatigueChart.tsx:200
+#: src/components/charts/FitnessFatigueChart.tsx:207
 msgid "Projected"
 msgstr "预测"
 
@@ -1749,7 +1749,7 @@ msgid "Push this workout to your Stryd calendar."
 msgstr "将此训练推送至您的 Stryd 日历。"
 
 #: src/components/UpcomingPlanCard.tsx:228
-#: src/components/UpcomingPlanCard.tsx:615
+#: src/components/UpcomingPlanCard.tsx:641
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
@@ -1757,7 +1757,7 @@ msgstr "推送到 Stryd"
 #~ msgid "Pushing..."
 #~ msgstr "正在推送..."
 
-#: src/components/UpcomingPlanCard.tsx:605
+#: src/components/UpcomingPlanCard.tsx:631
 msgid "Pushing…"
 msgstr "推送中…"
 
@@ -1768,7 +1768,7 @@ msgid "Race"
 msgstr "比赛"
 
 #: src/components/GoalEditor.tsx:139
-#: src/pages/Settings.tsx:1228
+#: src/pages/Settings.tsx:1236
 msgid "Race Date"
 msgstr "比赛日期"
 
@@ -1777,7 +1777,7 @@ msgid "Race date is required"
 msgstr "请填写比赛日期"
 
 #: src/components/GoalEditor.tsx:111
-#: src/pages/Settings.tsx:1217
+#: src/pages/Settings.tsx:1225
 msgid "Race Goal"
 msgstr "比赛目标"
 
@@ -1928,7 +1928,7 @@ msgid "Resting HR"
 msgstr "静息心率"
 
 #: src/components/UpcomingPlanCard.tsx:183
-#: src/components/UpcomingPlanCard.tsx:560
+#: src/components/UpcomingPlanCard.tsx:586
 #: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:319
@@ -2003,7 +2003,7 @@ msgid "Set a goal"
 msgstr "设定目标"
 
 #: src/components/SetupChecklist.tsx:75
-#: src/pages/Settings.tsx:1207
+#: src/pages/Settings.tsx:1215
 #: src/pages/Setup.tsx:764
 msgid "Set goal"
 msgstr "设定目标"
@@ -2283,13 +2283,13 @@ msgid "Target {metricName}"
 msgstr "目标 {metricName}"
 
 #: src/components/SetupChecklist.tsx:72
-#: src/pages/Settings.tsx:1203
+#: src/pages/Settings.tsx:1211
 #: src/pages/Setup.tsx:744
 msgid "Target a race or track continuous improvement"
 msgstr "瞄准一场比赛或追踪持续提升"
 
 #: src/components/GoalEditor.tsx:152
-#: src/pages/Settings.tsx:1234
+#: src/pages/Settings.tsx:1242
 msgid "Target Time"
 msgstr "目标时间"
 
@@ -2329,7 +2329,7 @@ msgstr "阈值配速"
 msgid "Threshold Pace Trend"
 msgstr "阈值配速趋势"
 
-#: src/pages/Settings.tsx:1271
+#: src/pages/Settings.tsx:1279
 msgid "Thresholds"
 msgstr "阈值"
 
@@ -2346,7 +2346,7 @@ msgid "To target"
 msgstr "距目标"
 
 #: src/components/AppSidebar.tsx:108
-#: src/components/charts/FitnessFatigueChart.tsx:243
+#: src/components/charts/FitnessFatigueChart.tsx:250
 #: src/components/RecoveryPanel.tsx:118
 #: src/pages/Today.tsx:20
 #: src/pages/Today.tsx:350
@@ -2414,11 +2414,15 @@ msgstr "训练区间"
 msgid "Translates training stress into fitness."
 msgstr "将训练应激转化为体能。"
 
+#: src/components/UpcomingPlanCard.tsx:655
+msgid "Try a longer window above."
+msgstr "尝试上方更长的时间窗口。"
+
 #: src/pages/Training.tsx:320
 msgid "TSB"
 msgstr "TSB"
 
-#: src/components/charts/FitnessFatigueChart.tsx:276
+#: src/components/charts/FitnessFatigueChart.tsx:283
 msgid "TSB (Form)"
 msgstr "TSB（状态）"
 
@@ -2430,7 +2434,7 @@ msgstr "超长距离功率分数（50K+）为估算值，研究支持有限。Ri
 msgid "Units"
 msgstr "单位"
 
-#: src/components/UpcomingPlanCard.tsx:584
+#: src/components/UpcomingPlanCard.tsx:610
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 
@@ -2487,7 +2491,7 @@ msgstr "查看配置（只读演示）"
 msgid "VO2max"
 msgstr "VO2max"
 
-#: src/pages/Settings.tsx:1186
+#: src/pages/Settings.tsx:1194
 msgid "VO2max, CP, LTHR, training status"
 msgstr "VO2max、CP、LTHR、训练状态"
 

--- a/web/src/pages/Goal.tsx
+++ b/web/src/pages/Goal.tsx
@@ -2,13 +2,13 @@ import { useState, type ReactNode } from 'react';
 import { useApi } from '@/hooks/useApi';
 import { useAuth } from '@/hooks/useAuth';
 import { useSettings } from '@/contexts/SettingsContext';
-import type { AiInsight, GoalResponse } from '@/types/api';
+import type { GoalResponse } from '@/types/api';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import GoalEditor from '@/components/GoalEditor';
-import AiInsightsCard from '@/components/AiInsightsCard';
+import AiInsightsCard, { type CoachFallback } from '@/components/AiInsightsCard';
 import CpTrendChart from '@/components/charts/CpTrendChart';
 import DataHint from '@/components/DataHint';
 import ScienceNote from '@/components/ScienceNote';
@@ -97,7 +97,7 @@ interface StripCell {
   tone?: StripTone;
 }
 
-function TrajectoryGoal({ data, hasCoachForecast }: { data: GoalResponse; hasCoachForecast: boolean }) {
+function TrajectoryGoal({ data }: { data: GoalResponse }) {
   const { t, i18n } = useLingui();
   const predictionNote = usePredictionNote();
   const ultraNote = useUltraNote();
@@ -326,7 +326,17 @@ function TrajectoryGoal({ data, hasCoachForecast }: { data: GoalResponse; hasCoa
       <div className="goal-cols">
         <div className="goal-col-chart">{chart}</div>
         <div className="goal-col-coach">
-          <AiInsightsCard insightType="race_forecast" attribution={attribution} />
+          {/* Praxys Coach receipt — single canonical narrative
+              surface. AI race-forecast insight when available, the
+              deterministic `trend_note` (rule-based reality-check
+              prose) otherwise. The receipt always renders so the user
+              sees a "why" beneath the headline regardless of AI
+              availability. */}
+          <AiInsightsCard
+            insightType="race_forecast"
+            attribution={attribution}
+            fallback={rCheck.trend_note ? { headline: rCheck.trend_note } as CoachFallback : undefined}
+          />
         </div>
       </div>
 
@@ -369,10 +379,6 @@ function TrajectoryGoal({ data, hasCoachForecast }: { data: GoalResponse; hasCoa
           </div>
         )}
 
-      {!hasCoachForecast && rCheck.trend_note && (
-        <p className="goal-rationale">{rCheck.trend_note}</p>
-      )}
-
       <ScienceNote text={note.text} sourceUrl={note.url} sourceLabel={t`Source`} />
       {isUltra && <ScienceNote text={ultraNote()} sourceUrl={SCIENCE_ULTRA_URL} sourceLabel={t`Discussion`} />}
     </div>
@@ -399,11 +405,6 @@ function GoalSkeleton() {
 
 export default function Goal() {
   const { data, loading, error, refetch } = useApi<GoalResponse>('/api/goal');
-  // Same query key as AiInsightsCard, dedupes via React Query.
-  const { data: forecastData } = useApi<{ insight: AiInsight | null }>(
-    '/api/insights/race_forecast',
-  );
-  const hasCoachForecast = forecastData?.insight != null;
   const { isDemo } = useAuth();
   const { config, updateSettings } = useSettings();
   const [isEditing, setIsEditing] = useState(false);
@@ -456,7 +457,7 @@ export default function Goal() {
         />
       )}
 
-      {data && <TrajectoryGoal data={data} hasCoachForecast={hasCoachForecast} />}
+      {data && <TrajectoryGoal data={data} />}
     </div>
   );
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -59,7 +59,10 @@ const CAPABILITY_LABELS: Record<string, MessageDescriptor> = {
 const PREFERENCE_CATEGORIES: { key: string; label: MessageDescriptor; desc: MessageDescriptor }[] = [
   { key: 'activities', label: msg`Activities`, desc: msg`Primary source for workout data` },
   { key: 'recovery', label: msg`Recovery`, desc: msg`Sleep, HRV, readiness` },
-  { key: 'plan', label: msg`Plan`, desc: msg`Training plan & targets` },
+  // Plan is always managed inside Praxys; this preference picks where
+  // Praxys pushes your authored plan to. Per-workout sync state
+  // (synced / mismatch / not synced) shows on each row in Training.
+  { key: 'plan', label: msg`Plan sync target`, desc: msg`Where Praxys pushes your plan. Per-workout sync state shows in Training.` },
 ];
 
 const BASE_CONFIG: Record<TrainingBase, { label: MessageDescriptor; desc: MessageDescriptor; icon: React.ReactNode }> = {
@@ -1108,10 +1111,51 @@ export default function Settings() {
         </CardHeader>
         <CardContent className="space-y-3">
           {PREFERENCE_CATEGORIES.map(({ key, label, desc }) => {
+            // Plan sync target is a write destination, not a read source —
+            // 'ai' isn't a target you can push to, only the platform names
+            // (currently just 'stryd') belong here. Activities/recovery
+            // keep their full provider lists.
             const providers = (availableProviders[key as keyof typeof availableProviders] || []).filter(
-              (p: string) => (connections as string[]).includes(p) || (key === 'plan' && p === 'ai')
+              (p: string) => (connections as string[]).includes(p),
             );
             const current = (config.preferences as Record<string, string>)[key] || providers[0];
+
+            // No connection that can serve this category — surface the
+            // gap so the user knows why they can't pick anything, rather
+            // than rendering an empty toggle group with no affordance.
+            if (providers.length === 0) {
+              return (
+                <div key={key} className="flex items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground">{i18n._(label)}</p>
+                    <p className="text-xs text-muted-foreground">{i18n._(desc)}</p>
+                  </div>
+                  <span className="text-xs text-muted-foreground italic">
+                    <Trans>Connect a platform</Trans>
+                  </span>
+                </div>
+              );
+            }
+
+            // Single provider → no choice to make. Render a static
+            // "selected by default" badge so the user can see that this
+            // category is wired up, instead of a one-button toggle that
+            // looks deactivatable but isn't.
+            if (providers.length === 1) {
+              const only = providers[0];
+              const meta = PLATFORM_META[only];
+              return (
+                <div key={key} className="flex items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground">{i18n._(label)}</p>
+                    <p className="text-xs text-muted-foreground">{i18n._(desc)}</p>
+                  </div>
+                  <Badge variant="secondary" className="font-medium">
+                    {meta?.label || only}
+                  </Badge>
+                </div>
+              );
+            }
 
             return (
               <div key={key} className="flex items-center justify-between gap-4">

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1118,7 +1118,15 @@ export default function Settings() {
             const providers = (availableProviders[key as keyof typeof availableProviders] || []).filter(
               (p: string) => (connections as string[]).includes(p),
             );
-            const current = (config.preferences as Record<string, string>)[key] || providers[0];
+            // Sanitise: a legacy DB row might have ``preferences.plan = 'ai'``
+            // from before the reframe. The toggle group renders one item per
+            // entry in ``providers``; if ``current`` doesn't match any of
+            // them, the whole group shows nothing selected and the user has
+            // to click to "fix" a state that's actually just stale config.
+            // Falling back to providers[0] surfaces the auto-selected target
+            // until the user explicitly picks otherwise (next save persists).
+            const rawCurrent = (config.preferences as Record<string, string>)[key];
+            const current = providers.includes(rawCurrent) ? rawCurrent : providers[0];
 
             // No connection that can serve this category — surface the
             // gap so the user knows why they can't pick anything, rather

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useApi, API_BASE, getAuthHeaders } from '@/hooks/useApi';
-import type { AiInsight, TodayResponse, TrainingSignal } from '@/types/api';
+import type { TodayResponse, TrainingSignal } from '@/types/api';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -8,7 +8,7 @@ import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 import type { MessageDescriptor } from '@lingui/core';
 import { useLocale } from '@/contexts/LocaleContext';
-import AiInsightsCard from '@/components/AiInsightsCard';
+import AiInsightsCard, { type CoachFallback } from '@/components/AiInsightsCard';
 
 // Skeleton mirrors the today-spread layout shape so the page doesn't flash
 // from the old space-y-6 grid into the new asymmetric layout when data
@@ -204,8 +204,6 @@ function formatPlan(plan: TrainingSignal['plan']): string | null {
 
 export default function Today() {
   const { data, loading, error, refetch } = useApi<TodayResponse>('/api/today');
-  // Same query key as AiInsightsCard, so React Query dedupes the fetch.
-  const { data: briefData } = useApi<{ insight: AiInsight | null }>('/api/insights/daily_brief');
   const { locale } = useLocale();
   const { i18n } = useLingui();
 
@@ -260,11 +258,6 @@ export default function Today() {
   const verdictText = i18n._(VERDICT_LABEL[signal.recommendation] ?? VERDICT_LABEL.follow_plan);
   const verdictSubtitle = i18n._(VERDICT_SUBTITLE[signal.recommendation] ?? VERDICT_SUBTITLE.follow_plan);
   const tone = TONE_CLASSES[VERDICT_TONE[signal.recommendation] ?? 'amber'];
-  // AiInsightsCard self-fetches /api/insights/daily_brief; React Query
-  // dedupes against the briefData fetch above. Today only needs the
-  // boolean to know whether to suppress the rule-based reason fallback.
-  const hasCoachBrief = briefData?.insight != null;
-
   const hrv = ra?.hrv ?? null;
   const trendArrow = hrv ? TREND_ARROW[hrv.trend] : '—';
   const trendLabel = hrv ? i18n._(HRV_TREND_LABEL[hrv.trend]) : '—';
@@ -419,9 +412,20 @@ export default function Today() {
           </span>
         </div>
         <p className={`text-xl font-semibold ${tone.text}`}>{verdictSubtitle}</p>
-        {!hasCoachBrief && <p className="text-sm text-muted-foreground text-center max-w-sm">{signal.reason}</p>}
       </div>
-      <AiInsightsCard insightType="daily_brief" attribution={attribution} />
+      {/* Praxys Coach receipt — single canonical reasoning surface.
+          Uses the LLM `daily_brief` insight when available, the
+          deterministic `signal.reason` (with `signal.alternatives` as
+          recommendations) otherwise. The receipt always renders, so
+          the user never sees a verdict without a "why" beneath it. */}
+      <AiInsightsCard
+        insightType="daily_brief"
+        attribution={attribution}
+        fallback={{
+          headline: signal.reason,
+          recommendations: signal.alternatives,
+        } as CoachFallback}
+      />
       <div className={`today-supporting ${readinessScore != null ? 'today-supporting--6' : ''}`.trim()}>
         <div className="today-cell"><span className="today-cell-label">HRV (ln RMSSD)</span><span className="today-cell-value font-data">{hrv ? hrv.today_ln.toFixed(2) : '—'}</span><span className="today-cell-sub font-data">{hrv?.today_ms != null ? `${hrv.today_ms} ms · ` : ''}{baselineLabel}</span></div>
         <div className="today-cell"><span className="today-cell-label"><Trans>7d Trend</Trans></span><span className="today-cell-value font-data">{trendArrow}</span><span className="today-cell-sub font-data">{hrv ? `${trendLabel} · CV ${trendCv}` : i18n._(msg`no data`)}</span></div>

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -459,10 +459,11 @@ export default function Training() {
       </section>
 
       {/* ════════════════════════════════════════════════════════════════
-          PLAN · standalone section. Phase 5 will add window pills +
-          per-row sync states + mismatch dialog.
+          PLAN · standalone section. Owns its own eyebrow + window pills,
+          so the wrapper just provides vertical breathing room and a
+          hairline separator from Diagnosis above.
           ════════════════════════════════════════════════════════════════ */}
-      <div className="mt-12 border-t border-border pt-8">
+      <div className="mt-12 border-t border-border pt-10">
         <UpcomingPlanCard />
       </div>
     </div>

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -392,19 +392,26 @@ export default function Training() {
                 {
                   id: 'form',
                   label: <Trans>Fitness / Fatigue / Form</Trans>,
-                  render: () => (
-                    <DataHint
-                      sufficient={data.data_meta?.pmc_sufficient ?? true}
-                      message={t`Not enough data for accurate fitness tracking`}
-                      hint={t`Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves.`}
-                    >
-                      <FitnessFatigueChart
-                        data={data.fitness_fatigue}
-                        scienceNote={data.science_notes?.load}
-                        workoutFlags={data.workout_flags}
-                      />
-                    </DataHint>
-                  ),
+                  render: () => {
+                    // PMC needs ~42 days of data before CTL stabilises;
+                    // until then the lines mostly trace recency bias and
+                    // mislead more than they help. Show the countdown so
+                    // the user knows when the chart will become useful.
+                    const dataDays = data.data_meta?.data_days ?? 0;
+                    const daysToPmc = Math.max(0, 42 - dataDays);
+                    return (
+                      <DataHint
+                        sufficient={data.data_meta?.pmc_sufficient ?? true}
+                        message={t`Not enough data yet for accurate fitness tracking`}
+                        hint={t`Banister PMC stabilises after about 42 days of activity. Need ${daysToPmc} more days.`}
+                      >
+                        <FitnessFatigueChart
+                          data={data.fitness_fatigue}
+                          scienceNote={data.science_notes?.load}
+                        />
+                      </DataHint>
+                    );
+                  },
                 },
                 ...(data.diagnosis.zone_ranges?.length > 0
                   ? [{
@@ -424,15 +431,19 @@ export default function Training() {
                 {
                   id: 'compliance',
                   label: <Trans>Load compliance</Trans>,
-                  render: () => (
-                    <DataHint
-                      sufficient={(data.data_meta?.data_days ?? 0) >= 14}
-                      message={t`Not enough data for weekly load comparison`}
-                      hint={t`Sync at least 2 weeks of data to compare planned vs actual training load.`}
-                    >
-                      <ComplianceChart data={data.weekly_review} loadLabel={activeDisplay?.load_label} />
-                    </DataHint>
-                  ),
+                  render: () => {
+                    const dataDays = data.data_meta?.data_days ?? 0;
+                    const daysToCompare = Math.max(0, 14 - dataDays);
+                    return (
+                      <DataHint
+                        sufficient={dataDays >= 14}
+                        message={t`Not enough data yet for weekly load comparison`}
+                        hint={t`Need 2 weeks of synced activity to compare planned vs actual. ${daysToCompare} more days to go.`}
+                      >
+                        <ComplianceChart data={data.weekly_review} loadLabel={activeDisplay?.load_label} />
+                      </DataHint>
+                    );
+                  },
                 },
               ]}
             />

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -1,36 +1,126 @@
+import { useState, type ReactNode } from 'react';
 import { useApi } from '@/hooks/useApi';
 import { useSettings } from '@/contexts/SettingsContext';
 import type { TrainingResponse } from '@/types/api';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-// Card imports kept for future use
-// import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import AiInsightsCard from '@/components/AiInsightsCard';
-import DiagnosisCard from '@/components/DiagnosisCard';
+import AiInsightsCard, { type CoachFallback } from '@/components/AiInsightsCard';
 import ZoneAnalysisCard from '@/components/ZoneAnalysisCard';
 import UpcomingPlanCard from '@/components/UpcomingPlanCard';
 import FitnessFatigueChart from '@/components/charts/FitnessFatigueChart';
-import CpTrendChart from '@/components/charts/CpTrendChart';
 import ComplianceChart from '@/components/charts/ComplianceChart';
-import SleepPerfChart from '@/components/charts/SleepPerfChart';
 import DataHint from '@/components/DataHint';
+import { msg } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { tDisplay } from '@/lib/display-labels';
+
+const DIAGNOSIS_CHART_KEY = 'praxys.diagnosis_chart';
+
+interface DiagnosisChartOption {
+  id: string;
+  label: ReactNode;
+  render: () => ReactNode;
+}
+
+/**
+ * Segmented chart switcher inside the Diagnosis section. One slot,
+ * one chart at a time. Active selection persisted to localStorage so
+ * power users land on their preferred chart on every visit.
+ *
+ * Tab order matches the stat-strip order (TSB → Form, Distribution
+ * match → Zone distribution, Load compliance → Compliance) so the
+ * user reads stat → looks at the corresponding chart below.
+ *
+ * Active tab styling: foreground ink + 2px primary underline that
+ * overlaps the parent's bottom border via `-mb-px`. Inactive tabs
+ * get a transparent border with hover lift.
+ */
+function DiagnosisChartSwitcher({ options }: { options: DiagnosisChartOption[] }) {
+  const [active, setActive] = useState<string>(() => {
+    if (typeof window === 'undefined') return options[0]?.id ?? '';
+    const stored = window.localStorage.getItem(DIAGNOSIS_CHART_KEY);
+    if (stored && options.some((o) => o.id === stored)) return stored;
+    return options[0]?.id ?? '';
+  });
+  const current = options.find((o) => o.id === active) ?? options[0];
+  if (!current) return null;
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Diagnosis chart"
+        className="flex items-center gap-1 mb-5 text-[10px] font-data uppercase tracking-[0.14em] border-b border-border"
+      >
+        {options.map((opt) => {
+          const isActive = opt.id === active;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => {
+                setActive(opt.id);
+                if (typeof window !== 'undefined') {
+                  window.localStorage.setItem(DIAGNOSIS_CHART_KEY, opt.id);
+                }
+              }}
+              className={`px-3 py-2 -mb-px border-b-2 transition-colors ${
+                isActive
+                  ? 'text-foreground border-primary'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
+              }`}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+      <div>{current.render()}</div>
+    </div>
+  );
+}
 
 function TrainingSkeleton() {
   return (
     <div>
-      <div className="mb-8">
-        <Skeleton className="h-8 w-44" />
-        <Skeleton className="h-4 w-28 mt-2" />
+      <Skeleton className="h-3 w-20" />
+      <div className="mt-3">
+        <Skeleton className="h-3 w-40 mb-7" />
+        <div className="flex flex-wrap gap-x-12 gap-y-6 mb-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i}>
+              <Skeleton className="h-3 w-16 mb-2" />
+              <Skeleton className="h-7 w-20 mb-1" />
+              <Skeleton className="h-3 w-14" />
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-1 gap-y-8 lg:grid-cols-[58fr_42fr] lg:gap-x-10">
+          <div>
+            <Skeleton className="h-3 w-32 mb-5" />
+            <Skeleton className="h-96 w-full rounded-lg" />
+          </div>
+          <div className="lg:border-l lg:border-border lg:pl-10">
+            <div className="coach-receipt">
+              <div className="coach-banner">
+                <Skeleton className="h-3 w-32 bg-card/30" />
+                <Skeleton className="h-3 w-12 bg-card/30" />
+              </div>
+              <div className="coach-body">
+                <Skeleton className="h-4 w-3/4 mb-3" />
+                <Skeleton className="h-3 w-full mb-2" />
+                <Skeleton className="h-3 w-5/6" />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-      <Skeleton className="h-64 rounded-2xl mb-6" />
-      <Skeleton className="h-48 rounded-2xl mb-6" />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <Skeleton className="h-96 rounded-2xl lg:col-span-2" />
-        <Skeleton className="h-80 rounded-2xl lg:col-span-2" />
-        <Skeleton className="h-80 rounded-2xl" />
-        <Skeleton className="h-80 rounded-2xl" />
+      <div className="mt-12 border-t border-border pt-8">
+        <Skeleton className="h-3 w-32 mb-4" />
+        <Skeleton className="h-40 rounded-lg" />
       </div>
     </div>
   );
@@ -39,7 +129,7 @@ function TrainingSkeleton() {
 export default function Training() {
   const { data, loading, error, refetch } = useApi<TrainingResponse>('/api/training');
   const { display } = useSettings();
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
 
   const activeDisplay = data?.display ?? display;
 
@@ -59,77 +149,310 @@ export default function Training() {
 
   if (!data) return null;
 
+  // Theory attribution for the receipt foot — prefers the diagnosis's
+  // own theory name, falls back to the load science-note label.
+  // AiInsightsCard suppresses the foot entirely when undefined.
+  const loadNote = data.science_notes?.load?.name;
+  const theoryName = data.diagnosis.theory_name || loadNote;
+
+  // Rule-based fallback for the Praxys Coach receipt — used when no
+  // LLM `training_review` insight exists yet (no AZURE_AI_ENDPOINT,
+  // or the post-sync runner hasn't populated the row). Lets the
+  // narrative-led shape persist regardless of AI availability.
+  const ruleFindings = data.diagnosis.diagnosis ?? [];
+  const ruleSuggestions = data.diagnosis.suggestions ?? [];
+
+  // Zone-distribution deviations folded into Coach findings + a
+  // derived recommendation. Previously these lived as a standalone
+  // Alert under the zone table; now they're owned by the receipt —
+  // single source of interpretation across pages.
+  const deviations = (data.diagnosis.distribution ?? [])
+    .filter((d) => d.target_pct != null && Math.abs(d.actual_pct - d.target_pct!) > 5)
+    .map((d) => {
+      const diff = d.actual_pct - d.target_pct!;
+      return {
+        name: d.name,
+        actual: d.actual_pct,
+        target: d.target_pct!,
+        diff,
+        absDiff: Math.abs(diff),
+      };
+    });
+  const distributionFindings = deviations.map((d) => ({
+    type: 'warning' as const,
+    text: t`${tDisplay(d.name, i18n)}: ${d.actual}% (${d.absDiff}pp ${d.diff > 0 ? t`above` : t`below`} ${d.target}% target)`,
+  }));
+  const worstDeviation = deviations.slice().sort((a, b) => b.absDiff - a.absDiff)[0];
+  const distributionRec = worstDeviation
+    ? worstDeviation.diff > 0
+      ? i18n._(
+          msg`Most over-target: ${tDisplay(worstDeviation.name, i18n)} at ${worstDeviation.actual}% (target ${worstDeviation.target}%). Shift 1-2 sessions next week toward an under-target zone.`,
+        )
+      : i18n._(
+          msg`Most under-target: ${tDisplay(worstDeviation.name, i18n)} at ${worstDeviation.actual}% (target ${worstDeviation.target}%). Add 1-2 sessions in this zone next week.`,
+        )
+    : null;
+  const allFindings = [
+    ...ruleFindings.map((f) => ({ type: f.type, text: f.message })),
+    ...distributionFindings,
+  ];
+  const allRecommendations = [
+    ...ruleSuggestions,
+    ...(distributionRec ? [distributionRec] : []),
+  ];
+  const lead =
+    ruleFindings.find((f) => f.type === 'warning') ??
+    ruleFindings.find((f) => f.type === 'positive') ??
+    ruleFindings[0];
+  const fallback: CoachFallback = {
+    headline: lead?.message ?? i18n._(msg`Weekly diagnosis ready.`),
+    findings: allFindings,
+    recommendations: allRecommendations,
+    stamp: `${data.diagnosis.lookback_weeks}wk`,
+  };
+
+  // Distribution-compliance score — 100 minus half the sum of absolute
+  // deviations from target. Equivalent to a Bray-Curtis similarity
+  // over the zone composition: 100% = identical, 0% = no overlap.
+  // Skipped when no targets exist.
+  const dist = data.diagnosis.distribution ?? [];
+  const distWithTarget = dist.filter((z) => z.target_pct != null);
+  const distCompliance = distWithTarget.length > 0
+    ? Math.max(
+        0,
+        Math.round(
+          100 -
+            distWithTarget.reduce(
+              (acc, z) => acc + Math.abs(z.actual_pct - (z.target_pct ?? 0)),
+              0,
+            ) / 2,
+        ),
+      )
+    : null;
+
+  // Load compliance — mean of weekly (actual / planned) over weeks
+  // where a plan target existed.
+  const wr = data.weekly_review;
+  const loadRatios = (wr?.planned_load ?? [])
+    .map((p, i) => {
+      const a = wr?.actual_load?.[i] ?? 0;
+      return p > 0 ? (a / p) * 100 : null;
+    })
+    .filter((r): r is number => r != null);
+  const loadCompliance = loadRatios.length > 0
+    ? Math.round(loadRatios.reduce((a, b) => a + b, 0) / loadRatios.length)
+    : null;
+
+  // Current TSB — last value in the fitness/fatigue series.
+  const tsbSeries = data.fitness_fatigue?.tsb ?? [];
+  const tsbCurrent = tsbSeries.length > 0 ? tsbSeries[tsbSeries.length - 1] : null;
+
+  // Tone helpers — explicit threshold buckets per stat.
+  const distTone =
+    distCompliance == null
+      ? 'muted'
+      : distCompliance >= 85
+        ? 'primary'
+        : distCompliance >= 70
+          ? 'amber'
+          : 'destructive';
+  const loadTone =
+    loadCompliance == null
+      ? 'muted'
+      : loadCompliance >= 80 && loadCompliance <= 120
+        ? 'primary'
+        : loadCompliance < 80
+          ? 'amber'
+          : 'destructive';
+  const tsbTone =
+    tsbCurrent == null
+      ? 'muted'
+      : tsbCurrent >= 5
+        ? 'primary'
+        : tsbCurrent >= -10
+          ? 'muted'
+          : 'destructive';
+  const toneClass = (tone: string) =>
+    tone === 'primary'
+      ? 'text-primary'
+      : tone === 'amber'
+        ? 'text-accent-amber'
+        : tone === 'destructive'
+          ? 'text-destructive'
+          : 'text-foreground';
+
   return (
     <div>
-      {/* Page header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground"><Trans>Training Insights</Trans></h1>
-        <p className="text-sm text-muted-foreground mt-1"><Trans>Weekly Review</Trans></p>
-      </div>
+      {/* Page eyebrow — h1 doubles as eyebrow per Today.tsx convention. */}
+      <h1 className="text-[10px] font-data uppercase tracking-[0.14em] text-muted-foreground">
+        <Trans>Training</Trans>
+      </h1>
 
-      {/* AI insights — shown when available from CLI analysis */}
-      <div className="mb-6">
-        <AiInsightsCard insightType="training_review" />
-      </div>
-
-      {/* Diagnosis card — full width */}
-      <div className="mb-6">
-        <DiagnosisCard diagnosis={data.diagnosis} display={activeDisplay ?? undefined} />
-      </div>
-
-      {/* Zone analysis card */}
-      {data.diagnosis.zone_ranges?.length > 0 && (
-        <div className="mb-6">
-          <ZoneAnalysisCard
-            distribution={data.diagnosis.distribution}
-            zoneRanges={data.diagnosis.zone_ranges}
-            theoryName={data.diagnosis.theory_name}
-            display={activeDisplay ?? undefined}
-          />
+      {/* ════════════════════════════════════════════════════════════════
+          DIAGNOSIS · key numbers as a one-liner stat strip on top, then
+          a 2-col below pairing the deep-dive chart (left) with the
+          Coach receipt (right). The four stats answer four distinct
+          training questions:
+            TSB             — current form (CTL−ATL)
+            Distribution    — how well your zone mix matches the target
+            Load compliance — how well you executed the planned load
+            Volume          — amount of work (orphan, no chart pair)
+          Stat order matches chart-tab order (TSB → Form chart, Dist →
+          Zones, Load → Compliance) so the user reads stat → glances
+          at the corresponding chart in the switcher.
+          ════════════════════════════════════════════════════════════════ */}
+      <section aria-label={t`Diagnosis`} className="mt-3">
+        <div className="flex items-baseline justify-between mb-7">
+          <p className="text-[10px] font-data uppercase tracking-[0.18em] text-foreground font-semibold">
+            <Trans>Diagnosis</Trans>
+            <span className="text-muted-foreground font-normal tracking-[0.14em] ml-2">
+              <Trans>· last {data.diagnosis.lookback_weeks} weeks</Trans>
+            </span>
+          </p>
         </div>
-      )}
 
-      {/* Upcoming plan schedule */}
-      <div className="mb-6">
+        {/* Stat strip — full-width one-liner. Wraps to 2x2 at narrow
+            viewports. */}
+        <div className="grid grid-cols-2 gap-x-10 gap-y-6 sm:flex sm:flex-wrap sm:gap-x-14 lg:gap-x-20 mb-8">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+              <Trans>TSB</Trans>
+            </p>
+            <p className={`text-2xl font-semibold font-data tabular-nums leading-none ${toneClass(tsbTone)}`}>
+              {tsbCurrent != null
+                ? `${tsbCurrent >= 0 ? '+' : ''}${tsbCurrent.toFixed(1)}`
+                : '—'}
+            </p>
+            <p className="text-[11px] text-muted-foreground font-data mt-1">
+              {tsbCurrent == null
+                ? <Trans>form (CTL−ATL)</Trans>
+                : tsbCurrent >= 5
+                  ? <Trans>fresh, primed</Trans>
+                  : tsbCurrent >= 0
+                    ? <Trans>balanced</Trans>
+                    : tsbCurrent >= -10
+                      ? <Trans>productive load</Trans>
+                      : <Trans>fatigue accumulating</Trans>}
+            </p>
+          </div>
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+              <Trans>Distribution match</Trans>
+            </p>
+            <p className={`text-2xl font-semibold font-data tabular-nums leading-none ${toneClass(distTone)}`}>
+              {distCompliance != null ? distCompliance : '—'}
+              {distCompliance != null && (
+                <span className="text-base text-muted-foreground ml-0.5 font-normal">%</span>
+              )}
+            </p>
+            <p className="text-[11px] text-muted-foreground font-data mt-1">
+              {data.diagnosis.theory_name ? (
+                <Trans>vs {data.diagnosis.theory_name}</Trans>
+              ) : (
+                <Trans>vs target zones</Trans>
+              )}
+            </p>
+          </div>
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+              <Trans>Load compliance</Trans>
+            </p>
+            <p className={`text-2xl font-semibold font-data tabular-nums leading-none ${toneClass(loadTone)}`}>
+              {loadCompliance != null ? loadCompliance : '—'}
+              {loadCompliance != null && (
+                <span className="text-base text-muted-foreground ml-0.5 font-normal">%</span>
+              )}
+            </p>
+            <p className="text-[11px] text-muted-foreground font-data mt-1">
+              <Trans>actual vs planned, avg</Trans>
+            </p>
+          </div>
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+              <Trans>Volume</Trans>
+            </p>
+            <p className="text-2xl font-semibold font-data text-foreground tabular-nums leading-none">
+              {data.diagnosis.volume?.weekly_avg_km != null
+                ? data.diagnosis.volume.weekly_avg_km.toFixed(1)
+                : '—'}
+            </p>
+            <p className="text-[11px] text-muted-foreground font-data mt-1">
+              <Trans>km / week, {data.diagnosis.lookback_weeks}wk avg</Trans>
+            </p>
+          </div>
+        </div>
+
+        {/* 2-col deep dive — chart switcher (left, 58%) + Coach receipt
+            (right, 42%). Vertical hairline anchors the split. */}
+        <div className="grid grid-cols-1 gap-y-8 lg:grid-cols-[58fr_42fr] lg:gap-x-10">
+          <div className="lg:col-start-1 lg:row-start-1">
+            <DiagnosisChartSwitcher
+              options={[
+                {
+                  id: 'form',
+                  label: <Trans>Fitness / Fatigue / Form</Trans>,
+                  render: () => (
+                    <DataHint
+                      sufficient={data.data_meta?.pmc_sufficient ?? true}
+                      message={t`Not enough data for accurate fitness tracking`}
+                      hint={t`Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves.`}
+                    >
+                      <FitnessFatigueChart
+                        data={data.fitness_fatigue}
+                        scienceNote={data.science_notes?.load}
+                        workoutFlags={data.workout_flags}
+                      />
+                    </DataHint>
+                  ),
+                },
+                ...(data.diagnosis.zone_ranges?.length > 0
+                  ? [{
+                      id: 'zones',
+                      label: <Trans>Zone distribution</Trans>,
+                      render: () => (
+                        <ZoneAnalysisCard
+                          distribution={data.diagnosis.distribution}
+                          zoneRanges={data.diagnosis.zone_ranges}
+                          theoryName={data.diagnosis.theory_name}
+                          display={activeDisplay ?? undefined}
+                          theoryDescription={data.science_notes?.zones?.description}
+                        />
+                      ),
+                    }]
+                  : []),
+                {
+                  id: 'compliance',
+                  label: <Trans>Load compliance</Trans>,
+                  render: () => (
+                    <DataHint
+                      sufficient={(data.data_meta?.data_days ?? 0) >= 14}
+                      message={t`Not enough data for weekly load comparison`}
+                      hint={t`Sync at least 2 weeks of data to compare planned vs actual training load.`}
+                    >
+                      <ComplianceChart data={data.weekly_review} loadLabel={activeDisplay?.load_label} />
+                    </DataHint>
+                  ),
+                },
+              ]}
+            />
+          </div>
+          <div className="lg:col-start-2 lg:row-start-1 lg:border-l lg:border-border lg:pl-10">
+            <AiInsightsCard
+              insightType="training_review"
+              attribution={theoryName}
+              fallback={fallback}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ════════════════════════════════════════════════════════════════
+          PLAN · standalone section. Phase 5 will add window pills +
+          per-row sync states + mismatch dialog.
+          ════════════════════════════════════════════════════════════════ */}
+      <div className="mt-12 border-t border-border pt-8">
         <UpcomingPlanCard />
       </div>
-
-      {/* Charts grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <div className="lg:col-span-2">
-          <DataHint
-            sufficient={data.data_meta?.pmc_sufficient ?? true}
-            message={t`Not enough data for accurate fitness tracking`}
-            hint={t`Sync at least 6 weeks of activity data to see meaningful fitness, fatigue, and form curves.`}
-          >
-            <FitnessFatigueChart data={data.fitness_fatigue} scienceNote={data.science_notes?.load} />
-          </DataHint>
-        </div>
-        <div className="lg:col-span-2">
-          <DataHint
-            sufficient={data.data_meta?.cp_trend_sufficient ?? true}
-            message={t`Not enough data to show CP trend`}
-            hint={t`Need at least 3 activities with power data to plot a meaningful trend.`}
-          >
-            <CpTrendChart data={data.cp_trend} label={activeDisplay?.trend_label} unit={activeDisplay?.threshold_unit} metricName={activeDisplay?.threshold_abbrev} />
-          </DataHint>
-        </div>
-        <DataHint
-          sufficient={(data.data_meta?.data_days ?? 0) >= 14}
-          message={t`Not enough data for weekly load comparison`}
-          hint={t`Sync at least 2 weeks of data to compare planned vs actual training load.`}
-        >
-          <ComplianceChart data={data.weekly_review} loadLabel={activeDisplay?.load_label} />
-        </DataHint>
-        <DataHint
-          sufficient={!!(data.data_meta?.has_recovery && (data.sleep_perf?.pairs?.length ?? 0) >= 2)}
-          message={t`Not enough data to show sleep vs performance`}
-          hint={t`Sync activities together with sleep data (Garmin, Oura, or similar) so we can pair them by date.`}
-        >
-          <SleepPerfChart data={data.sleep_perf} />
-        </DataHint>
-      </div>
-
     </div>
   );
 }

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -24,17 +24,18 @@ interface DiagnosisChartOption {
 }
 
 /**
- * Segmented chart switcher inside the Diagnosis section. One slot,
+ * Segmented pill switcher inside the Diagnosis section. One slot,
  * one chart at a time. Active selection persisted to localStorage so
  * power users land on their preferred chart on every visit.
  *
  * Tab order matches the stat-strip order (TSB → Form, Distribution
  * match → Zone distribution, Load compliance → Compliance) so the
- * user reads stat → looks at the corresponding chart below.
+ * user reads a stat then looks at the corresponding chart below.
  *
- * Active tab styling: foreground ink + 2px primary underline that
- * overlaps the parent's bottom border via `-mb-px`. Inactive tabs
- * get a transparent border with hover lift.
+ * Pill styling — solid primary fill on the active option, muted text
+ * on the rest — was chosen over a subtle underline because the latter
+ * read as static type at a glance and missed clicks. The pill is
+ * unmistakably an interactive control.
  */
 function DiagnosisChartSwitcher({ options }: { options: DiagnosisChartOption[] }) {
   const [active, setActive] = useState<string>(() => {
@@ -51,7 +52,7 @@ function DiagnosisChartSwitcher({ options }: { options: DiagnosisChartOption[] }
       <div
         role="tablist"
         aria-label="Diagnosis chart"
-        className="flex items-center gap-1 mb-5 text-[10px] font-data uppercase tracking-[0.14em] border-b border-border"
+        className="inline-flex items-center gap-1 mb-6 rounded-full bg-muted/60 p-1 text-[11px] font-medium"
       >
         {options.map((opt) => {
           const isActive = opt.id === active;
@@ -67,10 +68,10 @@ function DiagnosisChartSwitcher({ options }: { options: DiagnosisChartOption[] }
                   window.localStorage.setItem(DIAGNOSIS_CHART_KEY, opt.id);
                 }
               }}
-              className={`px-3 py-2 -mb-px border-b-2 transition-colors ${
+              className={`rounded-full px-4 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                 isActive
-                  ? 'text-foreground border-primary'
-                  : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {opt.label}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -185,11 +185,20 @@ export interface PlanData {
   description?: string;
 }
 
-/** Per-row Stryd sync state, derived server-side by joining the AI plan
- *  against (a) Praxys's push log and (b) Stryd-imported plan rows on
- *  the same date. The frontend overlays transient `pushing` and
- *  `error` states locally; these three are persistent. */
-export type SyncState = 'synced' | 'not_synced' | 'mismatch';
+/**
+ * Per-row Stryd sync state, derived server-side by joining the AI plan
+ * against (a) Praxys's push log and (b) Stryd-imported plan rows on the
+ * same date. The frontend overlays transient `pushing` / `error` states
+ * locally; these three are persistent.
+ *
+ * - `synced`     — Stryd has a workout on this date and its id matches
+ *                  the one we logged on push (a re-push is a no-op).
+ * - `mismatch`   — Stryd has a workout on this date but its id is
+ *                  unknown to us (user-edited on Stryd, or never pushed).
+ *                  UI confirms before overwriting.
+ * - `not_synced` — No Stryd workout on this date.
+ */
+export type PlanSyncState = 'synced' | 'mismatch' | 'not_synced';
 
 export interface PlannedWorkout {
   date: string;
@@ -199,24 +208,23 @@ export interface PlannedWorkout {
   power_min?: number;
   power_max?: number;
   description?: string;
-  /** Optional in legacy responses; required on the new /api/plan
-   *  contract. Drives the per-row sync icon. */
-  sync_state?: SyncState;
+  /** Drives the per-row sync icon. Optional only to tolerate cached
+   *  responses from before the /api/plan reshape. */
+  sync_state?: PlanSyncState;
 }
 
 export interface PlanResponse {
   workouts: PlannedWorkout[];
   /** Stryd push history. Used to be served by GET /api/plan/stryd-status. */
   stryd_status: StrydPushStatus;
-  /** Platform Praxys pushes the plan to. Currently always "stryd";
-   *  Garmin push is future work. */
-  sync_target?: 'stryd' | 'garmin';
-  /** Dates where Stryd has a workout but Praxys's AI plan doesn't.
-   *  Informational; frontend can surface as a footnote. */
-  stryd_only_dates?: string[];
-  /** Echoed window the server resolved the request to (clamped to 90d).
-   *  Useful for the frontend to confirm the response matches its pill. */
-  window?: { start: string; end: string };
+  /** Platform AI plan rows get pushed to. `null` when the user has no
+   *  push target connected — UI hides sync chrome in that case. */
+  sync_target: 'stryd' | null;
+  /** ISO dates within `window` where Stryd has a workout but the AI
+   *  plan does not (user-created on Stryd, or removed locally). */
+  stryd_only_dates: string[];
+  /** Server-resolved query window — clients echo this back when paging. */
+  window: { start: string; end: string };
 }
 
 export type StrydPushResult =

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -186,10 +186,10 @@ export interface PlanData {
 }
 
 /**
- * Per-row Stryd sync state, derived server-side by joining the AI plan
- * against (a) Praxys's push log and (b) Stryd-imported plan rows on the
- * same date. The frontend overlays transient `pushing` / `error` states
- * locally; these three are persistent.
+ * Per-row Stryd sync state, derived server-side for AI-source rows by
+ * joining against (a) Praxys's push log and (b) Stryd-imported plan
+ * rows on the same date. Stryd-source rows omit this field — they live
+ * natively on Stryd, so the AI-vs-Stryd sync question doesn't apply.
  *
  * - `synced`     — Stryd has a workout on this date and its id matches
  *                  the one we logged on push (a re-push is a no-op).
@@ -200,6 +200,9 @@ export interface PlanData {
  */
 export type PlanSyncState = 'synced' | 'mismatch' | 'not_synced';
 
+/** Origin of a planned workout: AI/Praxys-authored or imported from Stryd. */
+export type PlanWorkoutSource = 'ai' | 'stryd';
+
 export interface PlannedWorkout {
   date: string;
   workout_type: string;
@@ -208,8 +211,10 @@ export interface PlannedWorkout {
   power_min?: number;
   power_max?: number;
   description?: string;
-  /** Drives the per-row sync icon. Optional only to tolerate cached
-   *  responses from before the /api/plan reshape. */
+  /** Authoring system. `'ai'` rows are Praxys-authored and may be pushed
+   *  to Stryd; `'stryd'` rows were imported from Stryd directly. */
+  source: PlanWorkoutSource;
+  /** Present only on AI-source rows. Drives the per-row sync icon. */
   sync_state?: PlanSyncState;
 }
 
@@ -220,9 +225,6 @@ export interface PlanResponse {
   /** Platform AI plan rows get pushed to. `null` when the user has no
    *  push target connected — UI hides sync chrome in that case. */
   sync_target: 'stryd' | null;
-  /** ISO dates within `window` where Stryd has a workout but the AI
-   *  plan does not (user-created on Stryd, or removed locally). */
-  stryd_only_dates: string[];
   /** Server-resolved query window — clients echo this back when paging. */
   window: { start: string; end: string };
 }


### PR DESCRIPTION
## Summary

Reshape the **Training page** around the user's actual decision flow — read a number, glance at the matching chart, read the coach's explanation — and reshape **/api/plan** to match how the user actually authors and pushes a plan.

### Training page (Diagnosis section)

Stat strip → switchable chart → Coach receipt, in that reading order:

- **Stat strip** (one-liner, 4 stats): TSB · Distribution match · Load compliance · Volume. Stat order matches chart-tab order so eye → number → chart is one motion.
- **2-col deep dive**: pill switcher (Fitness/Fatigue/Form · Zone distribution · Load compliance) on the left at 58% width, Praxys Coach receipt on the right at 42%, vertical hairline between.
- **Pill switcher** replaces the underlined-tabs design — solid primary fill on active vs muted text on the rest, so the control is unmistakably interactive.
- **Coach receipt** (`AiInsightsCard`) accepts a rule-based fallback so the narrative-led shape persists when the LLM hasn't run yet (no `AZURE_AI_ENDPOINT` set, or `insights_runner` hasn't filled the row).
- **Zone distribution** redesigned to mirror the Mini Program: per-zone horizontal "actual fill / target tick" bar with `actual% / target%` on the right, instead of a 4-col table.

### Insufficient-data gating

PMC (CTL/ATL/TSB) and weekly load both need a minimum activity history before they're meaningful:

- "Banister PMC stabilises after about 42 days. Need N more days." — countdown instead of a vague nudge.
- "Need 2 weeks of synced activity to compare planned vs actual. N more days to go." — same on Load compliance.

### Plan reshape

Backend:

- **GET /api/plan** is now window-aware: `?start=&end=` query params (default `[today, today+14d]`, capped at 365d). Window mixed into the ETag salt so different windows can't bleed cache.
- Each workout carries its `source` (`ai` | `stryd`). AI rows get a derived `sync_state` (`synced` / `mismatch` / `not_synced`) by joining against (a) the per-user Stryd push log and (b) Stryd-imported plan rows on the same date. Stryd-source rows omit `sync_state` (they live natively on Stryd).
- New `external_id` column on `training_plans`, populated by the Stryd fetch and backfilled on existing rows so the join works for plans that pre-date the column.
- `cp_current` retired — it was dead on the frontend (today's planned upper bound, not actual CP). `get_plan_pack` retired with it; the route does its own projection.

Frontend (`UpcomingPlanCard`):

- Stripped Card chrome — flat eyebrow + 1wk/2wk/4wk window pills + Push to Stryd action on a single header row, choice persisted to localStorage.
- Per-row badge follows server-side `sync_state`: **Sync to Stryd** (cobalt CTA, never pushed) → **Synced** (primary check, hover swaps to refresh for re-push) → **Differs · overwrite** (amber warning, click to overwrite) → **Syncing…** (cobalt + spinner) → **Retry** (destructive, click to retry) → **From Stryd** (muted static label for imported rows).
- Always-visible labeled pills replace hover-only ghost icons — touch users couldn't discover the action before.
- Empty state renders the eyebrow + "No workouts scheduled in this window. Try a longer window above." instead of disappearing.

### FF chart bug fix (critical)

The Fitness/Fatigue/Form lines stopped 12 days before today on stale-data accounts. `get_fitness_pack` and `get_signal_pack` both built dates from a synthetic `pd.date_range(today-Nd, today)` and pulled values via `iloc[-len(date_range):]` from a series that might be shorter — fine when the user has ≥N days of history, but for shorter histories the dates list was longer than the values list and the React chart paired them off by index, dragging values back in time. `iloc[-N:]` on both produces same-length windows from a single source.

The "today" reference line now snaps to actual today (not the last data date) and hides itself when today is more than 10 days outside the chart window. Workout flag dots + FLAGGED legend dropped — judgment was crude and added clutter without helping diagnosis.

### Settings reframe

- **Plan preference** reframed from "Plan" / "Training plan & targets" to **"Plan sync target"** / "Where Praxys pushes your plan. Per-workout sync state shows in Training." The plan itself is always managed inside Praxys; this setting is purely about the write destination. `'ai'` dropped from the options (it's not a sync target).
- **Single-provider categories** render a static "selected" badge (e.g. `Garmin`) instead of a deactivatable-looking single-button toggle. Zero-connection categories show "Connect a platform" hint.

### i18n

- `PlanSyncState`, `PlanWorkoutSource` types added to `web/src/types/api.ts`.
- 49 zh translations populated for new strings (window pills, zone names, sync states, Praxys terminology). `display-labels.ts` learns the Seiler 3-zone names (Zone 1 (Easy) etc.).

## Test plan

- [x] `python -m pytest -q` — 750 pass, 1 skip
- [x] `npx eslint` on changed files — no new errors (5 pre-existing in `FitnessFatigueChart.tsx` `CustomTooltip` `any` types and `Settings.tsx` setState-in-effect)
- [x] New tests: `tests/test_plan_sync_state.py` covers all 4 sync_state branches, source filter, window clamp, ETag-per-window, invalid-window 400, and `sync_target` derivation
- [x] Visual smoke: stat strip / pill switcher / zone bars / coach receipt / window pills / per-row sync states all verified live with seeded test data covering every state
- [ ] Reviewer to check the Today page sparkline aligns correctly on stale-data accounts (same fix applied)
- [ ] Reviewer to check Goal page Coach fallback wording

## Deploy note

The `dashboard_cache` table will hold pre-fix bytes for users whose data revisions haven't changed since the deploy. The cache is date-salted, so stale rows expire by midnight UTC; the FF chart will look misaligned until then for users who happen to load Training in that window. If quicker invalidation is needed, `DELETE FROM dashboard_cache WHERE section = 'training'` after deploy is safe (the cache is best-effort, never load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
