### PR TITLE
Rename dddtc2005/praxys -> praxys-run/praxys across docs + config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Praxys training dashboard — MCP tools for training data, daily briefs, race forecasts, and AI plan management",
       "source": "./plugins/praxys",
       "category": "productivity",
-      "homepage": "https://github.com/dddtc2005/praxys"
+      "homepage": "https://github.com/praxys-run/praxys"
     }
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -104,7 +104,7 @@ PRAXYS_LOCAL_ENCRYPTION_KEY=
 # can promote it manually from the Admin page — only the auto-issue step is
 # skipped.
 #
-# Recommended target: the SAME repo as the code (e.g. dddtc2005/praxys) so the
+# Recommended target: the SAME repo as the code (e.g. praxys-run/praxys) so the
 # GitHub Copilot coding agent assigned the issue can open a fix PR in-repo.
 #
 # Auth uses a GitHub App (no token to rotate): the backend mints short-lived
@@ -114,7 +114,7 @@ PRAXYS_LOCAL_ENCRYPTION_KEY=
 # PRAXYS_GITHUB_APP_ID=
 # PRAXYS_GITHUB_APP_INSTALLATION_ID=
 # PRAXYS_GITHUB_APP_PRIVATE_KEY=
-# PRAXYS_FEEDBACK_GITHUB_REPO=dddtc2005/praxys
+# PRAXYS_FEEDBACK_GITHUB_REPO=praxys-run/praxys
 #
 # SECURITY: this repo is PUBLIC, so two layers protect against leaks before an
 # issue is filed: (1) a deterministic PII/secret scrub on everything published,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ sync/*.py → db/sync_writer.py → SQLite → analysis/metrics.py → api/deps.
 - **analysis/data_loader.py**: All data loading lives here
 - **api/deps.py**: Data layer — `get_dashboard_data()` is the central function
 - **api/routes/**: Thin wrappers calling deps, all under `/api/` prefix; **all endpoints require JWT auth** except `/api/register` and `/api/token`
-- **plugins/praxys/**: Skills (8 SKILL.md files) and MCP server. **Submodule** of the public [`dddtc2005/praxys-coach-plugin`](https://github.com/dddtc2005/praxys-coach-plugin) repo — edits land there, then the submodule pointer is bumped here
+- **plugins/praxys/**: Skills (8 SKILL.md files) and MCP server. **Submodule** of the public [`praxys-run/praxys-coach-plugin`](https://github.com/praxys-run/praxys-coach-plugin) repo — edits land there, then the submodule pointer is bumped here
 - **web/src/**: React + TypeScript + Tailwind v4 + Recharts
 
 ## Critical Rule: Split-Level Power Analysis

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -72,7 +72,7 @@ jobs:
   #   Variables:
   #     AZURE_AI_ENDPOINT      (https://<resource>.cognitiveservices.azure.com/)
   # The federated credential on the app must trust the subject
-  #   repo:dddtc2005/praxys:ref:refs/heads/main
+  #   repo:praxys-run/praxys:ref:refs/heads/main
   # (plus any additional refs you want to run from). The app needs
   # "Cognitive Services OpenAI User" on the Foundry resource — scope it there,
   # not at subscription level.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "plugins/praxys"]
 	path = plugins/praxys
-	url = https://github.com/dddtc2005/praxys-coach-plugin.git
+	url = https://github.com/praxys-run/praxys-coach-plugin.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 ### AI Features Agent
 - **Focus:** `api/ai.py`, `api/routes/ai.py`, `analysis/providers/ai.py`, frontend AI components
 - **Tasks:** Extend LLM-powered coaching, natural language queries, plan generation
-- **Context needed:** `api/deps.py` for data access, existing metrics for context injection, `plugins/praxys/` (git submodule of public [`dddtc2005/praxys-coach-plugin`](https://github.com/dddtc2005/praxys-coach-plugin)) for MCP tools
+- **Context needed:** `api/deps.py` for data access, existing metrics for context injection, `plugins/praxys/` (git submodule of public [`praxys-run/praxys-coach-plugin`](https://github.com/praxys-run/praxys-coach-plugin)) for MCP tools
 - **Key rule:** AI features must be optional — guard with `is_available()`, app works fully without API key
 
 ### Ops / DevOps Agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Garmin/Stryd/Oura APIs → sync/*.py → db/sync_writer.py → SQLite (trainsigh
 | `frontend_server/` | Static SPA host on its own App Service site (`praxys-frontend`) | `main.py` (`create_app(dist_dir)` factory, `SPAStaticFiles` with 404→`index.html` fallback for non-asset paths, cache-control middleware, `/healthz`). Decoupled from `api/` so the same `web/dist/` artifact can later sit on Tencent COS (CN audience, post-ICP) without Azure-specific glue. |
 | `web/src/` | React SPA | `pages/` (Today, Training, Goal, History, Science, Settings, Admin, Login, Setup), `components/`, `hooks/`, `contexts/`, `types/api.ts`, `lib/` |
 | `miniapp/` | WeChat Mini Program (native + Skyline + TypeScript) | `pages/` (login WebView, plus Skyline pages: today, training, goal, history, settings, science, legal), `components/` (`nav-bar` custom Skyline header, `line-chart` Canvas 2D), `utils/` (`api-client.ts` wx.request + JWT, `auth.ts` wx.login flow, `format.ts`/`share.ts`/`theme.ts`), `types/api.ts` auto-synced from `web/src/types/api.ts` by `scripts/sync-types.cjs`, and the EULA + Privacy text (`utils/legal.ts`) from `web/src/lib/legal.ts` by `scripts/sync-legal.cjs` (both run on `npm run typecheck`). The `legal` page renders those Terms/Privacy docs in-app and the login page links to them + gates the waitlist / account-link email capture behind an explicit consent checkbox (WeChat audit requirement). Build: WeChat DevTools handles TypeScript + Sass via `project.config.json` `useCompilerPlugins` — no webpack/babel toolchain. Open `miniapp/` as the DevTools project root; only devDeps are `miniprogram-api-typings` + `typescript` for `tsc --noEmit` CI checks. **Mini program position**: a view + manage companion to the web app. The mini program **owns the waitlist signup** as a CN-friendly entry point — WeChat is the primary discovery channel for that audience and the waitlist is just intent capture (email + optional note), no platform setup. **Full registration + the platform-connection wizard stays on praxys.run** because Garmin / Stryd / Oura OAuth is painful inside a miniapp WebView. Existing users link their account by email / password and then use the mini program day-to-day (signal, training, goal, sync, theory, training-base, theme / language). New users either join the waitlist inside WeChat or, if they already have an invitation code, are deep-linked to praxys.run to register. |
-| `plugins/praxys/` | Praxys plugin (**git submodule** of public [`dddtc2005/praxys-coach-plugin`](https://github.com/dddtc2005/praxys-coach-plugin), MIT) | `skills/` (8 SKILL.md), `mcp-server/` (local + remote MCP). Edits to anything inside `plugins/praxys/` are commits in the plugin repo, not this one — PRs there, then bump the submodule pointer here. |
+| `plugins/praxys/` | Praxys plugin (**git submodule** of public [`praxys-run/praxys-coach-plugin`](https://github.com/praxys-run/praxys-coach-plugin), MIT) | `skills/` (8 SKILL.md), `mcp-server/` (local + remote MCP). Edits to anything inside `plugins/praxys/` are commits in the plugin repo, not this one — PRs there, then bump the submodule pointer here. |
 | `tests/` | pytest suite | |
 | `data/` | Fixtures + science YAML | `sample/` (test CSVs — not live data), `science/` (theory YAMLs) |
 | `scripts/` | Utility + skill helpers | |
@@ -83,7 +83,7 @@ Domain-specific gotchas (Garmin sync quirks, CIQ field conventions, CN endpoint 
 - Visual design **may diverge** between web and miniapp: web is a desktop-first React + shadcn surface; miniapp is a mobile-first Skyline surface with native-feeling chrome (custom nav bar, custom tab bar, FAB share buttons). Keep brand tokens (colors, typography intent, semantic palette) consistent; layout and interaction patterns can be platform-appropriate.
 
 ### Git
-- **Commit / PR subjects state what the change does**, e.g. `Fix Garmin first-time sync…`. This repo is standalone (pushes to `dddtc2005/praxys`) — don't prefix with the folder name. The outer pensieve repo's `trail-running:` convention exists because that repo hosts multiple top-level projects; it doesn't apply here.
+- **Commit / PR subjects state what the change does**, e.g. `Fix Garmin first-time sync…`. This repo is standalone (pushes to `praxys-run/praxys`) — don't prefix with the folder name. The outer pensieve repo's `trail-running:` convention exists because that repo hosts multiple top-level projects; it doesn't apply here.
 - Commit body explains the *why* (motivation, root cause, trade-off). The diff shows the *what*.
 - Never put sensitive content (credentials, `.env` values, personal data) in commit messages or PR descriptions.
 
@@ -127,8 +127,8 @@ Always use the project venv at `.venv/` for Python commands.
 
 ```bash
 # First time: clone with submodules so plugins/praxys/ is populated
-# (the plugin is its own public repo, dddtc2005/praxys-coach-plugin)
-git clone --recurse-submodules https://github.com/dddtc2005/praxys.git
+# (the plugin is its own public repo, praxys-run/praxys-coach-plugin)
+git clone --recurse-submodules https://github.com/praxys-run/praxys.git
 cd praxys
 # (already cloned without --recurse-submodules? run: git submodule update --init)
 
@@ -251,7 +251,7 @@ Automations live in `.claude/` and are committed so every contributor using Clau
 
 ## AI Skills
 
-8 skills in `plugins/praxys/skills/` (submodule from public [`dddtc2005/praxys-coach-plugin`](https://github.com/dddtc2005/praxys-coach-plugin)) expose training features via the Praxys plugin (MCP server + skills):
+8 skills in `plugins/praxys/skills/` (submodule from public [`praxys-run/praxys-coach-plugin`](https://github.com/praxys-run/praxys-coach-plugin)) expose training features via the Praxys plugin (MCP server + skills):
 
 | Skill | Purpose |
 |-------|---------|

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sports science that meets you where you are. Praxys syncs data from Garmin, Stry
 | Web app | [`www.praxys.run`](https://www.praxys.run) | React SPA on Azure App Service; apex `praxys.run` redirects here. |
 | Backend API | [`api.praxys.run`](https://api.praxys.run) | FastAPI on Azure App Service (East Asia). JWT-auth on every route except `/api/register` and `/api/token`. |
 | WeChat Mini Program | `miniapp/` (Taro 4 + React) | Authenticates against the same backend via `/api/auth/wechat/*`. Build with `npm run build:weapp` and load `dist/` in WeChat DevTools. |
-| AI plugin | `plugins/praxys/` ([dddtc2005/praxys-coach-plugin](https://github.com/dddtc2005/praxys-coach-plugin), MIT, public) | 8 skills + a dual-mode MCP server (local SQLite, or remote against `api.praxys.run`). Vendored here as a git submodule; install with `git clone --recurse-submodules` (or run `git submodule update --init` after a plain clone). |
+| AI plugin | `plugins/praxys/` ([praxys-run/praxys-coach-plugin](https://github.com/praxys-run/praxys-coach-plugin), MIT, public) | 8 skills + a dual-mode MCP server (local SQLite, or remote against `api.praxys.run`). Vendored here as a git submodule; install with `git clone --recurse-submodules` (or run `git submodule update --init` after a plain clone). |
 
 **Cloud app (recommended):** register, connect your platforms, sync data, view the dashboard from anywhere. AI features are available via the Praxys plugin in remote mode.
 
@@ -23,7 +23,7 @@ Sports science that meets you where you are. Praxys syncs data from Garmin, Stry
 
 ```bash
 # 0. Clone with submodules (the AI plugin lives in its own public repo)
-git clone --recurse-submodules https://github.com/dddtc2005/praxys.git
+git clone --recurse-submodules https://github.com/praxys-run/praxys.git
 cd praxys
 
 # 1. Install Python dependencies

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,7 +73,7 @@ The database (`data/trainsight.db`) is created automatically on first startup. N
 ## Prerequisites (Azure)
 
 - Azure subscription
-- GitHub repository (dddtc2005/praxys)
+- GitHub repository (praxys-run/praxys)
 - Azure CLI installed locally
 
 ## Azure Setup (One-Time)
@@ -285,7 +285,7 @@ Repository → Settings → Secrets and variables → Actions → Variables tab.
 
 ```bash
 # Create app registration
-az ad app create --display-name trainsight-ci
+az ad app create --display-name trainsight-cicd
 
 # Create federated credential for GitHub Actions
 az ad app federated-credential create \
@@ -293,7 +293,7 @@ az ad app federated-credential create \
   --parameters '{
     "name": "github-main",
     "issuer": "https://token.actions.githubusercontent.com",
-    "subject": "repo:dddtc2005/praxys:ref:refs/heads/main",
+    "subject": "repo:praxys-run/praxys:ref:refs/heads/main",
     "audiences": ["api://AzureADTokenExchange"]
   }'
 

--- a/docs/dev/agentic-loops.md
+++ b/docs/dev/agentic-loops.md
@@ -129,10 +129,10 @@ toward auto-act, and only behind a fast rollback.
 
 ## 6. How it maps to the repos
 
-- **`dddtc2005/praxys` (this repo, public).** Hosts the **change loop** and the
+- **`praxys-run/praxys` (this repo, public).** Hosts the **change loop** and the
   **product/quality loop**, and is the natural home for the **shared substrate**
   (telemetry, the decisions/outcomes store, the eval corpus, the policy files).
-- **`dddtc2005/praxys-ops-agent` (private).** Hosts the **incident loop**;
+- **`praxys-run/praxys-ops-agent` (private).** Hosts the **incident loop**;
   consumes the same substrate. Event-triggered + ephemeral, acting on praxys via a
   scoped GitHub App + Azure OIDC.
 - **Cross-loop edges** (the interesting part): the incident loop can *emit into*
@@ -180,5 +180,5 @@ and product loops.
 - #362 — the change loop; **PR #373** — its implementation (+ shadow primitive,
   actionability gate). `docs/ops/change-loop.md` — the operator runbook.
 - **#377** — the self-improvement platform tracker (the substrate above).
-- `dddtc2005/praxys-ops-agent` — the incident loop (Loop B).
+- `praxys-run/praxys-ops-agent` — the incident loop (Loop B).
 - `docs/dev/architecture.md` — the (non-agentic) system architecture.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -49,7 +49,7 @@ How to extend Praxys with new features.
 
 ## Adding a New Skill
 
-> **Plugin lives in its own repo.** `plugins/praxys/` is a git submodule of the public [`dddtc2005/praxys-coach-plugin`](https://github.com/dddtc2005/praxys-coach-plugin) repo. Skill changes are PRed there; once merged, bump the submodule pointer in this repo (`git submodule update --remote plugins/praxys && git add plugins/praxys && git commit`).
+> **Plugin lives in its own repo.** `plugins/praxys/` is a git submodule of the public [`praxys-run/praxys-coach-plugin`](https://github.com/praxys-run/praxys-coach-plugin) repo. Skill changes are PRed there; once merged, bump the submodule pointer in this repo (`git submodule update --remote plugins/praxys && git add plugins/praxys && git commit`).
 
 1. **Create skill directory** `plugins/praxys/skills/{skill-name}/`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,7 @@ Run everything on your machine. Same features, same auth flow.
 ### 1. Clone and Install
 
 ```bash
-git clone https://github.com/dddtc2005/praxys.git
+git clone https://github.com/praxys-run/praxys.git
 cd praxys
 
 # Python dependencies

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -56,6 +56,6 @@ Full detail: [environment.md](./environment.md).
 Incident response, backup/restore, DR, secret rotation, scaling/cost, and sync
 troubleshooting now have runbooks. Remaining open items (on-call/escalation
 definitions, RPO/RTO targets, the Key Vault re-wrap drill, optionally exposing
-runbooks as a `plugins/praxys` skill) are tracked in **dddtc2005/praxys#338** and
+runbooks as a `plugins/praxys` skill) are tracked in **praxys-run/praxys#338** and
 flagged inline as `TODO(@dddtc2005)`. Add new runbooks against
 [`_TEMPLATE.md`](./_TEMPLATE.md) and link them from the index above.

--- a/docs/ops/admin-tasks.md
+++ b/docs/ops/admin-tasks.md
@@ -105,8 +105,8 @@ Auto-filing + the sensitivity gate are configured via the GitHub App settings
 To get emailed when something needs review, wire the alert in
 [monitoring-and-alerts.md](./monitoring-and-alerts.md).
 
-> The feedback feature ships in dddtc2005/praxys#328; ticket status sync, status
-> filtering, and priority suggestions in dddtc2005/praxys#359.
+> The feedback feature ships in praxys-run/praxys#328; ticket status sync, status
+> filtering, and priority suggestions in praxys-run/praxys#359.
 
 ## Related
 

--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -8,7 +8,7 @@
 
 Praxys runs two agentic loops. **The change loop (a.k.a. Loop A) lives here** and
 is GitHub-native: feedback → a drafted fix PR. The **incident loop (Loop B)** —
-AIOps / incident response — lives in the private `dddtc2005/praxys-ops-agent`
+AIOps / incident response — lives in the private `praxys-run/praxys-ops-agent`
 repo. This runbook is the change loop.
 
 ## How it works
@@ -98,8 +98,8 @@ gh api graphql -f query='query($o:String!,$n:String!){
 ### 2. Create the labels
 
 ```bash
-gh label create agent-ready -c 1D76DB -d "Trigger: hand this issue to the Copilot coding agent (change loop)" -R dddtc2005/praxys
-gh label create backlog     -c 5319E7 -d "Deferred; ineligible for auto-assign even if a bug" -R dddtc2005/praxys
+gh label create agent-ready -c 1D76DB -d "Trigger: hand this issue to the Copilot coding agent (change loop)" -R praxys-run/praxys
+gh label create backlog     -c 5319E7 -d "Deferred; ineligible for auto-assign even if a bug" -R praxys-run/praxys
 ```
 
 The workflow also honours an existing `later` label as a backlog synonym.
@@ -114,7 +114,7 @@ tokens` (issue #400). Without `COPILOT_ASSIGN_TOKEN` the workflow now fails
 
 Create a **fine-grained PAT**, least-privilege:
 
-- **Resource owner:** `dddtc2005`; **Repository access:** *Only select
+- **Resource owner:** `praxys-run`; **Repository access:** *Only select
   repositories* → `praxys` (this repo only).
 - **Permissions:** *Issues → Read and write* (nothing else).
 - **Expiration:** set one (e.g. 90 days) and calendar a rotation.
@@ -122,7 +122,7 @@ Create a **fine-grained PAT**, least-privilege:
 Then store it and re-run:
 
 ```bash
-gh secret set COPILOT_ASSIGN_TOKEN -R dddtc2005/praxys   # paste the PAT when prompted
+gh secret set COPILOT_ASSIGN_TOKEN -R praxys-run/praxys   # paste the PAT when prompted
 ```
 
 Manual assignment via the GitHub UI keeps working without this token (it uses
@@ -138,7 +138,7 @@ So the agent can draft but never ship, protect `main`:
   PR so the check name is selectable.
 
 ```bash
-gh api repos/dddtc2005/praxys/branches/main/protection --jq '{reviews:.required_pull_request_reviews, checks:.required_status_checks}'
+gh api repos/praxys-run/praxys/branches/main/protection --jq '{reviews:.required_pull_request_reviews, checks:.required_status_checks}'
 ```
 
 ## Tuning the agent (quality knobs)
@@ -234,7 +234,7 @@ and the cost is low).
 - Shadow mode on → no label is applied, but the decision is logged.
 
 ```bash
-gh run list --workflow=assign-copilot.yml -R dddtc2005/praxys --limit 5
+gh run list --workflow=assign-copilot.yml -R praxys-run/praxys --limit 5
 ```
 
 ## Rollback / Recovery
@@ -253,7 +253,7 @@ gh run list --workflow=assign-copilot.yml -R dddtc2005/praxys --limit 5
 - Agent guidance: `.github/copilot-instructions.md`.
 - Secrets / flags: [config-and-secrets.md](./config-and-secrets.md) (`COPILOT_ASSIGN_TOKEN`, `PRAXYS_AGENT_READY_SHADOW`).
 - Issue-filing setup: [setup-github-app.md](./setup-github-app.md).
-- Design: dddtc2005/praxys#362 (the change loop); #361 (backend pytest gate); #377 (self-improvement).
+- Design: praxys-run/praxys#362 (the change loop); #361 (backend pytest gate); #377 (self-improvement).
 
 ---
 _Last reviewed: 2026-07-05 · Owner: @dddtc2005_

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -76,7 +76,7 @@ to boot without a JWT secret.
 
 > Example: the feedback → GitHub-issue settings (`PRAXYS_GITHUB_APP_*`,
 > `PRAXYS_FEEDBACK_GITHUB_*`) follow exactly this pattern and are intentionally
-> optional. (Added by the feedback feature — dddtc2005/praxys#328.)
+> optional. (Added by the feedback feature — praxys-run/praxys#328.)
 
 ### Feedback screenshot storage (Azure Blob, keyless)
 

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -39,7 +39,7 @@
   *Key Vault Crypto User* (key wrap/unwrap) and *Monitoring Metrics Publisher*.
   See `api/main.py` (managed-identity wiring) and `.env.example`.
 - **GitHub Actions → Azure:** OIDC federated credentials on `trainsight-cicd`
-  (subjects `repo:dddtc2005/praxys:ref:refs/heads/main` and `…:i18n-azure-openai`).
+  (subjects `repo:praxys-run/praxys:ref:refs/heads/main` and `…:i18n-azure-openai`).
   No client secret. Moving repos to the `praxys-run` org changes these subjects —
   see [org-migration.md](./org-migration.md). See
   [config-and-secrets.md](./config-and-secrets.md).
@@ -58,7 +58,8 @@
 
 ## Repo governance
 
-- **`main` branch protection.** A required status check `backend-tests` (from `.github/workflows/ci-backend.yml`, issue #361) gates every PR to `main`: a failing backend `pytest` run blocks merge, **admins included** (`enforce_admins`). No required human review (`required_pull_request_reviews` unset) so the solo maintainer can self-merge a green PR. Managed via the branch-protection API on `repos/dddtc2005/praxys/branches/main/protection` — update that rule to change the required checks.
+- **Owner:** the repos live in the **`praxys-run`** org (GitHub **Free**; public repos keep branch protection + unlimited Actions minutes). Migrated from the `dddtc2005` personal account on 2026-07-10 — see [org-migration.md](./org-migration.md).
+- **`main` protection is two layers.** (1) **Classic branch protection**: required status check `backend-tests` (`ci-backend.yml`, #361) blocks merge on a failing `pytest`, **admins included** (`enforce_admins`); managed via `repos/praxys-run/praxys/branches/main/protection`. (2) **Repo ruleset `default`** (id `15208143`): **squash-only** merges + **1 required review**, with a **repo-admin `Always` bypass** so the solo maintainer self-merges a green PR; managed via the rulesets API. ⚠️ **Transfer gotcha:** moving a repo between accounts **wipes the ruleset's `bypass_actors`** — after the org migration the bypass list was empty (deadlocking solo self-merge) and had to be restored (`PUT repos/praxys-run/praxys/rulesets/15208143`, requires `admin:org` scope + the full ruleset body).
 
 ## Related
 

--- a/docs/ops/secret-rotation.md
+++ b/docs/ops/secret-rotation.md
@@ -14,7 +14,7 @@ again.** Schedule for a low-traffic window.
 
 ```bash
 NEW=$(python -c "import secrets; print(secrets.token_urlsafe(48))")
-printf '%s' "$NEW" | gh secret set PRAXYS_JWT_SECRET --repo dddtc2005/praxys
+printf '%s' "$NEW" | gh secret set PRAXYS_JWT_SECRET --repo praxys-run/praxys
 gh workflow run deploy-backend.yml --ref main
 ```
 Verify: log in fresh; existing tokens now 401 (expected).
@@ -23,7 +23,7 @@ Verify: log in fresh; existing tokens now 401 (expected).
 
 Rotate in mp.weixin.qq.com → 开发设置, then:
 ```bash
-printf '%s' '<NEW_SECRET>' | gh secret set WECHAT_MINIAPP_SECRET --repo dddtc2005/praxys
+printf '%s' '<NEW_SECRET>' | gh secret set WECHAT_MINIAPP_SECRET --repo praxys-run/praxys
 gh workflow run deploy-backend.yml --ref main
 ```
 Blast radius: WeChat mini-program login briefly fails until the deploy lands.
@@ -34,6 +34,21 @@ Generate a new private key on the GitHub App, set the secret from the new `.pem`
 re-deploy. Blast radius: low — only feedback auto-filing; reports still park for
 admin. Steps: [setup-github-app.md](./setup-github-app.md) (step 3). Delete the
 old key from the app afterwards.
+
+## `COPILOT_ASSIGN_TOKEN` — change-loop assignment PAT
+
+Fine-grained PAT (resource owner `praxys-run`, repo `praxys`, *Issues: read/write*)
+that lets `assign-copilot.yml` hand an `agent-ready` issue to the Copilot coding
+agent. **No auto-rotation** — fine-grained PATs simply expire. **Blast radius:
+low** — only auto-assignment, and if it lapses the workflow *fails loudly*
+(comments "assign manually" on the issue), so the change loop degrades to manual
+assignment rather than breaking silently.
+
+```bash
+# mint a new fine-grained PAT (praxys-run/praxys, Issues: RW, ~90d expiry), then:
+gh secret set COPILOT_ASSIGN_TOKEN -R praxys-run/praxys
+```
+Rotate ~every 90 days (calendar it). See [change-loop.md](./change-loop.md) §3.
 
 ## Key Vault RSA key `trainsight-master-key`
 
@@ -47,7 +62,7 @@ Until then, treat this key as non-rotatable.
 
 ## OIDC (`AZURE_CLIENT_ID` / federated credential)
 
-Managed by the `trainsight-ci` app registration (no client secret — OIDC). To
+Managed by the `trainsight-cicd` app registration (no client secret — OIDC). To
 rotate trust, update the federated credential subject; see `docs/deployment.md`.
 
 ## Related

--- a/docs/ops/setup-github-app.md
+++ b/docs/ops/setup-github-app.md
@@ -26,7 +26,7 @@ Gather these before step 3 — an agent can't derive them:
 
 Steps 1–3 (create / install / store config) can run any time and are safe to do
 early. **Step 4 (deploy → verify) only takes effect once the deployed backend
-includes the GitHub App support (PR dddtc2005/praxys#328 or later)** — setting the
+includes the GitHub App support (PR praxys-run/praxys#328 or later)** — setting the
 config before that ships just sits idle until the next backend deploy.
 
 ## Steps
@@ -44,7 +44,7 @@ GitHub → *Settings → Developer settings → GitHub Apps → New GitHub App*:
 
 ### 2. Install it on the repo  — human
 
-App → *Install App* → install on `dddtc2005/praxys` (or your triage repo), *Only
+App → *Install App* → install on `praxys-run/praxys` (or your triage repo), *Only
 select repositories* → that repo. After installing, the browser URL ends in
 `…/installations/<INSTALLATION_ID>` — **that number is the Installation ID.**
 
@@ -59,13 +59,13 @@ settings don't keep multi-line cleanly; the backend restores the newlines).
 
 ```bash
 # App ID + Installation ID are non-secret → Actions variables
-gh variable set PRAXYS_GITHUB_APP_ID --repo dddtc2005/praxys --body '<APP_ID>'
-gh variable set PRAXYS_GITHUB_APP_INSTALLATION_ID --repo dddtc2005/praxys --body '<INSTALLATION_ID>'
-gh variable set PRAXYS_FEEDBACK_GITHUB_REPO --repo dddtc2005/praxys --body 'dddtc2005/praxys'
+gh variable set PRAXYS_GITHUB_APP_ID --repo praxys-run/praxys --body '<APP_ID>'
+gh variable set PRAXYS_GITHUB_APP_INSTALLATION_ID --repo praxys-run/praxys --body '<INSTALLATION_ID>'
+gh variable set PRAXYS_FEEDBACK_GITHUB_REPO --repo praxys-run/praxys --body 'praxys-run/praxys'
 
 # Private key → Actions secret, flattened to one line with literal \n
 KEY_ONELINE=$(awk 'BEGIN{ORS="\\n"}{print}' path/to/private-key.pem)
-printf '%s' "$KEY_ONELINE" | gh secret set PRAXYS_GITHUB_APP_PRIVATE_KEY --repo dddtc2005/praxys
+printf '%s' "$KEY_ONELINE" | gh secret set PRAXYS_GITHUB_APP_PRIVATE_KEY --repo praxys-run/praxys
 ```
 
 ### 4. Roll out  — agent-executable
@@ -110,7 +110,7 @@ the app.
 ## Related
 
 - [config-and-secrets.md](./config-and-secrets.md) · [admin-tasks.md](./admin-tasks.md) · `api/github_issues.py`
-- Feedback feature: dddtc2005/praxys#328
+- Feedback feature: praxys-run/praxys#328
 
 ---
 _Last reviewed: 2026-06-30 · Owner: @dddtc2005_

--- a/docs/perf-baselines/azure-provisioning.md
+++ b/docs/perf-baselines/azure-provisioning.md
@@ -58,7 +58,7 @@ Even with MI auth, the backend still needs to know _where_ to send telemetry —
 
 The frontend value is a **repository variable**, not a secret — connection strings are write-only ingestion tokens and ship in every client bundle by design. Browsers have no MI path, so this is the correct pattern (see auth model summary above and the comment at the top of `web/src/lib/appinsights.ts`).
 
-1. GitHub → `dddtc2005/praxys` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab.
+1. GitHub → `praxys-run/praxys` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab.
 2. **New repository variable:**
    - **Name:** `VITE_APPINSIGHTS_CONNECTION_STRING`
    - **Value:** the same connection string from step 1.5

--- a/docs/perf-baselines/ci-setup.md
+++ b/docs/perf-baselines/ci-setup.md
@@ -130,7 +130,7 @@ python scripts/analyze_baseline.py --baseline-dir docs/perf-baselines/<YYYY-MM-D
 ## Azure resources
 
 All in `rg-trainsight`, subscription `3ff02750-211c-4579-94a6-8c9af4e6d891`.
-Already provisioned on the dddtc2005/praxys account.
+Already provisioned on the praxys-run/praxys account.
 
 | Resource | Name | Purpose |
 |---|---|---|

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,12 +10,12 @@ Praxys includes 8 AI skills that provide access to all training features via Cla
 
 ## Plugin Installation
 
-Skills are packaged as a Claude Code plugin. The plugin lives in its own public repo, [`dddtc2005/praxys-coach-plugin`](https://github.com/dddtc2005/praxys-coach-plugin) (MIT), and is vendored into this repo as a git submodule at `plugins/praxys/` for local-mode development.
+Skills are packaged as a Claude Code plugin. The plugin lives in its own public repo, [`praxys-run/praxys-coach-plugin`](https://github.com/praxys-run/praxys-coach-plugin) (MIT), and is vendored into this repo as a git submodule at `plugins/praxys/` for local-mode development.
 
 **End users** (running against praxys.run) install it as any Claude Code plugin:
 
 ```
-/plugin marketplace add github:dddtc2005/praxys-coach-plugin
+/plugin marketplace add github:praxys-run/praxys-coach-plugin
 /plugin install praxys
 ```
 

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Praxys training dashboard — MCP tools for training data, daily briefs, race forecasts, and AI plan management",
       "source": "./plugins/praxys",
       "category": "productivity",
-      "homepage": "https://github.com/dddtc2005/praxys"
+      "homepage": "https://github.com/praxys-run/praxys"
     }
   ]
 }

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -9,7 +9,7 @@ optionally, that the migrated credential blobs still decrypt).
 Rows are streamed in bounded chunks (memory-safe for large tables such as
 activity_samples), and orphaned user foreign keys left by SQLite's lack of FK
 enforcement are cleaned during copy (nullable -> NULL, NOT NULL -> row skipped;
-both reported). See dddtc2005/praxys#366.
+both reported). See praxys-run/praxys#366.
 
 Usage:
     python -m scripts.migrate_sqlite_to_postgres \
@@ -150,7 +150,7 @@ def migrate(
     # source can hold rows whose user-FK points at a since-deleted user (e.g.
     # invitations.used_by). PostgreSQL enforces FKs, so orphans are cleaned on
     # copy: a *nullable* orphaned FK is set NULL; a NOT NULL orphaned FK row is
-    # skipped. Both are reported. See dddtc2005/praxys#366.
+    # skipped. Both are reported. See praxys-run/praxys#366.
     with src.connect() as sconn:
         valid_users = {
             x[0] for x in sconn.exec_driver_sql("SELECT id FROM users").fetchall()

--- a/web/src/components/AiInsightsCard.tsx
+++ b/web/src/components/AiInsightsCard.tsx
@@ -52,7 +52,7 @@ interface Props {
   fallback?: CoachFallback;
 }
 
-const PLUGIN_URL = 'https://github.com/dddtc2005/praxys-coach-plugin#install';
+const PLUGIN_URL = 'https://github.com/praxys-run/praxys-coach-plugin#install';
 
 // Mirrors Today.tsx's helper. Should be extracted to web/src/lib/format.ts
 // when a third caller appears — see issue #236.


### PR DESCRIPTION
## What

Post‑migration docs sweep: `dddtc2005/praxys` → `praxys-run/praxys` across ~25 files (docs, CLAUDE/AGENTS, `.github/`, README, `.env.example`, `.gitmodules`, marketplace manifests, and two trivial code refs — the plugin link in `AiInsightsCard.tsx` and an issue ref in `migrate_sqlite_to_postgres.py`).

**Intentionally not swept:** `docs/ops/org-migration.md` (it documents the migration *from* `dddtc2005`) and the frozen `2026-04-26` perf checkpoint (historical run/issue URLs).

## Also (small correctness fixes)

- **change-loop.md** — the `COPILOT_ASSIGN_TOKEN` PAT resource owner is now `praxys-run`.
- **secret-rotation.md** — new `COPILOT_ASSIGN_TOKEN` rotation entry (no auto‑rotation; degrades to the fail‑loud manual‑assign fallback), and fixed the OIDC app name `trainsight-ci` → `trainsight-cicd` (also in `deployment.md`).
- **environment.md** — documented the two‑layer `main` protection (classic + ruleset) and the **transfer gotcha**: moving a repo wipes the ruleset `bypass_actors`, which had to be restored after the migration.

## Notes

- All still work via GitHub redirects — this is correctness/hygiene.
- Touches `web/`, so merging triggers a **frontend deploy that live‑verifies the new `praxys-run` OIDC credentials** (nice side benefit before Phase 4 removes the old ones).

Completes the docs portion of the org migration (#402 runbook).