### PR TITLE
Preserve valid app versions in feedback reports

### DIFF
--- a/api/feedback_scrub.py
+++ b/api/feedback_scrub.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import re
 
-from api.version import is_valid_build_version
+from api.version import find_valid_build_versions, is_valid_build_version
 
 # RFC 5322 is famously unparseable in full; this pragmatic pattern matches the
 # overwhelming majority of real addresses without catastrophic backtracking.
@@ -121,9 +121,26 @@ def _redact_formatted_number(match: re.Match[str]) -> str:
     return "[redacted-number]" if digit_count >= 9 else value
 
 
+def _protect_build_versions(text: str) -> tuple[str, dict[str, str]]:
+    """Protect strict public build IDs from generic long-number redaction."""
+    protected = text
+    placeholders: dict[str, str] = {}
+    placeholder_index = 0
+    for version in find_valid_build_versions(text):
+        while True:
+            placeholder = f"__praxys_build_{placeholder_index}__"
+            placeholder_index += 1
+            if placeholder not in protected:
+                break
+        protected = protected.replace(version, placeholder)
+        placeholders[placeholder] = version
+    return protected, placeholders
+
+
 def _scrub_unstructured_text(text: str) -> str:
     """Scrub a plain-text fragment without attempting JSON parsing."""
-    out = _PEM_PRIVATE_KEY_RE.sub("[redacted-private-key]", text)
+    out, protected_build_versions = _protect_build_versions(text)
+    out = _PEM_PRIVATE_KEY_RE.sub("[redacted-private-key]", out)
     out = _JSON_CREDENTIAL_RE.sub(r'\g<prefix>"[redacted]"', out)
     out = _AUTHORIZATION_HEADER_RE.sub(r"\1 [redacted]", out)
     out = _COOKIE_HEADER_RE.sub(r"\1: [redacted]", out)
@@ -138,6 +155,8 @@ def _scrub_unstructured_text(text: str) -> str:
     out = _IPV4_RE.sub("[redacted-ip]", out)
     out = _FORMATTED_NUMBER_RE.sub(_redact_formatted_number, out)
     out = _LONG_DIGITS_RE.sub("[redacted-number]", out)
+    for placeholder, version in protected_build_versions.items():
+        out = out.replace(placeholder, version)
     return out
 
 

--- a/api/version.py
+++ b/api/version.py
@@ -23,16 +23,30 @@ import re
 from pathlib import Path
 
 _BUILD_FILE = Path(__file__).resolve().parent / "_build_version.txt"
-_BUILD_VERSION_RE = re.compile(
-    r"^(?:develop|[0-9]{4}\.(?:0[1-9]|1[0-2])\."
-    r"(?:[0-9]{1,4}|(?:0[1-9]|[12][0-9]|3[01])\."
-    r"[0-9]{1,8}-[0-9a-f]{7}))$"
+_BUILD_VERSION_PATTERN = (
+    r"(?:develop|[0-9]{4}\.(?:0[1-9]|1[0-2])\."
+    r"(?:(?:0[1-9]|[12][0-9]|3[01])\."
+    r"[0-9]{1,8}-[0-9a-f]{7}|[0-9]{1,4}))"
+)
+_BUILD_VERSION_RE = re.compile(rf"^{_BUILD_VERSION_PATTERN}$")
+_BUILD_VERSION_IN_TEXT_RE = re.compile(
+    rf"(?<![A-Za-z0-9_.-]){_BUILD_VERSION_PATTERN}"
+    rf"(?![A-Za-z0-9_-]|\.[A-Za-z0-9_-])"
 )
 
 
 def is_valid_build_version(value: object) -> bool:
     """Return whether *value* is a supported release or CI build identifier."""
     return isinstance(value, str) and bool(_BUILD_VERSION_RE.fullmatch(value.strip()))
+
+
+def find_valid_build_versions(text: str) -> tuple[str, ...]:
+    """Return unique supported build identifiers embedded in ``text``."""
+    return tuple(
+        dict.fromkeys(
+            match.group(0) for match in _BUILD_VERSION_IN_TEXT_RE.finditer(text)
+        )
+    )
 
 
 def get_api_version() -> str:

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -255,6 +255,27 @@ def test_scrub_context_preserves_valid_ci_build_versions():
     assert secret not in unsafe["api_version"]
 
 
+def test_scrub_text_preserves_valid_ci_build_version():
+    from api.feedback_scrub import scrub_text
+
+    build_version = "2026.07.13.12345678-deadbee"
+    secret = "sk-abcdefghijklmnopqrstuvwxyz123456"
+    cleaned = scrub_text(f"app_version={build_version}\napi_key={secret}")
+
+    assert build_version in cleaned
+    assert secret not in cleaned
+
+
+def test_scrub_text_redacts_invalid_build_like_long_value():
+    from api.feedback_scrub import scrub_text
+
+    invalid_value = "2026.07.13.12345678-deadbeeX"
+    cleaned = scrub_text(f"app_version={invalid_value}")
+
+    assert invalid_value not in cleaned
+    assert "[redacted-number]" in cleaned
+
+
 # ---------------------------------------------------------------------------
 # DB-backed fixture
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve canonical release and CI build identifiers in public feedback environment metadata
- keep generic PII and secret redaction intact
- reject malformed build-like long values so they cannot bypass numeric redaction

## Root cause
The final public-body scrub treated a valid CI build identifier as a long number. `scrub_context` had already validated it, but the second scrub replaced its numeric portion with `[redacted-number]`.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_feedback.py tests\test_version.py -v`