### PR TITLE
docs(ops): document Blob GH Actions vars + require ops-handbook updates on config changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,7 @@ sync/*.py → db/sync_writer.py → SQLite → analysis/metrics.py → api/deps.
 - User config (goals, thresholds) stored in the database, managed via Settings/Goal page UI
 - Server config in `.env` (see `.env.example` for encryption key, JWT secret, admin email)
 - Data recomputed fresh per request in `api/deps.py`
+- **Ops-handbook currency:** any change to a deploy workflow, App Service setting, GitHub Actions secret/variable, Azure resource (storage, Key Vault, RBAC), or runtime config must be documented in `docs/ops/` (esp. `config-and-secrets.md`) **in the same PR** — where it's set and how to provision it.
 
 ## For Full Details
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - **Focus:** production operations — deploy, App Service config, secrets, monitoring/alerts, admin tasks
 - **Tasks:** wire alerts, rotate/add config, deploy & rollback, diagnose prod issues
 - **Context needed:** the operations handbook **`docs/ops/README.md`** (runbook index). Each runbook is self-contained: `Prerequisites · Steps · Verify · Rollback`. `docs/deployment.md` for one-time Azure setup.
-- **Key rule:** App Service settings are owned by `deploy-backend.yml`, not the portal — change the GitHub secret/variable and re-deploy. Never commit secrets.
+- **Key rule:** App Service settings are owned by `deploy-backend.yml`, not the portal — change the GitHub secret/variable and re-deploy. Never commit secrets. **Any config / secret / infra / deploy change must update `docs/ops/` (esp. `config-and-secrets.md`) in the same PR** — where it's set and how to provision it.
 
 ## Workflow Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ See `docs/dev/contributing.md` for which files to update with code changes. Key 
 
 For **production operations** (deploy, config & secrets, monitoring & alerts, admin tasks, troubleshooting), start at the operations handbook: `docs/ops/README.md` — consistently-structured runbooks meant to be consumed by humans *and* AI agents.
 
+**Ops-handbook currency (required).** Any PR that changes a deploy workflow, App Service setting, GitHub Actions secret/variable, Azure resource (storage, Key Vault, RBAC), or runtime config **must update `docs/ops/` in the same PR** — record *where* the value is set (source of truth) and *how* to provision it (`config-and-secrets.md`). A config/infra change without the matching runbook update is incomplete.
+
 ## Claude Code Automations
 
 Automations live in `.claude/` and are committed so every contributor using Claude Code sees the same behavior. See `.claude/settings.json` for hooks (block edits to secrets; run pytest on Python changes; run ESLint on web TS changes), `.claude/agents/` for subagents (`science-reviewer`, `metric-addition-reviewer`, `api-contract-reviewer` — all read-only), and `.claude/skills/` for dev-workflow skills.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -160,6 +160,7 @@ When making changes, update the relevant docs:
 | Convention changes | `CLAUDE.md` |
 | DB model changes | `CLAUDE.md` data sources |
 | New Claude automation (hook, agent, dev skill) | `CLAUDE.md` "Claude Code Automations" section |
+| Config / secret / infra / deploy change (env var, GitHub Actions secret/variable, App Service setting, Azure resource, RBAC, deploy workflow) | **`docs/ops/` handbook** — esp. `config-and-secrets.md` (where it's set + how to provision it) |
 
 ## Claude Code Dev Tooling
 

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -88,6 +88,11 @@ SUB=$(az account show --query id -o tsv)
 az role assignment create --assignee-object-id "$MI" --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Contributor" \
   --scope "/subscriptions/$SUB/resourceGroups/rg-trainsight/providers/Microsoft.Storage/storageAccounts/stperftrainsight/blobServices/default/containers/feedback-screenshots"
+
+# 3. Register the two non-secret GitHub Actions variables (the source of truth).
+#    deploy-backend.yml syncs them to the App Service settings on the next deploy.
+gh variable set PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL --body "https://stperftrainsight.blob.core.windows.net"
+gh variable set PRAXYS_FEEDBACK_BLOB_CONTAINER   --body "feedback-screenshots"
 ```
 
 The two `PRAXYS_FEEDBACK_BLOB_*` variables above point the app at it. Unset them


### PR DESCRIPTION
Addresses two gaps you flagged:

**1. Blob env vars weren't fully documented as GitHub Actions variables.** The `docs/ops/config-and-secrets.md` runbook (added in #354) covered the container + RBAC provisioning but not the `gh variable set` step. Added it, so the runbook now fully answers "where are `PRAXYS_FEEDBACK_BLOB_*` set" (GitHub Actions **variables** → synced to App Service by `deploy-backend.yml`). They were also already in the Variables table.

**2. No convention required updating the ops handbook on config/infra changes.** Added it to every doc agents + contributors read:
- `CLAUDE.md` — "Ops-handbook currency (required)" rule
- `.github/copilot-instructions.md` — Config section bullet
- `AGENTS.md` — Ops/DevOps agent Key rule
- `docs/dev/contributing.md` — new row in the "Documentation Updates" table

> Any PR that changes a deploy workflow, App Service setting, GitHub Actions secret/variable, Azure resource (storage, Key Vault, RBAC), or runtime config **must update `docs/ops/` (esp. `config-and-secrets.md`) in the same PR** — where it's set + how to provision it.

Docs-only; no code/CI impact.