### PR TITLE
Clear all user foreign-key references on account deletion (#366)

### DIFF
--- a/alembic/versions/7c2e9a4f1b83_user_fk_ondelete_set_null.py
+++ b/alembic/versions/7c2e9a4f1b83_user_fk_ondelete_set_null.py
@@ -1,0 +1,113 @@
+"""Set ON DELETE SET NULL on nullable user / invitation foreign keys
+
+Prevents dangling FK references when a user (or an invitation) is deleted, so a
+delete can't leave an orphaned reference that PostgreSQL's enforced foreign keys
+reject (issue #366). Applies to the nullable references held by rows we keep:
+
+* ``users.demo_of``                  -> users.id
+* ``app_config.updated_by``          -> users.id
+* ``waitlist_signups.invitation_id`` -> invitations.id
+
+``invitations.used_by`` is deliberately NOT changed here: invitation validity is
+"is_active AND used_by IS NULL", so a bare SET NULL would recycle a consumed
+code. The application (api/account_deletion.py) nulls used_by AND deactivates
+the code together instead.
+
+Revision ID: 7c2e9a4f1b83
+Revises: b7f1a2c9d3e4
+Create Date: 2026-07-04
+
+"""
+from typing import Sequence, Union
+
+from alembic import context, op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7c2e9a4f1b83"
+down_revision: Union[str, Sequence[str], None] = "b7f1a2c9d3e4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (table, referencing column, referenced table) for each FK re-created with
+# ON DELETE SET NULL. Each is independent; order does not matter.
+_TARGETS = (
+    ("users", "demo_of", "users"),
+    ("app_config", "updated_by", "users"),
+    ("waitlist_signups", "invitation_id", "invitations"),
+)
+
+
+def _pg_fk_name(bind, table: str, column: str) -> str | None:
+    """Return the live FK constraint name for ``table.column`` on PostgreSQL.
+
+    The baseline created these FKs unnamed, so PostgreSQL assigned its default
+    ``{table}_{column}_fkey``. We look the name up from the catalog rather than
+    trusting that convention blindly, so the migration is robust to any drift.
+    """
+    try:
+        return bind.execute(
+            sa.text(
+                """
+                SELECT tc.constraint_name
+                FROM information_schema.table_constraints AS tc
+                JOIN information_schema.key_column_usage AS kcu
+                  ON tc.constraint_name = kcu.constraint_name
+                 AND tc.table_schema = kcu.table_schema
+                WHERE tc.constraint_type = 'FOREIGN KEY'
+                  AND tc.table_name = :table
+                  AND kcu.column_name = :column
+                LIMIT 1
+                """
+            ),
+            {"table": table, "column": column},
+        ).scalar()
+    except Exception:
+        # Offline (--sql) mode has no live connection to query the catalog;
+        # the caller falls back to the conventional {table}_{column}_fkey name.
+        return None
+
+
+def _recreate_fks(ondelete: Union[str, None]) -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        # SQLite (dev / tests) builds the schema from the ORM via create_all,
+        # which already reflects these ondelete rules, and does not enforce FKs.
+        # No ALTER is needed or possible without a full table rebuild, so skip.
+        return
+    for table, column, referent in _TARGETS:
+        # Defensively clear any pre-existing orphan so re-adding the constraint
+        # cannot fail on a stray dangling row.
+        op.execute(
+            f"UPDATE {table} SET {column} = NULL "
+            f"WHERE {column} IS NOT NULL "
+            f"AND {column} NOT IN (SELECT id FROM {referent})"
+        )
+        name = _pg_fk_name(bind, table, column)
+        if name is None and context.is_offline_mode():
+            # No live connection to resolve the name in --sql mode; assume the
+            # conventional PostgreSQL default so the preview still emits a DROP.
+            name = f"{table}_{column}_fkey"
+        # Only drop when the constraint actually exists; if it is somehow already
+        # absent (online), skip to creating it rather than aborting the startup
+        # migration on a "constraint does not exist" error.
+        if name is not None:
+            op.drop_constraint(name, table, type_="foreignkey")
+        op.create_foreign_key(
+            f"{table}_{column}_fkey",
+            table,
+            referent,
+            [column],
+            ["id"],
+            ondelete=ondelete,
+        )
+
+
+def upgrade() -> None:
+    _recreate_fks("SET NULL")
+
+
+def downgrade() -> None:
+    _recreate_fks(None)

--- a/api/account_deletion.py
+++ b/api/account_deletion.py
@@ -5,7 +5,6 @@ import logging
 from dataclasses import dataclass
 
 from fastapi import HTTPException
-from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from db.models import (
@@ -13,6 +12,7 @@ from db.models import (
     ActivitySample,
     ActivitySplit,
     AiInsight,
+    AppConfig,
     CacheRevision,
     DashboardCache,
     Feedback,
@@ -23,6 +23,7 @@ from db.models import (
     User,
     UserConfig,
     UserConnection,
+    WaitlistSignup,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,24 @@ class AccountDeletionResult:
 
 
 def _delete_user_owned_rows(db: Session, user_id: str) -> None:
-    """Delete rows that directly belong to a user, excluding the user row."""
+    """Delete a user's owned rows and detach every remaining reference to them.
+
+    Rows keyed by a NOT-NULL ``user_id`` FK are the user's own data and are
+    deleted outright. References that other, surviving rows hold to this user are
+    cleared so nothing dangles once the ``users`` row is gone — PostgreSQL
+    enforces these foreign keys (SQLite historically did not, which is how issue
+    #366's orphaned ``invitations.used_by`` rows accrued):
+
+    * ``invitations.created_by`` (NOT NULL) — the invitation can't outlive its
+      required creator, so it is deleted; any ``waitlist_signups.invitation_id``
+      pointing at it is detached first so that FK doesn't dangle.
+    * ``invitations.used_by`` (nullable) — the invitation is kept as a record of
+      the creator's action, but the reference is nulled AND the code deactivated
+      so a now-ownerless code can't be re-claimed (a claim only checks
+      ``used_by IS NULL``; see api/invitations.py).
+    * ``app_config.updated_by`` (nullable) — the operator flag row is kept; only
+      the "who last changed this" reference is nulled.
+    """
     for model in (
         ActivitySample,
         ActivitySplit,
@@ -54,9 +72,34 @@ def _delete_user_owned_rows(db: Session, user_id: str) -> None:
     ):
         db.query(model).filter(model.user_id == user_id).delete(synchronize_session=False)
 
-    db.query(Invitation).filter(
-        or_(Invitation.used_by == user_id, Invitation.created_by == user_id)
-    ).delete(synchronize_session=False)
+    # Invitations this user created (created_by is NOT NULL, so it can't be
+    # nulled). Detach any waitlist signups linked to them first so that FK
+    # doesn't dangle, then delete the invitations.
+    created_invitation_ids = [
+        inv_id
+        for (inv_id,) in db.query(Invitation.id)
+        .filter(Invitation.created_by == user_id)
+        .all()
+    ]
+    if created_invitation_ids:
+        db.query(WaitlistSignup).filter(
+            WaitlistSignup.invitation_id.in_(created_invitation_ids)
+        ).update({WaitlistSignup.invitation_id: None}, synchronize_session=False)
+        db.query(Invitation).filter(
+            Invitation.id.in_(created_invitation_ids)
+        ).delete(synchronize_session=False)
+
+    # Invitations merely used by this user are preserved (they record who issued
+    # the code) but detached and deactivated so the freed code can't be redeemed.
+    db.query(Invitation).filter(Invitation.used_by == user_id).update(
+        {Invitation.used_by: None, Invitation.is_active: False},
+        synchronize_session=False,
+    )
+
+    # Operator config records who last toggled a flag; keep the row, drop the ref.
+    db.query(AppConfig).filter(AppConfig.updated_by == user_id).update(
+        {AppConfig.updated_by: None}, synchronize_session=False
+    )
 
 
 def _clear_tokenstore(user_id: str) -> None:

--- a/db/models.py
+++ b/db/models.py
@@ -42,7 +42,10 @@ class User(Base):
     is_superuser = Column(Boolean, default=False, nullable=False)
     is_verified = Column(Boolean, default=False, nullable=False)
     is_demo = Column(Boolean, default=False, nullable=False)
-    demo_of = Column(String(36), ForeignKey("users.id"), nullable=True)
+    # ondelete=SET NULL is a DB-level safety net: the account-deletion path
+    # removes a deleted user's demo mirror, but SET NULL guarantees a raw delete
+    # can't strand a dangling demo_of reference (issue #366).
+    demo_of = Column(String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     # Throttled last-activity timestamp powering the WAU/DAU admin gauge.
     # Written by api/auth.py on authenticated requests, but only when stale
@@ -78,6 +81,11 @@ class Invitation(Base):
     code = Column(String(12), unique=True, nullable=False, index=True)
     created_by = Column(String(36), ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+    # NOTE: intentionally NO ondelete=SET NULL here. Invitation validity is
+    # "is_active AND used_by IS NULL" (see api/invitations.py), so nulling
+    # used_by alone would recycle a consumed code. The account-deletion path
+    # nulls used_by AND deactivates the code together; a bare DB SET NULL can't
+    # flip is_active, so it is deliberately omitted (issue #366).
     used_by = Column(String(36), ForeignKey("users.id"), nullable=True)
     used_at = Column(DateTime, nullable=True)
     # Optional expiry for emailed invitations (waitlist-invite flow). NULL =
@@ -478,7 +486,10 @@ class WaitlistSignup(Base):
     locale = Column(String(10), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     invited_at = Column(DateTime, nullable=True)
-    invitation_id = Column(Integer, ForeignKey("invitations.id"), nullable=True)
+    # ondelete=SET NULL: a waitlist lead survives if the invitation it was sent
+    # is later deleted (e.g. the inviting admin's account is removed); the link
+    # is simply cleared rather than blocking the delete (issue #366).
+    invitation_id = Column(Integer, ForeignKey("invitations.id", ondelete="SET NULL"), nullable=True)
 
 
 class Feedback(Base):
@@ -568,4 +579,6 @@ class AppConfig(Base):
     key = Column(String(64), primary_key=True)
     value = Column(Text, nullable=True)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    updated_by = Column(String(36), ForeignKey("users.id"), nullable=True)
+    # ondelete=SET NULL: keep the operator flag row when the admin who last
+    # toggled it is deleted; just drop the stale reference (issue #366).
+    updated_by = Column(String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -57,10 +57,13 @@ There are **no deployment slots** on the B1 plan, so rollback = re-deploy a know
 1. **Revert the commit** on `main` (`git revert <sha> && git push`) — the deploy
    workflow re-runs and ships the reverted state. Safest for app bugs.
 2. **Re-tag a prior good commit** (`api-*` / `web-*`) to redeploy that exact build.
-3. **Schema note:** migrations are additive only (`init_db()` adds tables/columns,
-   never drops). A code rollback won't undo an added column — that's safe (old
-   code ignores unknown columns) but a *destructive* schema change would need a
-   forward-fix, not a rollback.
+3. **Schema note:** migrations are additive / non-destructive — `init_db()` runs
+   `alembic upgrade head`, which adds tables/columns and may tweak constraints
+   (e.g. adding `ON DELETE SET NULL` to a foreign key, #366) but does not drop
+   tables/columns or data. A code rollback won't undo an applied migration, and
+   that's safe: old code ignores added columns, and a data-preserving constraint
+   change is transparent to it. A genuinely *destructive* schema change would
+   need a forward-fix, not a rollback.
 
 > Config-only revert (a bad App Service setting): fix the GitHub secret/variable
 > and re-deploy — don't hand-edit the portal (it's overwritten next deploy).

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -93,6 +93,7 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         ActivitySample,
         ActivitySplit,
         AiInsight,
+        AppConfig,
         CacheRevision,
         DashboardCache,
         Feedback,
@@ -103,6 +104,7 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         User,
         UserConfig,
         UserConnection,
+        WaitlistSignup,
     )
 
     db = db_session.SessionLocal()
@@ -128,9 +130,17 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         db.add(CacheRevision(user_id=user_id, scope="activities", revision=1))
         db.add(DashboardCache(user_id=user_id, section="today", source_version="v1", payload_json=b"{}"))
         db.add(Feedback(user_id=user_id, kind="bug", message="delete me", status="new"))
-        db.add(Invitation(code="TS-USED-0001", created_by="admin", used_by=user_id, is_active=False))
-        db.add(Invitation(code="TS-MADE-0001", created_by=user_id, is_active=True))
         db.add(UserConfig(user_id="demo-user", display_name="Demo"))
+        used = Invitation(code="TS-USED-0001", created_by="admin", used_by=user_id, is_active=False)
+        made = Invitation(code="TS-MADE-0001", created_by=user_id, is_active=True)
+        db.add_all([used, made])
+        db.flush()
+        # A waitlist lead linked to the invitation the user *created*: it must
+        # survive the user's deletion with invitation_id detached (issue #366).
+        db.add(WaitlistSignup(email="lead@example.test", invitation_id=made.id))
+        # The user last toggled an operator flag; the row must survive with
+        # updated_by nulled rather than left dangling (issue #366).
+        db.add(AppConfig(key="registration_open", value="true", updated_by=user_id))
         db.commit()
     finally:
         db.close()
@@ -150,6 +160,7 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
         ActivitySample,
         ActivitySplit,
         AiInsight,
+        AppConfig,
         CacheRevision,
         DashboardCache,
         Feedback,
@@ -160,6 +171,7 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
         User,
         UserConfig,
         UserConnection,
+        WaitlistSignup,
     )
 
     db = db_session.SessionLocal()
@@ -183,6 +195,40 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
         assert db.query(Invitation).filter(
             (Invitation.used_by == "delete-me") | (Invitation.created_by == "delete-me")
         ).count() == 0
+
+        # The admin-issued invitation the deleted user *used* is preserved as an
+        # audit record, but detached (used_by NULL) and deactivated so the freed
+        # code cannot be re-claimed (issue #366).
+        used_inv = db.query(Invitation).filter(Invitation.code == "TS-USED-0001").one()
+        assert used_inv.used_by is None
+        assert used_inv.is_active is False
+
+        # The operator-config row the user last touched survives with its
+        # reference nulled, not deleted.
+        cfg_row = db.query(AppConfig).filter(AppConfig.key == "registration_open").one()
+        assert cfg_row.updated_by is None
+
+        # The waitlist lead survives even though the invitation it was linked to
+        # (created by the deleted user) is gone — the link is nulled (issue #366).
+        lead = db.query(WaitlistSignup).filter(WaitlistSignup.email == "lead@example.test").one()
+        assert lead.invitation_id is None
+
+        # Belt-and-braces: nothing anywhere still references a deleted id.
+        live_user_ids = {uid for (uid,) in db.query(User.id).all()}
+        dangling_user_refs = (
+            [r for (r,) in db.query(Invitation.used_by).filter(Invitation.used_by.isnot(None)).all()]
+            + [r for (r,) in db.query(Invitation.created_by).all()]
+            + [r for (r,) in db.query(AppConfig.updated_by).filter(AppConfig.updated_by.isnot(None)).all()]
+        )
+        assert all(ref in live_user_ids for ref in dangling_user_refs)
+        live_inv_ids = {iid for (iid,) in db.query(Invitation.id).all()}
+        waitlist_refs = [
+            iid
+            for (iid,) in db.query(WaitlistSignup.invitation_id)
+            .filter(WaitlistSignup.invitation_id.isnot(None))
+            .all()
+        ]
+        assert all(ref in live_inv_ids for ref in waitlist_refs)
     finally:
         db.close()
 
@@ -276,3 +322,102 @@ def test_run_sync_rolls_back_if_user_deactivated_before_commit(account_client, m
         assert conn.consecutive_failures == 0
     finally:
         db.close()
+def test_delete_user_account_no_dangling_fk_under_enforcement(monkeypatch):
+    """Deletion commits under enforced FKs (Postgres-like) with zero orphans.
+
+    Regression for #366: SQLite shipped FK enforcement off, so account deletion
+    silently left dangling ``invitations.used_by`` / ``app_config.updated_by`` /
+    ``waitlist_signups.invitation_id`` references. With ``PRAGMA foreign_keys=ON``
+    those orphans become a hard error at commit, so this proves the deletion path
+    clears every reference before dropping the user — exactly the invariant
+    PostgreSQL now enforces in production.
+    """
+    from datetime import date
+
+    from sqlalchemy import create_engine, event
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    import api.account_deletion as account_deletion
+    from db.models import (
+        Activity,
+        AppConfig,
+        Base,
+        Feedback,
+        Invitation,
+        User,
+        UserConfig,
+        WaitlistSignup,
+    )
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _enforce_fks(dbapi_conn, _rec):
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(engine)
+    # Mirror production's session config (db/session.py uses autoflush=False) so
+    # this stays a faithful proxy for the enforced-FK deletion path.
+    Session = sessionmaker(bind=engine, autoflush=False)
+
+    # delete_user_account commits before touching disk tokenstores; stub that
+    # step so the test stays DB-only (no DATA_DIR / filesystem dependency).
+    monkeypatch.setattr(account_deletion, "_clear_tokenstore", lambda uid: None)
+
+    db = Session()
+    try:
+        # Seed parents before children so inserts satisfy the enforced FKs: these
+        # models use bare ForeignKey columns with no ORM relationship, so the
+        # unit of work can't infer insert order (it mirrors the real app, which
+        # commits a user at registration before syncing that user's data).
+        db.add(User(id="admin", email="admin@x.test", hashed_password="x", is_superuser=True))
+        db.add(User(id="target", email="t@x.test", hashed_password="x"))
+        db.commit()
+        db.add(User(id="target-demo", email="d@x.test", hashed_password="x", is_demo=True, demo_of="target"))
+        db.commit()
+        db.add(UserConfig(user_id="target", display_name="T"))
+        db.add(Activity(user_id="target", activity_id="a1", date=date(2026, 6, 1)))
+        db.add(Feedback(user_id="target", kind="bug", message="hi", status="new"))
+        made = Invitation(code="TS-MADE-9999", created_by="target", is_active=True)
+        used = Invitation(code="TS-USED-9999", created_by="admin", used_by="target", is_active=True)
+        db.add_all([made, used])
+        db.commit()
+        db.add(WaitlistSignup(email="w1@x.test", invitation_id=made.id))
+        db.add(AppConfig(key="registration_open", value="true", updated_by="target"))
+        db.commit()
+    finally:
+        db.close()
+
+    db = Session()
+    try:
+        result = account_deletion.delete_user_account(db, "target", enforce_last_admin_guard=False)
+    finally:
+        db.close()
+
+    assert set(result.deleted_user_ids) == {"target", "target-demo"}
+
+    db = Session()
+    try:
+        assert db.query(User).filter(User.id.in_(["target", "target-demo"])).count() == 0
+        # Invitation the user *used* is preserved, detached, and deactivated.
+        used_row = db.query(Invitation).filter(Invitation.code == "TS-USED-9999").one()
+        assert used_row.used_by is None
+        assert used_row.is_active is False
+        # Invitation the user *created* is deleted (created_by is NOT NULL).
+        assert db.query(Invitation).filter(Invitation.code == "TS-MADE-9999").count() == 0
+        # Waitlist lead kept with its (now-deleted) invitation link nulled.
+        wl = db.query(WaitlistSignup).filter(WaitlistSignup.email == "w1@x.test").one()
+        assert wl.invitation_id is None
+        # Operator-config row kept, updated_by nulled.
+        cfg = db.query(AppConfig).filter(AppConfig.key == "registration_open").one()
+        assert cfg.updated_by is None
+    finally:
+        db.close()
+    engine.dispose()


### PR DESCRIPTION
Fixes #366.

## Problem
Account deletion removed a user's own rows and their invitations, but left **other tables' references to the deleted user dangling**. SQLite ships with foreign keys unenforced, so these orphans accrued silently. PostgreSQL (#360) enforces them — the cutover copy already hit a `ForeignKeyViolation` on `invitations.used_by`, and a post-cutover account delete would now **fail outright** on `app_config.updated_by`.

## FK audit (references to `users.id` / `invitations.id`)
| Reference | Nullable | Handling |
|---|---|---|
| `invitations.created_by` | NO | delete the invitation (after detaching its waitlist link) |
| `invitations.used_by` | yes | **null the ref + deactivate** the code |
| `app_config.updated_by` | yes | null the ref, keep the operator row |
| `waitlist_signups.invitation_id` | yes | null when its invitation is deleted |
| `users.demo_of` | yes | demo mirror already deleted; DB SET NULL safety net |
| `feedback.user_id` | yes | already deleted + already `ON DELETE SET NULL` |
| `*.user_id` (owned data) | NO | deleted (unchanged) |

## Why `used_by` is special
Invitation validity is `is_active AND used_by IS NULL` (see `api/invitations.py`). Nulling `used_by` **alone** — including a naive DB-level `ON DELETE SET NULL` — would turn a consumed code back into a claimable one. So the app nulls `used_by` **and** deactivates the code together, and `invitations.used_by` is the one nullable user-FK deliberately **excluded** from the DB-level `ON DELETE SET NULL`.

## Changes
- **`api/account_deletion.py`** — `_delete_user_owned_rows` now clears every reference above (was only deleting `used_by`/`created_by` invitations).
- **`alembic/versions/7c2e9a4f1b83_…`** — adds `ON DELETE SET NULL` to `users.demo_of`, `app_config.updated_by`, `waitlist_signups.invitation_id` as a DB-level safety net (Postgres-only; SQLite builds via `create_all`). Defensively nulls any pre-existing orphan first and looks up live constraint names from the catalog. Includes `downgrade()`.
- **`db/models.py`** — matching `ondelete="SET NULL"` on those three FKs so `create_all` (dev/tests) mirrors prod; a comment documents why `used_by` is excluded.
- **`tests/test_account_deletion.py`** — seed the newly covered references + assert no dangling refs remain, and a new `PRAGMA foreign_keys=ON` test that commits a deletion under enforced FKs (mirrors Postgres). Verified it **fails on the pre-fix logic**.
- **`docs/ops/deploy.md`** — refreshed the schema-note so "migrations are additive/non-destructive" stays accurate for a constraint tweak.

## Testing
- `pytest tests/test_account_deletion.py` → 5 passed (incl. the new enforcement test).
- Full suite: **854 passed, 2 skipped**.
- Migration smoke-tested: full `alembic upgrade head` + `downgrade` on SQLite; offline `--sql` against Postgres emits the expected `DROP/ADD CONSTRAINT … ON DELETE SET NULL`.

## Note for reviewers / merge
The migration bases on the current head `4507a109335c`. If another baseline-based migration lands first, re-point this one's `down_revision` to keep a single Alembic head.
