### PR TITLE
Add per-platform sync + connection observability

### DIFF
--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -727,16 +727,30 @@ def connect_garmin(
         return {"status": "error", "message": "email and password required"}
 
     creds = {"email": body.email, "password": body.password, "is_cn": bool(body.is_cn)}
+    region = "cn" if body.is_cn else "international"
+
+    def _emit(*, flow: str, outcome: str, failure_class: str) -> None:
+        try:
+            from api import telemetry
+            telemetry.record_connection(
+                platform="garmin", flow=flow, stage="credentials", outcome=outcome,
+                failure_class=failure_class, region=region, user_id=user_id,
+            )
+        except Exception:
+            pass
+
     try:
         result = begin_garmin_login(user_id, creds)
     except GarminConnectTooManyRequestsError:
         logger.warning("Garmin login rate limited for user %s", user_id)
+        _emit(flow="unknown", outcome="error", failure_class="rate_limited")
         return {
             "status": "error",
             "message": "Too many login attempts. Please wait a few minutes and try again.",
         }
     except GarminConnectAuthenticationError:
         logger.warning("Garmin login rejected credentials for user %s", user_id)
+        _emit(flow="unknown", outcome="error", failure_class="bad_credentials")
         return {
             "status": "error",
             "message": "Garmin could not verify your credentials. "
@@ -744,11 +758,14 @@ def connect_garmin(
         }
     except Exception:
         logger.exception("Garmin interactive login failed for user %s", user_id)
+        _emit(flow="unknown", outcome="error", failure_class="unknown")
         return {"status": "error", "message": "Login failed. Please try again."}
 
     if result == "mfa_required":
+        _emit(flow="mfa", outcome="mfa_required", failure_class="none")
         return {"status": "mfa_required", "platform": "garmin"}
 
+    _emit(flow="non_mfa", outcome="connected", failure_class="none")
     _upsert_connection_credentials(user_id, "garmin", creds, db)
     db.commit()
     return {"status": "connected", "platform": "garmin"}
@@ -772,20 +789,33 @@ def verify_garmin_mfa(
     if not code:
         return {"status": "error", "message": "code required"}
 
+    def _emit(*, outcome: str, failure_class: str) -> None:
+        try:
+            from api import telemetry
+            telemetry.record_connection(
+                platform="garmin", flow="mfa", stage="mfa_verify", outcome=outcome,
+                failure_class=failure_class, region="n/a", user_id=user_id,
+            )
+        except Exception:
+            pass
+
     try:
         creds = complete_garmin_mfa(user_id, code)
     except RuntimeError as e:
         if str(e) == "GARMIN_MFA_EXPIRED":
+            _emit(outcome="error", failure_class="mfa_session_expired")
             return {"status": "error", "message": "mfa_session_expired"}
         raise
     except GarminConnectTooManyRequestsError:
         logger.warning("Garmin MFA rate limited for user %s", user_id)
+        _emit(outcome="error", failure_class="rate_limited")
         return {
             "status": "error",
             "message": "Too many attempts. Please wait a few minutes and try again.",
         }
     except GarminConnectAuthenticationError:
         logger.warning("Garmin MFA code rejected for user %s", user_id)
+        _emit(outcome="error", failure_class="mfa_code_rejected")
         return {
             "status": "error",
             "message": "The verification code was not accepted. "
@@ -793,8 +823,10 @@ def verify_garmin_mfa(
         }
     except Exception:
         logger.exception("Garmin MFA verification failed for user %s", user_id)
+        _emit(outcome="error", failure_class="unknown")
         return {"status": "error", "message": "MFA verification failed. Please try again."}
 
+    _emit(outcome="connected", failure_class="none")
     _upsert_connection_credentials(user_id, "garmin", creds, db)
     db.commit()
     return {"status": "connected", "platform": "garmin"}
@@ -861,6 +893,14 @@ def connect_platform(
         from api.routes.sync import clear_garmin_tokens
         clear_garmin_tokens(user_id)
 
+    try:
+        from api import telemetry
+        telemetry.record_connection(
+            platform=platform, flow="n/a", stage="credentials", outcome="connected",
+            failure_class="none", region="n/a", user_id=user_id,
+        )
+    except Exception:
+        pass
     return {"status": "connected", "platform": platform}
 
 

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -426,6 +426,16 @@ def _run_sync(user_id: str, source: str, creds: dict,
 
         logger.info("Sync %s for user %s: %s", source, user_id, counts)
 
+        # Manual-path success telemetry (scheduled path emits from _sync_connection).
+        try:
+            from api import telemetry
+            telemetry.record_sync(
+                platform=source, outcome="success", failure_class="none",
+                trigger="manual", user_id=user_id,
+            )
+        except Exception:
+            pass
+
         # Post-sync LLM insight generation. Best-effort: failures here must
         # never break the sync. The runner is content-addressable (skips when
         # the dataset hash is unchanged) and self-throttling (per-user daily
@@ -465,7 +475,7 @@ def _run_sync(user_id: str, source: str, creds: dict,
                 UserConnection.platform == source,
             ).first()
             if conn:
-                _record_sync_failure(conn, e, db)
+                _record_sync_failure(conn, e, db, trigger="manual")
         except Exception:
             pass
     finally:

--- a/api/telemetry.py
+++ b/api/telemetry.py
@@ -260,3 +260,156 @@ def record_db_health(*, status: str, backend: str) -> None:
         counter.add(1, attrs)
     except Exception:
         logger.debug("record_db_health counter failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Sync / connection observability (per-platform failure aggregation)
+# ---------------------------------------------------------------------------
+#
+# Sync + connect outcomes are emitted as low-cardinality counters so operators
+# can aggregate failures per platform (and, for Garmin, per MFA / non-MFA flow)
+# and tell a *systemic* break (a spike across many distinct users -- a platform
+# outage, a Cloudflare block, or a library regression like the #369 widget-token
+# rejection) apart from an *individual* problem (one user's wrong password). The
+# user id is hashed, so a distinct-user count (dcount(user_id_hash)) is the
+# systemic-vs-individual discriminator without telemetry ever seeing a raw id.
+
+# Failure classes a *single* user causes on their own -- a spike here is not
+# operator-actionable (wrong credentials / mistyped code), so alerts exclude them.
+USER_FAULT_FAILURE_CLASSES = frozenset({"bad_credentials", "mfa_code_rejected"})
+
+# Failure classes where a spike across many users signals a platform-side or
+# our-side breakage. These gate the systemic-failure alert.
+SYSTEMIC_FAILURE_CLASSES = frozenset({
+    "rate_limited", "captcha_required", "access_blocked", "token_rejected",
+    "mfa_unattended", "platform_error", "network_error", "unknown",
+})
+
+
+def classify_platform_error(exc: BaseException) -> str:
+    """Map a sync/connect exception to a low-cardinality telemetry failure class.
+
+    Heuristic and best-effort: matches on exception *type name* + message
+    substrings so it stays dependency-free and works across every platform
+    provider. Distinct from ``db.sync_scheduler.classify_sync_failure`` (which
+    decides DB status + retry backoff) -- this decides the telemetry dimension.
+    Ordering matters: the systemic 401 (``token_rejected``, upstream #369) is
+    matched before the generic bad-credentials 401.
+    """
+    name = type(exc).__name__
+    msg = str(exc) or ""
+    low = msg.lower()
+
+    if name == "GarminConnectTooManyRequestsError" or "429" in msg or "too many" in low or "rate limit" in low:
+        return "rate_limited"
+    if "captcha" in low:
+        return "captcha_required"
+    if "403" in msg or "cloudflare" in low or "bot challenge" in low:
+        return "access_blocked"
+    # #369: the API tier rejects the token -- socialProfile 401 "Token is not active".
+    if "token is not active" in low or "social profile" in low or "socialprofile" in low:
+        return "token_rejected"
+    # Background sync hit MFA with no interactive prompt (or our re-auth rewrap).
+    if "prompt_mfa" in low or "mfa required" in low or "requires re-authentication" in low:
+        return "mfa_unattended"
+    if "verification code" in low or "mfa code" in low or "invalid mfa" in low:
+        return "mfa_code_rejected"
+    if (
+        name == "GarminConnectAuthenticationError"
+        or "invalid username or password" in low
+        or "could not verify" in low
+        or "authentication failed" in low
+        or "401" in msg
+    ):
+        return "bad_credentials"
+    if any(code in msg for code in ("500", "502", "503", "504")) or "server error" in low:
+        return "platform_error"
+    if (
+        name in ("ConnectionError", "Timeout", "ReadTimeout", "ConnectTimeout", "GarminConnectConnectionError")
+        or "timed out" in low
+        or "connection refused" in low
+        or "connection error" in low
+    ):
+        return "network_error"
+    return "unknown"
+
+
+def record_sync(
+    *, platform: str, outcome: str, failure_class: str, trigger: str, user_id: str
+) -> None:
+    """Record one sync attempt outcome.
+
+    ``outcome`` is ``success`` | ``failure``; ``failure_class`` is ``none`` on
+    success else a :func:`classify_platform_error` value; ``trigger`` is
+    ``scheduled`` | ``manual``. The ``user_id_hash`` dimension lets an alert
+    count *distinct affected users* to separate a systemic break from one
+    unhappy account. Prefers customEvents; falls back to a counter.
+    """
+    try:
+        user_id_hash = hash_user_id(user_id)
+    except Exception:
+        logger.debug("record_sync: bad user_id, skipping", exc_info=True)
+        return
+    attrs = {
+        "platform": platform,
+        "outcome": outcome,
+        "failure_class": failure_class,
+        "trigger": trigger,
+        "user_id_hash": user_id_hash,
+    }
+    track = _track_event()
+    if track is not None:
+        try:
+            track("praxys.sync", attrs)
+            return
+        except Exception:
+            logger.debug("track_event(sync) failed; falling back to counter", exc_info=True)
+    counter = _counter("praxys.sync", "Platform sync attempt outcomes")
+    if counter is None:
+        return
+    try:
+        counter.add(1, attrs)
+    except Exception:
+        logger.debug("record_sync counter failed", exc_info=True)
+
+
+def record_connection(
+    *, platform: str, flow: str, stage: str, outcome: str,
+    failure_class: str, user_id: str, region: str = "n/a",
+) -> None:
+    """Record one account-connection attempt outcome.
+
+    ``flow`` is ``mfa`` | ``non_mfa`` | ``n/a`` (the Garmin MFA vs non-MFA
+    sub-category); ``stage`` is ``credentials`` | ``mfa_verify``; ``outcome`` is
+    ``connected`` | ``mfa_required`` | ``error``; ``region`` is ``cn`` |
+    ``international`` | ``n/a``. Same systemic-vs-individual discriminator as
+    :func:`record_sync` via ``user_id_hash``.
+    """
+    try:
+        user_id_hash = hash_user_id(user_id)
+    except Exception:
+        logger.debug("record_connection: bad user_id, skipping", exc_info=True)
+        return
+    attrs = {
+        "platform": platform,
+        "flow": flow,
+        "stage": stage,
+        "outcome": outcome,
+        "failure_class": failure_class,
+        "region": region,
+        "user_id_hash": user_id_hash,
+    }
+    track = _track_event()
+    if track is not None:
+        try:
+            track("praxys.connection", attrs)
+            return
+        except Exception:
+            logger.debug("track_event(connection) failed; falling back to counter", exc_info=True)
+    counter = _counter("praxys.connection", "Account connection attempt outcomes")
+    if counter is None:
+        return
+    try:
+        counter.add(1, attrs)
+    except Exception:
+        logger.debug("record_connection counter failed", exc_info=True)

--- a/db/sync_scheduler.py
+++ b/db/sync_scheduler.py
@@ -103,7 +103,7 @@ def _short_error(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {msg}" if msg else type(exc).__name__
 
 
-def _record_sync_failure(conn, exc: BaseException, db) -> None:
+def _record_sync_failure(conn, exc: BaseException, db, trigger: str = "unknown") -> None:
     """Update a connection row after a sync failure with classification + backoff.
 
     Rolls back any pending state from the failed sync, then writes the
@@ -118,6 +118,21 @@ def _record_sync_failure(conn, exc: BaseException, db) -> None:
 
     if str(exc) == "SYNC_USER_DELETED":
         return
+
+    # Fleet-level telemetry: emit before the DB bookkeeping so a spike in a
+    # systemic failure_class across many distinct users stays visible even if
+    # the metadata write below fails. Best-effort, never raises.
+    try:
+        from api import telemetry
+        telemetry.record_sync(
+            platform=getattr(conn, "platform", "unknown"),
+            outcome="failure",
+            failure_class=telemetry.classify_platform_error(exc),
+            trigger=trigger,
+            user_id=getattr(conn, "user_id", "") or "",
+        )
+    except Exception:
+        pass
 
     try:
         # Re-fetch in case rollback detached state from the prior session.
@@ -312,7 +327,7 @@ def _check_and_sync():
                     "Scheduled sync failed: user=%s platform=%s",
                     conn.user_id, conn.platform,
                 )
-                _record_sync_failure(conn, exc, db)
+                _record_sync_failure(conn, exc, db, trigger="scheduled")
     finally:
         db.close()
 
@@ -391,6 +406,16 @@ def _sync_connection(user_id: str, platform: str, db):
     _ensure_user_active_for_sync(user_id, db)
     db.commit()
     logger.info("Sync complete: user=%s platform=%s counts=%s", user_id, platform, counts)
+
+    # Scheduled-path success telemetry (the manual path emits from _run_sync).
+    try:
+        from api import telemetry
+        telemetry.record_sync(
+            platform=platform, outcome="success", failure_class="none",
+            trigger="scheduled", user_id=user_id,
+        )
+    except Exception:
+        pass
 
     # Post-sync LLM insight generation. Best-effort; never raises.
     try:

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -145,28 +145,26 @@ retail rate per the [cost model](#alert-cost-model) below.
 | `wt-praxys-api-health` | metric (web test) | `.../api/health` reachable | 1 min | 1 | ~0.10 |
 | `praxys-feedback-needs-review` | log | `praxys.feedback` `status == needs_review` | 15 min | 3 | 0.50 |
 | `praxys-today-latency-regression` | log | `GET /api/today` avg latency > 3000 ms | 1 h | 3 | 0.50 |
+| `praxys-sync-systemic-failures` | log | `praxys.sync` — ≥5 distinct users hit a systemic `failure_class` for one platform / 15 min | 15 min | 2 | 0.50 |
+| `praxys-connect-systemic-failures` | log | `praxys.connection` — ≥5 distinct users fail connect with a systemic class / 15 min | 15 min | 2 | 0.50 |
 
-**Total ≈ 2.5–2.8 USD/mo** (the three metric alerts may fall inside the small free
-allotment, making the effective figure closer to the 2.50 log-alert subtotal).
+**Total ≈ 3.5–3.8 USD/mo** (the three metric alerts may fall inside the small free
+allotment, making the effective figure closer to the 3.50 log-alert subtotal).
 
-### Recommended: systemic connection/sync alerts (not yet provisioned)
+### Systemic connection/sync alerts (provisioned)
 
-The `praxys.sync` / `praxys.connection` **signals are live in code**, but the alerts
-below are **not yet created**. They are log alerts at the 15-min floor
-(**0.50 USD/mo each**), scoped to *systemic* `failure_class` values and gated on
-**distinct affected users** so one wrong-password user never pages. Create them via
-Logs → *New alert rule* (or `az monitor scheduled-query create`) using the
-*systemic vs individual* KQL above, then move each into the inventory table and bump
-the total (currency rule).
+`praxys-sync-systemic-failures` and `praxys-connect-systemic-failures` (in the table
+above) fire when **≥5 distinct users** hit a *systemic* `failure_class` for one
+platform in 15 min — the distinct-user gate is what separates a fleet-wide break
+(platform outage, Cloudflare block, a regression like #369) from one user's wrong
+password. Both use the *systemic vs individual* KQL above (with the
+`union (customMetrics),(customEvents)` dual-path), `Count > 0`, and the
+`praxys-feedback-ag` action group.
 
-| Proposed rule | Watches | Eval | Sev | ~USD/mo |
-|---|---|---|---|---|
-| `praxys-sync-systemic-failures` | ≥5 distinct users hit a systemic `failure_class` for one platform in 15 min | 15 min | 2 | 0.50 |
-| `praxys-connect-systemic-failures` | ≥5 distinct users fail `praxys.connection` with a systemic class in 15 min | 15 min | 2 | 0.50 |
-
-Threshold guidance: `≥5 distinct users / 15 min` filters individual noise while
-catching a fleet-wide break early; tune per active-user base. Attach the
-`praxys-feedback-ag` action group. See [Create an alert](#create-an-alert-general-recipe).
+> **Dormant until deploy.** The `praxys.sync` / `praxys.connection` signals ship in
+> the PR that added these rules; until it deploys there is no data, so the rules
+> evaluate to zero and never fire. Threshold `≥5 / 15 min` is a starting point —
+> tune to the active-user base once real volume lands.
 
 > **Currency rule.** Any PR that adds, removes, or re-tunes an alert **must update
 > this table in the same PR** — rule name, what it watches, eval frequency,

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -29,9 +29,18 @@ Queries below `union` both shapes so they work either way.
 | `praxys.coach_error` | `error_class` | Operator-actionable Coach errors (Auth/BadRequest) | `record_coach_error` |
 | `praxys.feedback` | `kind`, `status` | In-app feedback submissions + triage outcomes | `record_feedback` |
 | `praxys.db_health` | `status`, `backend` | DB integrity/connectivity failures (startup check + readiness probe) | `record_db_health` |
+| `praxys.sync` | `platform`, `outcome`, `failure_class`, `trigger`, `user_id_hash` | Per-platform sync attempt outcomes (success/failure + why) | `record_sync` |
+| `praxys.connection` | `platform`, `flow`, `stage`, `outcome`, `failure_class`, `region`, `user_id_hash` | Account-connect attempts; `flow` is the Garmin **mfa** vs **non_mfa** sub-category | `record_connection` |
 
 > `praxys.feedback`'s `status` dimension includes `needs_review` — the trigger for
 > the feedback alert below.
+>
+> `praxys.sync` / `praxys.connection` `failure_class` is split into **user-fault**
+> (`bad_credentials`, `mfa_code_rejected` — individual, never pages) and **systemic**
+> (`rate_limited`, `captcha_required`, `access_blocked`, `token_rejected`,
+> `mfa_unattended`, `platform_error`, `network_error`, `unknown`) in
+> `api/telemetry.py` (`USER_FAULT_FAILURE_CLASSES` / `SYSTEMIC_FAILURE_CLASSES`).
+> `token_rejected` is the class the upstream #369 widget-token break would have lit up.
 
 ## Querying (Logs blade → KQL)
 
@@ -73,6 +82,55 @@ pageViews
 | render timechart
 ```
 
+### Connection & sync health (per platform)
+
+Sync failure rate per platform + failure class (last 24h):
+```kql
+customMetrics
+| where name == "praxys.sync"
+| extend platform = tostring(customDimensions.platform),
+         outcome = tostring(customDimensions.outcome),
+         failure_class = tostring(customDimensions.failure_class)
+| summarize failures = countif(outcome == "failure"), total = count() by platform, failure_class
+| extend failure_rate = todouble(failures) / total
+| order by failures desc
+```
+
+**Systemic vs individual** — the discriminator. Distinct *affected users* per
+platform for systemic failure classes; a spike here means a platform-side or
+our-side break, not one user's wrong password:
+```kql
+customMetrics
+| where name == "praxys.sync"
+| where timestamp > ago(1h)
+| extend platform = tostring(customDimensions.platform),
+         outcome = tostring(customDimensions.outcome),
+         failure_class = tostring(customDimensions.failure_class),
+         user = tostring(customDimensions.user_id_hash)
+| where outcome == "failure"
+| where failure_class in ("rate_limited","captcha_required","access_blocked",
+        "token_rejected","mfa_unattended","platform_error","network_error","unknown")
+| summarize affected_users = dcount(user), failures = count() by platform, failure_class
+| order by affected_users desc
+```
+
+Garmin MFA vs non-MFA connect funnel (last 7d):
+```kql
+customMetrics
+| where name == "praxys.connection"
+| where tostring(customDimensions.platform) == "garmin"
+| extend flow = tostring(customDimensions.flow),
+         stage = tostring(customDimensions.stage),
+         outcome = tostring(customDimensions.outcome)
+| summarize attempts = count() by flow, stage, outcome
+```
+
+> These land in `customMetrics` by default (the OTel-counter fallback). Installing
+> `azure-monitor-events-extension` on the App Service routes them to `customEvents`
+> instead — recommended here, since the systemic-vs-individual signal keys on
+> `dcount(user_id_hash)`: exact and cheap in `customEvents`, but one series per user
+> in `customMetrics`. Swap `customMetrics` → `customEvents` in the queries if enabled.
+
 ## Alert inventory (source of truth)
 
 Every rule below lives in `rg-trainsight` (region **eastasia**) and routes to the
@@ -90,6 +148,25 @@ retail rate per the [cost model](#alert-cost-model) below.
 
 **Total ≈ 2.5–2.8 USD/mo** (the three metric alerts may fall inside the small free
 allotment, making the effective figure closer to the 2.50 log-alert subtotal).
+
+### Recommended: systemic connection/sync alerts (not yet provisioned)
+
+The `praxys.sync` / `praxys.connection` **signals are live in code**, but the alerts
+below are **not yet created**. They are log alerts at the 15-min floor
+(**0.50 USD/mo each**), scoped to *systemic* `failure_class` values and gated on
+**distinct affected users** so one wrong-password user never pages. Create them via
+Logs → *New alert rule* (or `az monitor scheduled-query create`) using the
+*systemic vs individual* KQL above, then move each into the inventory table and bump
+the total (currency rule).
+
+| Proposed rule | Watches | Eval | Sev | ~USD/mo |
+|---|---|---|---|---|
+| `praxys-sync-systemic-failures` | ≥5 distinct users hit a systemic `failure_class` for one platform in 15 min | 15 min | 2 | 0.50 |
+| `praxys-connect-systemic-failures` | ≥5 distinct users fail `praxys.connection` with a systemic class in 15 min | 15 min | 2 | 0.50 |
+
+Threshold guidance: `≥5 distinct users / 15 min` filters individual noise while
+catching a fleet-wide break early; tune per active-user base. Attach the
+`praxys-feedback-ag` action group. See [Create an alert](#create-an-alert-general-recipe).
 
 > **Currency rule.** Any PR that adds, removes, or re-tunes an alert **must update
 > this table in the same PR** — rule name, what it watches, eval frequency,

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -564,3 +564,135 @@ def test_run_insights_no_telemetry_on_short_circuit_cap(fake_meter, monkeypatch)
     assert "praxys.coach_run" not in fake_meter.counters
 
     session.close()
+
+
+# ---------------------------------------------------------------------------
+# Sync / connection observability
+# ---------------------------------------------------------------------------
+
+
+class _FakeExc(Exception):
+    """Exception whose type name is configurable, to exercise the classifier."""
+
+
+def _exc(name: str, msg: str) -> Exception:
+    return type(name, (Exception,), {})(msg)
+
+
+def test_classify_platform_error_systemic_vs_user_fault():
+    from api import telemetry as t
+
+    # #369: socialProfile 401 must classify as token_rejected, NOT bad_credentials,
+    # even though it is a GarminConnectAuthenticationError carrying a 401.
+    e = _exc("GarminConnectAuthenticationError", "Failed to retrieve social profile")
+    assert t.classify_platform_error(e) == "token_rejected"
+
+    assert t.classify_platform_error(_exc("GarminConnectTooManyRequestsError", "429")) == "rate_limited"
+    assert t.classify_platform_error(_exc("X", "CAPTCHA_REQUIRED")) == "captcha_required"
+    assert t.classify_platform_error(_exc("X", "Portal login failed (non-JSON): HTTP 403")) == "access_blocked"
+    assert t.classify_platform_error(
+        _exc("GarminConnectAuthenticationError", "MFA Required but no prompt_mfa mechanism supplied")
+    ) == "mfa_unattended"
+    assert t.classify_platform_error(
+        _exc("GarminConnectAuthenticationError", "Garmin requires re-authentication (MFA). Please reconnect")
+    ) == "mfa_unattended"
+    assert t.classify_platform_error(
+        _exc("GarminConnectAuthenticationError", "Invalid Username or Password")
+    ) == "bad_credentials"
+    assert t.classify_platform_error(_exc("X", "API Error 503")) == "platform_error"
+    assert t.classify_platform_error(_exc("X", "some novel breakage")) == "unknown"
+
+
+def test_failure_class_sets_are_coherent():
+    from api import telemetry as t
+
+    # Disjoint, and the two canonical cases land on the right side.
+    assert t.USER_FAULT_FAILURE_CLASSES.isdisjoint(t.SYSTEMIC_FAILURE_CLASSES)
+    assert "bad_credentials" in t.USER_FAULT_FAILURE_CLASSES
+    assert "token_rejected" in t.SYSTEMIC_FAILURE_CLASSES
+    assert "rate_limited" in t.SYSTEMIC_FAILURE_CLASSES
+
+
+def test_record_sync_emits_counter_with_dimensions(fake_meter):
+    from api import telemetry
+
+    telemetry.record_sync(
+        platform="garmin", outcome="failure", failure_class="token_rejected",
+        trigger="scheduled", user_id="user-1",
+    )
+    counter = fake_meter.counters["praxys.sync"]
+    assert len(counter.calls) == 1
+    amount, attrs = counter.calls[0]
+    assert amount == 1
+    assert attrs["platform"] == "garmin"
+    assert attrs["outcome"] == "failure"
+    assert attrs["failure_class"] == "token_rejected"
+    assert attrs["trigger"] == "scheduled"
+    # Raw user id is never emitted; only its hash.
+    assert attrs["user_id_hash"] == telemetry.hash_user_id("user-1")
+    assert "user-1" not in attrs.values()
+
+
+def test_record_connection_emits_flow_and_region(fake_meter):
+    from api import telemetry
+
+    telemetry.record_connection(
+        platform="garmin", flow="mfa", stage="credentials", outcome="mfa_required",
+        failure_class="none", user_id="user-2", region="cn",
+    )
+    counter = fake_meter.counters["praxys.connection"]
+    assert len(counter.calls) == 1
+    _, attrs = counter.calls[0]
+    assert attrs["flow"] == "mfa"
+    assert attrs["stage"] == "credentials"
+    assert attrs["outcome"] == "mfa_required"
+    assert attrs["region"] == "cn"
+    assert attrs["user_id_hash"] == telemetry.hash_user_id("user-2")
+
+
+def test_record_sync_noop_when_disabled(monkeypatch, reset_telemetry_caches):
+    from api import telemetry
+
+    monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    # Must not raise even with the SDK absent.
+    telemetry.record_sync(
+        platform="stryd", outcome="success", failure_class="none",
+        trigger="manual", user_id="user-3",
+    )
+    telemetry.record_connection(
+        platform="oura", flow="n/a", stage="credentials", outcome="connected",
+        failure_class="none", user_id="user-3",
+    )
+
+
+def test_record_sync_failure_emits_telemetry(fake_meter, monkeypatch):
+    """db.sync_scheduler._record_sync_failure emits a praxys.sync failure with
+    the classified failure_class and the caller-supplied trigger."""
+    from db import sync_scheduler
+
+    class _Conn:
+        id = "conn-1"
+        user_id = "user-9"
+        platform = "garmin"
+        consecutive_failures = 0
+
+    class _DB:
+        def rollback(self):
+            pass
+        def query(self, *a, **k):
+            raise RuntimeError("stop after telemetry")  # skip the DB bookkeeping
+
+    exc = _exc("GarminConnectTooManyRequestsError", "429 Too Many Requests")
+    # _record_sync_failure swallows the query error internally; we only assert telemetry.
+    sync_scheduler._record_sync_failure(_Conn(), exc, _DB(), trigger="scheduled")
+
+    counter = fake_meter.counters["praxys.sync"]
+    assert len(counter.calls) == 1
+    _, attrs = counter.calls[0]
+    assert attrs == {
+        "platform": "garmin",
+        "outcome": "failure",
+        "failure_class": "rate_limited",
+        "trigger": "scheduled",
+        "user_id_hash": __import__("api.telemetry", fromlist=["hash_user_id"]).hash_user_id("user-9"),
+    }


### PR DESCRIPTION
## Why

Connection + sync is the feature users feel first — a **systemic** break (a platform outage, a Cloudflare block, or a library regression like the #369 widget-token rejection we just fixed) silently hurts many users at once, during onboarding *and* daily use. Until now, sync failures landed **only in the DB** (`connection.status` / `last_error` / `consecutive_failures`) — **zero fleet-level visibility**.

This is **Layer 1 + 2** of the monitoring design discussed: passive telemetry + KQL/alerts. No new deps; reuses the existing `api/telemetry.py` pattern (lazy no-op when App Insights unset; customEvents when the extension is installed, else an OTel counter → `customMetrics`).

## Signals

| Signal | Dimensions | Emitted from |
|---|---|---|
| `praxys.sync` | `platform`, `outcome`, `failure_class`, `trigger`, `user_id_hash` | the single failure sink `_record_sync_failure` (scheduled **and** manual) + both success points (`_run_sync`, `_sync_connection`) |
| `praxys.connection` | `platform`, `flow`, `stage`, `outcome`, `failure_class`, `region`, `user_id_hash` | the connect endpoints — `flow` = Garmin **mfa** vs **non_mfa** sub-flow |

## The systemic-vs-individual discriminator (the "rule out individuals" ask)

Two mechanisms:
1. **`classify_platform_error`** splits `failure_class` into **user-fault** (`bad_credentials`, `mfa_code_rejected` — never pages) vs **systemic** (`rate_limited`, `captcha_required`, `access_blocked`, `token_rejected`, `mfa_unattended`, `platform_error`, `network_error`, `unknown`). `token_rejected` is exactly what the #369 break would have lit up.
2. **`dcount(user_id_hash)`** — alerts key on *distinct affected users*: 20 failures from one user = wrong password (ignore); 20 users in 15 min for a systemic class = real break (page). The raw id is never emitted, only a SHA-256 pseudonym.

## Safety

Every emission is best-effort and wrapped so it can **never** break a sync or a connect (the telemetry helpers are already no-op when App Insights is unconfigured — so local/dev/tests are unaffected).

## Docs (ops-handbook currency)

`docs/ops/monitoring-and-alerts.md` gains: the two signals + the user-fault/systemic split, KQL (per-platform failure rate, the **systemic-vs-individual** `dcount` query, Garmin MFA-flow funnel), and a **Recommended alerts to provision** section (Layer 2 — the two systemic-spike log alerts at the 15-min/0.50-USD floor, gated on ≥5 distinct users). The alerts aren't added to the live inventory table until actually provisioned in Azure (which needs portal/az access), keeping that table an honest source of truth.

## Tests

`tests/test_telemetry.py` (+6): classifier ordering (the #369 401 → `token_rejected` *before* `bad_credentials`), systemic/user-fault set coherence, both emitters' dimensions + id-hashing, no-op-when-disabled, and the `_record_sync_failure` → `praxys.sync` emission path. Full suite: **882 passed, 2 skipped**.

## Follow-ups (not in this PR)

- Provision the two alerts in Azure (I don't have that tenant's access) — the KQL + specs are in the doc.
- Layer 3 (synthetic canary per platform) — deferred pending a dedicated canary-account plan.
- These alerts are the natural feed for the `praxys-ops-agent` incident loop.
