### PR TITLE
Fix Postgres connection-pool exhaustion behind Settings 500s

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -147,6 +147,17 @@ jobs:
               SCM_DO_BUILD_DURING_DEPLOYMENT="true" \
               WEBSITE_HTTPLOGGING_RETENTION_DAYS="3"
 
+          # Always On keeps ONE warm container instead of stop/starting on idle.
+          # Each recycle abandons the backend's DB connection pool as idle
+          # "zombie" Postgres backends (they linger until TCP-keepalive reap);
+          # that churn helped exhaust the Burstable server in the 2026-07-05
+          # outage. Site config, NOT an app setting -> a separate command. See
+          # docs/ops/config-and-secrets.md.
+          az webapp config set \
+            --name trainsight-app \
+            --resource-group rg-trainsight \
+            --always-on true
+
       # NB: no pre-deploy on-demand DB snapshot. praxys-pg is a Burstable-tier
       # Flexible Server, which does not support customer on-demand backups; the
       # server's continuous PITR (14-day) provides the pre-deploy restore point

--- a/api/main.py
+++ b/api/main.py
@@ -106,6 +106,15 @@ async def lifespan(app: FastAPI):
                 stop_scheduler()
             except Exception:
                 logger.exception("Failed to stop sync scheduler cleanly")
+        # Release DB connection pools on shutdown so Postgres frees the backends
+        # immediately instead of leaving them idle until TCP-keepalive reap.
+        # Abandoned pools from container recycles accumulated as "zombie"
+        # backends and exhausted the Burstable server (2026-07-05 outage).
+        try:
+            from db.session import dispose_engines_async
+            await dispose_engines_async()
+        except Exception:
+            logger.exception("Failed to dispose DB engines cleanly")
 
 
 app = FastAPI(title="Praxys API", version=get_api_version(), lifespan=lifespan)

--- a/db/session.py
+++ b/db/session.py
@@ -256,9 +256,83 @@ def _skip_migrations() -> bool:
     )
 
 
-def init_db():
-    """Initialize sync and async database engines and ensure the schema exists."""
+def dispose_engines() -> None:
+    """Dispose the sync + async engine pools and clear the singletons.
+
+    Closes every pooled DB connection so PostgreSQL frees the backend at once,
+    instead of leaving it idle until TCP-keepalive reap. Called before any
+    re-initialization (so a forced init cannot orphan a live pool). For the
+    await-correct shutdown path use dispose_engines_async(). Best-effort;
+    never raises.
+
+    Background: abandoned pools accumulated as idle "zombie" backends across
+    container recycles and per-tick init_db() calls, exhausting the Burstable
+    server's small max_connections and 500ing every data endpoint (2026-07-05
+    outage). See docs/ops/incident-response.md.
+    """
     global engine, SessionLocal, async_engine, AsyncSessionLocal
+    if engine is not None:
+        try:
+            engine.dispose()
+        except Exception:
+            logger.debug("sync engine dispose failed", exc_info=True)
+    if async_engine is not None:
+        try:
+            # AsyncEngine wraps a sync core; disposing that core closes the
+            # pool synchronously (fine from sync callers and tests).
+            async_engine.sync_engine.dispose()
+        except Exception:
+            logger.debug("async engine dispose failed", exc_info=True)
+    engine = None
+    SessionLocal = None
+    async_engine = None
+    AsyncSessionLocal = None
+
+
+async def dispose_engines_async() -> None:
+    """Await-correct pool disposal for the FastAPI lifespan shutdown.
+
+    Uses ``await async_engine.dispose()`` so the async (psycopg3) pool closes
+    on the running event loop, then disposes the sync pool. Releasing pools on
+    shutdown stops abandoned connections from lingering as idle "zombie"
+    backends after a container recycle (2026-07-05 outage).
+    """
+    global engine, SessionLocal, async_engine, AsyncSessionLocal
+    if async_engine is not None:
+        try:
+            await async_engine.dispose()
+        except Exception:
+            logger.debug("async engine dispose failed", exc_info=True)
+    if engine is not None:
+        try:
+            engine.dispose()
+        except Exception:
+            logger.debug("sync engine dispose failed", exc_info=True)
+    engine = None
+    SessionLocal = None
+    async_engine = None
+    AsyncSessionLocal = None
+
+
+def init_db(force: bool = False):
+    """Initialize sync and async database engines and ensure the schema exists.
+
+    Idempotent: once the engines exist this is a no-op, so hot paths that only
+    need to guarantee initialization (the sync scheduler's per-tick call, the
+    get_db / get_async_db fallbacks) do not rebuild the pools or re-run
+    migrations. Rebuilding on every scheduler tick orphaned a pool each time
+    and was a root cause of the 2026-07-05 connection-exhaustion outage. Pass
+    ``force=True`` to rebuild (disposing the previous pools first); tests that
+    repoint DATA_DIR at a fresh database null the module globals, same effect.
+    """
+    global engine, SessionLocal, async_engine, AsyncSessionLocal
+
+    if not force and SessionLocal is not None and engine is not None:
+        return
+
+    # Drop any previous / half-initialized pool before rebuilding so a forced
+    # re-init cannot leak the old connections.
+    dispose_engines()
 
     url = get_database_url()
     async_url = get_async_database_url()

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -134,6 +134,44 @@ gh secret   set PRAXYS_DATABASE_URL --body "postgresql://trainsight-app@praxys-p
 clearing `PRAXYS_DATABASE_URL` cleanly rolls back to the frozen SQLite file.
 Provisioning + PITR + MI-as-AAD-principal wiring: [postgres-migration.md](./postgres-migration.md).
 
+### Database connection budget, pool sizing & Always On
+
+The production DB is a **Burstable B1ms** Flexible Server: `max_connections=50`
+(Azure default for the tier), of which ~15 are reserved
+(`superuser_reserved_connections=10` + `reserved_connections=5`, both Azure
+defaults) — leaving **~35 usable by the app**. Don't lower the reserved values;
+they're Azure-managed.
+
+The backend's SQLAlchemy pools are bounded (`db/session.py`) and tunable via
+optional App Service settings (defaults shown):
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `PRAXYS_DB_POOL_SIZE` | `5` | Steady pool size, **per engine, per worker** |
+| `PRAXYS_DB_MAX_OVERFLOW` | `5` | Burst connections above `pool_size` |
+| `PRAXYS_DB_POOL_RECYCLE` | `1800` | Recycle (reconnect) a connection after N seconds |
+
+There are **two** engines (sync + async), so one gunicorn worker holds at most
+`2 × (pool_size + max_overflow)` = **20** connections — under the 35-slot
+budget. If you raise the worker count or pool sizes, keep
+`workers × 2 × (pool_size + max_overflow)` **< 35**, or move off Burstable.
+These envs are optional (not in the required-settings loop).
+
+**Always On = `true`** — App Service **site config** (NOT an app setting), so a
+separate command, owned by `deploy-backend.yml`:
+`az webapp config set --name trainsight-app --resource-group rg-trainsight --always-on true`.
+It keeps one warm container instead of stop/starting on idle; each recycle
+abandons the container's pool as idle "zombie" backends that linger until
+TCP-keepalive reap (~6 min), and that churn helped exhaust Postgres in the
+2026-07-05 outage. The app also disposes its engines on shutdown
+(`dispose_engines`, `api/main.py` lifespan) so a *clean* recycle frees
+connections immediately.
+
+Guarded by two alerts (see
+[monitoring-and-alerts.md](./monitoring-and-alerts.md)):
+`praxys-pg-connections-high` (Sev 2, `active_connections` > 40) and
+`praxys-db-health-unhealthy` (Sev 1, DB unreachable/corrupt).
+
 ### Self-registration gate + email
 
 Opening self-registration is **runtime config, not a setting**: an admin toggles
@@ -185,4 +223,4 @@ outgrown.
 - `.github/workflows/deploy-backend.yml` (source of truth for App Service settings)
 
 ---
-_Last reviewed: 2026-07-04 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-05 · Owner: @dddtc2005_

--- a/docs/ops/incident-response.md
+++ b/docs/ops/incident-response.md
@@ -17,7 +17,8 @@ curl -s -o /dev/null -w "%{http_code}\n" https://www.praxys.run/healthz   # expe
 | `/healthz` fails, API ok | frontend host | **Frontend** below |
 | Both ok, data stale for some users | sync stuck | [sync-troubleshooting.md](./sync-troubleshooting.md) |
 | Started right after a deploy | bad release | [deploy.md](./deploy.md) → Rollback |
-| Errors mention DB / disk | storage / migration | **Database** below |
+| `/api/health` ok **but pages 500** | DB unreachable (readiness masks it) | **Database** below |
+| Errors mention DB / disk / connection slots | Postgres / migration | **Database** below |
 
 ## Backend (`trainsight-app`)
 
@@ -41,10 +42,60 @@ az webapp show -n praxys-frontend -g rg-trainsight --query state -o tsv
 az webapp restart -n praxys-frontend -g rg-trainsight
 ```
 
-## Database
+## Database (`praxys-pg`, Postgres)
 
-- `/home` is persistent; a crash loop citing the DB is usually a bad migration or
-  a full `/home`. Check boot logs (`az webapp log tail`) for `init_db` errors.
+Liveness `/api/health` returns 200 even when the DB is down — **check
+readiness**, which runs a real `SELECT 1`:
+
+```bash
+curl -s https://api.praxys.run/api/health/ready   # ready 200  vs  503 {"database":"error"}
+```
+
+A 503 here means the app can't reach Postgres. Most often it's **connection
+exhaustion**, not a server outage.
+
+### Connection exhaustion (the 2026-07-05 outage)
+
+**Signature:** readiness 503; App Insights `exceptions` show
+`OperationalError ... FATAL: remaining connection slots are reserved for roles
+with the SUPERUSER attribute`. The Burstable **B1ms** server has
+`max_connections=50` with ~15 reserved → only **~35 usable by the app**. Near
+that ceiling new app logins are refused and every data endpoint 500s.
+
+**Diagnose** (`$PG` = the praxys-pg resource ID):
+
+```bash
+az postgres flexible-server show -g rg-trainsight -n praxys-pg --query state -o tsv   # usually "Ready" — it is a client-side connection problem
+az monitor metrics list --resource "$PG" --metric active_connections --interval PT1M --aggregation Maximum --query "value[0].timeseries[0].data[-10:]" -o json   # pegged near 50?
+az monitor app-insights query --app appi-trainsight --analytics-query "exceptions | where timestamp > ago(1h) | where outerMessage has 'remaining connection slots' | count"
+```
+
+**Mitigate — in order:**
+
+1. `az webapp restart -n trainsight-app -g rg-trainsight`. **Often does NOT
+   help:** connections abandoned by prior container cycles linger idle
+   server-side and survive an app restart. Watch `active_connections`; if it
+   doesn't drop within a minute, go to step 2.
+2. **Restart Postgres** — the decisive lever; hard-resets every backend:
+   ```bash
+   az postgres flexible-server restart -g rg-trainsight -n praxys-pg
+   ```
+   ~1 min of DB downtime, acceptable when the service is already fully down. You
+   **can't** surgically `pg_terminate_backend()` — only superuser-reserved slots
+   remain, so even an Entra-admin login is refused. Verify readiness → 200 and
+   `active_connections` drops below ~15.
+
+**Prevent / root cause:** abandoned SQLAlchemy pools pile up as idle "zombie"
+backends across container recycles (worsened by a per-tick `init_db()` that
+rebuilt the pool). Fixed by disposing engines on shutdown + idempotent
+`init_db()` (`db/session.py`), `alwaysOn=true` (fewer recycles), and the
+`praxys-pg-connections-high` early-warning alert. Budget + tuning:
+[config-and-secrets.md](./config-and-secrets.md).
+
+### Corruption / bad migration
+
+- A boot crash-loop citing the DB is usually a bad migration — check boot logs
+  (`az webapp log tail`) for `init_db` / Alembic errors.
 - Corruption suspected → [backup-and-restore.md](./backup-and-restore.md).
 
 ## Escalate / rollback
@@ -62,4 +113,4 @@ user dashboard.
 - [deploy.md](./deploy.md) · [sync-troubleshooting.md](./sync-troubleshooting.md) · [monitoring-and-alerts.md](./monitoring-and-alerts.md)
 
 ---
-_Last reviewed: 2026-06-30 · Owner: @dddtc2005 · TODO(@dddtc2005): define severity levels + escalation contacts._
+_Last reviewed: 2026-07-05 · Owner: @dddtc2005 · TODO(@dddtc2005): define severity levels + escalation contacts._

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -108,12 +108,16 @@ group). To also catch publish failures use
 **Verify:** submit a test report that trips the gate (e.g. with `AZURE_AI_ENDPOINT`
 unset, or paste a fake `sk-...` token) and confirm the email within ~15 min.
 
-## Database health alert (#350)
+## Database health alert (#350) — WIRED
 
 `praxys.db_health` fires from the startup integrity check (`db/session.py`) and
 the `/api/health/ready` probe when the database is corrupt or unreachable - the
-gap that made the 2026-07-03 corruption invisible to the liveness-only
-`/api/health`. Alert on any occurrence:
+gap that made the 2026-07-03 corruption *and* the 2026-07-05 connection-
+exhaustion outage invisible to the liveness-only `/api/health` (nothing was
+watching the readiness 503).
+
+Live as scheduled-query rule **`praxys-db-health-unhealthy`** (Sev 1, every
+5 min, action group `praxys-feedback-ag`):
 
 ```kql
 union isfuzzy=true
@@ -124,10 +128,35 @@ union isfuzzy=true
 | where status in ("integrity_failed", "check_error", "readiness_failed")
 ```
 
-Wire it per the recipe above (results > 0, every 5 min, **Sev 1**, email action
-group). Also set the **App Service health check** path to `/api/health/ready`
-(Portal: App Service -> Monitoring -> Health check) so the load balancer routes
-away from an instance whose DB is down.
+Recreate it with (collapse the KQL above onto one line as `<KQL>`):
+
+```bash
+AI=$(az monitor app-insights component show -g rg-trainsight --query "[0].id" -o tsv)
+AG=$(az monitor action-group show -g rg-trainsight -n praxys-feedback-ag --query id -o tsv)
+az monitor scheduled-query create -g rg-trainsight -n praxys-db-health-unhealthy --scopes "$AI" --condition "count 'q' > 0" --condition-query "q=<KQL>" --evaluation-frequency 5m --window-size 5m --severity 1 --action-groups "$AG"
+```
+
+## Postgres connection-pressure alert — WIRED
+
+Catches the *cause* one layer before the readiness 503. Burstable B1ms allows
+`max_connections=50` (~35 usable by the app after reserved slots); healthy
+baseline is <15. Live as metric alert **`praxys-pg-connections-high`** (Sev 2,
+avg `active_connections` > 40 over 5 min, `praxys-feedback-ag`):
+
+```bash
+PG=$(az postgres flexible-server show -g rg-trainsight -n praxys-pg --query id -o tsv)
+AG=$(az monitor action-group show -g rg-trainsight -n praxys-feedback-ag --query id -o tsv)
+az monitor metrics alert create -g rg-trainsight -n praxys-pg-connections-high --scopes "$PG" --condition "avg active_connections > 40" --window-size 5m --evaluation-frequency 5m --severity 2 --action "$AG"
+```
+
+> **Health-check caveat (single instance).** Do **not** wire `/api/health/ready`
+> as the App Service *health-check path* on this single-instance backend: a
+> DB-down readiness failure would trigger health-check-driven container
+> restarts, and each restart abandons its connection pool — *amplifying* a
+> connection-exhaustion event instead of mitigating it (see the 2026-07-05
+> outage in [incident-response.md](./incident-response.md)). The two alerts
+> above page a human instead. Revisit only at ≥2 instances, where a health
+> check removes a bad instance from rotation without a restart storm.
 
 ## Rollback / Recovery
 
@@ -140,4 +169,4 @@ Tune the window/threshold to reduce noise rather than deleting.
 - In-app: Admin → User Feedback (badge + Approve/Retry/Reject).
 
 ---
-_Last reviewed: 2026-07-04 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-05 · Owner: @dddtc2005_

--- a/tests/test_db_engine_lifecycle.py
+++ b/tests/test_db_engine_lifecycle.py
@@ -1,0 +1,89 @@
+"""Engine lifecycle: idempotent init_db + pool disposal (2026-07-05 outage).
+
+Rebuilding the SQLAlchemy engines on every sync-scheduler tick orphaned a
+connection pool each time; combined with pools abandoned on container recycle,
+idle "zombie" backends piled up and exhausted the Burstable Postgres server's
+small max_connections, 500ing every data endpoint. These tests pin the fix:
+init_db() is a no-op once initialized, force=True rebuilds cleanly, and the
+dispose helpers release the pools and clear the singletons.
+"""
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def db_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PRAXYS_SYNC_SCHEDULER", "false")
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY",
+        "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=",
+    )
+    monkeypatch.delenv("PRAXYS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    from db import session as db_session
+
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+    try:
+        yield db_session
+    finally:
+        db_session.dispose_engines()
+
+
+def test_init_db_is_idempotent(db_env):
+    db_session = db_env
+    first_sync = db_session.engine
+    first_async = db_session.async_engine
+    first_maker = db_session.SessionLocal
+
+    # Repeated calls (as the sync scheduler does every tick) must NOT rebuild
+    # the engines -- rebuilding orphaned a pool each time.
+    for _ in range(5):
+        db_session.init_db()
+
+    assert db_session.engine is first_sync
+    assert db_session.async_engine is first_async
+    assert db_session.SessionLocal is first_maker
+
+
+def test_init_db_force_rebuilds(db_env):
+    from sqlalchemy import text
+
+    db_session = db_env
+    old_sync = db_session.engine
+    old_async = db_session.async_engine
+
+    db_session.init_db(force=True)
+
+    assert db_session.engine is not old_sync
+    assert db_session.async_engine is not old_async
+    with db_session.engine.connect() as conn:
+        assert conn.execute(text("SELECT 1")).scalar() == 1
+
+
+def test_dispose_engines_clears_singletons(db_env):
+    db_session = db_env
+    assert db_session.engine is not None
+    db_session.dispose_engines()
+    assert db_session.engine is None
+    assert db_session.SessionLocal is None
+    assert db_session.async_engine is None
+    assert db_session.AsyncSessionLocal is None
+    # Safe to call again on already-disposed state.
+    db_session.dispose_engines()
+
+
+def test_dispose_engines_async_clears_singletons(db_env):
+    db_session = db_env
+    assert db_session.async_engine is not None
+    asyncio.run(db_session.dispose_engines_async())
+    assert db_session.engine is None
+    assert db_session.SessionLocal is None
+    assert db_session.async_engine is None
+    assert db_session.AsyncSessionLocal is None


### PR DESCRIPTION
## Incident
Production 500'd on **Settings** and every data endpoint (~2026-07-05 11:00 UTC). Liveness `/api/health` stayed green while `/api/health/ready` returned `503 {"database":"error"}`. App Insights showed 30+ `OperationalError ... FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`.

**Mitigated live** by restarting Postgres — an app restart did *not* help (abandoned connections survive it). Service restored; `active_connections` dropped 45 -> 6.

## Root cause
Burstable **B1ms** `praxys-pg` allows `max_connections=50` (~35 usable by the app after Azure's reserved slots). The app abandoned its SQLAlchemy pools:
1. The FastAPI lifespan **never disposed the engines on shutdown**, so every container recycle left idle "zombie" backends that Postgres only reaps on TCP-keepalive timeout.
2. The sync scheduler called `init_db()` **every 10-min tick**, which unconditionally rebuilt both engines (sync + async) and re-ran migrations, **orphaning a pool each time**.

With `alwaysOn` off, deploys + idle reloads recycled the container repeatedly and zombies accumulated past the ceiling.

## Fix (code)
- `init_db(force=False)` is now **idempotent** — a no-op once initialized; `force=True` disposes-then-rebuilds. Kills the per-tick orphan + needless migration re-runs.
- Add `dispose_engines()` / `dispose_engines_async()`; the lifespan **disposes pools on shutdown** so a clean recycle frees connections immediately.
- New regression test `tests/test_db_engine_lifecycle.py`.

## Hardening (already applied live)
- **Always On = true** on `trainsight-app`, now owned by `deploy-backend.yml` — fewer recycles.
- **Alerts wired** (both were missing — why nothing paged):
  - `praxys-db-health-unhealthy` (Sev 1) on `praxys.db_health` — the documented-but-never-created #350 alert.
  - `praxys-pg-connections-high` (Sev 2) on `active_connections > 40` — early warning before exhaustion.

## Docs (ops-handbook currency)
- `incident-response.md`: Postgres **connection-exhaustion playbook** (diagnose + the PG-restart lever + why an app restart does not help).
- `monitoring-and-alerts.md`: both alerts marked wired + recreate commands; **health-check caveat** (don't wire readiness as the App Service health probe on a single instance — restart storms amplify exhaustion).
- `config-and-secrets.md`: connection **budget & pool sizing** (`PRAXYS_DB_POOL_SIZE` / `MAX_OVERFLOW` / `POOL_RECYCLE`) + Always On.

## Verify
- `python -m pytest tests/` -> **868 passed, 2 skipped**.
- Prod `/api/health/ready` -> 200; `active_connections` steady ~11.
- Merging deploys the permanent code fix (touches `api/**`, `db/**`).
