### PR TITLE
Fix feedback sensitivity gate parking benign reports

### DIFF
--- a/api/feedback_triage.py
+++ b/api/feedback_triage.py
@@ -77,10 +77,14 @@ def _system_prompt() -> str:
         "for features, and an 'Environment' bullet list from the provided context.\n"
         "- Be factual; do not invent details the user didn't provide.\n"
         "- Classify the report as exactly one kind: bug, feature, or other.\n"
-        "- Judge whether the report still contains personal, health, account, or "
-        "credential information that should NOT appear on a public issue tracker, "
-        "even after scrubbing. Set contains_sensitive accordingly; when unsure, "
-        "prefer true.\n"
+        "- The input is ALREADY PII-scrubbed (emails, tokens, keys, IPs, file "
+        "paths, and long numbers are removed and shown as [redacted-*]). Set "
+        "contains_sensitive=true ONLY if the report STILL clearly contains "
+        "personal data, health details about an identifiable person, account or "
+        "credential information, or private third-party info unsuitable for a "
+        "public tracker. A normal product bug report or feature request is NOT "
+        "sensitive — return false. Default to false, and ALWAYS include the "
+        "contains_sensitive field in your response.\n"
         "Respond with a JSON object: "
         "{\"kind\": str, \"title\": str, \"body\": str, \"contains_sensitive\": bool}."
     )
@@ -162,6 +166,10 @@ def triage_and_publish(feedback_id: int, *, _session: Optional[Session] = None) 
                 user=_user_payload(kind, clean_message, clean_context),
                 model=_TRIAGE_MODEL,
                 max_completion_tokens=1200,
+                # Deterministic: triage/classification shouldn't vary run-to-run.
+                # Low temperature minimises the rare false-positive sensitivity
+                # flip that parks benign reports.
+                temperature=0.0,
                 insight_type="feedback_triage",
             )
             if result and isinstance(result.get("title"), str) and isinstance(result.get("body"), str):

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -582,3 +582,39 @@ def test_github_app_malformed_mint_response_returns_none(monkeypatch):
 
     monkeypatch.setattr(gi.httpx, "post", lambda url, **kw: _BadResp())
     assert gi._bearer_token() is None  # must not raise
+
+# ---------------------------------------------------------------------------
+# Sensitivity-gate calibration (over-flagging fix)
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_defaults_sensitive_to_false():
+    """The triage prompt must not bias the model toward flagging benign reports
+    (regression for the 'when unsure, prefer true' over-flagging)."""
+    from api.feedback_triage import _system_prompt
+
+    p = _system_prompt()
+    assert "prefer true" not in p.lower()
+    assert "default to false" in p.lower()
+    assert "always include the contains_sensitive" in p.lower()
+
+
+def test_triage_uses_deterministic_temperature(db_with_users, monkeypatch):
+    """Triage must call the model at temperature 0 so the sensitivity verdict
+    doesn't vary run-to-run and rarely flip a benign report to sensitive."""
+    from api import feedback_triage as ft
+    from api.feedback_triage import triage_and_publish
+
+    db, _, _, user_id = db_with_users
+    captured: dict = {}
+
+    monkeypatch.setattr(ft.llm, "get_client", lambda: object())
+
+    def fake_chat_json(client, **kwargs):
+        captured.update(kwargs)
+        return {"kind": "bug", "title": "T", "body": "B", "contains_sensitive": False}
+
+    monkeypatch.setattr(ft.llm, "chat_json", fake_chat_json)
+    row = _new_row(db, user_id, "charts render slowly on the training page")
+    triage_and_publish(row.id, _session=db)
+    assert captured.get("temperature") == 0.0


### PR DESCRIPTION
## Symptom

A user submitted a **benign feature request** (a UI suggestion, no sensitive info) but it was parked as `needs_review` instead of auto-filing.

## Diagnosis (from the live prod row + endpoint)

- The feedback row (`id=1`) had `ai_labels: [..., "ai-triaged"]` and `error: null` → **the LLM ran** (`used_llm=true`); the gate parks when the model returns `contains_sensitive=true`.
- Verified the LLM tier is healthy: `gpt-5.4` deployed, the App Service MI has *Cognitive Services OpenAI User*, `chat_json` returns `200 OK` with valid JSON, `temperature` accepted.
- Ran the **exact** prod payload ~42× → `contains_sensitive=false` every time. So prod hit a **rare non-deterministic flip to `true`**, made more likely by:
  1. the prompt instruction *"when unsure, prefer true"* (an explicit bias toward flagging), and
  2. `result.get("contains_sensitive", True)` defaulting a **missing** field to *sensitive*.

So: not the content, not config — the sensitivity check was **biased toward false-positives and non-deterministic**.

## Fix

- **Debias the prompt:** the input is already PII-scrubbed; flag `true` **only** for clearly-remaining personal / health / credential / private third-party info; a normal bug or feature report is **not** sensitive; **default false** and **always include** the field.
- **`temperature=0`** for triage → deterministic verdict (and title/body).
- The deterministic regex key/token scrub backstop is unchanged (real secrets still always park).

**Validated** against the live model on the exact prod message: **0/10 flagged, field always present**. Regression tests added (prompt is debiased; triage uses temp 0).

## Notes

- Tests: 24 feedback tests pass. ⚠️ The full suite shows **2 pre-existing failures in `tests/test_strava_sync_route.py`** (`SYNC_USER_DELETED`) that exist on clean `main` (from the separate "Add account deletion" change) — unrelated to this PR, but they currently red the backend deploy's pytest gate. Flagging separately.
- The already-parked `id=1` can be released now via Admin → **Approve & file**.
