### PR TITLE
Tag telemetry with a hashed user id for registered-user DAU/WAU

### DIFF
--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -53,6 +53,26 @@ customMetrics | where name == "praxys.coach_run"
 | extend hit_rate = todouble(hits) / total
 ```
 
+Active users (DAU / WAU) of registered accounts. The SPA tags telemetry with
+`user_AuthenticatedId` = a SHA-256(user_id)[:16] pseudonym (set on login by
+`web/src/lib/appinsights.ts`, matching `api/telemetry.py::hash_user_id`), so this
+counts distinct *registered* users — not anonymous browsers — and correlates with
+the backend `praxys.*` events. Only authenticated navigation is counted (the
+anonymous landing page is excluded); demo accounts are included.
+```kql
+// WAU (last 7d) and DAU trend (last 30d)
+pageViews
+| where timestamp > ago(7d)
+| where isnotempty(user_AuthenticatedId)
+| summarize wau = dcount(user_AuthenticatedId)
+
+pageViews
+| where timestamp > ago(30d)
+| where isnotempty(user_AuthenticatedId)
+| summarize dau = dcount(user_AuthenticatedId) by bin(timestamp, 1d)
+| render timechart
+```
+
 ## Create an email alert (general recipe)
 
 1. **Application Insights → Monitoring → Alerts → Create → Alert rule.**
@@ -98,4 +118,4 @@ Tune the window/threshold to reduce noise rather than deleting.
 - In-app: Admin → User Feedback (badge + Approve/Retry/Reject).
 
 ---
-_Last reviewed: 2026-06-30 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-04 · Owner: @dddtc2005_

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, createContext, useContext } from 'rea
 import type { ReactNode } from 'react';
 import { KEYS, getCompatItem, setCompatItem, removeCompatItem } from '../lib/storage-compat';
 import { prefetchedMe } from '../lib/auth-prefetch';
+import { setAppInsightsUser, clearAppInsightsUser } from '../lib/appinsights';
 
 interface AuthState {
   token: string | null;
@@ -85,6 +86,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setIsDemo(data.is_demo ?? false);
           setTermsCurrent(data.terms_current ?? true);
           setCompatItem(KEYS.authAdmin.new, KEYS.authAdmin.legacy, String(data.is_superuser));
+          void setAppInsightsUser(data.id);
         }
       })
       .catch(() => {})
@@ -124,6 +126,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               setIsDemo(me.is_demo ?? false);
               setTermsCurrent(me.terms_current ?? true);
               setCompatItem(KEYS.authAdmin.new, KEYS.authAdmin.legacy, String(me.is_superuser));
+              void setAppInsightsUser(me.id);
             }
           })
           .catch(() => {});
@@ -189,6 +192,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsAdmin(false);
     setIsDemo(false);
     setTermsCurrent(true);
+    clearAppInsightsUser();
   }, []);
 
   const acceptTerms = useCallback(async (): Promise<boolean> => {

--- a/web/src/lib/appinsights.ts
+++ b/web/src/lib/appinsights.ts
@@ -62,6 +62,46 @@ export function getAppInsights(): ApplicationInsights | null {
   return appInsights
 }
 
+/**
+ * Tie all subsequent telemetry to a stable per-user pseudonym so registered-user
+ * DAU/WAU is derivable via `summarize dcount(user_AuthenticatedId)`.
+ *
+ * The raw user id (a UUID) is NEVER sent: we hash it to 16 hex chars, matching
+ * the backend's api/telemetry.py::hash_user_id, so (a) telemetry stays free of
+ * PII and (b) frontend pageViews and backend custom events share the same
+ * user_AuthenticatedId and correlate. No-op when App Insights is unconfigured
+ * (local dev) or Web Crypto is unavailable — telemetry must never break auth.
+ */
+export async function setAppInsightsUser(userId: string): Promise<void> {
+  const ai = getAppInsights()
+  if (!ai || !userId) return
+  try {
+    const hashed = await hashUserId(userId)
+    // authenticatedUserId must exclude spaces/commas/semicolons/pipes/equals —
+    // hex satisfies that. storeInCookie=true keeps it stable across reloads.
+    ai.setAuthenticatedUserContext(hashed, undefined, true)
+  } catch {
+    /* best-effort; never throw from a telemetry helper */
+  }
+}
+
+export function clearAppInsightsUser(): void {
+  try {
+    getAppInsights()?.clearAuthenticatedUserContext()
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function hashUserId(userId: string): Promise<string> {
+  // SHA-256, first 16 hex chars — mirrors api/telemetry.py::hash_user_id.
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(userId))
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16)
+}
+
 function getNetworkSnapshot(): NetworkConnection | null {
   const conn = (navigator as unknown as { connection?: NetworkConnection }).connection
   return conn ?? null

--- a/web/src/lib/auth-prefetch.ts
+++ b/web/src/lib/auth-prefetch.ts
@@ -19,7 +19,7 @@ const token = (() => {
 
 export interface PrefetchedMe {
   status: number;
-  data: { is_superuser: boolean; is_demo?: boolean; terms_current?: boolean } | null;
+  data: { id: string; is_superuser: boolean; is_demo?: boolean; terms_current?: boolean } | null;
 }
 
 export const prefetchedMe: Promise<PrefetchedMe> | null = token


### PR DESCRIPTION
## What & why

Follow-up to #363 — the "tier 2" from that discussion. Wires `setAuthenticatedUserContext` so App Insights telemetry carries a per-user id, making **registered-user DAU/WAU** queryable.

- The SPA sets `user_AuthenticatedId` on login/boot and clears it on logout.
- The id is **hashed** (SHA-256, first 16 hex) before it reaches telemetry, matching `api/telemetry.py::hash_user_id`, so the raw UUID never leaves the browser (telemetry stays PII-free, per the existing backend convention) and frontend pageViews **correlate** with backend `praxys.*` events on the same id.
- No-op when App Insights is unconfigured (local dev) or Web Crypto is unavailable — telemetry never breaks auth.
- Adds a DAU/WAU KQL recipe to `docs/ops/monitoring-and-alerts.md`.

Before this, page views were keyed to an anonymous browser cookie, so only "distinct browsers/day" was measurable, not distinct accounts. The in-app `last_seen` gauge on the Admin card is unchanged — this makes App Insights the accurate source for deeper active-user analysis.

## Testing
`npx tsc -b` clean; no new eslint errors (the 2 in useAuth are pre-existing); no new i18n strings; backend untouched.