### PR TITLE
Add pre-merge backend pytest CI gate on pull requests

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,0 +1,44 @@
+name: Backend CI
+
+# Pre-merge test gate (issue #361). Runs the backend pytest suite on every PR
+# targeting main so regressions are caught *before* merge — not only at deploy
+# time (deploy-backend.yml runs pytest post-merge, on push to main). This is the
+# safety net for autonomously drafted PRs (the Loop A Copilot coding-agent flow):
+# nothing merges without a green suite.
+#
+# Intentionally has NO `paths:` filter. This job is a *required* status check on
+# main, and a required check that a path filter skips is reported as permanently
+# "pending", which blocks the PR forever. Running the (fast, pip-cached) suite on
+# every PR keeps the gate always-reporting — and means an AI-generated PR that
+# touches *anything* still gets the backend safety net.
+
+on:
+  pull_request:
+    branches: [main]
+
+# One in-flight run per PR; cancel the previous when new commits land.
+concurrency:
+  group: backend-ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend-tests:
+    name: backend-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run backend tests
+        run: python -m pytest tests/ -v

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -335,6 +335,7 @@ This means deploying a new version with additional model columns just works — 
 
 ## CI/CD Workflows
 
+- **Backend tests (pre-merge gate)** (`.github/workflows/ci-backend.yml`) — runs on every `pull_request` to `main`: sets up Python 3.12, installs `requirements.txt` (pip-cached), and runs `python -m pytest tests/`. A **required status check** (`backend-tests`) on `main`, so a failing test blocks merge — regressions are caught *before* merge (the `deploy-backend.yml` suite runs only post-merge). No `paths:` filter on purpose: a required check skipped by a path filter stays permanently pending and blocks the PR.
 - **Backend** (`.github/workflows/deploy-backend.yml`) — triggers on changes to `api/`, `analysis/`, `sync/`, `db/`, `data/science/`, `tests/`, `requirements.txt`. Runs tests first, then deploys via OIDC to `trainsight-app`.
 - **Frontend** (`.github/workflows/deploy-frontend-appservice.yml`) — triggers on changes to `web/` or `frontend_server/`. Runs the static-server's 11-test suite first, then builds `web/dist/` (with `VITE_API_URL` baked in), packages it alongside `frontend_server/`, and deploys via OIDC to `praxys-frontend`. Oryx runs `pip install -r requirements.txt` (the frontend-only one) on the App Service side.
 

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -15,6 +15,8 @@
 All three authenticate to Azure / WeChat via OIDC or the upload key — no
 passwords. Backend + frontend run their test/build gates **before** deploying.
 
+**Pre-merge gate.** Before any deploy, `ci-backend.yml` runs the backend `pytest` suite on every PR to `main` and reports a **required** status check (`backend-tests`). A red suite blocks merge, so regressions never reach the deploy step (see [environment.md](./environment.md) → Repo governance). `deploy-backend.yml` re-runs the same suite post-merge as a deploy-time backstop.
+
 ## Backend deploy
 
 Automatic on merge to `main` (for the paths above). The workflow:
@@ -74,4 +76,4 @@ There are **no deployment slots** on the B1 plan, so rollback = re-deploy a know
 - `docs/deployment.md` (one-time Azure setup) · `.github/workflows/`
 
 ---
-_Last reviewed: 2026-06-30 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-05 · Owner: @dddtc2005_

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -54,10 +54,14 @@
 - **Platform credentials:** Fernet-encrypted in the DB; each user's Fernet DEK is
   wrapped by the Key Vault RSA master key (`db/crypto.py`).
 
+## Repo governance
+
+- **`main` branch protection.** A required status check `backend-tests` (from `.github/workflows/ci-backend.yml`, issue #361) gates every PR to `main`: a failing backend `pytest` run blocks merge, **admins included** (`enforce_admins`). No required human review (`required_pull_request_reviews` unset) so the solo maintainer can self-merge a green PR. Managed via the branch-protection API on `repos/dddtc2005/praxys/branches/main/protection` — update that rule to change the required checks.
+
 ## Related
 
 - [config-and-secrets.md](./config-and-secrets.md) · [deploy.md](./deploy.md)
 - `docs/deployment.md` (one-time Azure setup) · `docs/perf-baselines/azure-provisioning.md`
 
 ---
-_Last reviewed: 2026-06-30 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-05 · Owner: @dddtc2005_


### PR DESCRIPTION
Closes #361.

## What

Adds `.github/workflows/ci-backend.yml`, a `pull_request`-triggered workflow that runs the backend test suite as a **pre-merge gate**. Until now the backend suite ran only inside `deploy-backend.yml` at deploy time (post-merge to `main`), so a PR could merge without the tests ever running against it.

The `backend-tests` job:
- Triggers on `pull_request` → `main`
- Sets up Python 3.12
- Installs `requirements.txt` with **pip caching** (`actions/setup-python` `cache: pip`)
- Runs `python -m pytest tests/ -v`
- Cancels superseded runs on the same PR (`concurrency`)

## Scope (from the issue)

- [x] `pull_request`-triggered workflow: Python 3.12 + install `requirements.txt` + `python -m pytest tests/`
- [x] Cache pip for speed
- [x] Make it a **required status check** on `main` — enabled via branch protection right after this merges (documented in `docs/ops/environment.md` → Repo governance)

## Why no `paths:` filter

A required status check that a `paths:` filter *skips* is reported by GitHub as permanently **pending**, which blocks the PR forever. Running the fast, pip-cached suite on every PR keeps the gate always-reporting — and means an AI-generated PR (Loop A) that touches *anything* still gets the backend safety net.

## Docs

- `docs/deployment.md` — CI/CD Workflows list
- `docs/ops/deploy.md` — pre-merge gate note
- `docs/ops/environment.md` — new **Repo governance** section describing the required `backend-tests` check

## Verification

- `backend-tests` runs on this PR — it is the same suite `deploy-backend.yml` runs today, and no Python changed.
- After merge: enable branch protection requiring `backend-tests`, then confirm a deliberately-failing PR is blocked (the issue's final acceptance criterion).
