### PR TITLE
Fix Garmin MFA sync by forcing the API-accepted portal login strategy

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -164,6 +164,35 @@ def _prune_expired_mfa() -> None:
             _pending_garmin_mfa.pop(uid, None)
 
 
+# garminconnect tries login strategies in order (mobile, widget, portal).
+# The ``widget+cffi`` strategy handles MFA, but the DI token it mints is
+# rejected by the Garmin API tier (401 "Token is not active" on
+# /userprofile-service/socialProfile) — upstream
+# cyberjunky/python-garminconnect issue #369. The ``portal`` strategy mints a
+# token the API accepts *and* handles MFA, so we force it for every login.
+# Validated end-to-end against a live MFA-enabled garmin.cn account: portal
+# token → socialProfile / user-settings 200.
+_GARMIN_API_REJECTED_STRATEGIES = frozenset(
+    {"mobile+cffi", "mobile+requests", "widget+cffi"}
+)
+
+
+def _force_portal_login_strategy(client) -> None:
+    """Skip the login strategies whose DI tokens the API tier rejects (#369).
+
+    Leaves only ``portal+cffi`` / ``portal+requests`` — confirmed to mint
+    API-accepted tokens for MFA accounts. Best-effort: if the library ever
+    drops ``skip_strategies`` we log and fall back to the default chain.
+    """
+    try:
+        client.client.skip_strategies = set(_GARMIN_API_REJECTED_STRATEGIES)
+    except Exception:
+        logger.warning(
+            "Could not force Garmin portal login strategy; using default chain",
+            exc_info=True,
+        )
+
+
 def _persist_garmin_tokens(client, token_dir: str) -> None:
     """Best-effort dump of the authenticated Garmin session to the tokenstore.
 
@@ -172,10 +201,14 @@ def _persist_garmin_tokens(client, token_dir: str) -> None:
     written, background syncs reuse the cached OAuth tokens and never re-hit
     SSO/MFA until they expire.
     """
-    import contextlib
-
-    with contextlib.suppress(Exception):
+    try:
         client.client.dump(token_dir)
+    except Exception:
+        logger.warning(
+            "Failed to persist Garmin tokens to %s; the next sync will have to "
+            "re-authenticate (and cannot complete MFA headless)", token_dir,
+            exc_info=True,
+        )
 
 
 def begin_garmin_login(user_id: str, creds: dict) -> str:
@@ -201,6 +234,7 @@ def begin_garmin_login(user_id: str, creds: dict) -> str:
     client = Garmin(
         creds["email"], creds["password"], is_cn=is_cn, return_on_mfa=True,
     )
+    _force_portal_login_strategy(client)
     mfa_status, _ = client.login(token_dir)
     if mfa_status == "needs_mfa":
         _prune_expired_mfa()
@@ -460,11 +494,28 @@ def _login_garmin_with_cn_fallback(client, creds: dict, token_dir: str) -> None:
     import contextlib
     from garminconnect import GarminConnectAuthenticationError
 
+    # Force the portal strategy: the widget strategy mints tokens the API
+    # tier rejects (#369) and is also the MFA-handling path, so a re-auth
+    # would otherwise re-mint a rejected token. Portal mints accepted tokens.
+    _force_portal_login_strategy(client)
+
     try:
         client.login(token_dir)
         return
     except GarminConnectAuthenticationError as e:
-        if "JWT_WEB cookie not set" not in str(e):
+        msg = str(e)
+        # A background sync has no user present to answer an MFA challenge.
+        # When cached tokens are gone/rejected and a fresh credential login
+        # hits MFA, garminconnect raises "MFA Required but no prompt_mfa
+        # mechanism supplied". Surface a clean, actionable status
+        # (classify_sync_failure maps GarminConnectAuthenticationError →
+        # auth_required) instead of leaking the raw library string.
+        if "MFA" in msg and "prompt_mfa" in msg:
+            raise GarminConnectAuthenticationError(
+                "Garmin requires re-authentication (MFA). Please reconnect "
+                "your account from Settings to enter a verification code."
+            ) from e
+        if "JWT_WEB cookie not set" not in msg:
             raise
         logger.warning(
             "Garmin login hit JWT_WEB fallback bug (hardcoded .com host); "

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -31,6 +31,14 @@ Same priority applies to activity-level `averagePower` / `maxPower` in `parse_ac
 
 With this fallback in place, CN portal login produces real DI Bearer tokens that `connectapi.garmin.cn` accepts, and `Client.dump(token_dir)` persists them so subsequent syncs skip SSO. Reproduction + verification tooling lives in `scripts/garmin_diagnose.py` — subcommands `login` (five-strategy chain, instrumented), `api` (post-login endpoint / header variants), `grants` (credential-free grant_type sweep against `diauth.garmin.cn`), `all`. GitHub issue #75.
 
+### MFA logins must use the `portal` strategy — widget tokens are API-rejected (#369)
+
+`garminconnect` tries login strategies in order (`mobile+cffi`, `mobile+requests`, `widget+cffi`, `portal+cffi`, `portal+requests`). For an MFA-enabled account, whichever strategy detects the MFA challenge *first* owns the whole handshake — and since upstream PR #371 that's the **`widget`** strategy. But the DI token the widget strategy mints is **rejected by the Garmin API tier**: `GET /userprofile-service/socialProfile` returns `401 "Token is not active"` (upstream [cyberjunky/python-garminconnect#369](https://github.com/cyberjunky/python-garminconnect/issues/369), open; reproduces on 0.3.3–0.3.6, `.com` and `.cn`). The **`portal`** strategy mints a token the API accepts *and* handles MFA.
+
+**Why it surfaced as "MFA Required but no prompt_mfa mechanism supplied."** The interactive connect (`begin_garmin_login`) succeeds — `resume_login`'s profile fetch is lenient and swallows the 401 — so a widget token gets persisted and the connection shows *connected*. But the next background sync loads that token, `_load_profile_and_settings()` 401s, and garminconnect's recovery path **discards the cache and retries a fresh credential login** with `prompt_mfa=None` (the sync path has no MFA mechanism). That login hits MFA and raises the raw error, which `classify_sync_failure` maps to `auth_required` — but reconnecting just re-mints another rejected widget token, so the account stays stuck.
+
+**Fix.** `_force_portal_login_strategy(client)` in `api/routes/sync.py` sets `client.client.skip_strategies = {"mobile+cffi", "mobile+requests", "widget+cffi"}` before every login (interactive connect **and** background sync), leaving only the portal strategies. Validated end-to-end against a live MFA-enabled `garmin.cn` account: portal token → `socialProfile` + `user-settings` both `200`. The sync path additionally rewraps a bubbled headless-MFA error into an actionable "reconnect" message. Re-validate after any `garminconnect` bump with `scripts/garmin_mfa_probe.py --strategy portal` (`--strategy widget` reproduces the bug). If upstream fixes #369 so widget/mobile tokens are accepted, the skip set can be relaxed.
+
 ### Garmin CN endpoint parity is incomplete
 
 Expect individual endpoints to 400/404 on `connectapi.garmin.cn` even when the account is healthy. Confirmed patchy endpoints as of 2026-04:

--- a/scripts/garmin_mfa_probe.py
+++ b/scripts/garmin_mfa_probe.py
@@ -1,0 +1,103 @@
+r"""One-shot Garmin MFA token-acceptance probe (praxys #378 / upstream garminconnect #369).
+
+Mirrors the app's real login flow (Garmin(return_on_mfa=True) -> resume_login)
+but FORCES one login strategy via skip_strategies. Goal: for an MFA-enabled
+account, confirm the `portal` strategy mints a DI token the Garmin API tier
+ACCEPTS -- unlike the `widget` strategy (the MFA path today), whose token
+/userprofile-service/socialProfile rejects with 401 (upstream #369).
+
+Forcing portal sends exactly ONE MFA code. Enter the code that arrives RIGHT
+AFTER the 'needs_mfa' line -- ignore any older codes from earlier attempts,
+and enter it promptly (codes expire).
+
+    $env:GARMIN_EMAIL="you@example.com"
+    $env:GARMIN_PASSWORD="..."
+    # $env:GARMIN_IS_CN="true"     # for garmin.cn accounts
+    .venv\Scripts\python.exe scripts\garmin_mfa_probe.py --strategy portal
+
+Options: --strategy {portal,widget,default}  (default: portal = candidate fix)
+
+Prints only hostnames, status codes and booleans -- no credentials/tokens/PII.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time as _time
+
+
+def _creds() -> tuple[str, str, bool]:
+    email = os.environ.get("GARMIN_EMAIL") or os.environ.get("GARMIN_CN_EMAIL")
+    password = os.environ.get("GARMIN_PASSWORD") or os.environ.get("GARMIN_CN_PASSWORD")
+    if not email or not password:
+        sys.exit("Set GARMIN_EMAIL and GARMIN_PASSWORD env vars first.")
+    is_cn = os.environ.get("GARMIN_IS_CN", "").strip().lower() in ("1", "true", "yes", "y")
+    return email, password, is_cn
+
+
+SKIP = {
+    "portal": {"mobile+cffi", "mobile+requests", "widget+cffi"},
+    "widget": {"mobile+cffi", "mobile+requests", "portal+cffi", "portal+requests"},
+    "default": set(),
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Probe Garmin login-strategy token acceptance for MFA accounts.")
+    ap.add_argument("--strategy", choices=["portal", "widget", "default"], default="portal")
+    args = ap.parse_args()
+
+    email, password, is_cn = _creds()
+
+    from garminconnect import Garmin
+
+    g = Garmin(email, password, is_cn=is_cn, return_on_mfa=True)
+    g.client.skip_strategies = set(SKIP[args.strategy])
+    print(f"# is_cn={is_cn}  forcing strategy={args.strategy}  (skipping: {sorted(g.client.skip_strategies) or 'none'})")
+    print("# note: portal login has a built-in ~10-20s anti-WAF delay before the code is sent.")
+
+    try:
+        status, _ = g.login()
+    except Exception as e:
+        print(f"# login() raised: {type(e).__name__}: {str(e)[:400]}")
+        return 2
+
+    if status == "needs_mfa":
+        print(f"# needs_mfa at {_time.strftime('%H:%M:%S')} via flow={getattr(g.client, '_mfa_flow', '?')}")
+        print("# --> enter the code that arrives RIGHT NOW (ignore older codes)")
+        code = input("Enter MFA code: ").strip()
+        try:
+            g.resume_login({}, code)
+        except Exception as e:
+            print(f"# resume_login FAILED: {type(e).__name__}: {str(e)[:500]}")
+            return 2
+        print("# MFA completed.")
+    else:
+        print(f"# login returned status={status!r} (no MFA challenge on this path)")
+
+    print(f"# di_token present: {bool(getattr(g.client, 'di_token', None))}")
+
+    ok = True
+    for path in (
+        "/userprofile-service/socialProfile",
+        "/userprofile-service/userprofile/user-settings",
+    ):
+        try:
+            resp = g.client.connectapi(path)
+            has = isinstance(resp, dict) and len(resp) > 0
+            print(f"#   GET {path} -> 200 (payload: {'yes' if has else 'empty'})")
+        except Exception as e:
+            ok = False
+            print(f"#   GET {path} -> FAIL: {type(e).__name__}: {str(e)[:200]}")
+
+    print()
+    if ok:
+        print(f"RESULT: '{args.strategy}' strategy token ACCEPTED by API tier  -> WORKS for MFA sync")
+    else:
+        print(f"RESULT: '{args.strategy}' strategy token REJECTED by API tier  -> matches upstream #369")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_garmin_mfa_connect.py
+++ b/tests/test_garmin_mfa_connect.py
@@ -19,6 +19,7 @@ class _FakeInnerClient:
 
     def __init__(self) -> None:
         self.dumped: list[str] = []
+        self.skip_strategies: set[str] = set()
 
     def dump(self, path: str) -> None:
         self.dumped.append(path)
@@ -152,6 +153,11 @@ def test_connect_without_mfa_persists_credentials(api_client, monkeypatch):
     # Credentials stored and tokens dumped for future background syncs.
     assert _connection_status(api_client["user_id"]) == "connected"
     assert instances[0].client.dumped, "tokens should be persisted on success"
+    # The portal login strategy is forced so the minted token is one the
+    # Garmin API tier accepts (avoids the widget-token rejection, #369).
+    assert instances[0].client.skip_strategies == {
+        "mobile+cffi", "mobile+requests", "widget+cffi",
+    }
 
 
 def test_connect_requiring_mfa_then_verify(api_client, monkeypatch):
@@ -176,6 +182,9 @@ def test_connect_requiring_mfa_then_verify(api_client, monkeypatch):
     assert _connection_status(api_client["user_id"]) == "connected"
     assert instances[0].resume_calls == ["123456"]
     assert instances[0].client.dumped, "tokens should be persisted after MFA"
+    assert instances[0].client.skip_strategies == {
+        "mobile+cffi", "mobile+requests", "widget+cffi",
+    }
 
 
 def test_verify_with_wrong_code_keeps_session_for_retry(api_client, monkeypatch):
@@ -252,3 +261,43 @@ def test_expired_pending_mfa_is_pruned(api_client, monkeypatch):
         json={"code": "123456"},
     )
     assert res.json()["message"] == "mfa_session_expired"
+
+
+def test_sync_login_forces_portal_and_rewraps_headless_mfa(tmp_path):
+    """Background sync forces the portal strategy and, when a re-auth hits MFA
+    with no user present, surfaces a clean auth_required message instead of the
+    raw garminconnect string."""
+    from api.routes.sync import _login_garmin_with_cn_fallback
+    from db.sync_scheduler import classify_sync_failure
+    from garminconnect import GarminConnectAuthenticationError
+
+    class _Inner:
+        def __init__(self) -> None:
+            self.skip_strategies: set[str] = set()
+
+    class _Client:
+        def __init__(self) -> None:
+            self.client = _Inner()
+
+        def login(self, token_dir):
+            raise GarminConnectAuthenticationError(
+                "MFA Required but no prompt_mfa mechanism supplied"
+            )
+
+    c = _Client()
+    with pytest.raises(GarminConnectAuthenticationError) as ei:
+        _login_garmin_with_cn_fallback(
+            c, {"email": "a@example.com", "password": "pw"}, str(tmp_path)
+        )
+
+    # Portal strategy forced (widget/mobile skipped) so a re-auth can't re-mint
+    # a token the API tier rejects (#369).
+    assert c.client.skip_strategies == {
+        "mobile+cffi", "mobile+requests", "widget+cffi",
+    }
+    # The raw library string is replaced with an actionable reconnect message
+    # that still classifies as a terminal auth_required.
+    msg = str(ei.value)
+    assert "prompt_mfa" not in msg
+    assert "reconnect" in msg.lower()
+    assert classify_sync_failure(ei.value) == ("auth_required", True)


### PR DESCRIPTION
## Problem

MFA-enabled Garmin accounts (#378) can complete the interactive connect, but **every background sync then fails** with `Last sync failed: MFA Required but no prompt_mfa mechanism supplied`, leaving the connection stuck in `auth_required`. Reconnecting doesn't help. PR #379 added the interactive MFA connect flow, but the account still can't sync.

## Root cause

An interaction with an **open upstream `garminconnect` bug — [#369](https://github.com/cyberjunky/python-garminconnect/issues/369)**:

- `garminconnect` logs in via a 5-strategy chain; the **`widget+cffi`** strategy is the MFA-handling path (since upstream PR #371).
- The DI token the widget strategy mints is **rejected by the Garmin API tier**: `GET /userprofile-service/socialProfile` -> `401 "Token is not active"`. The **`portal`** strategy mints a token the API accepts.
- Interactive connect still reports *connected* (its profile fetch is lenient and swallows the 401), so a bad widget token is persisted.
- The next background sync (`_sync_garmin`, no `return_on_mfa`/`prompt_mfa`) loads that token -> `_load_profile_and_settings()` 401s -> garminconnect's recovery path **discards the cache and re-logs-in with `prompt_mfa=None`** -> hits MFA -> raises the raw error -> `classify_sync_failure` -> `auth_required`.

Full verified chain and evidence added to `docs/dev/gotchas.md`.

## Fix

`_force_portal_login_strategy(client)` sets `client.client.skip_strategies = {"mobile+cffi", "mobile+requests", "widget+cffi"}` before **every** login (interactive connect **and** background sync), leaving only the portal strategies. Portal mints an API-accepted token and handles MFA.

Plus:
- Sync path rewraps a bubbled headless-MFA error into an actionable *reconnect* message (no raw library string in the UI).
- `_persist_garmin_tokens` logs dump failures instead of silently suppressing them.

## Validation

**Live-validated against a real MFA-enabled `garmin.cn` account** with the added `scripts/garmin_mfa_probe.py`:

```
# needs_mfa at 23:15:41 via flow=portal
# di_token present: True
#   GET /userprofile-service/socialProfile -> 200 (payload: yes)
#   GET /userprofile-service/userprofile/user-settings -> 200 (payload: yes)
RESULT: 'portal' strategy token ACCEPTED by API tier  -> WORKS for MFA sync
```

- `python -m pytest tests/` -> **876 passed, 2 skipped**.
- New test `test_sync_login_forces_portal_and_rewraps_headless_mfa` + skip-strategy assertions on the connect tests.

## Notes / follow-ups

- Skipping `mobile` too (not just the confirmed-bad `widget`) is deliberate: mobile token acceptance is untested upstream (429-prone) and #369 suggests broad API-tier tightening. If upstream fixes #369, the skip set can be relaxed - re-check with `scripts/garmin_mfa_probe.py`.
- Couples to the library-internal `skip_strategies` (documented; the repo already couples to `_portal_web_login_cffi`); pinned `garminconnect>=0.3.4,<0.4.0`.
- Existing users who connected via widget before this fix will need to **reconnect once** to mint a portal token.

Fixes #378.
