### PR TITLE
Store feedback screenshots in Azure Blob (keyless, reuse stperftrainsight)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -79,6 +79,11 @@ jobs:
           PRAXYS_FEEDBACK_GITHUB_LABELS: ${{ vars.PRAXYS_FEEDBACK_GITHUB_LABELS }}
           PRAXYS_FEEDBACK_GITHUB_ASSIGNEES: ${{ vars.PRAXYS_FEEDBACK_GITHUB_ASSIGNEES }}
           PRAXYS_FEEDBACK_AUTOFILE_WITHOUT_AI: ${{ vars.PRAXYS_FEEDBACK_AUTOFILE_WITHOUT_AI }}
+          # Feedback screenshot storage (issue #337): keyless Azure Blob via the
+          # app's managed identity (granted Storage Blob Data Contributor on the
+          # container). Unset → local filesystem fallback under DATA_DIR.
+          PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL: ${{ vars.PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL }}
+          PRAXYS_FEEDBACK_BLOB_CONTAINER: ${{ vars.PRAXYS_FEEDBACK_BLOB_CONTAINER }}
         run: |
           for var in AZURE_AI_ENDPOINT KEY_VAULT_URL KEY_VAULT_KEY_NAME \
                      APPLICATIONINSIGHTS_CONNECTION_STRING PRAXYS_JWT_SECRET \
@@ -106,6 +111,8 @@ jobs:
               PRAXYS_FEEDBACK_GITHUB_LABELS="${PRAXYS_FEEDBACK_GITHUB_LABELS}" \
               PRAXYS_FEEDBACK_GITHUB_ASSIGNEES="${PRAXYS_FEEDBACK_GITHUB_ASSIGNEES}" \
               PRAXYS_FEEDBACK_AUTOFILE_WITHOUT_AI="${PRAXYS_FEEDBACK_AUTOFILE_WITHOUT_AI}" \
+              PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL="${PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL}" \
+              PRAXYS_FEEDBACK_BLOB_CONTAINER="${PRAXYS_FEEDBACK_BLOB_CONTAINER}" \
               WEBSITES_PORT="8000" \
               DATA_DIR="/home/data" \
               SCM_DO_BUILD_DURING_DEPLOYMENT="true" \

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -37,6 +37,8 @@ secret/variable (or the workflow literal) and re-deploy.
 | `AZURE_AI_ENDPOINT` | Azure OpenAI endpoint for insights/triage | App Service setting + `i18n.yml` |
 | `KEY_VAULT_URL` / `KEY_VAULT_KEY_NAME` | Key Vault + RSA key name | App Service setting |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | App Insights routing | App Service setting |
+| `PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL` (`https://stperftrainsight.blob.core.windows.net`) | Private Blob store for feedback screenshots (keyless via MI) | App Service setting (backend) |
+| `PRAXYS_FEEDBACK_BLOB_CONTAINER` (`feedback-screenshots`) | Blob container for screenshots | App Service setting (backend) |
 
 ### Azure App Service → Application settings (backend `trainsight-app`)
 Source of truth = `deploy-backend.yml`. Literals set inline: `DATA_DIR=/home/data`,
@@ -68,6 +70,30 @@ to boot without a JWT secret.
 > Example: the feedback → GitHub-issue settings (`PRAXYS_GITHUB_APP_*`,
 > `PRAXYS_FEEDBACK_GITHUB_*`) follow exactly this pattern and are intentionally
 > optional. (Added by the feedback feature — dddtc2005/praxys#328.)
+
+### Feedback screenshot storage (Azure Blob, keyless)
+
+Screenshots attached to feedback (issue #337) are stored **privately** in Blob
+(reusing the `stperftrainsight` account). Auth is keyless via the backend's
+system-assigned managed identity — no key or connection string. One-time infra:
+
+```bash
+# 1. Dedicated container (kept separate from the perf data in this account)
+az storage container create --account-name stperftrainsight \
+  --name feedback-screenshots --auth-mode login
+
+# 2. Grant the app MI data access on JUST that container (least privilege)
+MI=$(az webapp identity show -n trainsight-app -g rg-trainsight --query principalId -o tsv)
+SUB=$(az account show --query id -o tsv)
+az role assignment create --assignee-object-id "$MI" --assignee-principal-type ServicePrincipal \
+  --role "Storage Blob Data Contributor" \
+  --scope "/subscriptions/$SUB/resourceGroups/rg-trainsight/providers/Microsoft.Storage/storageAccounts/stperftrainsight/blobServices/default/containers/feedback-screenshots"
+```
+
+The two `PRAXYS_FEEDBACK_BLOB_*` variables above point the app at it. Unset them
+and the app falls back to local filesystem storage under `DATA_DIR` (persistent
+on `/home`, but not the recommended long-term home). `api/feedback_storage.py`
+selects the backend and authenticates with `DefaultAzureCredential`.
 
 ## Rotation
 


### PR DESCRIPTION
Wires feedback screenshot storage (issue #337) to **Azure Blob**, reusing the existing `stperftrainsight` account with a **dedicated private container**, authenticated **keyless** via the backend's managed identity.

### Why
`PRAXYS_FEEDBACK_BLOB_*` was never set, so screenshots fell back to local FS at `/home/data/feedback_images`. That's *persistent* (Azure Files) so nothing was lost — but it lives on the same SMB share as the SQLite DB (the share we want to lighten after this week's incident), and it doesn't scale.

### What
- `deploy-backend.yml` now syncs `PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL` + `PRAXYS_FEEDBACK_BLOB_CONTAINER` (GitHub Actions **variables**) into the App Service settings.
- `docs/ops/config-and-secrets.md`: the two new vars + a one-time keyless provisioning runbook.
- **No app code change** — `api/feedback_storage.py` already handles account-url + `DefaultAzureCredential`, and `load_image` falls back to local FS, so the existing local screenshot keeps serving while new uploads go to Blob.

### Infra already provisioned (out-of-band, since RBAC/data-plane)
- ✅ Container `feedback-screenshots` created in `stperftrainsight`.
- ✅ App MI (`79b0822e…`) granted **Storage Blob Data Contributor** scoped to **just that container** (least privilege — no access to the perf data in the account).
- ✅ GH Actions variables set (`PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL`, `PRAXYS_FEEDBACK_BLOB_CONTAINER`).

### Verify after merge
1. `deploy-backend.yml` runs → App Service picks up the two settings (allow a minute for MI role propagation).
2. Submit feedback with a screenshot in prod.
3. `az storage blob list --account-name stperftrainsight --container-name feedback-screenshots --auth-mode login -o table` → the new object appears under `feedback/<id>/<index>.<ext>`.

I'll do that verification once this is merged/deployed.

---
Separately noted for a future session (your idea): an **admin ops agent in a private repo** (Copilot CLI / Claude Code plugin, manual-trigger first) — that private repo also becomes the natural place to *attach* screenshots to triage issues safely (issue #337's "attach when the target repo is private").