### PR TITLE
Fix EULA gate: literal escape, locale toggle, and harden accept-terms

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -229,18 +229,34 @@ def accept_terms(
     Stamps the live TERMS_VERSION and acceptance timestamp so a user whose
     stored terms_version is stale (or null) clears the re-consent gate.
     WeChat-linked users authenticate with the same JWT, so they are covered.
+
+    The acceptance timestamp is captured before commit and returned directly
+    rather than re-read from the ORM, so the response never depends on a
+    post-commit attribute refresh. On any DB error we roll back and log the
+    traceback: a true 500 skips the CORS middleware, so the browser only sees
+    an opaque "No Access-Control-Allow-Origin" failure and server-side logging
+    is the only way to diagnose the real cause.
     """
+    import logging
     from datetime import datetime, timezone
 
     from db.models import User
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(404, "User not found")
+    accepted_at = datetime.now(timezone.utc)
     user.terms_version = TERMS_VERSION
-    user.terms_accepted_at = datetime.now(timezone.utc)
-    db.commit()
+    user.terms_accepted_at = accepted_at
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        logging.getLogger(__name__).exception(
+            "accept-terms failed for user %s", user_id
+        )
+        raise HTTPException(500, "ACCEPT_TERMS_FAILED")
     return {
-        "terms_version": user.terms_version,
+        "terms_version": TERMS_VERSION,
         "terms_current": True,
-        "terms_accepted_at": utc_isoformat(user.terms_accepted_at),
+        "terms_accepted_at": utc_isoformat(accepted_at),
     }

--- a/web/src/components/TermsGate.tsx
+++ b/web/src/components/TermsGate.tsx
@@ -9,11 +9,16 @@ import { TERMS_VERSION, EFFECTIVE_DATE } from "@/lib/legal";
  * version is stale (or null). Mirrors the registration agree UI: a checkbox plus
  * links to the full Terms and Privacy. The app stays gated until the user
  * acknowledges, which stamps the live TERMS_VERSION via POST /api/me/accept-terms.
- * Bilingual via the locale ternary, matching LegalPage.
+ *
+ * The modal follows the app locale (set globally from the user's saved language
+ * preference / browser detection). It deliberately has no own language toggle:
+ * LocaleSync owns the authed-area locale and would immediately revert a
+ * local-only switch back to config.language. Readers who want the other
+ * language can open the full Terms / Privacy pages, which carry their own toggle.
  */
 export default function TermsGate() {
   const { acceptTerms } = useAuth();
-  const { locale, setLocale } = useLocale();
+  const { locale } = useLocale();
   const zh = locale === "zh";
   const [agreed, setAgreed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -25,7 +30,7 @@ export default function TermsGate() {
     setError(null);
     const ok = await acceptTerms();
     if (!ok) {
-      setError(zh ? "\u63d0\u4ea4\u5931\u8d25\uff0c\u8bf7\u91cd\u8bd5\u3002" : "Could not save \u2014 please try again.");
+      setError(zh ? "提交失败，请重试。" : "Could not save — please try again.");
       setSubmitting(false);
     }
     // On success the gate unmounts as termsCurrent flips true.
@@ -34,24 +39,15 @@ export default function TermsGate() {
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
       <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-lg">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">
-            {zh ? "\u6761\u6b3e\u5df2\u66f4\u65b0" : "Updated Terms"}
-          </h2>
-          <button
-            type="button"
-            onClick={() => setLocale(zh ? "en" : "zh")}
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
-            {zh ? "EN" : "\u4e2d\u6587"}
-          </button>
-        </div>
+        <h2 className="text-lg font-semibold">
+          {zh ? "条款已更新" : "Updated Terms"}
+        </h2>
         <p className="mt-1 text-sm text-muted-foreground font-data">
-          v{TERMS_VERSION} \u00b7 {zh ? "\u751f\u6548\u65e5\u671f " : "Effective "}{EFFECTIVE_DATE}
+          v{TERMS_VERSION} · {zh ? "生效日期 " : "Effective "}{EFFECTIVE_DATE}
         </p>
         <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
           {zh
-            ? "\u6211\u4eec\u66f4\u65b0\u4e86\u670d\u52a1\u6761\u6b3e\u4e0e\u9690\u79c1\u653f\u7b56\u3002\u8bf7\u9605\u8bfb\u5e76\u540c\u610f\u540e\u7ee7\u7eed\u4f7f\u7528\u3002"
+            ? "我们更新了服务条款与隐私政策。请阅读并同意后继续使用。"
             : "We've updated our Terms and Privacy Policy. Please review and accept to continue."}
         </p>
 
@@ -64,15 +60,15 @@ export default function TermsGate() {
             className="mt-0.5 flex-none"
           />
           <span>
-            {zh ? "\u6211\u540c\u610f" : "I agree to the"}{" "}
+            {zh ? "我同意" : "I agree to the"}{" "}
             <Link to="/terms" target="_blank" className="text-primary hover:underline">
-              {zh ? "\u670d\u52a1\u6761\u6b3e" : "Terms of Service"}
+              {zh ? "服务条款" : "Terms of Service"}
             </Link>{" "}
-            {zh ? "\u4e0e" : "and"}{" "}
+            {zh ? "与" : "and"}{" "}
             <Link to="/privacy" target="_blank" className="text-primary hover:underline">
-              {zh ? "\u9690\u79c1\u653f\u7b56" : "Privacy Policy"}
+              {zh ? "隐私政策" : "Privacy Policy"}
             </Link>
-            {zh ? "\u3002" : "."}
+            {zh ? "。" : "."}
           </span>
         </label>
 
@@ -85,8 +81,8 @@ export default function TermsGate() {
           className="mt-6 w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
         >
           {submitting
-            ? (zh ? "\u4fdd\u5b58\u4e2d\u2026" : "Saving\u2026")
-            : (zh ? "\u540c\u610f\u5e76\u7ee7\u7eed" : "Accept and continue")}
+            ? (zh ? "保存中…" : "Saving…")
+            : (zh ? "同意并继续" : "Accept and continue")}
         </button>
       </div>
     </div>


### PR DESCRIPTION
Follow-up fixes to the EULA re-acceptance gate (#326), all found while testing locally.

## 1. Literal `\u00b7` in the modal
The version line rendered a literal `\u00b7` instead of `·`. The middot was in **JSX text position**, where JSX does *not* decode `\uXXXX` escapes (only JS string literals do). Root cause: the component file was generated from a raw string that kept the escape sequences. Rewrote `TermsGate.tsx` using real Unicode characters.

## 2. Language couldn't be switched in the gate
The gate had its own EN/中文 toggle, but `LocaleSync` (which owns the authed-area locale) immediately reverts any local-only `setLocale` back to the user's saved `config.language` — so the toggle appeared dead for anyone with a saved language preference. Removed the redundant toggle; the modal now follows the **global app locale** (already the user's chosen/detected language). The public Terms/Privacy links it shows keep their own working toggle for reading the other language.

## 3. Hardened `POST /api/me/accept-terms` (the 500 / CORS symptom)
The reported `net::ERR_FAILED 500` + *"No ''Access-Control-Allow-Origin''"* is a **500 masking** — a true 500 is emitted by `ServerErrorMiddleware` (outermost), which bypasses the CORS middleware, so the browser never sees the CORS header. The endpoint returns 200 against a healthy, migrated DB (verified end-to-end incl. preflight + idempotent retry), so the root cause is environment/DB-state specific. To make it robust and diagnosable:
- Capture the acceptance timestamp **before** commit and return it directly — no post-commit ORM attribute refresh.
- Roll back and **log the traceback** on any DB error, returning `ACCEPT_TERMS_FAILED`. Since the browser hides the real error behind CORS, server-side logging is now the only way to see it.

If the 500 still reproduces after a backend restart, the server log will now show the exact exception (e.g. a locked DB or schema gap).

## Verification
- `pytest tests/test_wechat_auth.py -k "terms or accept"` -> 5 passed
- `npm run build` (tsc + vite) clean; ESLint clean on `TermsGate.tsx`
- Live repro on a temp DB: register -> login -> force stale -> preflight + POST + idempotent retry all 200 with CORS headers
