### PR TITLE
Move existing Stryd plan rows on re-sync instead of leaving stale dates

### DIFF
--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -636,6 +636,22 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
             changed = False
             # Stryd is source of truth for platform rows: move the date and
             # refresh fields so reschedules and the tz date fix propagate.
+            # Before moving, clear any *other* row already holding the target
+            # (date, type) slot — a stale Stryd entry the calendar replaced —
+            # so the move can't trip the unique constraint and roll back the
+            # whole sync. Flush the delete before the survivor's UPDATE.
+            if existing.date != d or (wt and existing.workout_type != wt):
+                conflict = db.query(TrainingPlan).filter(
+                    TrainingPlan.user_id == user_id,
+                    TrainingPlan.date == d,
+                    TrainingPlan.source == source,
+                    TrainingPlan.workout_type == wt,
+                    TrainingPlan.id != existing.id,
+                ).first()
+                if conflict is not None:
+                    db.delete(conflict)
+                    db.flush()
+                    count += 1
             if existing.date != d:
                 existing.date = d
                 changed = True

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -585,12 +585,12 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
                         db: Session) -> int:
     """Write training plan rows to DB. Returns count of new + updated.
 
-    Existing rows on the same (user, date, source, workout_type) get
-    their `external_id` refreshed if the incoming row has one — needed
-    so `/api/plan` can detect mismatches against Stryd's calendar
-    after the `external_id` column was added. Without the refresh, all
-    pre-existing Stryd rows would stay null and look like external
-    user-created workouts forever.
+    Platform rows reconcile by `external_id` (Stryd's stable workout id):
+    a matching row is updated in place — including its date — so a
+    rescheduled or tz-corrected workout moves instead of leaving a stale
+    duplicate at the old date. Rows without an external_id fall back to
+    matching on (date, type). `external_id` is refreshed but never
+    cleared, so a transient gap can't drop a known id.
     """
     if not rows:
         return 0
@@ -601,21 +601,63 @@ def write_training_plan(user_id: str, rows: list[dict], source: str,
             continue
         wt = _str(row.get("workout_type"))
         new_external_id = _str(row.get("external_id")) or None
-        existing = db.query(TrainingPlan).filter(
-            TrainingPlan.user_id == user_id,
-            TrainingPlan.date == d,
-            TrainingPlan.source == source,
-            TrainingPlan.workout_type == wt,
-        ).first()
+        # Reconcile by external_id first when present: a workout keeps its
+        # Stryd id across reschedules, so matching on it lets a moved date
+        # update in place instead of orphaning the old row at the stale
+        # date. Match on (date, type) only as a fallback for legacy rows
+        # without an external_id. Dedupe any same-id duplicates a prior
+        # date-keyed sync may have created.
+        existing = None
+        if new_external_id:
+            matches = db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == user_id,
+                TrainingPlan.source == source,
+                TrainingPlan.external_id == new_external_id,
+            ).order_by(TrainingPlan.id).all()
+            if matches:
+                existing = matches[0]
+                for extra in matches[1:]:
+                    db.delete(extra)
+                    count += 1
+                # Flush deletes before mutating the survivor: the survivor may
+                # move into a date a duplicate just vacated, and SQLAlchemy
+                # would otherwise issue the UPDATE before the DELETE, tripping
+                # the (user, date, source, type) unique constraint.
+                if len(matches) > 1:
+                    db.flush()
+        if existing is None:
+            existing = db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == user_id,
+                TrainingPlan.date == d,
+                TrainingPlan.source == source,
+                TrainingPlan.workout_type == wt,
+            ).first()
         if existing:
-            # Backfill external_id on rows that pre-date the column.
-            # Intentionally one-way: once an ``external_id`` is set we
-            # never clear it (``new_external_id`` only overwrites when
-            # it's truthy). A future Stryd response that omits the id
-            # for the same workout — older API revision, partial
-            # response — must not drop known data on a transient gap.
+            changed = False
+            # Stryd is source of truth for platform rows: move the date and
+            # refresh fields so reschedules and the tz date fix propagate.
+            if existing.date != d:
+                existing.date = d
+                changed = True
+            if wt and existing.workout_type != wt:
+                existing.workout_type = wt
+                changed = True
+            for attr, val in (
+                ("planned_duration_min", _float(row.get("planned_duration_min"))),
+                ("planned_distance_km", _float(row.get("planned_distance_km"))),
+                ("target_power_min", _float(row.get("target_power_min"))),
+                ("target_power_max", _float(row.get("target_power_max"))),
+                ("workout_description", _str(row.get("workout_description"))),
+            ):
+                if val not in (None, "") and getattr(existing, attr) != val:
+                    setattr(existing, attr, val)
+                    changed = True
+            # Backfill external_id one-way: never clear a known id on a
+            # transient gap (older API revision / partial response).
             if new_external_id and existing.external_id != new_external_id:
                 existing.external_id = new_external_id
+                changed = True
+            if changed:
                 count += 1
             continue
         db.add(TrainingPlan(

--- a/tests/test_sync_writer_backfill.py
+++ b/tests/test_sync_writer_backfill.py
@@ -431,3 +431,34 @@ def test_write_training_plan_dedupes_stale_duplicate(db_with_user):
     rows = db.query(TrainingPlan).filter(TrainingPlan.external_id == "dup-1").all()
     assert len(rows) == 1
     assert rows[0].date == today + timedelta(days=1)
+
+
+def test_write_training_plan_move_displaces_different_id_at_target(db_with_user):
+    """Moving a workout onto a slot held by a different external_id must
+    displace the stale row, not trip the unique constraint and abort sync."""
+    from db import sync_writer
+    from db.models import TrainingPlan
+
+    db, user_id = db_with_user
+    today = date.today()
+    tomorrow = today + timedelta(days=1)
+    db.add(TrainingPlan(user_id=user_id, date=today, source="stryd",
+                        workout_type="time trial", external_id="keep-1"))
+    db.add(TrainingPlan(user_id=user_id, date=tomorrow, source="stryd",
+                        workout_type="time trial", external_id="stale-2"))
+    db.commit()
+
+    # Stryd now reports keep-1 on tomorrow (same type as stale-2 already there).
+    n = sync_writer.write_training_plan(user_id, [{
+        "date": tomorrow.isoformat(), "workout_type": "time trial",
+        "external_id": "keep-1",
+    }], "stryd", db)
+    db.commit()
+
+    rows = db.query(TrainingPlan).filter(
+        TrainingPlan.user_id == user_id, TrainingPlan.source == "stryd",
+    ).all()
+    assert n > 0
+    assert len(rows) == 1
+    assert rows[0].external_id == "keep-1"
+    assert rows[0].date == tomorrow

--- a/tests/test_sync_writer_backfill.py
+++ b/tests/test_sync_writer_backfill.py
@@ -369,3 +369,65 @@ def test_write_recovery_oura_skips_when_existing_complete(db_with_user):
     count = sync_writer.write_recovery(user_id, db=db, **payload)
     db.commit()
     assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Training plan: reconcile by external_id (date moves on reschedule / tz fix)
+# ---------------------------------------------------------------------------
+
+
+def test_write_training_plan_moves_date_by_external_id(db_with_user):
+    """A workout that shifts date keeps its Stryd id and moves in place.
+
+    The tz fix re-derives a future workout one day later; the existing row
+    must move to the new date, not leave a stale duplicate at the old one.
+    """
+    from db import sync_writer
+    from db.models import TrainingPlan
+
+    db, user_id = db_with_user
+    today = date.today()
+    wrong = today.isoformat()
+    right = (today + timedelta(days=1)).isoformat()
+
+    sync_writer.write_training_plan(user_id, [{
+        "date": wrong, "workout_type": "time trial",
+        "external_id": "stryd-tt-1", "planned_duration_min": "30",
+    }], "stryd", db)
+    db.commit()
+
+    sync_writer.write_training_plan(user_id, [{
+        "date": right, "workout_type": "time trial",
+        "external_id": "stryd-tt-1", "planned_duration_min": "30",
+    }], "stryd", db)
+    db.commit()
+
+    rows = db.query(TrainingPlan).filter(
+        TrainingPlan.user_id == user_id, TrainingPlan.source == "stryd",
+    ).all()
+    assert len(rows) == 1, "must move, not duplicate"
+    assert rows[0].date == today + timedelta(days=1)
+
+
+def test_write_training_plan_dedupes_stale_duplicate(db_with_user):
+    """A pre-existing stale row + new correct row collapse to one on re-sync."""
+    from db import sync_writer
+    from db.models import TrainingPlan
+
+    db, user_id = db_with_user
+    today = date.today()
+    db.add(TrainingPlan(user_id=user_id, date=today, source="stryd",
+                        workout_type="long", external_id="dup-1"))
+    db.add(TrainingPlan(user_id=user_id, date=today + timedelta(days=1),
+                        source="stryd", workout_type="long", external_id="dup-1"))
+    db.commit()
+
+    sync_writer.write_training_plan(user_id, [{
+        "date": (today + timedelta(days=1)).isoformat(),
+        "workout_type": "long", "external_id": "dup-1",
+    }], "stryd", db)
+    db.commit()
+
+    rows = db.query(TrainingPlan).filter(TrainingPlan.external_id == "dup-1").all()
+    assert len(rows) == 1
+    assert rows[0].date == today + timedelta(days=1)


### PR DESCRIPTION
## Summary
Follow-up to #315. After deploying the timezone fix, existing future workouts still showed on the wrong day. Root cause: even with the corrected date, the writer never moved already-synced rows.

## Why the first fix wasn''t enough
`write_training_plan` matched rows on `(user_id, date, source, workout_type)` and, on a match, only refreshed `external_id`. A tz-corrected workout has a **new** date, so it either inserted a fresh row (leaving the stale one) or didn''t move. Existing workouts stayed frozen at the wrong date.

## Fix
Reconcile Stryd rows by their stable `external_id`:
- Update the matched row **in place** — including its date — and refresh fields, so reschedules and the tz fix propagate to existing data.
- Dedupe same-id duplicates a prior date-keyed sync may have created; `flush()` deletes before moving the survivor so the `(user, date, source, type)` unique constraint holds.
- Legacy rows without an `external_id` keep the date+type fallback (one-way `external_id` backfill preserved).

Existing mis-dated rows correct themselves on the next Stryd sync.

## Testing
- Added `test_write_training_plan_moves_date_by_external_id` + `test_write_training_plan_dedupes_stale_duplicate`
- Full suite: `pytest tests/` -> 780 passed, 1 skipped
