### PR TITLE
Show "Joined" on waitlist rows once the invited lead registers

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -295,7 +295,7 @@ def update_config(
 # ---------------------------------------------------------------------------
 
 
-def _serialize_waitlist(row, code: str | None) -> dict:
+def _serialize_waitlist(row, code: str | None, registered: bool = False) -> dict:
     return {
         "id": row.id,
         "email": row.email,
@@ -305,6 +305,7 @@ def _serialize_waitlist(row, code: str | None) -> dict:
         "invited_at": utc_isoformat(row.invited_at),
         "invitation_id": row.invitation_id,
         "invitation_code": code,
+        "registered": registered,
     }
 
 
@@ -315,7 +316,9 @@ def list_waitlist(
 ) -> dict:
     """List waitlist signups (newest first) with any issued invitation code."""
     _require_admin(user_id, db)
-    from db.models import Invitation, WaitlistSignup
+    from sqlalchemy import func
+
+    from db.models import Invitation, User, WaitlistSignup
 
     rows = db.query(WaitlistSignup).order_by(WaitlistSignup.created_at.desc()).all()
     inv_ids = [r.invitation_id for r in rows if r.invitation_id]
@@ -323,9 +326,27 @@ def list_waitlist(
     if inv_ids:
         for inv in db.query(Invitation).filter(Invitation.id.in_(inv_ids)).all():
             codes[inv.id] = inv.code
+
+    # A signup is "registered" once an account exists for its email (any
+    # registration path - invited or open), compared case-insensitively. Lets
+    # the admin UI stop offering "Re-invite" - which would mint a fresh code and
+    # reserve another seat - for people who have already joined.
+    emails = {(r.email or "").lower() for r in rows if r.email}
+    registered: set[str] = set()
+    if emails:
+        for (uemail,) in (
+            db.query(User.email).filter(func.lower(User.email).in_(emails)).all()
+        ):
+            if uemail:
+                registered.add(uemail.lower())
+
     return {
         "signups": [
-            _serialize_waitlist(r, codes.get(r.invitation_id) if r.invitation_id else None)
+            _serialize_waitlist(
+                r,
+                codes.get(r.invitation_id) if r.invitation_id else None,
+                (r.email or "").lower() in registered,
+            )
             for r in rows
         ]
     }

--- a/tests/test_registration_gate.py
+++ b/tests/test_registration_gate.py
@@ -272,6 +272,7 @@ def test_waitlist_invite_generates_marks_and_emails(env):
     client.post("/api/auth/waitlist", json={"email": "lead@x.com", "note": "hi", "locale": "zh"})
     wl = client.get("/api/admin/waitlist", headers=H).json()["signups"]
     assert len(wl) == 1 and wl[0]["invited_at"] is None
+    assert wl[0]["registered"] is False
     sid = wl[0]["id"]
 
     res = client.post(f"/api/admin/waitlist/{sid}/invite", headers=H).json()
@@ -288,9 +289,32 @@ def test_waitlist_invite_generates_marks_and_emails(env):
     r = _reg(client, "lead@x.com", invitation_code=res["code"])
     assert r.status_code == 200
 
+    # Once the lead has an account the row reports registered=True, so the admin
+    # UI shows "Joined" and drops the (seat-wasting) Re-invite affordance.
+    wl3 = client.get("/api/admin/waitlist", headers=H).json()["signups"][0]
+    assert wl3["registered"] is True
+
     # Re-inviting revokes the previous (now-used) code and issues a new one.
     res2 = client.post(f"/api/admin/waitlist/{sid}/invite", headers=H).json()
     assert res2["code"] != res["code"]
+
+
+def test_waitlist_registered_flag_ignores_case_and_unrelated(env):
+    client, _, _ = env
+    tok = _admin_token(client)
+    H = {"Authorization": f"Bearer {tok}"}
+
+    # One lead who will register (with different casing), one who won't.
+    client.post("/api/auth/waitlist", json={"email": "Mixed.Case@x.com"})
+    client.post("/api/auth/waitlist", json={"email": "pending@x.com"})
+
+    code = client.post("/api/admin/invitations", headers=H, json={}).json()["code"]
+    assert _reg(client, "mixed.case@x.com", invitation_code=code).status_code == 200
+
+    rows = client.get("/api/admin/waitlist", headers=H).json()["signups"]
+    by_email = {r["email"]: r for r in rows}
+    assert by_email["Mixed.Case@x.com"]["registered"] is True
+    assert by_email["pending@x.com"]["registered"] is False
 
 
 def test_last_seen_feeds_activity_counts(env):

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -89,12 +89,12 @@ msgid "+ {0}d projected from plan"
 msgstr "+ {0}d projected from plan"
 
 #. placeholder {0}: roleChangeUser?.email
-#: src/pages/Admin.tsx:785
+#: src/pages/Admin.tsx:797
 msgid "<0>{0}</0> will gain admin privileges. They will be able to manage all users, delete accounts, and generate invitation codes."
 msgstr "<0>{0}</0> will gain admin privileges. They will be able to manage all users, delete accounts, and generate invitation codes."
 
 #. placeholder {0}: roleChangeUser?.email
-#: src/pages/Admin.tsx:780
+#: src/pages/Admin.tsx:792
 msgid "<0>{0}</0> will lose admin privileges. They will no longer be able to manage users or invitation codes."
 msgstr "<0>{0}</0> will lose admin privileges. They will no longer be able to manage users or invitation codes."
 
@@ -231,11 +231,11 @@ msgid "Action"
 msgstr "Action"
 
 #: src/pages/Admin.tsx:440
-#: src/pages/Admin.tsx:949
+#: src/pages/Admin.tsx:961
 msgid "Actions"
 msgstr "Actions"
 
-#: src/pages/Admin.tsx:901
+#: src/pages/Admin.tsx:913
 msgid "Activate"
 msgstr "Activate"
 
@@ -315,7 +315,7 @@ msgstr "Already have an invitation code?"
 msgid "An unexpected error occurred."
 msgstr "An unexpected error occurred."
 
-#: src/pages/Admin.tsx:1013
+#: src/pages/Admin.tsx:1025
 msgid "Approve & file"
 msgstr "Approve & file"
 
@@ -402,7 +402,7 @@ msgstr "Baseline"
 msgid "below"
 msgstr "below"
 
-#: src/pages/Admin.tsx:849
+#: src/pages/Admin.tsx:861
 msgid "Body (optional)"
 msgstr "Body (optional)"
 
@@ -410,7 +410,7 @@ msgstr "Body (optional)"
 msgid "Bug report"
 msgstr "Bug report"
 
-#: src/pages/Admin.tsx:933
+#: src/pages/Admin.tsx:945
 msgid "Bug reports and feature requests submitted from the app. Auto-triaged to GitHub when configured."
 msgstr "Bug reports and feature requests submitted from the app. Auto-triaged to GitHub when configured."
 
@@ -437,8 +437,8 @@ msgstr "by"
 
 #: src/components/FeedbackDialog.tsx:314
 #: src/components/GoalEditor.tsx:174
-#: src/pages/Admin.tsx:794
-#: src/pages/Admin.tsx:817
+#: src/pages/Admin.tsx:806
+#: src/pages/Admin.tsx:829
 #: src/pages/Settings.tsx:1011
 #: src/pages/Settings.tsx:1048
 #: src/pages/Settings.tsx:1444
@@ -622,7 +622,7 @@ msgid "Cooldown"
 msgstr "Cooldown"
 
 #: src/pages/Admin.tsx:641
-#: src/pages/Admin.tsx:685
+#: src/pages/Admin.tsx:677
 msgid "Copy code"
 msgstr "Copy code"
 
@@ -643,8 +643,8 @@ msgstr "Couldn't send your feedback. Please try again."
 msgid "CP Trend"
 msgstr "CP Trend"
 
-#: src/pages/Admin.tsx:758
-#: src/pages/Admin.tsx:877
+#: src/pages/Admin.tsx:770
+#: src/pages/Admin.tsx:889
 msgid "Create"
 msgstr "Create"
 
@@ -673,8 +673,8 @@ msgstr "Created"
 msgid "Creating account…"
 msgstr "Creating account…"
 
-#: src/pages/Admin.tsx:758
-#: src/pages/Admin.tsx:877
+#: src/pages/Admin.tsx:770
+#: src/pages/Admin.tsx:889
 msgid "Creating..."
 msgstr "Creating..."
 
@@ -741,7 +741,7 @@ msgstr "days"
 msgid "Days left"
 msgstr "Days left"
 
-#: src/pages/Admin.tsx:901
+#: src/pages/Admin.tsx:913
 msgid "Deactivate"
 msgstr "Deactivate"
 
@@ -773,12 +773,12 @@ msgstr "Delete my account?"
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: src/pages/Admin.tsx:807
-#: src/pages/Admin.tsx:820
+#: src/pages/Admin.tsx:819
+#: src/pages/Admin.tsx:832
 msgid "Delete User"
 msgstr "Delete User"
 
-#: src/pages/Admin.tsx:820
+#: src/pages/Admin.tsx:832
 #: src/pages/Settings.tsx:1451
 msgid "Deleting..."
 msgstr "Deleting..."
@@ -787,7 +787,7 @@ msgstr "Deleting..."
 msgid "Demo"
 msgstr "Demo"
 
-#: src/pages/Admin.tsx:723
+#: src/pages/Admin.tsx:735
 msgid "Demo Accounts"
 msgstr "Demo Accounts"
 
@@ -795,25 +795,25 @@ msgstr "Demo Accounts"
 msgid "Demo mode — read only"
 msgstr "Demo mode — read only"
 
-#: src/pages/Admin.tsx:765
+#: src/pages/Admin.tsx:777
 msgid "Demo users can browse your dashboard (Today, Training, Goal, History) but cannot change settings, sync data, or modify plans. Share the email and password with anyone you want to demo to."
 msgstr "Demo users can browse your dashboard (Today, Training, Goal, History) but cannot change settings, sync data, or modify plans. Share the email and password with anyone you want to demo to."
 
-#: src/pages/Admin.tsx:746
+#: src/pages/Admin.tsx:758
 msgid "demo-password"
 msgstr "demo-password"
 
-#: src/pages/Admin.tsx:736
+#: src/pages/Admin.tsx:748
 msgid "demo@example.com"
 msgstr "demo@example.com"
 
 #: src/pages/Admin.tsx:481
-#: src/pages/Admin.tsx:797
+#: src/pages/Admin.tsx:809
 msgid "Demote"
 msgstr "Demote"
 
 #: src/pages/Admin.tsx:478
-#: src/pages/Admin.tsx:776
+#: src/pages/Admin.tsx:788
 msgid "Demote to User"
 msgstr "Demote to User"
 
@@ -854,7 +854,7 @@ msgstr "Disconnect"
 msgid "Discussion"
 msgstr "Discussion"
 
-#: src/pages/Admin.tsx:835
+#: src/pages/Admin.tsx:847
 msgid "Dismissible banners shown to all users"
 msgstr "Dismissible banners shown to all users"
 
@@ -957,7 +957,7 @@ msgstr "Elevated"
 
 #: src/pages/Admin.tsx:437
 #: src/pages/Admin.tsx:656
-#: src/pages/Admin.tsx:733
+#: src/pages/Admin.tsx:745
 #: src/pages/Login.tsx:360
 #: src/pages/Login.tsx:448
 #: src/pages/Login.tsx:557
@@ -1375,15 +1375,15 @@ msgstr "Invitation Codes"
 msgid "Invitation emailed to {0} · code {1}"
 msgstr "Invitation emailed to {0} · code {1}"
 
-#: src/pages/Admin.tsx:704
+#: src/pages/Admin.tsx:714
 msgid "Invite"
 msgstr "Invite"
 
-#: src/pages/Admin.tsx:679
+#: src/pages/Admin.tsx:696
 msgid "Invited"
 msgstr "Invited"
 
-#: src/pages/Admin.tsx:948
+#: src/pages/Admin.tsx:960
 msgid "Issue"
 msgstr "Issue"
 
@@ -1394,6 +1394,7 @@ msgid "Join the waitlist"
 msgstr "Join the waitlist"
 
 #: src/pages/Admin.tsx:658
+#: src/pages/Admin.tsx:691
 msgid "Joined"
 msgstr "Joined"
 
@@ -1452,11 +1453,11 @@ msgstr "Link at least one data source to start"
 msgid "Link Garmin, Strava, Stryd, or Oura to pull your training data"
 msgstr "Link Garmin, Strava, Stryd, or Oura to pull your training data"
 
-#: src/pages/Admin.tsx:864
+#: src/pages/Admin.tsx:876
 msgid "Link text (optional)"
 msgstr "Link text (optional)"
 
-#: src/pages/Admin.tsx:869
+#: src/pages/Admin.tsx:881
 msgid "Link URL (optional)"
 msgstr "Link URL (optional)"
 
@@ -1610,7 +1611,7 @@ msgstr "Network error. Is the server running?"
 msgid "Network error. Please email {SUPPORT_EMAIL} directly."
 msgstr "Network error. Please email {SUPPORT_EMAIL} directly."
 
-#: src/pages/Admin.tsx:842
+#: src/pages/Admin.tsx:854
 msgid "New announcement"
 msgstr "New announcement"
 
@@ -1634,7 +1635,7 @@ msgstr "Next sync"
 msgid "No activities found."
 msgstr "No activities found."
 
-#: src/pages/Admin.tsx:883
+#: src/pages/Admin.tsx:895
 msgid "No announcements yet"
 msgstr "No announcements yet"
 
@@ -1653,7 +1654,7 @@ msgstr "no data"
 msgid "No Data"
 msgstr "No Data"
 
-#: src/pages/Admin.tsx:940
+#: src/pages/Admin.tsx:952
 msgid "No feedback yet."
 msgstr "No feedback yet."
 
@@ -1798,7 +1799,7 @@ msgstr "Overwrite Stryd with Praxys version"
 msgid "Pace"
 msgstr "Pace"
 
-#: src/pages/Admin.tsx:743
+#: src/pages/Admin.tsx:755
 #: src/pages/Login.tsx:377
 #: src/pages/Login.tsx:574
 #: src/pages/Setup.tsx:207
@@ -1944,12 +1945,12 @@ msgid "Projected"
 msgstr "Projected"
 
 #: src/pages/Admin.tsx:483
-#: src/pages/Admin.tsx:797
+#: src/pages/Admin.tsx:809
 msgid "Promote"
 msgstr "Promote"
 
 #: src/pages/Admin.tsx:478
-#: src/pages/Admin.tsx:776
+#: src/pages/Admin.tsx:788
 msgid "Promote to Admin"
 msgstr "Promote to Admin"
 
@@ -2022,7 +2023,7 @@ msgstr "Race Prediction"
 #~ msgid "Range"
 #~ msgstr "Range"
 
-#: src/pages/Admin.tsx:704
+#: src/pages/Admin.tsx:714
 msgid "Re-invite"
 msgstr "Re-invite"
 
@@ -2030,7 +2031,7 @@ msgstr "Re-invite"
 msgid "Re-push to Stryd"
 msgstr "Re-push to Stryd"
 
-#: src/pages/Admin.tsx:725
+#: src/pages/Admin.tsx:737
 msgid "Read-only accounts that mirror your dashboard data"
 msgstr "Read-only accounts that mirror your dashboard data"
 
@@ -2136,7 +2137,7 @@ msgstr "Registered accounts"
 msgid "Registration"
 msgstr "Registration"
 
-#: src/pages/Admin.tsx:1034
+#: src/pages/Admin.tsx:1046
 msgid "Reject"
 msgstr "Reject"
 
@@ -2152,7 +2153,7 @@ msgstr "Remove image"
 msgid "Rep"
 msgstr "Rep"
 
-#: src/pages/Admin.tsx:947
+#: src/pages/Admin.tsx:959
 msgid "Report"
 msgstr "Report"
 
@@ -2187,7 +2188,7 @@ msgstr "Resting HR"
 
 #: src/components/UpcomingPlanCard.tsx:186
 #: src/components/UpcomingPlanCard.tsx:589
-#: src/pages/Admin.tsx:1024
+#: src/pages/Admin.tsx:1036
 #: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:323
@@ -2256,7 +2257,7 @@ msgstr "Science"
 msgid "Science pillars"
 msgstr "Science pillars"
 
-#: src/pages/Admin.tsx:973
+#: src/pages/Admin.tsx:985
 msgid "Screenshot flagged sensitive"
 msgstr "Screenshot flagged sensitive"
 
@@ -2288,7 +2289,7 @@ msgid "Sending an invitation reserves a seat. Self-registration auto-closes at t
 msgstr "Sending an invitation reserves a seat. Self-registration auto-closes at the cap; review readiness before raising it."
 
 #: src/components/FeedbackDialog.tsx:317
-#: src/pages/Admin.tsx:704
+#: src/pages/Admin.tsx:714
 #: src/pages/Login.tsx:409
 msgid "Sending…"
 msgstr "Sending…"
@@ -2423,7 +2424,7 @@ msgstr "Start sync"
 
 #: src/pages/Admin.tsx:554
 #: src/pages/Admin.tsx:659
-#: src/pages/Admin.tsx:946
+#: src/pages/Admin.tsx:958
 msgid "Status"
 msgstr "Status"
 
@@ -2559,7 +2560,7 @@ msgstr "Syncing…"
 msgid "System"
 msgstr "System"
 
-#: src/pages/Admin.tsx:834
+#: src/pages/Admin.tsx:846
 msgid "System Announcements"
 msgstr "System Announcements"
 
@@ -2617,7 +2618,7 @@ msgid "This permanently deletes your account, synced training data, plans, setti
 msgstr "This permanently deletes your account, synced training data, plans, settings, platform connections, encrypted credentials, and any Garmin tokenstore on this device. You will be signed out immediately."
 
 #. placeholder {0}: deleteUser?.email
-#: src/pages/Admin.tsx:809
+#: src/pages/Admin.tsx:821
 msgid "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 msgstr "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 
@@ -2651,7 +2652,7 @@ msgstr "Thresholds"
 msgid "Time range"
 msgstr "Time range"
 
-#: src/pages/Admin.tsx:844
+#: src/pages/Admin.tsx:856
 msgid "Title"
 msgstr "Title"
 
@@ -2741,7 +2742,7 @@ msgid "TSB (Form)"
 msgstr "TSB (Form)"
 
 #: src/components/FeedbackDialog.tsx:210
-#: src/pages/Admin.tsx:945
+#: src/pages/Admin.tsx:957
 msgid "Type"
 msgstr "Type"
 
@@ -2761,7 +2762,7 @@ msgstr "Units"
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 
-#: src/pages/Admin.tsx:797
+#: src/pages/Admin.tsx:809
 msgid "Updating..."
 msgstr "Updating..."
 
@@ -2798,7 +2799,7 @@ msgstr "Used By"
 msgid "User"
 msgstr "User"
 
-#: src/pages/Admin.tsx:925
+#: src/pages/Admin.tsx:937
 msgid "User Feedback"
 msgstr "User Feedback"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -89,12 +89,12 @@ msgid "+ {0}d projected from plan"
 msgstr "计划中还有 {0} 天预测"
 
 #. placeholder {0}: roleChangeUser?.email
-#: src/pages/Admin.tsx:785
+#: src/pages/Admin.tsx:797
 msgid "<0>{0}</0> will gain admin privileges. They will be able to manage all users, delete accounts, and generate invitation codes."
 msgstr "<0>{0}</0> 将获得管理员权限。他们将能够管理所有用户、删除账户并生成邀请码。"
 
 #. placeholder {0}: roleChangeUser?.email
-#: src/pages/Admin.tsx:780
+#: src/pages/Admin.tsx:792
 msgid "<0>{0}</0> will lose admin privileges. They will no longer be able to manage users or invitation codes."
 msgstr "<0>{0}</0> 将失去管理员权限。他们将不再能够管理用户或邀请码。"
 
@@ -231,11 +231,11 @@ msgid "Action"
 msgstr ""
 
 #: src/pages/Admin.tsx:440
-#: src/pages/Admin.tsx:949
+#: src/pages/Admin.tsx:961
 msgid "Actions"
 msgstr "操作"
 
-#: src/pages/Admin.tsx:901
+#: src/pages/Admin.tsx:913
 msgid "Activate"
 msgstr "激活"
 
@@ -315,7 +315,7 @@ msgstr "已有邀请码？"
 msgid "An unexpected error occurred."
 msgstr "发生了意外错误。"
 
-#: src/pages/Admin.tsx:1013
+#: src/pages/Admin.tsx:1025
 msgid "Approve & file"
 msgstr "批准并提交"
 
@@ -402,7 +402,7 @@ msgstr "基准"
 msgid "below"
 msgstr "低于"
 
-#: src/pages/Admin.tsx:849
+#: src/pages/Admin.tsx:861
 msgid "Body (optional)"
 msgstr "正文（可选）"
 
@@ -410,7 +410,7 @@ msgstr "正文（可选）"
 msgid "Bug report"
 msgstr "问题反馈"
 
-#: src/pages/Admin.tsx:933
+#: src/pages/Admin.tsx:945
 msgid "Bug reports and feature requests submitted from the app. Auto-triaged to GitHub when configured."
 msgstr "从应用内提交的问题反馈和功能建议。配置后会自动分流到 GitHub。"
 
@@ -437,8 +437,8 @@ msgstr "作者"
 
 #: src/components/FeedbackDialog.tsx:314
 #: src/components/GoalEditor.tsx:174
-#: src/pages/Admin.tsx:794
-#: src/pages/Admin.tsx:817
+#: src/pages/Admin.tsx:806
+#: src/pages/Admin.tsx:829
 #: src/pages/Settings.tsx:1011
 #: src/pages/Settings.tsx:1048
 #: src/pages/Settings.tsx:1444
@@ -622,7 +622,7 @@ msgid "Cooldown"
 msgstr "放松"
 
 #: src/pages/Admin.tsx:641
-#: src/pages/Admin.tsx:685
+#: src/pages/Admin.tsx:677
 msgid "Copy code"
 msgstr ""
 
@@ -643,8 +643,8 @@ msgstr "反馈发送失败，请重试。"
 msgid "CP Trend"
 msgstr "CP 趋势"
 
-#: src/pages/Admin.tsx:758
-#: src/pages/Admin.tsx:877
+#: src/pages/Admin.tsx:770
+#: src/pages/Admin.tsx:889
 msgid "Create"
 msgstr "创建"
 
@@ -673,8 +673,8 @@ msgstr "创建时间"
 msgid "Creating account…"
 msgstr "正在创建账户…"
 
-#: src/pages/Admin.tsx:758
-#: src/pages/Admin.tsx:877
+#: src/pages/Admin.tsx:770
+#: src/pages/Admin.tsx:889
 msgid "Creating..."
 msgstr "创建中..."
 
@@ -741,7 +741,7 @@ msgstr "天"
 msgid "Days left"
 msgstr "剩余天数"
 
-#: src/pages/Admin.tsx:901
+#: src/pages/Admin.tsx:913
 msgid "Deactivate"
 msgstr "停用"
 
@@ -773,12 +773,12 @@ msgstr "删除我的账号？"
 msgid "Delete permanently"
 msgstr "永久删除"
 
-#: src/pages/Admin.tsx:807
-#: src/pages/Admin.tsx:820
+#: src/pages/Admin.tsx:819
+#: src/pages/Admin.tsx:832
 msgid "Delete User"
 msgstr "删除用户"
 
-#: src/pages/Admin.tsx:820
+#: src/pages/Admin.tsx:832
 #: src/pages/Settings.tsx:1451
 msgid "Deleting..."
 msgstr "删除中..."
@@ -787,7 +787,7 @@ msgstr "删除中..."
 msgid "Demo"
 msgstr "演示"
 
-#: src/pages/Admin.tsx:723
+#: src/pages/Admin.tsx:735
 msgid "Demo Accounts"
 msgstr "演示账号"
 
@@ -795,25 +795,25 @@ msgstr "演示账号"
 msgid "Demo mode — read only"
 msgstr "演示模式 — 仅供查看"
 
-#: src/pages/Admin.tsx:765
+#: src/pages/Admin.tsx:777
 msgid "Demo users can browse your dashboard (Today, Training, Goal, History) but cannot change settings, sync data, or modify plans. Share the email and password with anyone you want to demo to."
 msgstr "演示用户可以浏览您的仪表盘（今日、训练、目标、历史），但不能更改设置、同步数据或修改计划。请把邮箱和密码分享给任何您想演示的人。"
 
-#: src/pages/Admin.tsx:746
+#: src/pages/Admin.tsx:758
 msgid "demo-password"
 msgstr "demo-password"
 
-#: src/pages/Admin.tsx:736
+#: src/pages/Admin.tsx:748
 msgid "demo@example.com"
 msgstr "demo@example.com"
 
 #: src/pages/Admin.tsx:481
-#: src/pages/Admin.tsx:797
+#: src/pages/Admin.tsx:809
 msgid "Demote"
 msgstr "降级"
 
 #: src/pages/Admin.tsx:478
-#: src/pages/Admin.tsx:776
+#: src/pages/Admin.tsx:788
 msgid "Demote to User"
 msgstr "降级为普通用户"
 
@@ -854,7 +854,7 @@ msgstr "断开连接"
 msgid "Discussion"
 msgstr "讨论"
 
-#: src/pages/Admin.tsx:835
+#: src/pages/Admin.tsx:847
 msgid "Dismissible banners shown to all users"
 msgstr "向所有用户显示的可关闭横幅"
 
@@ -957,7 +957,7 @@ msgstr "升高"
 
 #: src/pages/Admin.tsx:437
 #: src/pages/Admin.tsx:656
-#: src/pages/Admin.tsx:733
+#: src/pages/Admin.tsx:745
 #: src/pages/Login.tsx:360
 #: src/pages/Login.tsx:448
 #: src/pages/Login.tsx:557
@@ -1375,15 +1375,15 @@ msgstr "邀请码"
 msgid "Invitation emailed to {0} · code {1}"
 msgstr ""
 
-#: src/pages/Admin.tsx:704
+#: src/pages/Admin.tsx:714
 msgid "Invite"
 msgstr ""
 
-#: src/pages/Admin.tsx:679
+#: src/pages/Admin.tsx:696
 msgid "Invited"
 msgstr ""
 
-#: src/pages/Admin.tsx:948
+#: src/pages/Admin.tsx:960
 msgid "Issue"
 msgstr "工单"
 
@@ -1394,8 +1394,9 @@ msgid "Join the waitlist"
 msgstr "加入候补名单"
 
 #: src/pages/Admin.tsx:658
+#: src/pages/Admin.tsx:691
 msgid "Joined"
-msgstr ""
+msgstr "已加入"
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
 #: src/pages/Training.tsx:381
@@ -1452,11 +1453,11 @@ msgstr "至少关联一个数据源以开始"
 msgid "Link Garmin, Strava, Stryd, or Oura to pull your training data"
 msgstr "关联 Garmin、Strava、Stryd 或 Oura 以拉取您的训练数据"
 
-#: src/pages/Admin.tsx:864
+#: src/pages/Admin.tsx:876
 msgid "Link text (optional)"
 msgstr "链接文本（可选）"
 
-#: src/pages/Admin.tsx:869
+#: src/pages/Admin.tsx:881
 msgid "Link URL (optional)"
 msgstr "链接 URL（可选）"
 
@@ -1610,7 +1611,7 @@ msgstr "网络错误。服务器在运行吗？"
 msgid "Network error. Please email {SUPPORT_EMAIL} directly."
 msgstr "网络错误。请直接发送邮件至 {SUPPORT_EMAIL}。"
 
-#: src/pages/Admin.tsx:842
+#: src/pages/Admin.tsx:854
 msgid "New announcement"
 msgstr "新公告"
 
@@ -1634,7 +1635,7 @@ msgstr "下次同步"
 msgid "No activities found."
 msgstr "未找到活动。"
 
-#: src/pages/Admin.tsx:883
+#: src/pages/Admin.tsx:895
 msgid "No announcements yet"
 msgstr "还没有公告"
 
@@ -1653,7 +1654,7 @@ msgstr "无数据"
 msgid "No Data"
 msgstr "无数据"
 
-#: src/pages/Admin.tsx:940
+#: src/pages/Admin.tsx:952
 msgid "No feedback yet."
 msgstr "暂无反馈。"
 
@@ -1798,7 +1799,7 @@ msgstr "用 Praxys 版本覆盖 Stryd"
 msgid "Pace"
 msgstr "配速"
 
-#: src/pages/Admin.tsx:743
+#: src/pages/Admin.tsx:755
 #: src/pages/Login.tsx:377
 #: src/pages/Login.tsx:574
 #: src/pages/Setup.tsx:207
@@ -1944,12 +1945,12 @@ msgid "Projected"
 msgstr "预测"
 
 #: src/pages/Admin.tsx:483
-#: src/pages/Admin.tsx:797
+#: src/pages/Admin.tsx:809
 msgid "Promote"
 msgstr "提升"
 
 #: src/pages/Admin.tsx:478
-#: src/pages/Admin.tsx:776
+#: src/pages/Admin.tsx:788
 msgid "Promote to Admin"
 msgstr "提升为管理员"
 
@@ -2022,7 +2023,7 @@ msgstr "比赛预测"
 #~ msgid "Range"
 #~ msgstr "范围"
 
-#: src/pages/Admin.tsx:704
+#: src/pages/Admin.tsx:714
 msgid "Re-invite"
 msgstr ""
 
@@ -2030,7 +2031,7 @@ msgstr ""
 msgid "Re-push to Stryd"
 msgstr "重新推送到 Stryd"
 
-#: src/pages/Admin.tsx:725
+#: src/pages/Admin.tsx:737
 msgid "Read-only accounts that mirror your dashboard data"
 msgstr "镜像您仪表盘数据的只读账号"
 
@@ -2136,7 +2137,7 @@ msgstr "注册账号"
 msgid "Registration"
 msgstr ""
 
-#: src/pages/Admin.tsx:1034
+#: src/pages/Admin.tsx:1046
 msgid "Reject"
 msgstr "驳回"
 
@@ -2152,7 +2153,7 @@ msgstr "移除图片"
 msgid "Rep"
 msgstr "组"
 
-#: src/pages/Admin.tsx:947
+#: src/pages/Admin.tsx:959
 msgid "Report"
 msgstr "反馈内容"
 
@@ -2187,7 +2188,7 @@ msgstr "静息心率"
 
 #: src/components/UpcomingPlanCard.tsx:186
 #: src/components/UpcomingPlanCard.tsx:589
-#: src/pages/Admin.tsx:1024
+#: src/pages/Admin.tsx:1036
 #: src/pages/Goal.tsx:443
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:323
@@ -2256,7 +2257,7 @@ msgstr "科学"
 msgid "Science pillars"
 msgstr "科学支柱"
 
-#: src/pages/Admin.tsx:973
+#: src/pages/Admin.tsx:985
 msgid "Screenshot flagged sensitive"
 msgstr "截图被标记为敏感"
 
@@ -2288,7 +2289,7 @@ msgid "Sending an invitation reserves a seat. Self-registration auto-closes at t
 msgstr ""
 
 #: src/components/FeedbackDialog.tsx:317
-#: src/pages/Admin.tsx:704
+#: src/pages/Admin.tsx:714
 #: src/pages/Login.tsx:409
 msgid "Sending…"
 msgstr "发送中…"
@@ -2423,7 +2424,7 @@ msgstr "开始同步"
 
 #: src/pages/Admin.tsx:554
 #: src/pages/Admin.tsx:659
-#: src/pages/Admin.tsx:946
+#: src/pages/Admin.tsx:958
 msgid "Status"
 msgstr "状态"
 
@@ -2559,7 +2560,7 @@ msgstr "正在同步…"
 msgid "System"
 msgstr "跟随系统"
 
-#: src/pages/Admin.tsx:834
+#: src/pages/Admin.tsx:846
 msgid "System Announcements"
 msgstr "系统公告"
 
@@ -2617,7 +2618,7 @@ msgid "This permanently deletes your account, synced training data, plans, setti
 msgstr "这会永久删除您的账号、同步训练数据、计划、设置、平台连接、加密凭据，以及此设备上的 Garmin 令牌存储。您会立即退出登录。"
 
 #. placeholder {0}: deleteUser?.email
-#: src/pages/Admin.tsx:809
+#: src/pages/Admin.tsx:821
 msgid "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 msgstr "这将永久删除 <0>{0}</0> 及其所有数据（活动、配置、连接、计划）。此操作无法撤销。"
 
@@ -2651,7 +2652,7 @@ msgstr "阈值"
 msgid "Time range"
 msgstr "时间范围"
 
-#: src/pages/Admin.tsx:844
+#: src/pages/Admin.tsx:856
 msgid "Title"
 msgstr "标题"
 
@@ -2741,7 +2742,7 @@ msgid "TSB (Form)"
 msgstr "TSB（状态）"
 
 #: src/components/FeedbackDialog.tsx:210
-#: src/pages/Admin.tsx:945
+#: src/pages/Admin.tsx:957
 msgid "Type"
 msgstr "类型"
 
@@ -2761,7 +2762,7 @@ msgstr "单位"
 msgid "Upcoming Plan"
 msgstr "即将到来的计划"
 
-#: src/pages/Admin.tsx:797
+#: src/pages/Admin.tsx:809
 msgid "Updating..."
 msgstr "更新中..."
 
@@ -2798,7 +2799,7 @@ msgstr "使用者"
 msgid "User"
 msgstr "用户"
 
-#: src/pages/Admin.tsx:925
+#: src/pages/Admin.tsx:937
 msgid "User Feedback"
 msgstr "用户反馈"
 

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -668,44 +668,56 @@ export default function Admin() {
                   </TableCell>
                 </TableRow>
               ) : (
-                waitlist.map((s) => (
+                waitlist.map((s) => {
+                  const codeButton = s.invitation_code ? (
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 text-xs font-data text-muted-foreground hover:text-foreground"
+                      onClick={() => copyInviteCode(s.invitation_code!)}
+                      title={t`Copy code`}
+                    >
+                      {s.invitation_code}
+                      {copiedCode === s.invitation_code ? <Check className="h-3 w-3 text-primary" /> : <Copy className="h-3 w-3" />}
+                    </button>
+                  ) : null;
+                  return (
                   <TableRow key={s.id}>
                     <TableCell className="font-medium">{s.email}</TableCell>
                     <TableCell className="text-xs text-muted-foreground max-w-[16rem] truncate">{s.note || '—'}</TableCell>
                     <TableCell className="text-xs text-muted-foreground font-data">{s.created_at ? new Date(s.created_at).toLocaleDateString() : '—'}</TableCell>
                     <TableCell>
-                      {s.invited_at ? (
+                      {s.registered ? (
+                        <div className="flex items-center gap-1.5">
+                          <Badge className="bg-primary text-primary-foreground border-transparent"><Trans>Joined</Trans></Badge>
+                          {codeButton}
+                        </div>
+                      ) : s.invited_at ? (
                         <div className="flex items-center gap-1.5">
                           <Badge className="bg-primary/15 text-primary border-primary/30"><Trans>Invited</Trans></Badge>
-                          {s.invitation_code && (
-                            <button
-                              type="button"
-                              className="inline-flex items-center gap-1 text-xs font-data text-muted-foreground hover:text-foreground"
-                              onClick={() => copyInviteCode(s.invitation_code!)}
-                              title={t`Copy code`}
-                            >
-                              {s.invitation_code}
-                              {copiedCode === s.invitation_code ? <Check className="h-3 w-3 text-primary" /> : <Copy className="h-3 w-3" />}
-                            </button>
-                          )}
+                          {codeButton}
                         </div>
                       ) : (
                         <span className="text-xs text-muted-foreground">—</span>
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button
-                        size="sm"
-                        variant={s.invited_at ? 'outline' : 'default'}
-                        onClick={() => handleInviteWaitlist(s)}
-                        disabled={invitingId === s.id}
-                      >
-                        <Send className="h-3 w-3 mr-1" />
-                        {invitingId === s.id ? <Trans>Sending…</Trans> : s.invited_at ? <Trans>Re-invite</Trans> : <Trans>Invite</Trans>}
-                      </Button>
+                      {s.registered ? (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant={s.invited_at ? 'outline' : 'default'}
+                          onClick={() => handleInviteWaitlist(s)}
+                          disabled={invitingId === s.id}
+                        >
+                          <Send className="h-3 w-3 mr-1" />
+                          {invitingId === s.id ? <Trans>Sending…</Trans> : s.invited_at ? <Trans>Re-invite</Trans> : <Trans>Invite</Trans>}
+                        </Button>
+                      )}
                     </TableCell>
                   </TableRow>
-                ))
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -710,6 +710,8 @@ export interface WaitlistSignupItem {
   invited_at: string | null;
   invitation_id: number | null;
   invitation_code: string | null;
+  /** True once an account exists for this email (invited or open path). */
+  registered: boolean;
 }
 
 /** POST /api/admin/waitlist/{id}/invite result. */


### PR DESCRIPTION
## What

Waitlist rows in the Admin console kept showing the **"Invited"** badge and an active **"Re-invite"** button even after the invited person had actually registered, because the status was derived purely from `invited_at` — nothing checked whether the invitation was ever redeemed.

This adds a `registered` signal so a joined lead is shown as **"Joined"** (solid-green badge) with the Re-invite affordance removed.

## Why it mattered

Re-inviting an already-registered user:
- mints a **fresh invitation code**,
- **reserves another committed seat** against the registration cap (outstanding invites count toward the cap), and
- **re-emails** someone who has already joined.

It was also just misleading — you could not tell at a glance who had actually signed up.

## Changes

- **`api/routes/admin.py`** — `GET /api/admin/waitlist` now returns a `registered: bool` per signup, derived from whether a `User` account exists for that email (any registration path — invited *or* open), compared **case-insensitively** (`func.lower`). One extra query, guarded for the empty case.
- **`web/src/types/api.ts`** — `registered: boolean` added to `WaitlistSignupItem` (contract parity).
- **`web/src/pages/Admin.tsx`** — joined rows show a solid-green **"Joined"** badge and a muted dash in the action column instead of **"Re-invite"**. Hoisted the code-copy button so it is reused across the Joined/Invited branches.
- **i18n** — reuses the existing `Joined` msgid; `en` catalog refreshed via `lingui extract`, `zh` pre-filled `已加入` (avoids the pre-existing `Registered → 注册于` date-label collision).
- **`tests/test_registration_gate.py`** — asserts the `invited → registered` transition in the existing invite test, plus a focused case-insensitive / unrelated-row test.

## Validation

- `pytest tests/test_registration_gate.py tests/test_waitlist.py` → **16 passed**
- `npm run build` (tsc + vite) → **green**
- `npm run i18n:extract` → `en` catalog up to date (only reference-line shifts + the badge usage)

No API/infra/secret/config changes, so no `docs/ops/` update required.
