### PR TITLE
Stop SQLite WAL corruption on Azure Files: use a rollback journal

### DIFF
--- a/db/session.py
+++ b/db/session.py
@@ -14,17 +14,27 @@ from db.models import Base
 
 # SQLite tuning pragmas applied to every new connection.
 #
-# Why this matters: on Azure App Service Linux the /home volume is an Azure
-# Files (SMB) mount with high per-IOP latency. Default SQLite (rollback
-# journal + synchronous=FULL) issues many small fsync()s per write, so each
-# of those amplifies into an SMB round-trip. Even read-mostly workloads
-# pay this cost on metadata pages. WAL + synchronous=NORMAL together cut
-# the fsync count substantially while keeping crash-safety: a power loss
-# may lose the last in-flight transaction but the database stays
-# consistent. The other pragmas are pure cache/locality wins.
+# ⚠️ journal_mode is DELETE (rollback journal), NOT WAL — deliberately.
+# On Azure App Service Linux the DATA_DIR (/home) is an Azure Files (SMB)
+# network mount, and SQLite's WAL mode requires a shared-memory index (the
+# ``-shm`` file) backed by mmap that does NOT work over a network filesystem.
+# SQLite documents this explicitly ("WAL does not work over a network
+# filesystem", https://www.sqlite.org/wal.html). Running WAL on /home caused
+# "database disk image is malformed" corruption in production — the failure
+# is amplified by multiple gunicorn worker processes acting as concurrent
+# writers over SMB. A classic rollback journal works over SMB (byte-range
+# locks); paired with a SINGLE writer (run the backend with one gunicorn
+# worker — see docs/ops/backup-and-restore.md) and busy_timeout, writes stay
+# safe.
+#
+# synchronous=FULL (not NORMAL): on the SMB mount a container recycle mid-write
+# (every deploy/scale) is the "power loss" equivalent, and FULL fsyncs the
+# rollback journal so an interrupted write can't corrupt the file. It costs
+# extra SMB round-trips per commit, but on this low-traffic workload
+# correctness beats throughput. The remaining pragmas are cache/locality wins.
 _SQLITE_PRAGMAS = (
-    ("journal_mode", "WAL"),
-    ("synchronous", "NORMAL"),
+    ("journal_mode", "DELETE"),
+    ("synchronous", "FULL"),
     # 20 MB SQLite page cache (negative value = KB; default is 2 MB).
     ("cache_size", "-20000"),
     ("temp_store", "MEMORY"),

--- a/docs/ops/backup-and-restore.md
+++ b/docs/ops/backup-and-restore.md
@@ -69,9 +69,59 @@ Keep the pre-restore file (download it before overwriting) so a bad restore is
 itself reversible. If the app won't boot, restore the previous-known-good
 snapshot.
 
+## Recover from corruption (no snapshot)
+
+If `az webapp log tail` shows `sqlite3.DatabaseError: database disk image is
+malformed` and you have **no backup**, salvage the live file with SQLite's
+`.recover` (it parses the b-tree pages directly and rebuilds a clean DB,
+skipping unreadable pages). Run inside `az webapp ssh` (or the Kudu console):
+
+```bash
+cd /home/data
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+# 1. Preserve the corrupt triplet (reversible if recovery goes wrong)
+cp -v trainsight.db "trainsight.db.corrupt.$ts"
+[ -f trainsight.db-wal ] && cp -v trainsight.db-wal "trainsight.db-wal.corrupt.$ts"
+[ -f trainsight.db-shm ] && cp -v trainsight.db-shm "trainsight.db-shm.corrupt.$ts"
+
+# 2. Salvage into a fresh file (non-destructive)
+sqlite3 trainsight.db ".recover" 2>recover.err | sqlite3 trainsight.rebuilt.db
+sqlite3 trainsight.rebuilt.db "PRAGMA integrity_check;"   # want: ok
+sqlite3 trainsight.rebuilt.db "SELECT count(*) FROM activities;"  # sanity
+
+# 3. Stop the app so nothing writes, then swap in the rebuilt file
+az webapp stop -n trainsight-app -g rg-trainsight    # from your workstation
+mv trainsight.db "trainsight.db.corrupt.main.$ts"
+rm -f trainsight.db-wal trainsight.db-shm            # stale sidecars
+mv trainsight.rebuilt.db trainsight.db
+az webapp start -n trainsight-app -g rg-trainsight   # init_db() re-adds any missing columns
+```
+
+If the container lacks the `sqlite3` CLI, run the same `.recover` from the app
+venv's Python, or `apt-get install -y sqlite3` (you're root in the SSH shell).
+
+## Prevent corruption
+
+`trainsight.db` sits on Azure Files (SMB). Two rules keep it safe (both enforced
+in code / docs as of the WAL-corruption incident):
+
+1. **No WAL on `/home`.** SQLite WAL needs a shared-memory index (`-shm`) that
+   does not work over a network filesystem — it corrupts the file. `db/session.py`
+   pins `journal_mode=DELETE` + `synchronous=FULL` for exactly this reason; do
+   not switch back to WAL while the DB is on Azure Files.
+2. **One writer.** Run the backend with a **single** gunicorn worker so there is
+   only one process writing the SQLite file — multiple worker processes over SMB
+   is the other half of the corruption trigger. Set the startup command to e.g.
+   `gunicorn -k uvicorn.workers.UvicornWorker -w 1 -b 0.0.0.0:8000 api.main:app`
+   (`az webapp config set --startup-file "…"`). Scale out via App Service
+   instances only if you first move off SQLite (managed DB) or a WAL-safe store.
+
+**Take a snapshot before every risky deploy** (this incident had no backup):
+`sqlite3 trainsight.db ".backup '/home/data/backups/pre-deploy-<ts>.db'"`.
+
 ## Related
 
-- [disaster-recovery.md](./disaster-recovery.md) · [deploy.md](./deploy.md) · `db/session.py` (`init_db`)
+- [disaster-recovery.md](./disaster-recovery.md) · [deploy.md](./deploy.md) · `db/session.py` (`init_db`, `_SQLITE_PRAGMAS`)
 
 ---
 _Last reviewed: 2026-06-30 · Owner: @dddtc2005 · TODO(@dddtc2005): pick a backup cadence + retention and (optionally) automate it._

--- a/tests/test_db_perf_pragmas_and_dek_cache.py
+++ b/tests/test_db_perf_pragmas_and_dek_cache.py
@@ -36,17 +36,24 @@ def file_backed_engine():
                 pass
 
 
-def test_journal_mode_is_wal(file_backed_engine):
+def test_journal_mode_is_delete(file_backed_engine):
+    # DELETE (rollback journal), NOT WAL. The prod DB lives on Azure Files
+    # (SMB), where WAL's shared-memory index is unsupported and corrupts the
+    # file ("database disk image is malformed"). Do not revert to WAL — see the
+    # comment on _SQLITE_PRAGMAS in db/session.py.
     with file_backed_engine.connect() as conn:
         mode = conn.execute(text("PRAGMA journal_mode")).scalar()
-    assert mode == "wal", f"Expected WAL journal mode, got {mode!r}"
+    assert mode == "delete", f"Expected DELETE journal mode (WAL is unsafe on Azure Files), got {mode!r}"
 
 
-def test_synchronous_is_normal(file_backed_engine):
+def test_synchronous_is_full(file_backed_engine):
     with file_backed_engine.connect() as conn:
         # PRAGMA synchronous returns int: 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA
         sync = conn.execute(text("PRAGMA synchronous")).scalar()
-    assert sync == 1, f"Expected synchronous=NORMAL (1), got {sync}"
+    # FULL: on the SMB mount a container recycle mid-write (every deploy) is the
+    # "power loss" equivalent; FULL fsyncs the rollback journal so an interrupted
+    # write can't corrupt the file.
+    assert sync == 2, f"Expected synchronous=FULL (2) for crash-safety on Azure Files, got {sync}"
 
 
 def test_temp_store_is_memory(file_backed_engine):
@@ -68,7 +75,7 @@ def test_pragmas_apply_to_every_new_connection(file_backed_engine):
     """
     for _ in range(3):
         with file_backed_engine.connect() as conn:
-            assert conn.execute(text("PRAGMA journal_mode")).scalar() == "wal"
+            assert conn.execute(text("PRAGMA journal_mode")).scalar() == "delete"
 
 
 def test_listener_is_no_op_for_non_sqlite(monkeypatch):


### PR DESCRIPTION
## Root cause

Production hit `sqlite3.DatabaseError: database disk image is malformed` on `fitness_data` reads (`api/routes/settings.py:_detect_thresholds_from_db`, `api/deps.py:get_dashboard_data`), which 500'd every DB-backed endpoint and dropped users onto the first-run Setup guide (`useSetupStatus` sees no connections when `/api/settings/connections` 500s).

`trainsight.db` lives on `/home` — Azure App Service's **Azure Files (SMB)** mount — and `db/session.py` had `journal_mode=WAL`. **SQLite's WAL mode does not work over a network filesystem** ([sqlite.org/wal.html](https://www.sqlite.org/wal.html)): it needs a shared-memory index (`-shm`) via mmap that SMB can't provide reliably, so the file corrupts — especially with multiple gunicorn worker processes writing concurrently. A deploy's rolling restart was the trigger.

## Change

- `db/session.py`: `journal_mode` **WAL → DELETE** (rollback journal, safe over SMB), `synchronous` **NORMAL → FULL** (fsync the journal so a container recycle mid-write can't tear the file).
- Updated the pragma tests to lock the corruption-safe values (and explain why, so nobody reverts to WAL).
- `docs/ops/backup-and-restore.md`: a **corruption-recovery** runbook (`sqlite3 .recover`, the exact procedure used for this incident) and a **prevention** section (no WAL on `/home`; one gunicorn writer; snapshot before deploys).

## ⚠️ Deploy ordering

1. **Recover the corrupt prod DB first** (runbook § "Recover from corruption") — this PR fixes the *config*, it does not repair the already-corrupt file.
2. Then merge/deploy this so the recovered DB uses the rollback journal going forward.

## Operator follow-ups (not code — can't be done from the repo safely)

- **Pin the backend to one gunicorn worker** (single SQLite writer):
  `az webapp config set --name trainsight-app --resource-group rg-trainsight --startup-file "gunicorn -k uvicorn.workers.UvicornWorker -w 1 -b 0.0.0.0:8000 api.main:app"` (verify against your current startup command first).
- **Automate a pre-deploy DB snapshot** so a future corruption is always recoverable (this incident had no backup).
- Longer term: if you need to scale out to multiple instances/workers, move off SQLite-on-Azure-Files (managed Postgres / Azure SQL).

## Verification

- `python -m pytest tests/` → **822 passed, 1 skipped** (the 3 pragma tests now assert DELETE/FULL).
- Smoke: `init_db()` → `PRAGMA journal_mode` = `delete`, `PRAGMA synchronous` = `2` (FULL).