### PR TITLE
HR/pace: thread fitness frame through threshold helpers, kill duplicate load_data_from_db

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -988,11 +988,16 @@ def _build_activities_list(
 def _compute_threshold_data(
     merged: pd.DataFrame, config, data_dir: str = None,
     user_id: str = None, db=None,
+    fitness_data: pd.DataFrame | None = None,
 ) -> tuple[float | None, dict, pd.Series, list[tuple[float, float]]]:
     """Compute active threshold value, trend data, CP values, and power-pace pairs.
 
     Returns (latest_threshold, trend_data, cp_values, power_pace_pairs).
-    When user_id and db are provided, uses DB-based fitness data for HR/pace trends.
+    When user_id and db are provided, queries fitness_data for CP estimates.
+    When ``fitness_data`` is also provided (the wide-pivoted DataFrame from
+    :func:`load_data_from_db`'s ``"fitness"`` key), it's used for the HR/pace
+    threshold trend; otherwise the helper re-runs ``load_data_from_db`` as a
+    fallback for callers that don't already hold the frame.
     """
     cp_values = (
         pd.to_numeric(merged["cp_estimate"], errors="coerce")
@@ -1075,11 +1080,14 @@ def _compute_threshold_data(
         from analysis.metrics import compute_threshold_trend
         col = "lthr_bpm" if config.training_base == "hr" else "lt_pace_sec_km"
 
-        lt_df = pd.DataFrame()
-        if user_id and db:
+        if fitness_data is not None:
+            lt_df = fitness_data
+        elif user_id and db:
             from analysis.data_loader import load_data_from_db
             db_data = load_data_from_db(user_id, db)
             lt_df = db_data.get("fitness", pd.DataFrame())
+        else:
+            lt_df = pd.DataFrame()
 
         if not lt_df.empty and col in lt_df.columns:
             lt_df = lt_df.sort_values("date")
@@ -1201,10 +1209,13 @@ def _compute_recovery_analysis(recovery: pd.DataFrame) -> tuple[dict, float | No
 def _build_threshold_trend_chart(
     merged: pd.DataFrame, config, data_dir: str = None,
     user_id: str = None, db=None,
+    fitness_data: pd.DataFrame | None = None,
 ) -> dict:
     """Build threshold trend chart data based on training base.
 
-    When user_id and db are provided, uses DB-based fitness data.
+    For HR/pace base, ``fitness_data`` (the wide-pivoted DataFrame from
+    :func:`load_data_from_db`'s ``"fitness"`` key) is used when supplied;
+    otherwise the helper re-runs ``load_data_from_db`` as a fallback.
     """
     chart: dict = {"dates": [], "values": []}
     if config.training_base == "power":
@@ -1215,11 +1226,14 @@ def _build_threshold_trend_chart(
                 "values": [round(float(v), 1) for v in cp_data["cp_estimate"].values],
             }
     elif config.training_base in ("hr", "pace"):
-        lt_df = pd.DataFrame()
-        if user_id and db:
+        if fitness_data is not None:
+            lt_df = fitness_data
+        elif user_id and db:
             from analysis.data_loader import load_data_from_db
             db_data = load_data_from_db(user_id, db)
             lt_df = db_data.get("fitness", pd.DataFrame())
+        else:
+            lt_df = pd.DataFrame()
 
         if not lt_df.empty:
             lt_df = lt_df.sort_values("date")
@@ -1403,6 +1417,7 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
     # base-native threshold: watts for power, bpm for HR, sec/km for pace.
     latest_cp, cp_trend_data, cp_values, power_pace_pairs = _compute_threshold_data(
         merged, config, data_dir=data_dir, user_id=user_id, db=db,
+        fitness_data=data.get("fitness"),
     )
 
     # CP-in-watts for power-based formulas. HR/pace users' ``latest_cp`` is
@@ -1500,6 +1515,7 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
     }
     cp_trend_chart = _build_threshold_trend_chart(
         merged, config, data_dir=data_dir, user_id=user_id, db=db,
+        fitness_data=data.get("fitness"),
     )
 
     # Supplementary data

--- a/api/packs.py
+++ b/api/packs.py
@@ -252,9 +252,14 @@ class RequestContext:
 
     @cached_property
     def threshold_data(self) -> dict:
+        # ``fitness_data`` is the wide-pivoted fitness frame already loaded
+        # by ``self._data``. Passing it through keeps HR/pace requests off
+        # a second ``load_data_from_db`` round-trip; power requests don't
+        # consult it but the kwarg is still cheap to forward.
         latest, trend, cp_values, pairs = _compute_threshold_data(
             self.merged_activities, self.config,
             user_id=self.user_id, db=self.db,
+            fitness_data=self._data.get("fitness"),
         )
         return {
             "latest": latest,
@@ -268,6 +273,7 @@ class RequestContext:
         return _build_threshold_trend_chart(
             self.merged_activities, self.config,
             user_id=self.user_id, db=self.db,
+            fitness_data=self._data.get("fitness"),
         )
 
     @cached_property

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -256,6 +256,33 @@ def test_packs_share_cache_across_calls(db_with_seeded_user, monkeypatch):
     )
 
 
+def _count_load_data_from_db(monkeypatch) -> dict:
+    """Patch ``load_data_from_db`` everywhere it can be reached and
+    return a {'n': int} call counter.
+
+    Patching only ``api.packs.load_data_from_db`` (the eager top-level
+    import) misses lazy ``from analysis.data_loader import load_data_from_db``
+    statements buried inside ``_compute_threshold_data`` and
+    ``_build_threshold_trend_chart``. Those lazy imports resolve against
+    ``analysis.data_loader`` at call time, so a future regression that
+    reintroduced a re-load via the deps.py path would slip past a single-
+    site patch. Patch both modules so any code path counts.
+    """
+    from api import packs as packs_mod
+    import analysis.data_loader as loader_mod
+
+    real_loader = loader_mod.load_data_from_db
+    calls = {"n": 0}
+
+    def counting_loader(uid, _db):
+        calls["n"] += 1
+        return real_loader(uid, _db)
+
+    monkeypatch.setattr(loader_mod, "load_data_from_db", counting_loader)
+    monkeypatch.setattr(packs_mod, "load_data_from_db", counting_loader)
+    return calls
+
+
 @pytest.mark.parametrize("training_base", ["hr", "pace"])
 def test_threshold_helpers_dont_reload_on_hr_pace_base(
     db_with_seeded_user, monkeypatch, training_base,
@@ -277,16 +304,9 @@ def test_threshold_helpers_dont_reload_on_hr_pace_base(
     db.add(UserConfigModel(user_id=user_id, training_base=training_base))
     db.commit()
 
+    calls = _count_load_data_from_db(monkeypatch)
+
     from api import packs as packs_mod
-    real_loader = packs_mod.load_data_from_db
-    calls = {"n": 0}
-
-    def counting_loader(uid, _db):
-        calls["n"] += 1
-        return real_loader(uid, _db)
-
-    monkeypatch.setattr(packs_mod, "load_data_from_db", counting_loader)
-
     ctx = packs_mod.RequestContext(user_id=user_id, db=db)
     _ = ctx.threshold_data
     _ = ctx.cp_trend_chart
@@ -294,6 +314,32 @@ def test_threshold_helpers_dont_reload_on_hr_pace_base(
     assert calls["n"] == 1, (
         f"expected loader to run exactly once per request on "
         f"training_base={training_base!r}, got {calls['n']}"
+    )
+
+
+@pytest.mark.parametrize("training_base", ["hr", "pace"])
+def test_get_dashboard_data_does_not_double_load_on_hr_pace_base(
+    db_with_seeded_user, monkeypatch, training_base,
+):
+    """The legacy ``get_dashboard_data`` path (still wired in for CLI /
+    skill scripts and a handful of tests) ran the threshold helpers with
+    the same pre-fix double-load pattern. Cover it explicitly so the
+    fallback path can't silently regress.
+    """
+    from db.models import UserConfig as UserConfigModel
+
+    db, user_id = db_with_seeded_user
+    db.add(UserConfigModel(user_id=user_id, training_base=training_base))
+    db.commit()
+
+    calls = _count_load_data_from_db(monkeypatch)
+
+    from api.deps import get_dashboard_data
+    get_dashboard_data(user_id=user_id, db=db)
+
+    assert calls["n"] == 1, (
+        f"get_dashboard_data on training_base={training_base!r} ran the "
+        f"loader {calls['n']} times — expected 1."
     )
 
 

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -256,6 +256,47 @@ def test_packs_share_cache_across_calls(db_with_seeded_user, monkeypatch):
     )
 
 
+@pytest.mark.parametrize("training_base", ["hr", "pace"])
+def test_threshold_helpers_dont_reload_on_hr_pace_base(
+    db_with_seeded_user, monkeypatch, training_base,
+):
+    """``_compute_threshold_data`` and ``_build_threshold_trend_chart``
+    used to call ``load_data_from_db`` a second time inside the request
+    on HR/pace base — bypassing ``RequestContext._data`` and paying for
+    a full re-load of activities + splits + recovery + fitness + plan
+    just to read the wide-fitness frame they already had upstream.
+
+    With ``fitness_data`` threaded through both helpers, this regression
+    is silenced. The test exercises both ``threshold_data`` and
+    ``cp_trend_chart`` cached_properties (the two consumers) and asserts
+    the loader still runs exactly once.
+    """
+    from db.models import UserConfig as UserConfigModel
+
+    db, user_id = db_with_seeded_user
+    db.add(UserConfigModel(user_id=user_id, training_base=training_base))
+    db.commit()
+
+    from api import packs as packs_mod
+    real_loader = packs_mod.load_data_from_db
+    calls = {"n": 0}
+
+    def counting_loader(uid, _db):
+        calls["n"] += 1
+        return real_loader(uid, _db)
+
+    monkeypatch.setattr(packs_mod, "load_data_from_db", counting_loader)
+
+    ctx = packs_mod.RequestContext(user_id=user_id, db=db)
+    _ = ctx.threshold_data
+    _ = ctx.cp_trend_chart
+
+    assert calls["n"] == 1, (
+        f"expected loader to run exactly once per request on "
+        f"training_base={training_base!r}, got {calls['n']}"
+    )
+
+
 def test_today_route_payload_includes_as_of_date(db_with_seeded_user):
     """The /api/today payload must carry the server-local calendar date.
 


### PR DESCRIPTION
## Why

Follow-up to #283. While auditing whether other endpoints had similar cold-path issues to /api/training, I found a smaller but real one on HR/pace base.

`_compute_threshold_data` (api/deps.py:1078) and `_build_threshold_trend_chart` (api/deps.py:1218) each re-ran `load_data_from_db(user_id, db)` inside the request when `training_base ∈ {hr, pace}` — solely to read the wide-pivoted `"fitness"` frame that `RequestContext._data` already had on hand for the same request. So a single /api/training cold read paid for **two** full DB loads on top of the request-scoped one (activities + splits + recovery + fitness + plan ≈ 15 ms each on the local dev DB), and /api/goal paid for **two** as well (`threshold_data` + `cp_trend_chart`).

Power-base users were never affected — neither helper hits the LTHR/pace branch.

## What

Both helpers now take an optional `fitness_data: pd.DataFrame | None` kwarg. When supplied, they use it directly. The `user_id` + `db` fallback that triggers `load_data_from_db` stays in place for backward compatibility with any caller that doesn't already hold the frame — the fix is additive, not a contract change.

Callers updated:
- `api/packs.py::RequestContext.threshold_data` and `cp_trend_chart` → pass `self._data.get("fitness")`
- `api/deps.py::get_dashboard_data` (the legacy single-call path used by tests / skill scripts) → pass `data.get("fitness")`

## Test plan

- [x] **New parametrized regression test** `test_threshold_helpers_dont_reload_on_hr_pace_base[hr|pace]` (tests/test_packs.py): seeds a `UserConfig` row with `training_base="hr"` (and `"pace"`), monkeypatches `load_data_from_db` with a counter, accesses both `ctx.threshold_data` and `ctx.cp_trend_chart`, and asserts the loader ran exactly once. The pre-fix code would have produced 3 calls; with the fix it stays at 1.
- [x] Existing `test_packs_share_cache_across_calls` (power base) stays green.
- [x] Full suite: **764 passed, 1 skipped** under the project venv.

## Notes

- The CLAUDE.md `metrics.py` purity rule is unaffected — this is in `deps.py` and `packs.py`.
- No frontend or API contract change.