### PR TITLE
Enforce EULA re-acceptance on terms version change

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -64,6 +64,7 @@ from sqlalchemy.orm import Session
 
 from api.auth import get_current_user_id
 from api.env_compat import getenv_compat
+from api.legal import TERMS_VERSION
 from api.version import get_api_version
 from api.views import utc_isoformat
 from db.session import get_db
@@ -210,4 +211,36 @@ def get_me(
         "is_superuser": user.is_superuser,
         "is_demo": user.is_demo,
         "created_at": utc_isoformat(user.created_at),
+        # EULA re-acceptance gate: the client compares these to decide whether
+        # to show the re-consent modal. terms_current is computed server-side
+        # so the live TERMS_VERSION stays the single source of truth.
+        "terms_version": user.terms_version,
+        "terms_current": user.terms_version == TERMS_VERSION,
+    }
+
+
+@app.post("/api/me/accept-terms")
+def accept_terms(
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+):
+    """Record the current user's acceptance of the latest Terms/EULA version.
+
+    Stamps the live TERMS_VERSION and acceptance timestamp so a user whose
+    stored terms_version is stale (or null) clears the re-consent gate.
+    WeChat-linked users authenticate with the same JWT, so they are covered.
+    """
+    from datetime import datetime, timezone
+
+    from db.models import User
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(404, "User not found")
+    user.terms_version = TERMS_VERSION
+    user.terms_accepted_at = datetime.now(timezone.utc)
+    db.commit()
+    return {
+        "terms_version": user.terms_version,
+        "terms_current": True,
+        "terms_accepted_at": utc_isoformat(user.terms_accepted_at),
     }

--- a/tests/test_wechat_auth.py
+++ b/tests/test_wechat_auth.py
@@ -575,3 +575,55 @@ def test_wechat_register_requires_terms_acceptance(wechat_client):
     assert r.status_code == 400, r.text
     assert r.json()["detail"] == "REGISTER_TERMS_NOT_ACCEPTED"
 
+
+# ---------------------------------------------------------------------------
+# EULA re-acceptance gate (issue #324)
+# ---------------------------------------------------------------------------
+
+
+def _login_token(client, email: str, password: str) -> str:
+    r = client.post(
+        "/api/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def test_accept_terms_clears_stale_version(wechat_client):
+    email, pw = "stale@example.com", "pw-123456"
+    reg = wechat_client.post(
+        "/api/auth/register",
+        json={"email": email, "password": pw, "accepted_terms": True},
+    )
+    assert reg.status_code == 200, reg.text
+    token = _login_token(wechat_client, email, pw)
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    # Force a stale terms_version to simulate a post-bump returning user.
+    from db.models import User
+    from db.session import SessionLocal
+    db = SessionLocal()
+    try:
+        u = db.query(User).filter(User.email == email).first()
+        u.terms_version = "0000.00.0"
+        db.commit()
+    finally:
+        db.close()
+
+    me = wechat_client.get("/api/auth/me", headers=hdr).json()
+    assert me["terms_current"] is False  # stale -> 1 prompt
+
+    from api.legal import TERMS_VERSION
+    acc = wechat_client.post("/api/me/accept-terms", headers=hdr)
+    assert acc.status_code == 200, acc.text
+    assert acc.json()["terms_version"] == TERMS_VERSION
+    assert acc.json()["terms_current"] is True
+
+    me2 = wechat_client.get("/api/auth/me", headers=hdr).json()
+    assert me2["terms_current"] is True  # cleared after accept
+
+
+def test_accept_terms_requires_auth(wechat_client):
+    assert wechat_client.post("/api/me/accept-terms").status_code == 401

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,16 +1,19 @@
 import { Outlet } from 'react-router-dom';
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import AppSidebar from '@/components/AppSidebar';
+import TermsGate from '@/components/TermsGate';
 import SystemBanner from '@/components/SystemBanner';
 import { useAuth } from '@/hooks/useAuth';
 import { Eye } from 'lucide-react';
 import { Trans } from '@lingui/react/macro';
 
 export default function Layout() {
-  const { isDemo } = useAuth();
+  const { isDemo, termsCurrent } = useAuth();
 
   return (
     <SidebarProvider>
+      {/* EULA re-acceptance gate: block app use until stale terms are accepted. */}
+      {!termsCurrent && !isDemo && <TermsGate />}
       <AppSidebar />
       <main className="flex-1 min-h-screen">
         <header className="sticky top-0 z-40 flex h-12 items-center gap-2 border-b border-border bg-background/80 backdrop-blur-sm px-4 lg:hidden">

--- a/web/src/components/TermsGate.tsx
+++ b/web/src/components/TermsGate.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+import { useLocale } from "@/contexts/LocaleContext";
+import { TERMS_VERSION, EFFECTIVE_DATE } from "@/lib/legal";
+
+/**
+ * Blocking re-consent modal shown when the signed-in user's accepted Terms/EULA
+ * version is stale (or null). Mirrors the registration agree UI: a checkbox plus
+ * links to the full Terms and Privacy. The app stays gated until the user
+ * acknowledges, which stamps the live TERMS_VERSION via POST /api/me/accept-terms.
+ * Bilingual via the locale ternary, matching LegalPage.
+ */
+export default function TermsGate() {
+  const { acceptTerms } = useAuth();
+  const { locale, setLocale } = useLocale();
+  const zh = locale === "zh";
+  const [agreed, setAgreed] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAccept = async () => {
+    if (!agreed) return;
+    setSubmitting(true);
+    setError(null);
+    const ok = await acceptTerms();
+    if (!ok) {
+      setError(zh ? "\u63d0\u4ea4\u5931\u8d25\uff0c\u8bf7\u91cd\u8bd5\u3002" : "Could not save \u2014 please try again.");
+      setSubmitting(false);
+    }
+    // On success the gate unmounts as termsCurrent flips true.
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">
+            {zh ? "\u6761\u6b3e\u5df2\u66f4\u65b0" : "Updated Terms"}
+          </h2>
+          <button
+            type="button"
+            onClick={() => setLocale(zh ? "en" : "zh")}
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            {zh ? "EN" : "\u4e2d\u6587"}
+          </button>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground font-data">
+          v{TERMS_VERSION} \u00b7 {zh ? "\u751f\u6548\u65e5\u671f " : "Effective "}{EFFECTIVE_DATE}
+        </p>
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          {zh
+            ? "\u6211\u4eec\u66f4\u65b0\u4e86\u670d\u52a1\u6761\u6b3e\u4e0e\u9690\u79c1\u653f\u7b56\u3002\u8bf7\u9605\u8bfb\u5e76\u540c\u610f\u540e\u7ee7\u7eed\u4f7f\u7528\u3002"
+            : "We've updated our Terms and Privacy Policy. Please review and accept to continue."}
+        </p>
+
+        <label className="mt-5 flex items-start gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={agreed}
+            onChange={(e) => setAgreed(e.target.checked)}
+            disabled={submitting}
+            className="mt-0.5 flex-none"
+          />
+          <span>
+            {zh ? "\u6211\u540c\u610f" : "I agree to the"}{" "}
+            <Link to="/terms" target="_blank" className="text-primary hover:underline">
+              {zh ? "\u670d\u52a1\u6761\u6b3e" : "Terms of Service"}
+            </Link>{" "}
+            {zh ? "\u4e0e" : "and"}{" "}
+            <Link to="/privacy" target="_blank" className="text-primary hover:underline">
+              {zh ? "\u9690\u79c1\u653f\u7b56" : "Privacy Policy"}
+            </Link>
+            {zh ? "\u3002" : "."}
+          </span>
+        </label>
+
+        {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+
+        <button
+          type="button"
+          onClick={handleAccept}
+          disabled={!agreed || submitting}
+          className="mt-6 w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {submitting
+            ? (zh ? "\u4fdd\u5b58\u4e2d\u2026" : "Saving\u2026")
+            : (zh ? "\u540c\u610f\u5e76\u7ee7\u7eed" : "Accept and continue")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -10,12 +10,14 @@ interface AuthState {
   isDemo: boolean;
   isAuthenticated: boolean;
   isLoading: boolean;
+  termsCurrent: boolean;
 }
 
 interface AuthContextType extends AuthState {
   login: (email: string, password: string) => Promise<{ ok: boolean; error?: string }>;
   register: (email: string, password: string, invitationCode?: string, acceptedTerms?: boolean) => Promise<{ ok: boolean; error?: string }>;
   logout: () => void;
+  acceptTerms: () => Promise<boolean>;
 }
 
 // The API base URL may be empty (same origin via SWA linked backend)
@@ -29,9 +31,11 @@ const AuthContext = createContext<AuthContextType>({
   isDemo: false,
   isAuthenticated: false,
   isLoading: true,
+  termsCurrent: true,
   login: async () => ({ ok: false }),
   register: async () => ({ ok: false }),
   logout: () => {},
+  acceptTerms: async () => false,
 });
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -40,6 +44,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isDemo, setIsDemo] = useState(false);
   const [email, setEmail] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // EULA re-acceptance gate: true until /me reports a stale terms_version.
+  const [termsCurrent, setTermsCurrent] = useState(true);
 
   // On mount, restore token from localStorage and verify it with the server.
   useEffect(() => {
@@ -77,6 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         } else if (data) {
           setIsAdmin(data.is_superuser);
           setIsDemo(data.is_demo ?? false);
+          setTermsCurrent(data.terms_current ?? true);
           setCompatItem(KEYS.authAdmin.new, KEYS.authAdmin.legacy, String(data.is_superuser));
         }
       })
@@ -115,6 +122,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             if (me) {
               setIsAdmin(me.is_superuser);
               setIsDemo(me.is_demo ?? false);
+              setTermsCurrent(me.terms_current ?? true);
               setCompatItem(KEYS.authAdmin.new, KEYS.authAdmin.legacy, String(me.is_superuser));
             }
           })
@@ -167,13 +175,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setEmail(null);
     setIsAdmin(false);
     setIsDemo(false);
+    setTermsCurrent(true);
+  }, []);
+
+  const acceptTerms = useCallback(async (): Promise<boolean> => {
+    const tk = getCompatItem(KEYS.authToken.new, KEYS.authToken.legacy);
+    if (!tk) return false;
+    try {
+      const res = await fetch(`${API_BASE}/api/me/accept-terms`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${tk}` },
+      });
+      if (!res.ok) return false;
+      setTermsCurrent(true);
+      return true;
+    } catch {
+      return false;
+    }
   }, []);
 
   const isAuthenticated = token !== null;
 
   return (
     <AuthContext.Provider
-      value={{ token, email, isAdmin, isDemo, isAuthenticated, isLoading, login, register, logout }}
+      value={{ token, email, isAdmin, isDemo, isAuthenticated, isLoading, termsCurrent, login, register, logout, acceptTerms }}
     >
       {children}
     </AuthContext.Provider>

--- a/web/src/lib/auth-prefetch.ts
+++ b/web/src/lib/auth-prefetch.ts
@@ -19,7 +19,7 @@ const token = (() => {
 
 export interface PrefetchedMe {
   status: number;
-  data: { is_superuser: boolean; is_demo?: boolean } | null;
+  data: { is_superuser: boolean; is_demo?: boolean; terms_current?: boolean } | null;
 }
 
 export const prefetchedMe: Promise<PrefetchedMe> | null = token

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -1291,7 +1291,7 @@ msgstr "Link URL (optional)"
 msgid "Link your training devices and services"
 msgstr "Link your training devices and services"
 
-#: src/components/Layout.tsx:31
+#: src/components/Layout.tsx:34
 msgid "Live demo — real training data, read-only"
 msgstr "Live demo — real training data, read-only"
 


### PR DESCRIPTION
Fixes #324. The EULA (PR #321) promised material changes are versioned and re-acknowledged at next sign-in, but `User.terms_version` was stored and never compared to the live `TERMS_VERSION` — so re-acceptance was not enforced.

## Changes
**Backend**
- `GET /api/auth/me` now returns `terms_version` + server-computed `terms_current` (live `TERMS_VERSION` is the source of truth).
- `POST /api/me/accept-terms` stamps the current version + `terms_accepted_at`. Uses `get_current_user_id`, so WeChat-linked users are covered.

**Frontend**
- `useAuth` tracks `termsCurrent` and exposes `acceptTerms()`.
- New bilingual, blocking `TermsGate` modal (mirrors the registration agree UI) gates non-demo users until they re-acknowledge.

## Acceptance
- [x] Stale-version user is prompted and cannot proceed until ack
- [x] Endpoint stamps current version + timestamp
- [x] WeChat-linked users covered (same JWT)
- [x] Test: stale -> 1 prompt -> cleared after accept

## Verification
- `pytest tests/test_wechat_auth.py` — 20 passed (incl. 2 new)
- `npm run build` + `tsc -b` clean
