### PR TITLE
Fix change-loop detail gating for CJK feedback

### DIFF
--- a/api/feedback_triage.py
+++ b/api/feedback_triage.py
@@ -92,10 +92,12 @@ def _gate_blocks_publish(
 # drafting the fix; merge stays human (branch protection).
 AGENT_READY_LABEL = "agent-ready"
 
-# Minimum word count for the scrubbed user message to count as "enough detail".
 # A cheap floor beneath the model's own actionability verdict: a terse "it's
-# broken" should not burn a coding-agent run. Deterministic + reproducible.
+# broken" should not burn a coding-agent run. Whitespace-delimited languages use
+# a word floor; scripts such as Chinese that do not separate words with spaces
+# use a Unicode alphanumeric-character floor instead.
 _AGENT_MIN_DETAIL_WORDS = 6
+_AGENT_MIN_DETAIL_ALNUM_CHARS = 16
 
 
 def _agent_ready_shadow() -> bool:
@@ -109,7 +111,10 @@ def _agent_ready_shadow() -> bool:
 
 def _has_enough_detail(message: str) -> bool:
     """Whether a report says enough for a coding agent to attempt a fix."""
-    return len((message or "").split()) >= _AGENT_MIN_DETAIL_WORDS
+    text = (message or "").strip()
+    if len(text.split()) >= _AGENT_MIN_DETAIL_WORDS:
+        return True
+    return sum(char.isalnum() for char in text) >= _AGENT_MIN_DETAIL_ALNUM_CHARS
 
 
 def _qualifies_for_agent(

--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -37,7 +37,9 @@ it only when **all** of these hold (`_qualifies_for_agent` in
 3. **The sensitivity gate did not withhold it** — a `needs_review`/sensitive
    report is never tagged, and because the tag is gated on this, it never even
    lands in `ai_labels`, so a later admin *approve* cannot auto-assign it either.
-4. **It has enough detail** — a cheap word-count floor beneath the model verdict.
+4. **It has enough detail** — a cheap language-aware floor beneath the model
+   verdict: whitespace-delimited words or Unicode alphanumeric characters for
+   scripts such as Chinese.
 
 **Backlog escape hatch:** a `backlog` or `later` label makes an issue ineligible
 even if it is a bug (the workflow skips it). **Merge is always human** — autonomy

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1094,10 +1094,11 @@ def test_triage_priority_none_without_llm(db_with_users):
 
 
 # ---------------------------------------------------------------------------
-# Loop A: agent-ready gating for the Copilot coding agent (issue #362)
+# Change loop: agent-ready gating for the Copilot coding agent (issue #362)
 # ---------------------------------------------------------------------------
 
 _DETAILED_BUG = "The training charts fail to render after a sync completes"
+_DETAILED_CJK_BUG = "今日页面状态建议休息，但 Praxys 教练建议完成长距离训练，两条建议相互矛盾"
 
 
 def test_triage_tags_agent_ready_for_qualifying_bug(db_with_users, monkeypatch):
@@ -1109,6 +1110,24 @@ def test_triage_tags_agent_ready_for_qualifying_bug(db_with_users, monkeypatch):
     _stub_github(monkeypatch, calls)
     _stub_llm(monkeypatch, sensitive=False)
     row = _new_row(db, user_id, _DETAILED_BUG)
+
+    result = triage_and_publish(row.id, _session=db)
+    assert result["status"] == "issue_created"
+    assert result["agent_ready"] is True
+    db.refresh(row)
+    assert "agent-ready" in (row.ai_labels or [])
+    assert "agent-ready" in calls[0]["labels"]
+
+
+def test_triage_tags_agent_ready_for_detailed_cjk_bug(db_with_users, monkeypatch):
+    """Detailed feedback without whitespace word boundaries still qualifies."""
+    from api.feedback_triage import triage_and_publish
+
+    db, _, _, user_id = db_with_users
+    calls: list = []
+    _stub_github(monkeypatch, calls)
+    _stub_llm(monkeypatch, sensitive=False)
+    row = _new_row(db, user_id, _DETAILED_CJK_BUG)
 
     result = triage_and_publish(row.id, _session=db)
     assert result["status"] == "issue_created"
@@ -1155,7 +1174,8 @@ def test_triage_no_agent_ready_when_sensitive(db_with_users, monkeypatch):
     assert "agent-ready" not in (row.ai_labels or [])
 
 
-def test_triage_no_agent_ready_for_low_detail_bug(db_with_users, monkeypatch):
+@pytest.mark.parametrize("message", ["totally broken", "页面坏了"])
+def test_triage_no_agent_ready_for_low_detail_bug(db_with_users, monkeypatch, message):
     """A terse bug is published but too thin to hand to the coding agent."""
     from api.feedback_triage import triage_and_publish
 
@@ -1163,7 +1183,7 @@ def test_triage_no_agent_ready_for_low_detail_bug(db_with_users, monkeypatch):
     calls: list = []
     _stub_github(monkeypatch, calls)
     _stub_llm(monkeypatch, sensitive=False)
-    row = _new_row(db, user_id, "totally broken")
+    row = _new_row(db, user_id, message)
 
     result = triage_and_publish(row.id, _session=db)
     assert result["status"] == "issue_created"


### PR DESCRIPTION
## Summary
- make the change-loop minimum-detail guard work for scripts without whitespace word boundaries
- preserve the conservative floor for terse English and Chinese reports
- document the language-aware qualification rule

## Root cause
Issue #418 contained a detailed 51-character Chinese report, but `str.split()` counted only 3 whitespace tokens, below the 6-word floor. The issue was therefore filed as a high-priority AI-triaged bug without `agent-ready`, so the assignment workflow correctly skipped it.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\ -q` (967 passed, 2 skipped)