### PR TITLE
Fix Stryd planned-workout date shifting a day earlier for UTC+ users

### DIFF
--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -350,10 +350,22 @@ def fetch_training_plan_api(
         if item.get("deleted"):
             continue
 
-        # Parse date from ISO format: "2026-04-04T02:00:00Z"
+        # Parse date from ISO format: "2026-04-04T02:00:00Z". Stryd schedules a
+        # workout at local midnight but serializes it as UTC, so truncating the
+        # date in UTC drops a calendar day for users east of UTC (a Tue workout
+        # at 00:00 +08:00 is "Mon 16:00Z" -> wrongly shows as Monday). Convert to
+        # the workout's local timezone first - matching activity parsing above -
+        # so the calendar day matches what the user scheduled.
         date_str = item.get("date", "")
+        tz_name = item.get("time_zone", "")
         try:
-            workout_date = datetime.fromisoformat(date_str.replace("Z", "+00:00")).strftime("%Y-%m-%d")
+            from zoneinfo import ZoneInfo
+            local_tz = ZoneInfo(tz_name) if tz_name else None
+        except (ImportError, KeyError):
+            local_tz = None
+        try:
+            workout_dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            workout_date = workout_dt.astimezone(local_tz).strftime("%Y-%m-%d")
         except (ValueError, AttributeError):
             continue
 

--- a/tests/test_stryd_sync.py
+++ b/tests/test_stryd_sync.py
@@ -55,3 +55,28 @@ def test_fetch_training_plan_parses_power_targets(mock_get):
     assert rows[0]["target_power_min"] == "238"  # round(250 * 95 / 100)
     assert rows[0]["target_power_max"] == "262"  # round(250 * 105 / 100) = 262 (banker's rounding)
     assert rows[0]["workout_type"] == "threshold"
+
+
+@patch("sync.stryd_sync.requests.get")
+def test_fetch_training_plan_date_uses_local_timezone(mock_get):
+    """Date must truncate in the workout's local tz, not UTC. A workout at
+    local midnight is serialized by Stryd as the prior day 16:00Z for +08:00;
+    truncating in UTC drops a day, so tomorrow's session shows as today."""
+    workout = {
+        "deleted": False,
+        # Tue Apr 7 00:00 +08:00 -> Mon Apr 6 16:00 UTC. Naive UTC truncation
+        # would yield 2026-04-06; the local date is 2026-04-07.
+        "date": "2026-04-06T16:00:00Z",
+        "time_zone": "Asia/Shanghai",
+        "duration": 3600,
+        "workout": {"title": "Day 11 - Time Trial", "type": "time trial", "blocks": []},
+    }
+    mock_get.return_value = MagicMock(
+        json=MagicMock(return_value={"workouts": [workout]}),
+        raise_for_status=MagicMock(),
+    )
+
+    rows = fetch_training_plan_api("user-1", "tok")
+
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-04-07"


### PR DESCRIPTION
## Summary
Future workouts synced from Stryd were displaying one day early (e.g. tomorrow''s "Time Trial" showed as today) on both the Today and Training pages for users east of UTC.

## Root cause
A timezone bug, not the "next-workout-as-today" logic. `fetch_training_plan_api` in `sync/stryd_sync.py` truncated the planned date in **UTC**:

```python
datetime.fromisoformat(date_str.replace("Z","+00:00")).strftime("%Y-%m-%d")
```

Stryd schedules a workout at local midnight but serializes it as UTC, so for UTC+8 a workout at 00:00 local is `…T16:00Z` of the prior day — UTC truncation drops a calendar day. Activity parsing already converted to local time; only the plan parser didn''t. `_get_todays_plan` and `upcoming_workouts` both filter strictly, ruling out the "next workout as today" theory.

## Fix
- Convert the parsed timestamp to the workout''s `time_zone` (server-local fallback) before truncating, matching the activity parser and the app''s server-local `date.today()`.
- Add a regression test (`Asia/Shanghai`, 16:00Z → +1 day).

## Notes
Already-stored mis-dated rows correct themselves on the next Stryd sync.

## Testing
- `pytest tests/test_stryd_sync.py` — 3 passed
- `pytest tests/test_integration.py tests/test_packs.py tests/test_plan_endpoints.py` — 45 passed
