### PR TITLE
Fix change-loop assignment cancellation

### DIFF
--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -30,14 +30,6 @@ on:
 permissions:
   issues: write
 
-concurrency:
-  # One effective run per issue: an issue is often created with several labels
-  # at once, firing multiple events in the same group — cancel the superseded
-  # duplicates so we don't post duplicate failure comments. Assignment is
-  # idempotent, so cancelling a redundant in-flight run is safe.
-  group: assign-copilot-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   assign-to-copilot:
     # Fire only when `agent-ready` is the reason (labeled) or is already present
@@ -50,6 +42,12 @@ jobs:
       ) &&
       !contains(github.event.issue.labels.*.name, 'backlog') &&
       !contains(github.event.issue.labels.*.name, 'later')
+    # A feedback label batch emits one workflow run per label. Scope duplicate
+    # suppression to this eligible job so a later unrelated label cannot cancel
+    # the agent-ready assignment before it starts.
+    concurrency:
+      group: assign-copilot-${{ github.event.issue.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Check the assignment token is configured

--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -41,6 +41,11 @@ it only when **all** of these hold (`_qualifies_for_agent` in
    verdict: whitespace-delimited words or Unicode alphanumeric characters for
    scripts such as Chinese.
 
+The feedback bot can add several labels in one batch, and GitHub emits one
+`issues.labeled` event for each label. Duplicate suppression is scoped to the
+eligible assignment job, so a later unrelated label cannot cancel an
+`agent-ready` assignment before it starts.
+
 **Backlog escape hatch:** a `backlog` or `later` label makes an issue ineligible
 even if it is a bug (the workflow skips it). **Merge is always human** — autonomy
 is *drafting* the fix; branch protection keeps a human in the loop.

--- a/tests/test_assign_copilot_workflow.py
+++ b/tests/test_assign_copilot_workflow.py
@@ -1,0 +1,21 @@
+"""Regression tests for the change-loop assignment workflow."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "assign-copilot.yml"
+
+
+def test_assignment_deduplication_is_job_scoped() -> None:
+    """Unrelated label events must not cancel an eligible assignment job."""
+    workflow = WORKFLOW.read_text(encoding="utf-8").replace("\r\n", "\n")
+    workflow_prefix, jobs = workflow.split("\njobs:\n", maxsplit=1)
+    assignment_job = jobs.split("  assign-to-copilot:\n", maxsplit=1)[1]
+
+    assert "\nconcurrency:" not in workflow_prefix
+    assert assignment_job.index("\n    if:") < assignment_job.index(
+        "\n    concurrency:"
+    )
+    assert "group: assign-copilot-${{ github.event.issue.number }}" in assignment_job
+    assert "cancel-in-progress: true" in assignment_job


### PR DESCRIPTION
## Summary
- move per-issue duplicate suppression from workflow scope to the eligible assignment job
- prevent later non-eligible label events from cancelling an `agent-ready` assignment
- add a workflow regression test and document the label-batch behavior

## Root cause
The feedback bot applies several labels to a new issue. GitHub starts one workflow run per `issues.labeled` event; workflow-level concurrency let the final non-eligible label run cancel the eligible `agent-ready` run, then skip its job. This affected #422.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_assign_copilot_workflow.py -v`
- parsed `.github/workflows/assign-copilot.yml` with PyYAML

After this reaches `main`, remove and re-add the `agent-ready` label on #422 to retry the workflow path.