### PR TITLE
Fix date-dependent AI plan validation test

### DIFF
--- a/tests/test_ai_plan.py
+++ b/tests/test_ai_plan.py
@@ -58,7 +58,9 @@ def _make_plan(days: int = 28, start: date | None = None, **overrides) -> list[d
 class TestValidatePlan:
     def test_valid_plan(self, sample_context):
         from api.ai import validate_plan
-        plan = _make_plan(28)
+        today = date.today()
+        next_monday = today + timedelta(days=(-today.weekday()) % 7)
+        plan = _make_plan(28, start=next_monday)
         valid, errors = validate_plan(plan, sample_context)
         assert valid, f"Expected valid plan, got errors: {errors}"
 


### PR DESCRIPTION
## Summary
- Start the valid 28-day AI-plan fixture on the next ISO Monday.
- Keep every six-or-more-day validation week paired with its planned rest day, independent of the day CI runs.

## Validation
- `D:\dev\tf-personal-pensieve\praxys\.venv\Scripts\python.exe -m pytest tests\ -q`
