### PR TITLE
Point Coach receipt plugin link at praxys-coach-plugin#install

### DIFF
--- a/web/src/components/AiInsightsCard.tsx
+++ b/web/src/components/AiInsightsCard.tsx
@@ -52,7 +52,7 @@ interface Props {
   fallback?: CoachFallback;
 }
 
-const PLUGIN_URL = 'https://github.com/dddtc2005/praxys';
+const PLUGIN_URL = 'https://github.com/dddtc2005/praxys-coach-plugin#install';
 
 // Mirrors Today.tsx's helper. Should be extracted to web/src/lib/format.ts
 // when a third caller appears — see issue #236.


### PR DESCRIPTION
## Summary
- `web/src/components/AiInsightsCard.tsx:55` — change the bare `dddtc2005/praxys` URL behind "Run /praxys:..." CTA to the public plugin repo, anchored at `#install` since that's what users clicking through actually want.
- Once `dddtc2005/praxys` flips private, every non-collaborator visitor hits a 404 from the Coach receipt — this lands the fix before that switch.

## Scope notes
- The companion `UpcomingPlanCard.tsx:728` link called out in #273 was already removed by the Training reshape (#280) when the window-aware Plan replaced the deterministic empty state. Re-grepped: no other bare `dddtc2005/praxys` URLs remain in user-facing web/miniapp code.
- No miniapp parity gap — miniapp has no plugin URLs (issue confirmed this; re-verified before commit).
- Did not lift `PLUGIN_URL` to `web/src/lib/` yet — still single-caller. The `timeAgo` extraction note in this same file (issue #236) tracks the same "extract on third caller" rule.

## Test plan
- [x] `npx eslint src/components/AiInsightsCard.tsx` — clean
- [x] `npx tsc --noEmit` — only the pre-existing `baseUrl` deprecation warning, unrelated
- [x] Visited `https://github.com/dddtc2005/praxys-coach-plugin#install` — anchor exists in the README
- [ ] Reviewer: verify the Coach receipt CTA still renders + the anchor scrolls to the Install section

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)