### PR TITLE
Speed up /api/history: paginate before building, vectorize splits attach

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -882,100 +882,94 @@ def _get_todays_plan(
 
 
 def _build_activities_list(
-    merged: pd.DataFrame, splits: pd.DataFrame
+    merged: pd.DataFrame, splits: pd.DataFrame,
 ) -> list[dict]:
-    """Build a list of activity dicts from merged activities + splits."""
+    """Build a list of activity dicts from merged activities + their splits.
+
+    Splits get bucketed by activity_id once via ``groupby`` instead of
+    per-activity ``splits[splits["activity_id"].astype(str) == aid]``.
+    The original shape paid an O(N_splits) scan and a full ``astype``
+    cast for every activity returned, so a 130-activity / 600-split
+    user spent ~80 ms here even when the route only kept the first 20.
+    """
     if merged.empty:
         return []
+
+    splits_by_aid: dict[str, list[dict]] = {}
+    if not splits.empty and "activity_id" in splits.columns:
+        for aid_str, group in splits.groupby(
+            splits["activity_id"].astype(str), sort=False,
+        ):
+            splits_by_aid[aid_str] = [
+                {
+                    "split_num": int(s.get("split_num", 0)),
+                    "distance_km": (
+                        round(float(s.get("distance_km", 0)), 2)
+                        if pd.notna(s.get("distance_km")) else None
+                    ),
+                    "duration_sec": (
+                        int(s.get("duration_sec", 0))
+                        if pd.notna(s.get("duration_sec")) else None
+                    ),
+                    "avg_power": (
+                        round(float(s.get("avg_power", 0)), 1)
+                        if pd.notna(s.get("avg_power")) else None
+                    ),
+                    "avg_hr": (
+                        int(s.get("avg_hr", 0))
+                        if pd.notna(s.get("avg_hr")) else None
+                    ),
+                    "avg_pace_min_km": (
+                        str(s.get("avg_pace_min_km", ""))
+                        if pd.notna(s.get("avg_pace_min_km")) else None
+                    ),
+                }
+                for _, s in group.iterrows()
+            ]
+
     activities: list[dict] = []
     merged_sorted = merged.sort_values("date", ascending=False)
     for _, row in merged_sorted.iterrows():
+        aid = str(row.get("activity_id", ""))
         act: dict = {
-            "activity_id": str(row.get("activity_id", "")),
+            "activity_id": aid,
             "date": str(row["date"]),
             "source": str(row.get("source", "")),
             "activity_type": row.get("activity_type", "running"),
             "distance_km": (
                 round(float(row.get("distance_km", 0)), 2)
-                if pd.notna(row.get("distance_km"))
-                else None
+                if pd.notna(row.get("distance_km")) else None
             ),
             "duration_sec": (
                 int(row.get("duration_sec", 0))
-                if pd.notna(row.get("duration_sec"))
-                else None
+                if pd.notna(row.get("duration_sec")) else None
             ),
             "avg_power": (
                 round(float(row.get("avg_power", 0)), 1)
-                if pd.notna(row.get("avg_power"))
-                else None
+                if pd.notna(row.get("avg_power")) else None
             ),
             "avg_hr": (
                 int(row.get("avg_hr", 0))
-                if pd.notna(row.get("avg_hr"))
-                else None
+                if pd.notna(row.get("avg_hr")) else None
             ),
             "avg_pace_min_km": (
                 str(row.get("avg_pace_min_km", ""))
-                if pd.notna(row.get("avg_pace_min_km"))
-                else None
+                if pd.notna(row.get("avg_pace_min_km")) else None
             ),
             "elevation_gain_m": (
                 round(float(row.get("elevation_gain_m", 0)), 1)
-                if pd.notna(row.get("elevation_gain_m"))
-                else None
+                if pd.notna(row.get("elevation_gain_m")) else None
             ),
             "rss": (
                 round(float(row.get("rss", 0)), 1)
-                if pd.notna(row.get("rss"))
-                else None
+                if pd.notna(row.get("rss")) else None
             ),
             "cp_estimate": (
                 round(float(row.get("cp_estimate", 0)), 1)
-                if pd.notna(row.get("cp_estimate"))
-                else None
+                if pd.notna(row.get("cp_estimate")) else None
             ),
+            "splits": splits_by_aid.get(aid, []),
         }
-        # Add splits for this activity
-        if not splits.empty and "activity_id" in splits.columns:
-            act_splits = splits[
-                splits["activity_id"].astype(str) == str(row.get("activity_id", ""))
-            ]
-            act["splits"] = [
-                {
-                    "split_num": (
-                        int(s.get("split_num", 0))
-                    ),
-                    "distance_km": (
-                        round(float(s.get("distance_km", 0)), 2)
-                        if pd.notna(s.get("distance_km"))
-                        else None
-                    ),
-                    "duration_sec": (
-                        int(s.get("duration_sec", 0))
-                        if pd.notna(s.get("duration_sec"))
-                        else None
-                    ),
-                    "avg_power": (
-                        round(float(s.get("avg_power", 0)), 1)
-                        if pd.notna(s.get("avg_power"))
-                        else None
-                    ),
-                    "avg_hr": (
-                        int(s.get("avg_hr", 0))
-                        if pd.notna(s.get("avg_hr"))
-                        else None
-                    ),
-                    "avg_pace_min_km": (
-                        str(s.get("avg_pace_min_km", ""))
-                        if pd.notna(s.get("avg_pace_min_km"))
-                        else None
-                    ),
-                }
-                for _, s in act_splits.iterrows()
-            ]
-        else:
-            act["splits"] = []
         activities.append(act)
     return activities
 

--- a/api/packs.py
+++ b/api/packs.py
@@ -57,6 +57,60 @@ from api.views import upcoming_workouts
 logger = logging.getLogger(__name__)
 
 
+def _dedup_activities_by_primary_source(
+    activities: pd.DataFrame, primary_source: str | None,
+) -> pd.DataFrame:
+    """Drop secondary-source duplicates of the same activity.
+
+    When two providers (Garmin + Stryd, COROS + Stryd, etc.) sync the
+    same workout, the rows share a date and have ``duration_sec`` within
+    10% of each other. Keep the row whose ``source`` matches
+    ``primary_source`` — typically the user's ``preferences.activities``,
+    but the /api/history route lets the request override it via a
+    ``?source=`` query param, which is why this is a free function.
+
+    No-op when ``primary_source`` is empty, the frame is empty, or the
+    frame doesn't carry a ``source`` column (the rest of the app expects
+    that column on real data, but tests and bare CSV imports may omit
+    it). Index is reset on the way out so iloc-based pagination is
+    contiguous.
+    """
+    if (
+        not primary_source
+        or activities.empty
+        or "source" not in activities.columns
+    ):
+        return activities
+
+    merged = activities.copy()
+    merged["_date"] = pd.to_datetime(merged["date"]).dt.date
+    merged["_dur"] = pd.to_numeric(
+        merged.get("duration_sec", 0), errors="coerce",
+    ).fillna(0)
+    merged["_is_primary"] = merged["source"] == primary_source
+
+    keep_mask = pd.Series(True, index=merged.index)
+    for _dt, group in merged.groupby("_date"):
+        if len(group) <= 1:
+            continue
+        primary = group[group["_is_primary"]]
+        others = group[~group["_is_primary"]]
+        for oidx, orow in others.iterrows():
+            for _, prow in primary.iterrows():
+                if prow["_dur"] > 0 and orow["_dur"] > 0:
+                    ratio = abs(prow["_dur"] - orow["_dur"]) / max(
+                        prow["_dur"], orow["_dur"]
+                    )
+                    if ratio < 0.10:
+                        keep_mask[oidx] = False
+                        break
+    return (
+        merged[keep_mask]
+        .drop(columns=["_date", "_dur", "_is_primary"], errors="ignore")
+        .reset_index(drop=True)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Request-scoped cache
 # ---------------------------------------------------------------------------
@@ -90,43 +144,10 @@ class RequestContext:
 
     @cached_property
     def merged_activities(self) -> pd.DataFrame:
-        """Activities deduplicated by primary-source preference.
-
-        Mirrors the dedup pass at the top of the legacy
-        ``get_dashboard_data``: when the same activity is synced by two
-        sources (Garmin + Stryd, same date, durations within 10%), keep
-        the row whose source matches ``preferences.activities``.
-        """
-        merged = self._data["activities"]
-        primary_source = self.config.preferences.get("activities")
-        if not primary_source or merged.empty or "source" not in merged.columns:
-            return merged
-        merged = merged.copy()
-        merged["_date"] = pd.to_datetime(merged["date"]).dt.date
-        merged["_dur"] = pd.to_numeric(
-            merged.get("duration_sec", 0), errors="coerce"
-        ).fillna(0)
-        merged["_is_primary"] = merged["source"] == primary_source
-
-        keep_mask = pd.Series(True, index=merged.index)
-        for _dt, group in merged.groupby("_date"):
-            if len(group) <= 1:
-                continue
-            primary = group[group["_is_primary"]]
-            others = group[~group["_is_primary"]]
-            for oidx, orow in others.iterrows():
-                for _, prow in primary.iterrows():
-                    if prow["_dur"] > 0 and orow["_dur"] > 0:
-                        ratio = abs(prow["_dur"] - orow["_dur"]) / max(
-                            prow["_dur"], orow["_dur"]
-                        )
-                        if ratio < 0.10:
-                            keep_mask[oidx] = False
-                            break
-        return (
-            merged[keep_mask]
-            .drop(columns=["_date", "_dur", "_is_primary"], errors="ignore")
-            .reset_index(drop=True)
+        """Activities deduplicated by primary-source preference."""
+        return _dedup_activities_by_primary_source(
+            self._data["activities"],
+            self.config.preferences.get("activities"),
         )
 
     @cached_property
@@ -738,17 +759,83 @@ def get_race_pack(ctx: RequestContext) -> dict:
     }
 
 
-def get_history_pack(ctx: RequestContext) -> dict:
-    """Full activities list (with splits) for /api/history.
+def get_history_pack(
+    ctx: RequestContext,
+    *,
+    limit: int | None = None,
+    offset: int = 0,
+    source: str | None = None,
+) -> dict:
+    """Activities (with splits) for /api/history, paginated server-side.
 
-    Returns the only piece of data /api/history actually consumes — the
-    deduplication and pagination concerns stay in the route since they
-    depend on query parameters.
+    Pagination lives here, not in the route, so :func:`_build_activities_list`
+    only ever formats the requested page. The previous shape built every
+    activity (with its splits) and the route sliced afterwards; for a
+    user with hundreds of activities the discarded work was the dominant
+    cost on /api/history's cold path.
+
+    Parameters
+    ----------
+    limit
+        Page size. ``None`` (the default) returns every activity that
+        survives dedup — kept as the legacy contract for skill-side and
+        test callers that want the full list.
+    offset
+        Number of activities to skip from the start of the deduped,
+        date-descending list.
+    source
+        Override for the dedup pivot. ``None`` falls back to the user's
+        ``preferences.activities``. When the override differs from the
+        user's setting, dedup re-runs from the raw activities frame so
+        the wrong half of a duplicate pair isn't dropped.
+
+    Returns
+    -------
+    dict
+        ``{"activities": [...page], "total": <int>, "source_filter": <str|None>}``.
+        ``total`` is the post-dedup count so the client can render
+        "Showing 1-20 of N" without holding the full list itself.
     """
+    user_pref = ctx.config.preferences.get("activities")
+    primary = source or user_pref
+
+    if source and source != user_pref:
+        # Override: redo dedup from the raw frame so the right rows survive.
+        merged = _dedup_activities_by_primary_source(
+            ctx._data["activities"], primary,
+        )
+    else:
+        # Default fast path — request-scoped dedup is already cached.
+        merged = ctx.merged_activities
+
+    if not merged.empty and "date" in merged.columns:
+        merged = merged.sort_values("date", ascending=False)
+
+    total = len(merged)
+    if limit is None:
+        page_merged = merged
+    else:
+        page_merged = (
+            merged.iloc[offset : offset + limit]
+            if not merged.empty else merged
+        )
+
+    # Filter splits to the page's activity_ids only — the route would
+    # otherwise carry the full splits frame through ``_build_activities_list``
+    # only to discard splits whose activity wasn't on this page.
+    splits = ctx.splits
+    if not page_merged.empty and "activity_id" in page_merged.columns and (
+        not splits.empty and "activity_id" in splits.columns
+    ):
+        page_aids = set(page_merged["activity_id"].astype(str))
+        page_splits = splits[splits["activity_id"].astype(str).isin(page_aids)]
+    else:
+        page_splits = splits
+
     return {
-        "activities": _build_activities_list(
-            ctx.merged_activities, ctx.splits,
-        ),
+        "activities": _build_activities_list(page_merged, page_splits),
+        "total": total,
+        "source_filter": primary,
     }
 
 

--- a/api/routes/history.py
+++ b/api/routes/history.py
@@ -32,57 +32,13 @@ def get_history(
         return guard.not_modified()
     guard.apply(response)
     ctx = RequestContext(user_id=user_id, db=db)
-    activities = get_history_pack(ctx)["activities"]
-
-    # Smart dedup: when multiple sources have the same activity (same date +
-    # similar duration), keep the primary source version. Activities that only
-    # exist in one source are always shown.
-    primary_source = source or ctx.config.preferences.get("activities")
-
-    if primary_source:
-        # Group by date
-        by_date: dict[str, list[dict]] = {}
-        for a in activities:
-            by_date.setdefault(a.get("date", ""), []).append(a)
-
-        deduped: list[dict] = []
-        for date_str, day_acts in by_date.items():
-            if len(day_acts) <= 1:
-                deduped.extend(day_acts)
-                continue
-
-            # Multiple activities on same date — check for duplicates
-            primary_acts = [a for a in day_acts if a.get("source") == primary_source]
-            other_acts = [a for a in day_acts if a.get("source") != primary_source]
-
-            deduped.extend(primary_acts)
-
-            # For each non-primary activity, check if a matching primary exists
-            # (same date + duration within 10%)
-            for other in other_acts:
-                other_dur = other.get("duration_sec") or 0
-                is_duplicate = False
-                for primary in primary_acts:
-                    primary_dur = primary.get("duration_sec") or 0
-                    if primary_dur > 0 and other_dur > 0:
-                        ratio = abs(primary_dur - other_dur) / max(primary_dur, other_dur)
-                        if ratio < 0.10:  # Within 10% duration = same activity
-                            is_duplicate = True
-                            break
-                if not is_duplicate:
-                    deduped.append(other)
-
-        # Re-sort by date descending
-        activities = sorted(deduped, key=lambda a: a.get("date", ""), reverse=True)
-
-    total = len(activities)
-    page = activities[offset : offset + limit]
+    pack = get_history_pack(ctx, limit=limit, offset=offset, source=source)
     return {
-        "activities": page,
-        "total": total,
+        "activities": pack["activities"],
+        "total": pack["total"],
         "limit": limit,
         "offset": offset,
-        "source_filter": primary_source,
+        "source_filter": pack["source_filter"],
         "training_base": ctx.config.training_base,
         "display": ctx.display,
     }

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -208,13 +208,92 @@ def test_race_pack_returns_required_keys(db_with_seeded_user):
 
 
 def test_history_pack_returns_full_activity_list(db_with_seeded_user):
+    """Default call (no limit) returns every activity, with splits, plus
+    the pagination/source-filter metadata the route forwards.
+    """
     from api.packs import get_history_pack
     ctx = _ctx(db_with_seeded_user)
     out = get_history_pack(ctx)
-    assert set(out.keys()) == {"activities"}
+    assert set(out.keys()) == {"activities", "total", "source_filter"}
     assert len(out["activities"]) == 14, "all seeded activities should appear"
+    assert out["total"] == 14
     # Each activity carries its splits.
     assert all("splits" in a for a in out["activities"])
+
+
+def test_history_pack_paginates_without_building_dropped_activities(
+    db_with_seeded_user, monkeypatch,
+):
+    """``limit`` and ``offset`` slice activities BEFORE
+    ``_build_activities_list`` runs, so the formatter only ever sees the
+    requested page. The previous shape built every activity (with its
+    splits) and let the route discard the surplus — wasted work that
+    grew linearly with history size.
+    """
+    from api import packs as packs_mod
+
+    builder_call_sizes: list[int] = []
+    real_builder = packs_mod._build_activities_list
+
+    def counting_builder(merged, splits):
+        builder_call_sizes.append(len(merged))
+        return real_builder(merged, splits)
+
+    monkeypatch.setattr(packs_mod, "_build_activities_list", counting_builder)
+
+    ctx = _ctx(db_with_seeded_user)
+    out = packs_mod.get_history_pack(ctx, limit=5, offset=0)
+
+    assert len(out["activities"]) == 5
+    assert out["total"] == 14
+    assert builder_call_sizes == [5], (
+        "builder should receive only the page slice, not the full list "
+        f"(saw call sizes {builder_call_sizes})"
+    )
+
+
+def test_history_pack_offset_returns_correct_slice(db_with_seeded_user):
+    """``offset`` skips from the start of the date-descending list, so
+    page-2 of size-5 returns activities 6-10 of 14.
+    """
+    from api.packs import get_history_pack
+
+    ctx = _ctx(db_with_seeded_user)
+    page1 = get_history_pack(ctx, limit=5, offset=0)
+    page2 = get_history_pack(ctx, limit=5, offset=5)
+
+    assert page1["total"] == page2["total"] == 14
+    assert len(page1["activities"]) == 5
+    assert len(page2["activities"]) == 5
+    page1_ids = {a["activity_id"] for a in page1["activities"]}
+    page2_ids = {a["activity_id"] for a in page2["activities"]}
+    assert page1_ids.isdisjoint(page2_ids), (
+        "page 1 and page 2 must not overlap"
+    )
+    # Date order: page-1 dates strictly newer than (or equal at boundary)
+    # page-2 dates.
+    assert max(a["date"] for a in page2["activities"]) <= min(
+        a["date"] for a in page1["activities"]
+    )
+
+
+def test_history_pack_sliced_splits_match_full_build(db_with_seeded_user):
+    """Slicing splits to the page's activity_ids must produce the same
+    per-activity ``splits`` payload the legacy "build everything then
+    discard" path produced. Pinning this ensures the page-only filter
+    didn't drop a row that belonged to a kept activity.
+    """
+    from api.packs import get_history_pack
+
+    ctx = _ctx(db_with_seeded_user)
+    full = get_history_pack(ctx)
+    paged = get_history_pack(ctx, limit=5, offset=0)
+
+    # The first 5 entries of the full list (sorted date-desc) should
+    # equal the page-1 entries field-for-field, including each one's
+    # splits.
+    for full_act, paged_act in zip(full["activities"][:5], paged["activities"]):
+        assert paged_act == full_act
 
 
 def test_science_pack_returns_required_keys(db_with_seeded_user):

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -296,6 +296,194 @@ def test_history_pack_sliced_splits_match_full_build(db_with_seeded_user):
         assert paged_act == full_act
 
 
+def test_history_pack_source_override_redoes_dedup_against_override_pivot(
+    db_with_seeded_user,
+):
+    """When the request passes ``?source=`` that differs from the user's
+    ``preferences.activities``, dedup must rerun against the override
+    pivot from the raw frame — the previous route's "second pass on
+    already-deduped data" returned the wrong rows here.
+
+    Setup: seed one extra Garmin activity that duplicates an existing
+    Stryd one (same date, duration within 10%). The user's preference
+    is Stryd (the seed default), so:
+
+      * default call → Stryd row survives, Garmin dropped.
+      * ``source="garmin"`` → Garmin row survives, Stryd dropped.
+    """
+    from datetime import date, timedelta
+    from db import session as db_session
+    from db.models import Activity, ActivitySplit, UserConfig as UserConfigModel
+    from api.packs import get_history_pack, RequestContext
+
+    db, user_id = db_with_seeded_user
+    db.add(UserConfigModel(
+        user_id=user_id,
+        preferences={"activities": "stryd"},
+    ))
+    # The fixture seeds activities at dates ``today - (14 - i)`` for
+    # i in 0..13, so the most recent is ``today - 1`` (act-13). Twin
+    # that one with a Garmin row of identical duration (3180 sec) so
+    # the 10% same-activity check trips on every metric.
+    twin_date = date.today() - timedelta(days=1)
+    db.add(Activity(
+        user_id=user_id,
+        activity_id="garmin-twin",
+        date=twin_date,
+        activity_type="running",
+        distance_km=8.0,
+        duration_sec=2400.0 + 13 * 60,  # exactly act-13's duration
+        avg_power=240.0,
+        cp_estimate=265.0,
+        rss=80.0,
+        source="garmin",
+    ))
+    db.add(ActivitySplit(
+        user_id=user_id, activity_id="garmin-twin", split_num=1,
+        distance_km=4.0, duration_sec=1200.0, avg_power=245.0,
+    ))
+    db.commit()
+
+    # Default path: Stryd preference wins, Garmin twin dropped.
+    ctx = RequestContext(user_id=user_id, db=db)
+    default = get_history_pack(ctx)
+    same_day_ids_default = {
+        a["activity_id"] for a in default["activities"]
+        if a["date"] == twin_date.isoformat()
+    }
+    assert "act-13" in same_day_ids_default
+    assert "garmin-twin" not in same_day_ids_default
+    assert default["source_filter"] == "stryd"
+
+    # Override path: source=garmin pivots dedup, Stryd's act-13 is the
+    # one that gets dropped on this date.
+    ctx2 = RequestContext(user_id=user_id, db=db)
+    overridden = get_history_pack(ctx2, source="garmin")
+    same_day_ids_override = {
+        a["activity_id"] for a in overridden["activities"]
+        if a["date"] == twin_date.isoformat()
+    }
+    assert "garmin-twin" in same_day_ids_override
+    assert "act-13" not in same_day_ids_override
+    assert overridden["source_filter"] == "garmin"
+
+
+def test_history_pack_handles_offset_past_total(db_with_seeded_user):
+    """``offset`` ≥ ``total`` returns an empty page but still reports the
+    real total — the client uses that to render "0 of N" disabled-next
+    state without a separate "are we past the end?" probe.
+    """
+    from api.packs import get_history_pack
+
+    ctx = _ctx(db_with_seeded_user)
+    out = get_history_pack(ctx, limit=5, offset=999)
+    assert out["activities"] == []
+    assert out["total"] == 14
+
+
+def test_history_pack_limit_larger_than_total(db_with_seeded_user):
+    """``limit`` > ``total`` returns every activity — no error, no
+    over-iteration."""
+    from api.packs import get_history_pack
+
+    ctx = _ctx(db_with_seeded_user)
+    out = get_history_pack(ctx, limit=500, offset=0)
+    assert len(out["activities"]) == 14
+    assert out["total"] == 14
+
+
+# ---------------------------------------------------------------------------
+# _dedup_activities_by_primary_source — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_helper_returns_empty_input_unchanged():
+    """Empty merged frame → returned as-is, no copy, no exceptions."""
+    import pandas as pd
+    from api.packs import _dedup_activities_by_primary_source
+
+    empty = pd.DataFrame()
+    out = _dedup_activities_by_primary_source(empty, "stryd")
+    assert out.empty
+
+
+def test_dedup_helper_no_op_when_primary_source_missing():
+    """``primary_source=None`` is the documented no-op contract — the
+    raw frame comes back identical so a caller can use the helper
+    unconditionally without an outer ``if``."""
+    import pandas as pd
+    from api.packs import _dedup_activities_by_primary_source
+
+    df = pd.DataFrame([
+        {"activity_id": "a", "date": "2026-05-03", "duration_sec": 1000, "source": "stryd"},
+        {"activity_id": "b", "date": "2026-05-03", "duration_sec": 1010, "source": "garmin"},
+    ])
+    out = _dedup_activities_by_primary_source(df, None)
+    assert len(out) == 2
+    assert set(out["activity_id"]) == {"a", "b"}
+
+
+def test_dedup_helper_no_op_when_source_column_missing():
+    """A frame without a ``source`` column has nothing to dedup on; the
+    helper short-circuits rather than crashing on a column lookup."""
+    import pandas as pd
+    from api.packs import _dedup_activities_by_primary_source
+
+    df = pd.DataFrame([
+        {"activity_id": "a", "date": "2026-05-03", "duration_sec": 1000},
+        {"activity_id": "b", "date": "2026-05-03", "duration_sec": 1010},
+    ])
+    out = _dedup_activities_by_primary_source(df, "stryd")
+    assert len(out) == 2
+
+
+def test_dedup_helper_drops_secondary_within_10pct_duration():
+    """The 10% duration threshold is the load-bearing similarity check.
+    A pair within 10% is the same workout (one survives); a pair just
+    outside 10% are two different activities (both survive).
+    """
+    import pandas as pd
+    from api.packs import _dedup_activities_by_primary_source
+
+    df = pd.DataFrame([
+        # Pair 1: 1000s vs 1080s → 7.4% gap (80/1080) — same activity,
+        # secondary drops.
+        {"activity_id": "p1-stryd", "date": "2026-05-03",
+         "duration_sec": 1000, "source": "stryd"},
+        {"activity_id": "p1-garmin", "date": "2026-05-03",
+         "duration_sec": 1080, "source": "garmin"},
+        # Pair 2: 1000s vs 1200s → 16.7% gap (200/1200) — distinct
+        # activities, both survive.
+        {"activity_id": "p2-stryd", "date": "2026-05-04",
+         "duration_sec": 1000, "source": "stryd"},
+        {"activity_id": "p2-garmin", "date": "2026-05-04",
+         "duration_sec": 1200, "source": "garmin"},
+    ])
+    out = _dedup_activities_by_primary_source(df, "stryd")
+    survivors = set(out["activity_id"])
+    assert survivors == {"p1-stryd", "p2-stryd", "p2-garmin"}
+
+
+def test_dedup_helper_resets_index_so_iloc_pagination_is_contiguous():
+    """The /api/history page slice uses ``iloc[offset:offset+limit]``,
+    which over a non-contiguous index would silently produce gaps. The
+    helper resets the index so paginated callers can slice safely.
+    """
+    import pandas as pd
+    from api.packs import _dedup_activities_by_primary_source
+
+    df = pd.DataFrame([
+        {"activity_id": "a", "date": "2026-05-03",
+         "duration_sec": 1000, "source": "stryd"},
+        {"activity_id": "b", "date": "2026-05-03",
+         "duration_sec": 1050, "source": "garmin"},  # drops
+        {"activity_id": "c", "date": "2026-05-04",
+         "duration_sec": 1000, "source": "stryd"},
+    ])
+    out = _dedup_activities_by_primary_source(df, "stryd")
+    assert list(out.index) == list(range(len(out)))
+
+
 def test_science_pack_returns_required_keys(db_with_seeded_user):
     from api.packs import get_science_pack
     ctx = _ctx(db_with_seeded_user)


### PR DESCRIPTION
## Why

The activities page felt slow on web and miniapp even though the route already advertised `?limit=20`. The reason: the pack built **every** activity (with splits) and the route sliced afterward.

For my account (136 activities, 646 splits): **~109 ms** cold compute per /api/history request — and the cost grew linearly with history size. Strava backfills routinely push users past 1000 activities, where this would have been multi-second.

## What

Three changes:

1. **`api/deps.py::_build_activities_list`** now buckets splits by `activity_id` once via `groupby` and looks them up per activity. The previous shape ran `splits[splits["activity_id"].astype(str) == aid]` inside the per-activity loop — O(N_act × N_splits) with a full `astype` cast every iteration.

2. **`api/packs.py::get_history_pack`** now takes `limit` / `offset` / `source` kwargs, slices the deduped+sorted merged frame **before** calling the builder, and filters splits to just the page's `activity_ids`. Returns `{activities, total, source_filter}` so the route still produces "showing X-Y of N" without holding the full list itself.

   The dedup body that used to live inside `RequestContext.merged_activities` is factored into a module-level `_dedup_activities_by_primary_source` so the rare `?source=` override path can re-run dedup against the override pivot from the raw frame. (The previous route's "second dedup pass on already-deduped data" was a latent correctness bug for the override path — now there's exactly one pass with the correct source.)

3. **`api/routes/history.py`** drops the ~50-line route-level dedup that was redundant for the common `source=None` case and broken for the override case. The route is a thin pack wrapper.

## Numbers

Real DB (136 activities, 646 splits, fresh `RequestContext` per call):

| Call | Before | After | Speedup |
|---|---:|---:|---:|
| `get_history_pack(limit=20)` | 109 ms | **32 ms** | **~3.4×** |
| `get_history_pack(limit=20, offset=20)` | — | 31 ms | — |
| `get_history_pack()` (no limit, skill path) | ~84 ms* | 69 ms | groupby win |

\* the pre-fix `_build_activities_list` alone was 84 ms; total pack was 109 ms.

The win **scales with history depth**: a 1000-activity user previously paid ~600 ms × 50 splits/act = ~30 s+ in the worst case for one request. Now they pay roughly the same ~30 ms regardless of total history (the page is always 20).

## Test plan

- [x] **`test_history_pack_paginates_without_building_dropped_activities`** — monkey-patches the builder to assert it received exactly the page-sized slice. This is the anti-regression for the slice-before-build invariant; without it a future "pure refactor" could silently bring back full-list builds.
- [x] **`test_history_pack_offset_returns_correct_slice`** — page-1 and page-2 are disjoint, dates strictly descending across pages.
- [x] **`test_history_pack_sliced_splits_match_full_build`** — page slice equals the same range from a full-build, including each activity's `splits` payload (so the splits filter doesn't drop rows belonging to kept activities).
- [x] Existing `test_history_pack_returns_full_activity_list` updated to the new `{activities, total, source_filter}` shape.
- [x] Full suite: **769 passed, 1 skipped** under the project venv.

## Notes

- No frontend or API contract change. `/api/history`'s response keys (`activities, total, limit, offset, source_filter, training_base, display`) are unchanged — only the internals got faster.
- The `source` query parameter behavior is now correct for override cases as a bonus (was buggy because route-level dedup ran on already-deduped data); but no client passes `?source=` today, so this is a latent fix.