### PR TITLE
Separate frontend and backend App Insights trust boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,18 +68,19 @@ PRAXYS_LOCAL_ENCRYPTION_KEY=
 # Leave unset in local dev to use the app's detected callback route.
 # PRAXYS_STRAVA_REDIRECT_URI=https://your-api.example.com/api/settings/connections/strava/callback
 
-# Optional: Azure Application Insights connection string for production
+# Optional: backend-only Azure Application Insights routing for production
 # observability (traces, metrics, logs). When set, the app auto-ships
-# per-request timings + DB dependency spans + Python logs to the
-# configured App Insights resource. Leave unset locally — app runs fine
-# without it. Copy from the "Connection String" field on the Overview
-# blade of your Application Insights resource in the Azure portal.
+# per-request timings + DB dependency spans + Python logs to that component.
+# Leave unset locally — app runs fine without it.
 #
 # On Azure App Service, the server authenticates to App Insights via the
 # App Service's system-assigned managed identity (no secret in app
-# settings); the connection string is only used for routing. The MI must
-# hold the "Monitoring Metrics Publisher" role on the AI resource — see
-# docs/perf-baselines/azure-provisioning.md.
+# settings); the connection string is only used for routing. Production
+# resolves it from the backend component named in
+# .github/azure-observability.env. That component disables local auth so a
+# browser-held instrumentation key cannot forge trusted backend events. The
+# MI must hold "Monitoring Metrics Publisher" on that exact resource — see
+# docs/ops/config-and-secrets.md.
 # APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...;IngestionEndpoint=...
 
 # Optional: Azure OpenAI for LLM-generated bilingual insights (post-sync

--- a/.github/azure-observability.env
+++ b/.github/azure-observability.env
@@ -1,0 +1,5 @@
+AZURE_RESOURCE_GROUP=rg-trainsight
+AZURE_LOCATION=eastasia
+LOG_ANALYTICS_WORKSPACE=log-trainsight
+FRONTEND_APPINSIGHTS_NAME=appi-trainsight
+BACKEND_APPINSIGHTS_NAME=appi-praxys-backend

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -11,6 +11,8 @@ on:
       - 'data/science/**'
       - 'tests/**'
       - 'requirements.txt'
+      - 'scripts/appinsights_boundary.sh'
+      - '.github/azure-observability.env'
       - '.github/workflows/deploy-backend.yml'
     tags:
       - 'api-*'
@@ -38,6 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Load observability resource names
+        shell: bash
+        run: cat .github/azure-observability.env >> "$GITHUB_ENV"
+
       - name: Stamp build version
         # Write ``api/_build_version.txt`` so ``api.version.get_api_version()``
         # returns the deploy build instead of ``"develop"``. Mirrors the web
@@ -60,12 +66,15 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Enforce backend telemetry trust boundary
+        shell: bash
+        run: bash scripts/appinsights_boundary.sh backend-preflight
+
       - name: Sync App Service settings
         env:
           AZURE_AI_ENDPOINT: ${{ vars.AZURE_AI_ENDPOINT }}
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}
           KEY_VAULT_KEY_NAME: ${{ vars.KEY_VAULT_KEY_NAME }}
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
           PRAXYS_JWT_SECRET: ${{ secrets.PRAXYS_JWT_SECRET }}
           # Database (#360). When PRAXYS_DATABASE_URL is set the backend uses
           # PostgreSQL; empty/unset keeps the legacy SQLite file on /home/data,
@@ -120,7 +129,6 @@ jobs:
               AZURE_AI_ENDPOINT="${AZURE_AI_ENDPOINT}" \
               KEY_VAULT_URL="${KEY_VAULT_URL}" \
               KEY_VAULT_KEY_NAME="${KEY_VAULT_KEY_NAME}" \
-              APPLICATIONINSIGHTS_CONNECTION_STRING="${APPLICATIONINSIGHTS_CONNECTION_STRING}" \
               PRAXYS_JWT_SECRET="${PRAXYS_JWT_SECRET}" \
               PRAXYS_DATABASE_URL="${PRAXYS_DATABASE_URL}" \
               PRAXYS_DB_AUTH="${PRAXYS_DB_AUTH}" \
@@ -145,7 +153,8 @@ jobs:
               WEBSITES_PORT="8000" \
               DATA_DIR="/home/data" \
               SCM_DO_BUILD_DURING_DEPLOYMENT="true" \
-              WEBSITE_HTTPLOGGING_RETENTION_DAYS="3"
+              WEBSITE_HTTPLOGGING_RETENTION_DAYS="3" \
+            --output none
 
           # Always On keeps ONE warm container instead of stop/starting on idle.
           # Each recycle abandons the backend's DB connection pool as idle
@@ -157,6 +166,10 @@ jobs:
             --name trainsight-app \
             --resource-group rg-trainsight \
             --always-on true
+
+      - name: Cut over backend telemetry and alerts
+        shell: bash
+        run: bash scripts/appinsights_boundary.sh backend-cutover
 
       # NB: no pre-deploy on-demand DB snapshot. praxys-pg is a Burstable-tier
       # Flexible Server, which does not support customer on-demand backups; the

--- a/.github/workflows/deploy-frontend-appservice.yml
+++ b/.github/workflows/deploy-frontend-appservice.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - 'web/**'
       - 'frontend_server/**'
+      - 'scripts/appinsights_boundary.sh'
+      - '.github/azure-observability.env'
       - '.github/workflows/deploy-frontend-appservice.yml'
     tags:
       - 'web-*'
@@ -45,6 +47,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: Load observability resource names
+        shell: bash
+        run: cat .github/azure-observability.env >> "$GITHUB_ENV"
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve frontend telemetry resource
+        shell: bash
+        run: bash scripts/appinsights_boundary.sh frontend-resolve
 
       - uses: actions/setup-node@v6
         with:
@@ -78,7 +95,6 @@ jobs:
           npm run build
         env:
           VITE_API_URL: ${{ vars.VITE_API_URL }}
-          VITE_APPINSIGHTS_CONNECTION_STRING: ${{ vars.VITE_APPINSIGHTS_CONNECTION_STRING }}
           VITE_APP_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Stage deploy package
@@ -92,13 +108,6 @@ jobs:
           cp -r web/dist deploy-pkg/web/dist
           cp frontend_server/requirements-frontend.txt deploy-pkg/requirements.txt
           ls -R deploy-pkg | head -50
-
-      - name: Azure Login (OIDC)
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to praxys-frontend
         uses: azure/webapps-deploy@v3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -279,7 +279,11 @@ Repository → Settings → Secrets and variables → Actions → Variables tab.
 | Variable | Value |
 |--------|-------|
 | `VITE_API_URL` | `https://api.praxys.run` |
-| `VITE_APPINSIGHTS_CONNECTION_STRING` | App Insights connection string for browser RUM |
+
+Application Insights routing is not stored in GitHub variables. Both deploy
+workflows load the tracked resource names from `.github/azure-observability.env`
+and fetch the appropriate connection string through Azure OIDC. See
+[`docs/ops/config-and-secrets.md`](ops/config-and-secrets.md#application-insights-trust-boundary-417).
 
 **Setting up OIDC:**
 

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -11,9 +11,10 @@ The backend's App Service **application settings are owned by the deploy
 workflow**, not the portal. `.github/workflows/deploy-backend.yml` → *Sync App
 Service settings* runs `az webapp config appsettings set` on **every deploy**
 with a fixed list sourced from GitHub Actions secrets/variables (plus a few
-literals). **Editing those keys in the Azure Portal is transient — the next
-deploy overwrites them.** To change one permanently, update the GitHub
-secret/variable (or the workflow literal) and re-deploy.
+literals). The Application Insights routing string is the deliberate exception
+to the GitHub-value source: the workflow resolves it directly from the
+backend-only Azure component. **Editing these keys in the Azure Portal is
+transient — the next deploy overwrites them.**
 
 ## Where each thing lives
 
@@ -37,10 +38,8 @@ secret/variable (or the workflow literal) and re-deploy.
 | Variable | Purpose | Consumed by |
 |---|---|---|
 | `VITE_API_URL` (`https://api.praxys.run`) | API base baked into the SPA | `deploy-frontend-appservice.yml` build |
-| `VITE_APPINSIGHTS_CONNECTION_STRING` | Browser RUM | SPA build |
 | `AZURE_AI_ENDPOINT` | Azure OpenAI endpoint for insights, triage, i18n, and Agentic Workflows. Keep the trailing `/`; the agent workflows append `openai/v1`. | App Service setting + `i18n.yml` + Agentic Workflow `.md` sources |
 | `KEY_VAULT_URL` / `KEY_VAULT_KEY_NAME` | Key Vault + RSA key name | App Service setting |
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | App Insights routing | App Service setting |
 | `PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL` (`https://stperftrainsight.blob.core.windows.net`) | Private Blob store for feedback screenshots (keyless via MI) | App Service setting (backend) |
 | `PRAXYS_FEEDBACK_BLOB_CONTAINER` (`feedback-screenshots`) | Blob container for screenshots | App Service setting (backend) |
 | `PRAXYS_SMTP_HOST` / `PRAXYS_SMTP_PORT` / `PRAXYS_SMTP_USER` / `PRAXYS_SMTP_FROM` / `PRAXYS_SMTP_STARTTLS` | SMTP transport for verification + invitation emails (non-secret; the password is the secret above). **Optional.** | App Service setting (backend) |
@@ -48,11 +47,17 @@ secret/variable (or the workflow literal) and re-deploy.
 | `PRAXYS_DB_AUTH` (`entra` or unset) | Postgres auth mode: `entra` = AAD token via managed identity, no password. **Optional.** | App Service setting (backend) |
 | `PRAXYS_PG_SERVER` | Postgres Flexible Server name. **Reserved / currently unused** - the on-demand backup jobs it gated were removed (Burstable tier can't do on-demand backups; PITR covers backup). Kept for a future off-site backup job. | (reserved) |
 
+Application Insights resource names are tracked in
+`.github/azure-observability.env`, not repository variables. The deploy
+workflows use Azure OIDC to read each component's connection string at runtime;
+the frontend workflow receives only the frontend/RUM value.
+
 ### Azure App Service → Application settings (backend `trainsight-app`)
 Source of truth = `deploy-backend.yml`. Literals set inline: `DATA_DIR=/home/data`,
 `WEBSITES_PORT=8000`, `SCM_DO_BUILD_DURING_DEPLOYMENT=true`,
-`WEBSITE_HTTPLOGGING_RETENTION_DAYS=3`. Everything else comes from the
-secrets/variables above.
+`WEBSITE_HTTPLOGGING_RETENTION_DAYS=3`. `APPLICATIONINSIGHTS_CONNECTION_STRING`
+comes from `appi-praxys-backend` through `scripts/appinsights_boundary.sh`;
+everything else comes from the secrets/variables above.
 
 ### Azure Key Vault (`kv-trainsight`)
 - RSA key `trainsight-master-key` — the master key that wraps the per-user
@@ -65,12 +70,129 @@ Local only; never committed. See [`.env.example`](../../.env.example) for the fu
 annotated list. Minimum: `PRAXYS_LOCAL_ENCRYPTION_KEY` (Fernet); `PRAXYS_ENV=development`
 to boot without a JWT secret.
 
+### Application Insights trust boundary (#417)
+
+Both components store data in `log-trainsight`, but they have separate ingestion
+identities and resource IDs:
+
+| Component | Purpose | Ingestion auth | Exposed to browser |
+|---|---|---|---|
+| `appi-trainsight` | SPA page views, dependencies, exceptions, Web Vitals; homepage availability test | Local/instrumentation-key auth enabled | **Yes** — expected |
+| `appi-praxys-backend` | API requests/traces/logs, `praxys.*` product and Coach signals, backend alerts, API availability test | Entra-only (`DisableLocalAuth=true`) through `trainsight-app` MI | **No** |
+
+The existing `appi-trainsight` instrumentation key was already shipped in
+browser bundles, so it is permanently treated as untrusted RUM ingestion. The
+new backend component was created with a fresh key and immediately locked to
+Entra authentication. Sharing a Log Analytics workspace does not collapse the
+boundary: alerts and queries remain scoped to the component resource ID (or
+filter `_ResourceId` at workspace scope).
+
+#### One-time provisioning
+
+```bash
+RG=rg-trainsight
+WORKSPACE_ID=$(az monitor log-analytics workspace show \
+  -g "$RG" -n log-trainsight --query id -o tsv)
+
+# Existing frontend component: keep local auth enabled for the browser SDK.
+FRONTEND_ID=$(az resource show -g "$RG" -n appi-trainsight \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
+az resource update --ids "$FRONTEND_ID" \
+  --set properties.DisableLocalAuth=false \
+        tags.trustBoundary=frontend \
+        tags.managedBy=deploy-frontend-appservice
+
+# Backend-only component. Safe to re-run if it already exists by skipping create.
+az monitor app-insights component create \
+  -g "$RG" -a appi-praxys-backend -l eastasia \
+  --workspace "$WORKSPACE_ID" --kind web --application-type web
+BACKEND_ID=$(az resource show -g "$RG" -n appi-praxys-backend \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
+az resource update --ids "$BACKEND_ID" \
+  --set properties.DisableLocalAuth=true \
+        tags.trustBoundary=backend \
+        tags.managedBy=deploy-backend
+
+# The deploy identity is RG Contributor and cannot grant RBAC; an operator with
+# role-assignment permission performs this once.
+MI=$(az webapp identity show -g "$RG" -n trainsight-app \
+  --query principalId -o tsv)
+az role assignment create \
+  --assignee-object-id "$MI" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Monitoring Metrics Publisher" \
+  --scope "$BACKEND_ID"
+```
+
+Record only the five non-secret identifiers in
+`.github/azure-observability.env`. Do **not**
+create `APPLICATIONINSIGHTS_CONNECTION_STRING` or
+`VITE_APPINSIGHTS_CONNECTION_STRING` GitHub variables. On every deployment:
+
+1. `backend-preflight` confirms distinct resources, shared workspace linkage,
+   backend local-auth disabled, exact-resource MI RBAC, and a 401/403 response
+   when an anonymous forged `praxys.product_event` is sent with the backend
+   instrumentation key.
+2. The backend cutover updates the App Service routing plus all backend alert
+   scopes as one rollback-guarded operation.
+3. `frontend-resolve` refuses to build unless only the frontend component allows
+   local auth, then injects that frontend connection string into Vite.
+
+#### Verify production
+
+```bash
+set -a
+source .github/azure-observability.env
+set +a
+export GITHUB_ENV=$(mktemp)
+bash scripts/appinsights_boundary.sh backend-preflight
+
+BACKEND_ID=$(az resource show -g "$AZURE_RESOURCE_GROUP" \
+  -n "$BACKEND_APPINSIGHTS_NAME" \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
+az resource show --ids "$BACKEND_ID" \
+  --query "{workspace:properties.WorkspaceResourceId,localAuthDisabled:properties.DisableLocalAuth}" \
+  -o table
+az webapp config appsettings list -g "$AZURE_RESOURCE_GROUP" \
+  -n trainsight-app \
+  --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].name" -o tsv
+```
+
+The preflight's forged-event probe is the trust test: HTTP 401/403 proves that a
+browser possessing an instrumentation key cannot place
+`praxys.product_event` or `praxys.coach_feedback` into the backend component.
+The authenticated product API can still accept its documented enum payload,
+but the server owns the telemetry timestamp, pseudonym, provenance, and final
+dimensions.
+
+#### Rollback
+
+`backend-cutover` captures the prior App Service value, scheduled-query scopes,
+web-test link, and metric-alert component. Any failed mutation restores all of
+them automatically. To reverse a successful cutover, pause/revert the backend
+deploy workflow first (otherwise the next deploy re-applies the boundary), then
+run the rollback mode:
+
+```bash
+set -a
+source .github/azure-observability.env
+set +a
+bash scripts/appinsights_boundary.sh rollback-to-frontend
+```
+
+The reverse cutover atomically restores backend routing, all five scheduled
+queries, the API web-test hidden link, and its metric-alert component to
+`appi-trainsight`. It restores the previous shared-resource behavior and
+therefore removes the trust boundary; use it only as temporary telemetry
+recovery while fixing the backend component or RBAC.
+
 ## Adding a NEW backend setting (checklist)
 
 1. Read it in code via `os.environ` / `getenv_compat` (treat unset as a safe default).
 2. Add it to `.env.example` (annotated) for local dev.
 3. Add it to `deploy-backend.yml`: the `env:` block (from `secrets.*` or `vars.*`)
-   **and** the `az webapp config appsettings set` arg list.
+   **and** the `az webapp config appsettings set` arg list. Azure-derived routing
+   values such as Application Insights belong in a deployment helper instead.
 4. If it must be present, add it to the *required-settings* loop; if optional,
    **leave it out** of that loop so an unset value can't fail the deploy.
 5. Create the GitHub secret (sensitive) or variable (non-sensitive).
@@ -235,7 +357,7 @@ outgrown.
 | `PRAXYS_JWT_SECRET` | New `secrets.PRAXYS_JWT_SECRET`, re-deploy backend | **All active sessions invalidated** — every user must log in again. |
 | `WECHAT_MINIAPP_SECRET` | Rotate in mp.weixin.qq.com, update GitHub secret, re-deploy | Mini program auth briefly fails until deploy lands. |
 | `WECHAT_MINIAPP_UPLOAD_KEY` | Regenerate in mp.weixin.qq.com, update GitHub secret | Only affects mini program CI publishing. |
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Update variable, re-deploy | Telemetry routes to the new resource. |
+| Frontend/backend Application Insights routing | Provision the replacement component, update `.github/azure-observability.env`, grant backend MI RBAC if needed, and re-deploy | The workflows fetch fresh routing strings directly from Azure; no GitHub value rotates. |
 | Feedback GitHub App key (`PRAXYS_GITHUB_APP_PRIVATE_KEY`) | Generate a new private key on the app, update the secret, re-deploy (rarely needed). Setup: [setup-github-app.md](./setup-github-app.md). | Issue auto-filing dormant until updated; rest of app unaffected. |
 | SMTP auth code (`PRAXYS_SMTP_PASSWORD`) | Regenerate the 客户端授权码 in the Exmail/WeCom mailbox settings, update the GitHub secret, re-deploy. | Verification + invitation emails fail to send until updated (codes can still be copied by hand). |
 | Key Vault RSA key `trainsight-master-key` | ⚠️ **High-impact** — the per-user DEKs were wrapped with the current key; rotating without a re-wrap/re-encrypt migration makes stored platform credentials undecryptable. **TODO(@dddtc2005):** document the re-wrap drill before rotating. | Users would have to reconnect platforms. |
@@ -243,7 +365,8 @@ outgrown.
 ## Related
 
 - [deploy.md](./deploy.md) · [environment.md](./environment.md) · `docs/deployment.md`
-- `.github/workflows/deploy-backend.yml` (source of truth for App Service settings)
+- `.github/workflows/deploy-backend.yml` and `scripts/appinsights_boundary.sh`
+  (source of truth for App Service settings and telemetry routing)
 
 ---
-_Last reviewed: 2026-07-05 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-18 · Owner: @dddtc2005_

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -21,7 +21,9 @@
 | PostgreSQL (**primary DB**, live 2026-07-04) | `praxys-pg` Flexible Server (Burstable B1ms, PG16, DB `praxys`, Entra auth, PITR 14d) | [postgres-migration.md](./postgres-migration.md); `PRAXYS_PG_SERVER` var |
 | Key Vault | `kv-trainsight` (`https://kv-trainsight.vault.azure.net`) | live `KEY_VAULT_URL` |
 | — RSA key | `trainsight-master-key` | live `KEY_VAULT_KEY_NAME` |
-| Application Insights | connection string in app settings; MI-authenticated | `.env.example`, `api/main.py` |
+| Frontend Application Insights | `appi-trainsight` (Application ID `d10e388f-3a26-4c3d-b57d-d83fc4637a9b`; browser/RUM, local auth enabled) | `.github/azure-observability.env` |
+| Backend Application Insights | `appi-praxys-backend` (Application ID `066f94a3-a340-498d-9ee1-6f093a7b8911`; managed-identity ingestion, local auth disabled) | `.github/azure-observability.env`, `scripts/appinsights_boundary.sh` |
+| Log Analytics workspace | `log-trainsight` (shared storage; queries must retain component scope / `_ResourceId`) | `.github/azure-observability.env` |
 | Perf-baseline storage | `stperftrainsight` (RG `rg-trainsight`, East Asia) | `docs/perf-baselines/ci-setup.md` |
 | CI/deploy app registration | `trainsight-cicd` — appId `d3deb736-e95d-400e-b5a5-c2f76b23ae25` (OIDC federated creds `github-deploy`, `i18n`) | live `az ad app` |
 
@@ -34,10 +36,13 @@
 
 ## Identity & auth model
 
-- **App → Key Vault / App Insights:** the backend App Service uses its
+- **App → Key Vault / backend App Insights:** the backend App Service uses its
   **system-assigned managed identity** (no secret in app settings). The MI holds
-  *Key Vault Crypto User* (key wrap/unwrap) and *Monitoring Metrics Publisher*.
-  See `api/main.py` (managed-identity wiring) and `.env.example`.
+  *Key Vault Crypto User* (key wrap/unwrap) and *Monitoring Metrics Publisher*
+  on `appi-praxys-backend`. That component disables local authentication; the
+  public browser connection string points only to `appi-trainsight`.
+  See `api/main.py`, `.github/azure-observability.env`, and
+  `scripts/appinsights_boundary.sh`.
 - **GitHub Actions → Azure:** OIDC federated credentials on `trainsight-cicd`
   (tenant `bd18218b-ffc1-4eef-b717-fb07368336c0`, application
   `d3deb736-e95d-400e-b5a5-c2f76b23ae25`; subjects
@@ -72,4 +77,4 @@
 - `docs/deployment.md` (one-time Azure setup) · `docs/perf-baselines/azure-provisioning.md`
 
 ---
-_Last reviewed: 2026-07-05 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-18 · Owner: @dddtc2005_

--- a/docs/ops/incident-response.md
+++ b/docs/ops/incident-response.md
@@ -67,7 +67,7 @@ that ceiling new app logins are refused and every data endpoint 500s.
 ```bash
 az postgres flexible-server show -g rg-trainsight -n praxys-pg --query state -o tsv   # usually "Ready" — it is a client-side connection problem
 az monitor metrics list --resource "$PG" --metric active_connections --interval PT1M --aggregation Maximum --query "value[0].timeseries[0].data[-10:]" -o json   # pegged near 50?
-az monitor app-insights query --app appi-trainsight --analytics-query "exceptions | where timestamp > ago(1h) | where outerMessage has 'remaining connection slots' | count"
+az monitor app-insights query --app appi-praxys-backend --analytics-query "exceptions | where timestamp > ago(1h) | where outerMessage has 'remaining connection slots' | count"
 ```
 
 **Mitigate — in order:**

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -7,21 +7,35 @@
 
 ## Telemetry model
 
-The backend ships traces, request/dependency timings, and Python logs to
-**Application Insights** automatically when `APPLICATIONINSIGHTS_CONNECTION_STRING`
-is set (it is in prod; on App Service the app authenticates via its managed
-identity — see `api/main.py`). Raw user ids are never emitted: custom signals use
-a SHA-256 pseudonym. Product events carry only allowlisted enums and build/surface
-metadata. The one free-text field, an optional Coach-feedback comment, is
-PII/secret-scrubbed, whitespace-collapsed, and truncated to 120 characters before
-it reaches telemetry; the raw comment is never persisted or logged.
+Production has two workspace-linked Application Insights components with
+different trust levels:
+
+| Component | Data | Trust / auth |
+|---|---|---|
+| `appi-trainsight` | Browser page views, exceptions, dependencies, Web Vitals; homepage availability test | Untrusted RUM. Local/instrumentation-key auth is enabled because the connection string ships in the SPA. |
+| `appi-praxys-backend` | API requests/traces/logs, every `praxys.*` signal, backend alerts, API availability test | Trusted server emission. Local auth is disabled; `trainsight-app` must present its managed identity. |
+
+Both write to `log-trainsight`, so a workspace query can see both. The trust
+boundary is the component resource ID: keep alert scopes component-specific and
+filter `_ResourceId` when querying the workspace directly.
+
+The backend ships telemetry automatically when
+`APPLICATIONINSIGHTS_CONNECTION_STRING` is set (it is resolved from
+`appi-praxys-backend` by the deploy workflow; on App Service the SDK
+authenticates via managed identity — see `api/main.py`). Raw user ids are never
+emitted: custom signals use a SHA-256 pseudonym. Product events carry only
+allowlisted enums and build/surface metadata. The one free-text field, an
+optional Coach-feedback comment, is PII/secret-scrubbed, whitespace-collapsed,
+and truncated to 120 characters before it reaches telemetry; the raw comment is
+never persisted or logged.
 
 Custom signals are emitted by `api/telemetry.py`. Each lands as either:
 - a **customEvent** with that name through the required
   `azure-monitor-events-extension` runtime dependency, **or**
 - a **customMetric** counter when the extension is unavailable at runtime.
 
-Queries below `union` both shapes so they remain valid during fallback.
+Queries below `union` both shapes so they remain valid during fallback. All
+custom signals in the table below belong to `appi-praxys-backend`.
 
 ## Signals
 
@@ -49,6 +63,13 @@ Queries below `union` both shapes so they remain valid during fallback.
 
 ## Querying (Logs blade → KQL)
 
+Run backend requests, traces, logs, and `praxys.*` queries from
+`appi-praxys-backend`. Run browser `pageViews`, client exceptions/dependencies,
+and `WebVitals.*` from `appi-trainsight`. There are currently **no live Azure
+Workbook resources**; these checked-in queries are the product-measurement
+source of truth. Any future saved workbook must pin each query to the component
+named above or explicitly use a cross-resource `app(...)` query.
+
 Daily LLM token spend by surface:
 ```kql
 customMetrics
@@ -67,7 +88,8 @@ customMetrics | where name == "praxys.coach_run"
 | extend hit_rate = todouble(hits) / total
 ```
 
-Active users (DAU / WAU) of registered accounts. The SPA tags telemetry with
+In **`appi-trainsight`**, active users (DAU / WAU) of registered accounts. The
+SPA tags telemetry with
 `user_AuthenticatedId` = a SHA-256(user_id)[:16] pseudonym (set on login by
 `web/src/lib/appinsights.ts`, matching `api/telemetry.py::hash_user_id`), so this
 counts distinct *registered* users — not anonymous browsers — and correlates with
@@ -92,11 +114,30 @@ pageViews
 `praxys.product_event` is emitted by both clients through the authenticated
 `POST /api/product-events` endpoint. The server supplies the timestamp and user
 pseudonym; clients may send only the documented event/response enums — never
-health values, recommendation prose, email, OpenID, or raw ids. Because browser
-RUM currently shares the App Insights resource, these analytics are directional
-product signals rather than tamper-resistant audit or billing data; production
-should use a separate backend-only telemetry resource before treating them as
-adversarially trustworthy.
+health values, recommendation prose, email, OpenID, or raw ids. The resulting
+event is emitted only to `appi-praxys-backend`, where local authentication is
+disabled. A browser can call the documented product endpoint, but it cannot use
+an exposed instrumentation key to forge event names, timestamps, user hashes,
+Coach provenance, or arbitrary dimensions in the trusted component.
+
+The cutover occurred on 2026-07-18. Historical product/Coach events in
+`appi-trainsight` remain **legacy shared-ingestion data** and must not be
+silently mixed with trusted data. A continuity workbook may query both
+Application IDs, but keep the trust epoch visible:
+
+```kql
+let trusted = app("066f94a3-a340-498d-9ee1-6f093a7b8911").customEvents
+  | where name in ("praxys.product_event", "praxys.coach_feedback")
+  | extend trust_epoch = "backend_enforced";
+let legacy = app("d10e388f-3a26-4c3d-b57d-d83fc4637a9b").customEvents
+  | where name in ("praxys.product_event", "praxys.coach_feedback")
+  | extend trust_epoch = "legacy_shared";
+union trusted, legacy
+| summarize events=count() by trust_epoch, name, bin(timestamp, 1d)
+```
+
+Run the product and Coach queries below in **`appi-praxys-backend`** for
+post-cutover trusted measurement.
 
 Clients first reserve a two-minute render window through
 `POST /api/product-events/today-feedback-claim`. After the prompt is onscreen,
@@ -292,16 +333,16 @@ Every rule below lives in `rg-trainsight` (region **eastasia**) and routes to th
 `praxys-feedback-ag` action group (→ `support@praxys.run`). Costs are the eastasia
 retail rate per the [cost model](#alert-cost-model) below.
 
-| Rule | Type | Watches | Eval | Sev | ~USD/mo |
-|---|---|---|---|---|---|
-| `praxys-db-health-unhealthy` | log | `praxys.db_health` failure (corrupt/unreachable DB) | 5 min | 1 | **1.50** |
-| `praxys-pg-connections-high` | metric | `praxys-pg` `active_connections` avg > 40 | 5 min | 2 | ~0.10 |
-| `wt-praxys-homepage` | metric (web test) | `https://www.praxys.run/` reachable | 1 min | 1 | ~0.10 |
-| `wt-praxys-api-health` | metric (web test) | `.../api/health` reachable | 1 min | 1 | ~0.10 |
-| `praxys-feedback-needs-review` | log | `praxys.feedback` `status == needs_review` | 15 min | 3 | 0.50 |
-| `praxys-today-latency-regression` | log | `GET /api/today` avg latency > 3000 ms | 1 h | 3 | 0.50 |
-| `praxys-sync-systemic-failures` | log | `praxys.sync` — ≥5 distinct users hit a systemic `failure_class` for one platform / 15 min | 15 min | 2 | 0.50 |
-| `praxys-connect-systemic-failures` | log | `praxys.connection` — ≥5 distinct users fail connect with a systemic class / 15 min | 15 min | 2 | 0.50 |
+| Rule | Type | Scope | Watches | Eval | Sev | ~USD/mo |
+|---|---|---|---|---|---|---|
+| `praxys-db-health-unhealthy` | log | `appi-praxys-backend` | `praxys.db_health` failure (corrupt/unreachable DB) | 5 min | 1 | **1.50** |
+| `praxys-pg-connections-high` | metric | `praxys-pg` | `active_connections` avg > 40 | 5 min | 2 | ~0.10 |
+| `wt-praxys-homepage` | metric (web test) | `appi-trainsight` + homepage test | `https://www.praxys.run/` reachable | 1 min | 1 | ~0.10 |
+| `wt-praxys-api-health` | metric (web test) | `appi-praxys-backend` + API test | `.../api/health` reachable | 1 min | 1 | ~0.10 |
+| `praxys-feedback-needs-review` | log | `appi-praxys-backend` | `praxys.feedback` `status == needs_review` | 15 min | 3 | 0.50 |
+| `praxys-today-latency-regression` | log | `appi-praxys-backend` | `GET /api/today` avg latency > 3000 ms | 1 h | 3 | 0.50 |
+| `praxys-sync-systemic-failures` | log | `appi-praxys-backend` | `praxys.sync` — ≥5 distinct users hit a systemic `failure_class` for one platform / 15 min | 15 min | 2 | 0.50 |
+| `praxys-connect-systemic-failures` | log | `appi-praxys-backend` | `praxys.connection` — ≥5 distinct users fail connect with a systemic class / 15 min | 15 min | 2 | 0.50 |
 
 **Total ≈ 3.5–3.8 USD/mo** (the three metric alerts may fall inside the small free
 allotment, making the effective figure closer to the 3.50 log-alert subtotal).
@@ -314,7 +355,8 @@ platform in 15 min — the distinct-user gate is what separates a fleet-wide bre
 (platform outage, Cloudflare block, a regression like #369) from one user's wrong
 password. Both use the *systemic vs individual* KQL above (with the
 `union (customMetrics),(customEvents)` dual-path), `Count > 0`, and the
-`praxys-feedback-ag` action group.
+`praxys-feedback-ag` action group. `scripts/appinsights_boundary.sh` keeps both
+rules scoped to `appi-praxys-backend` on every backend deployment.
 
 > **Dormant until deploy.** The `praxys.sync` / `praxys.connection` signals ship in
 > the PR that added these rules; until it deploys there is no data, so the rules
@@ -328,9 +370,9 @@ password. Both use the *systemic vs individual* KQL above (with the
 Verify the live state at any time:
 ```bash
 az monitor scheduled-query list -g rg-trainsight \
-  --query "[].{name:name,enabled:enabled,sev:severity,freq:evaluationFrequency,hasAG:length(actions.actionGroups)}" -o table
+  --query "[].{name:name,scope:scopes[0],enabled:enabled,sev:severity,freq:evaluationFrequency,hasAG:length(actions.actionGroups)}" -o table
 az monitor metrics alert list -g rg-trainsight \
-  --query "[].{name:name,enabled:enabled,sev:severity,freq:evaluationFrequency,hasAG:length(actions)}" -o table
+  --query "[].{name:name,scopes:scopes,enabled:enabled,sev:severity,freq:evaluationFrequency,hasAG:length(actions)}" -o json
 ```
 
 ## Alert cost model
@@ -405,7 +447,8 @@ When you add or change a feature, treat monitoring as part of "done":
 ## Create an alert (general recipe)
 
 1. **Application Insights → Monitoring → Alerts → Create → Alert rule.**
-2. **Scope:** the Praxys Application Insights resource (or `praxys-pg` for DB metrics).
+2. **Scope:** `appi-praxys-backend` for server signals,
+   `appi-trainsight` for browser RUM, or `praxys-pg` for DB metrics.
 3. **Condition → Custom log search:** paste a KQL query that returns rows only
    when you want to fire. Measurement = **Number of results**, **> 0**. Choose the
    evaluation frequency with the cost model in mind (15 min is the log floor; go to
@@ -460,7 +503,8 @@ union isfuzzy=true
 
 Recreate it with (collapse the KQL above onto one line as `<KQL>`):
 ```bash
-AI=$(az monitor app-insights component show -g rg-trainsight --query "[0].id" -o tsv)
+AI=$(az resource show -g rg-trainsight -n appi-praxys-backend \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
 AG=$(az monitor action-group show -g rg-trainsight -n praxys-feedback-ag --query id -o tsv)
 az monitor scheduled-query create -g rg-trainsight -n praxys-db-health-unhealthy --scopes "$AI" --condition "count 'q' > 0" --condition-query "q=<KQL>" --evaluation-frequency 5m --window-size 5m --severity 1 --action-groups "$AG"
 ```
@@ -502,7 +546,8 @@ requests
 ```
 
 ```bash
-AI=$(az monitor app-insights component show -g rg-trainsight --query "[0].id" -o tsv)
+AI=$(az resource show -g rg-trainsight -n appi-praxys-backend \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
 AG=$(az monitor action-group show -g rg-trainsight -n praxys-feedback-ag --query id -o tsv)
 az monitor scheduled-query create -g rg-trainsight -n praxys-today-latency-regression --scopes "$AI" --condition "count 'q' > 0" --condition-query "q=<KQL>" --evaluation-frequency 1h --window-size 24h --severity 3 --action-groups "$AG"
 ```
@@ -516,10 +561,10 @@ has an auto-created **metric alert** (Sev 1, `praxys-feedback-ag`) that fires wh
 **≥1 location** reports failure. This is black-box coverage that complements the
 inside-the-process db-health / readiness probes.
 
-| Web test | Target |
-|---|---|
-| `wt-praxys-homepage` | `https://www.praxys.run/` |
-| `wt-praxys-api-health` | `https://trainsight-app.azurewebsites.net/api/health` |
+| Web test | Component | Target |
+|---|---|---|
+| `wt-praxys-homepage` | `appi-trainsight` | `https://www.praxys.run/` |
+| `wt-praxys-api-health` | `appi-praxys-backend` | `https://trainsight-app.azurewebsites.net/api/health` |
 
 Standard web-test execution is **0.00** in eastasia (free grant); the two alerts
 are cheap metric alerts. **Keep each web test and its alert in the same enabled
@@ -529,7 +574,12 @@ state** — a probe that runs while its alert is disabled pays to watch nothing
 
 ## Rollback / Recovery
 
-Alerts are non-destructive — disable or delete the rule to stop notifications.
+`scripts/appinsights_boundary.sh backend-cutover` restores the prior App Service
+routing, scheduled-query scopes, API web-test hidden link, and metric-alert
+component if any step fails. For an operator-requested reverse migration,
+`rollback-to-frontend` moves the same complete set back to `appi-trainsight`.
+Alerts are otherwise non-destructive — disable or delete the rule to stop
+notifications.
 To cut cost, remember the log floor: dropping a log alert below 15 min is the only
 frequency change that saves money; slowing one past 15 min saves nothing. To cut
 noise, tune the window/threshold rather than deleting. Update the inventory table
@@ -541,4 +591,4 @@ after any change.
 - In-app: Admin → User Feedback (badge + Approve/Retry/Reject).
 
 ---
-_Last reviewed: 2026-07-05 · Owner: @dddtc2005 · Alert inventory + cost model current as of this review._
+_Last reviewed: 2026-07-18 · Owner: @dddtc2005 · Alert inventory + cost model current as of this review._

--- a/docs/perf-baselines/README.md
+++ b/docs/perf-baselines/README.md
@@ -12,7 +12,7 @@ Mainland-China users cross the Great Firewall to hit our Azure East Asia deploym
 |---|---|---|---|
 | **Lab synthetic** | Catch code regressions in controlled conditions | Lighthouse CI in GitHub Actions | On every `web/**` PR (added in a later phase) |
 | **Multi-region synthetic** | Ground truth for each phase's delta | **sitespeed.io** — local Docker for CN probes, ACI on demand for `eastasia` / `westus` / `northeurope` (see runners below); **WebPageTest** as a fallback if sitespeed breaks | Before & after each phase merges |
-| **Production RUM** | Real user experience over time | Azure Application Insights (wired in `api/main.py` + `web/src/lib/appinsights.ts`) | Continuous, once `APPLICATIONINSIGHTS_CONNECTION_STRING` is set |
+| **Production RUM** | Real user experience over time | Frontend Azure Application Insights `appi-trainsight` (`web/src/lib/appinsights.ts`); backend telemetry is isolated in `appi-praxys-backend` | Continuous after the deploy workflows resolve both components |
 
 Azure Availability Tests (cheap URL pings from multiple Azure regions) provide an always-on uptime + TTFB baseline — see [`azure-provisioning.md`](./azure-provisioning.md) to set them up.
 

--- a/docs/perf-baselines/azure-provisioning.md
+++ b/docs/perf-baselines/azure-provisioning.md
@@ -1,30 +1,57 @@
 # Azure provisioning for observability
 
-One-time steps to stand up the Azure resources that make the RUM fabric work. After these, redeploy frontend + backend once and data starts flowing.
+One-time steps to stand up the Azure resources that make the RUM fabric work.
+Production uses separate frontend and backend Application Insights components;
+the canonical names live in `.github/azure-observability.env`.
 
-**Prereqs:** you already have the App Service (`trainsight-app` in `rg-trainsight`) and the Static Web App live.
+**Prereqs:** you already have the App Services (`trainsight-app` and
+`praxys-frontend` in `rg-trainsight`) plus the `log-trainsight` Log Analytics
+workspace.
 
 ## Auth model summary
 
-Two different auth paths in the same fabric, and that's intentional:
+Two different auth paths and components in the same workspace, and that is
+intentional:
 
-- **Backend → App Insights:** App Service system-assigned **managed identity**. No secret in app settings; the `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is only used for routing (endpoint URL). Steps 2 + 4 below.
-- **Browser → App Insights:** build-time-embedded **connection string** as a write-only ingestion token (Microsoft's intended pattern — no MI flow exists for browsers). Step 5 below.
+- **Backend → `appi-praxys-backend`:** App Service system-assigned **managed
+  identity**. Local authentication is disabled, so a browser-held
+  instrumentation key cannot forge backend product or Coach events.
+- **Browser → `appi-trainsight`:** build-time-embedded connection string as a
+  write-only ingestion token (Microsoft's intended pattern — no MI flow exists
+  for browsers). This component is treated as untrusted RUM.
 
-Because the browser path needs ingestion-key auth, the App Insights resource **must leave local authentication enabled** (step 1d). Granting the backend a Monitor-Publisher role alongside doesn't weaken that; both paths coexist.
+Both components link to `log-trainsight`; component IDs and alert scopes preserve
+the trust boundary inside the shared workspace.
 
-## 1. Create the Application Insights resource
+## 1. Create the Application Insights resources
 
-1. Azure Portal → **Create a resource** → search **Application Insights** → Create.
-2. Settings:
-   - **Name:** `praxys-appinsights` (or your preference)
-   - **Region:** **East Asia** (same as App Service — minimises ingestion latency)
-   - **Resource group:** `rg-trainsight`
-   - **Resource mode:** **Workspace-based** (the only supported mode — picks or creates a Log Analytics workspace)
-   - **Log Analytics workspace:** create new `praxys-logs` in East Asia, or reuse an existing one
-3. Review + Create.
-4. Once deployed, open the resource → **Properties** blade → confirm **Local Authentication** is **Enabled**. Leave it as-is. (Disabling it would force AAD-only ingestion, which breaks the browser SDK — see auth model summary above.)
-5. Open **Overview** → copy the **Connection String** (a long `InstrumentationKey=...;IngestionEndpoint=...;...` blob). You'll paste it into App Service and GitHub in the next steps.
+```bash
+RG=rg-trainsight
+WORKSPACE_ID=$(az monitor log-analytics workspace show \
+  -g "$RG" -n log-trainsight --query id -o tsv)
+
+# Frontend/RUM component. Existing production name is legacy but intentional.
+az monitor app-insights component create \
+  -g "$RG" -a appi-trainsight -l eastasia \
+  --workspace "$WORKSPACE_ID" --kind web --application-type web
+FRONTEND_ID=$(az resource show -g "$RG" -n appi-trainsight \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
+az resource update --ids "$FRONTEND_ID" \
+  --set properties.DisableLocalAuth=false tags.trustBoundary=frontend
+
+# Backend-only component.
+az monitor app-insights component create \
+  -g "$RG" -a appi-praxys-backend -l eastasia \
+  --workspace "$WORKSPACE_ID" --kind web --application-type web
+BACKEND_ID=$(az resource show -g "$RG" -n appi-praxys-backend \
+  --resource-type Microsoft.Insights/components --query id -o tsv)
+az resource update --ids "$BACKEND_ID" \
+  --set properties.DisableLocalAuth=true tags.trustBoundary=backend
+```
+
+Skip a `create` command when that component already exists. Do not copy either
+connection string into GitHub settings; the deploy workflows fetch them through
+Azure OIDC.
 
 ## 2. Enable system-assigned managed identity on App Service
 
@@ -32,51 +59,52 @@ Because the browser path needs ingestion-key auth, the App Insights resource **m
 2. **System assigned** tab → Status: **On** → Save → confirm.
 3. Once enabled, the portal shows an **Object (principal) ID** — you'll need it in step 3. (The UI also offers direct "Azure role assignments" as a shortcut; step 3 uses the App Insights side of the assignment, which is simpler to reason about.)
 
-## 3. Grant the App Service MI the Monitoring Metrics Publisher role on App Insights
+## 3. Grant the App Service MI access to the backend component
 
-1. Azure Portal → Application Insights `praxys-appinsights` → **Access control (IAM)** → **Add** → **Add role assignment**.
+1. Azure Portal → Application Insights `appi-praxys-backend` → **Access control (IAM)** → **Add** → **Add role assignment**.
 2. **Role:** search for **Monitoring Metrics Publisher** → Next.
 3. **Members:** **Managed identity** → **Select members** → App Service → `trainsight-app` → Select → Next.
 4. Review + assign.
 5. Propagation usually takes <60s; give it a minute before redeploying.
 
-## 4. Wire the routing endpoint into App Service (backend)
+CLI equivalent:
 
-Even with MI auth, the backend still needs to know _where_ to send telemetry — that's what the connection string is for.
-
-1. App Service `trainsight-app` → **Settings** → **Environment variables** (or **Configuration** → **Application settings** on older portal UI).
-2. Add:
-   - **Name:** `APPLICATIONINSIGHTS_CONNECTION_STRING`
-   - **Value:** the connection string from step 1.5
-3. **Save** → confirm restart.
-
-`api/main.py` detects that `WEBSITE_SITE_NAME` is set (→ we're on App Service) and calls `configure_azure_monitor(credential=ManagedIdentityCredential())`. The InstrumentationKey portion of the env var is used only to route; auth is an AAD token from the MI.
+```bash
+MI=$(az webapp identity show -g rg-trainsight -n trainsight-app \
+  --query principalId -o tsv)
+az role assignment create \
+  --assignee-object-id "$MI" \
+  --assignee-principal-type ServicePrincipal \
+  --role "Monitoring Metrics Publisher" \
+  --scope "$BACKEND_ID"
+```
 
 > If you ever switch to user-assigned MI: also add `AZURE_CLIENT_ID` to app settings with the UAMI's client ID. The code picks it up automatically.
 
-## 5. Wire the connection string into GitHub (frontend)
+## 4. Let deployment own routing
 
-The frontend value is a **repository variable**, not a secret — connection strings are write-only ingestion tokens and ship in every client bundle by design. Browsers have no MI path, so this is the correct pattern (see auth model summary above and the comment at the top of `web/src/lib/appinsights.ts`).
+Keep these names in `.github/azure-observability.env`. The backend workflow
+fetches `appi-praxys-backend`'s connection string, verifies Entra-only
+ingestion/RBAC, and writes the App Service setting. The frontend workflow fetches
+only `appi-trainsight` and injects it into Vite. Do not create
+`APPLICATIONINSIGHTS_CONNECTION_STRING` or
+`VITE_APPINSIGHTS_CONNECTION_STRING` repository variables.
 
-1. GitHub → `praxys-run/praxys` → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab.
-2. **New repository variable:**
-   - **Name:** `VITE_APPINSIGHTS_CONNECTION_STRING`
-   - **Value:** the same connection string from step 1.5
-3. Save.
+`api/main.py` uses `ManagedIdentityCredential`; the backend connection string
+selects the endpoint/component but does not authenticate the exporter.
 
-The `.github/workflows/deploy-frontend.yml` workflow already references this variable in its `env:` block — the next deploy picks it up automatically.
+## 5. Kick a redeploy
 
-## 6. Kick a redeploy
+Merge a change touching `.github/azure-observability.env`,
+`scripts/appinsights_boundary.sh`, or either deploy workflow. Both deploys will
+run.
 
-Easiest: push any small change that triggers both workflows, or manually trigger them via **Actions** tab → select workflow → **Run workflow** (the deploy backend workflow doesn't have a manual trigger yet, so the push route is simpler).
-
-## 7. Verify data is flowing
+## 6. Verify data is flowing
 
 Wait 2–5 minutes after the deploys finish, then:
 
 1. Browse the production site once — hit the homepage, log in, open Today, navigate to Training.
-2. Azure Portal → Application Insights `praxys-appinsights` → **Investigate** → **Live Metrics**. You should see the request come through in near real-time.
-3. **Logs** blade, run:
+2. In `appi-trainsight` → **Logs**, run:
    ```kusto
    customMetrics
    | where name startswith "WebVitals."
@@ -84,7 +112,7 @@ Wait 2–5 minutes after the deploys finish, then:
    | take 20
    ```
    You should see FCP / LCP / INP / CLS / TTFB events with `netinfo_effectiveType` / `netinfo_downlink` / `netinfo_rtt` in `customDimensions`. The telemetry initializer prefixes these with `netinfo_` to avoid shadowing SDK-native envelope fields — see the module header in `web/src/lib/appinsights.ts`.
-4. Confirm server-side:
+3. In `appi-praxys-backend` → **Logs**, confirm server-side:
    ```kusto
    requests
    | where timestamp > ago(15m)
@@ -93,9 +121,22 @@ Wait 2–5 minutes after the deploys finish, then:
    | take 20
    ```
 
-If either side is empty after 10 minutes, check: env-var name spelling, workflow ran & succeeded, Python package install included `azure-monitor-opentelemetry`, MI role assignment propagated (check `AZ-ARM` logs if a `401` shows up on the exporter side), and — for the frontend — that the connection string made it into the built bundle (search `dist/assets/*.js` for the ingestion endpoint hostname).
+4. Re-run the enforced trust probe:
+   ```bash
+   set -a
+   source .github/azure-observability.env
+   set +a
+   GITHUB_ENV=$(mktemp) bash scripts/appinsights_boundary.sh backend-preflight
+   ```
+   It must observe HTTP 401/403 when it attempts an anonymous forged
+   `praxys.product_event`.
 
-## 8. Create Standard availability tests
+If either side is empty after 10 minutes, check the workflow, workspace linkage,
+the exact-resource MI role assignment, and — for the frontend — that the
+connection string made it into the built bundle (search `dist/assets/*.js` for
+the ingestion endpoint hostname).
+
+## 7. Create Standard availability tests
 
 Always-on uptime + TTFB trend from Azure POPs. Free-ish (a few cents per month per test at 5-min cadence). Use **Standard tests**; the legacy "URL ping test" is retiring 30 Sept 2026.
 
@@ -115,7 +156,7 @@ After 15 minutes you'll have first data points; after 24 hours you'll have usabl
 
 **Note:** Azure has no mainland China POPs, so these tests run from Hong Kong at closest. They complement but don't replace the WebPageTest probes run from inside mainland China — see `scripts/run-baseline.md`.
 
-## 9. (Later) Dashboards
+## 8. (Later) Dashboards
 
 Once data's flowing, build an Azure Workbook that pivots by:
 - `customDimensions.netinfo_effectiveType` — 4g / 3g / slow-2g / wifi (note the prefix — `effectiveType` on its own won't match)

--- a/scripts/appinsights_boundary.sh
+++ b/scripts/appinsights_boundary.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly BACKEND_APP_SERVICE="trainsight-app"
+readonly API_WEBTEST_NAME="wt-praxys-api-health"
+readonly BACKEND_ALERT_NAMES=(
+  "praxys-db-health-unhealthy"
+  "praxys-feedback-needs-review"
+  "praxys-today-latency-regression"
+  "praxys-sync-systemic-failures"
+  "praxys-connect-systemic-failures"
+)
+
+fail() {
+  echo "ERROR: $*" >&2
+  return 1
+}
+
+require_env() {
+  local name
+  for name in "$@"; do
+    [[ -n "${!name:-}" ]] || fail "required environment variable ${name} is empty"
+  done
+}
+
+ids_equal() {
+  [[ "${1,,}" == "${2,,}" ]]
+}
+
+component_id() {
+  az resource show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --name "$1" \
+    --resource-type Microsoft.Insights/components \
+    --query id -o tsv
+}
+
+load_boundary_resources() {
+  require_env \
+    AZURE_RESOURCE_GROUP \
+    LOG_ANALYTICS_WORKSPACE \
+    FRONTEND_APPINSIGHTS_NAME \
+    BACKEND_APPINSIGHTS_NAME
+
+  WORKSPACE_ID="$(az monitor log-analytics workspace show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --workspace-name "${LOG_ANALYTICS_WORKSPACE}" \
+    --query id -o tsv)"
+  FRONTEND_AI_ID="$(component_id "${FRONTEND_APPINSIGHTS_NAME}")"
+  BACKEND_AI_ID="$(component_id "${BACKEND_APPINSIGHTS_NAME}")"
+
+  [[ -n "${WORKSPACE_ID}" && -n "${FRONTEND_AI_ID}" && -n "${BACKEND_AI_ID}" ]] ||
+    fail "observability resources must exist before deployment"
+  ! ids_equal "${FRONTEND_AI_ID}" "${BACKEND_AI_ID}" ||
+    fail "frontend and backend Application Insights resources must be distinct"
+
+  local resource_id linked_workspace
+  for resource_id in "${FRONTEND_AI_ID}" "${BACKEND_AI_ID}"; do
+    linked_workspace="$(az resource show \
+      --ids "${resource_id}" \
+      --query properties.WorkspaceResourceId -o tsv)"
+    ids_equal "${linked_workspace}" "${WORKSPACE_ID}" ||
+      fail "${resource_id} is not linked to ${LOG_ANALYTICS_WORKSPACE}"
+  done
+}
+
+write_github_env() {
+  require_env GITHUB_ENV
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_ENV}"
+}
+
+verify_anonymous_ingestion_rejected() {
+  local connection_string="$1"
+  local instrumentation_key=""
+  local ingestion_endpoint=""
+  local segment key value
+
+  while IFS= read -r segment; do
+    key="${segment%%=*}"
+    value="${segment#*=}"
+    case "${key}" in
+      InstrumentationKey) instrumentation_key="${value}" ;;
+      IngestionEndpoint) ingestion_endpoint="${value}" ;;
+    esac
+  done < <(tr ';' '\n' <<< "${connection_string}")
+
+  [[ -n "${instrumentation_key}" && -n "${ingestion_endpoint}" ]] ||
+    fail "backend connection string is missing ingestion routing fields"
+
+  local payload response_file status
+  payload="$(jq -cn \
+    --arg ikey "${instrumentation_key}" \
+    --arg time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      name: "Microsoft.ApplicationInsights.Event",
+      time: $time,
+      iKey: $ikey,
+      data: {
+        baseType: "EventData",
+        baseData: {
+          ver: 2,
+          name: "praxys.product_event",
+          properties: {
+            event_name: "forged_browser_probe",
+            source: "deployment-boundary-check"
+          }
+        }
+      }
+    }')"
+  response_file="$(mktemp)"
+  status="$(curl \
+    --silent \
+    --show-error \
+    --output "${response_file}" \
+    --write-out "%{http_code}" \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data "${payload}" \
+    "${ingestion_endpoint%/}/v2.1/track")"
+  rm -f "${response_file}"
+
+  case "${status}" in
+    401|403) return 0 ;;
+    *) fail "backend accepted anonymous instrumentation-key ingestion (HTTP ${status})" ;;
+  esac
+}
+
+backend_preflight() {
+  load_boundary_resources
+
+  az resource update \
+    --ids "${BACKEND_AI_ID}" \
+    --set \
+      properties.DisableLocalAuth=true \
+      tags.trustBoundary=backend \
+      tags.managedBy=deploy-backend \
+    --output none
+
+  local disable_local_auth
+  disable_local_auth="$(az resource show \
+    --ids "${BACKEND_AI_ID}" \
+    --query properties.DisableLocalAuth -o tsv)"
+  [[ "${disable_local_auth,,}" == "true" ]] ||
+    fail "backend Application Insights local authentication is not disabled"
+
+  local backend_mi_principal publisher_role_count
+  backend_mi_principal="$(az webapp identity show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --name "${BACKEND_APP_SERVICE}" \
+    --query principalId -o tsv)"
+  publisher_role_count="$(az role assignment list \
+    --assignee-object-id "${backend_mi_principal}" \
+    --scope "${BACKEND_AI_ID}" \
+    --query "[?roleDefinitionName=='Monitoring Metrics Publisher'] | length(@)" \
+    -o tsv)"
+  [[ "${publisher_role_count:-0}" != "0" ]] ||
+    fail "${BACKEND_APP_SERVICE} managed identity lacks Monitoring Metrics Publisher on ${BACKEND_APPINSIGHTS_NAME}; see docs/ops/config-and-secrets.md"
+
+  local connection_string
+  connection_string="$(az resource show \
+    --ids "${BACKEND_AI_ID}" \
+    --query properties.ConnectionString -o tsv)"
+  [[ -n "${connection_string}" ]] ||
+    fail "backend Application Insights connection string is empty"
+
+  verify_anonymous_ingestion_rejected "${connection_string}"
+
+  echo "::add-mask::${connection_string}"
+  write_github_env "APPLICATIONINSIGHTS_CONNECTION_STRING" "${connection_string}"
+  write_github_env "FRONTEND_APPINSIGHTS_RESOURCE_ID" "${FRONTEND_AI_ID}"
+  write_github_env "BACKEND_APPINSIGHTS_RESOURCE_ID" "${BACKEND_AI_ID}"
+}
+
+frontend_resolve() {
+  load_boundary_resources
+
+  local frontend_local_auth backend_local_auth
+  frontend_local_auth="$(az resource show \
+    --ids "${FRONTEND_AI_ID}" \
+    --query properties.DisableLocalAuth -o tsv)"
+  backend_local_auth="$(az resource show \
+    --ids "${BACKEND_AI_ID}" \
+    --query properties.DisableLocalAuth -o tsv)"
+  [[ "${frontend_local_auth,,}" != "true" ]] ||
+    fail "frontend Application Insights must allow browser instrumentation-key ingestion"
+  [[ "${backend_local_auth,,}" == "true" ]] ||
+    fail "backend Application Insights must reject instrumentation-key ingestion"
+
+  az resource update \
+    --ids "${FRONTEND_AI_ID}" \
+    --set \
+      tags.trustBoundary=frontend \
+      tags.managedBy=deploy-frontend-appservice \
+    --output none
+
+  local connection_string
+  connection_string="$(az resource show \
+    --ids "${FRONTEND_AI_ID}" \
+    --query properties.ConnectionString -o tsv)"
+  [[ -n "${connection_string}" ]] ||
+    fail "frontend Application Insights connection string is empty"
+
+  echo "::add-mask::${connection_string}"
+  write_github_env "VITE_APPINSIGHTS_CONNECTION_STRING" "${connection_string}"
+}
+
+telemetry_cutover() {
+  local target="$1"
+  load_boundary_resources
+
+  local target_ai_id other_ai_id target_connection_string target_name
+  case "${target}" in
+    backend)
+      require_env \
+        APPLICATIONINSIGHTS_CONNECTION_STRING \
+        FRONTEND_APPINSIGHTS_RESOURCE_ID \
+        BACKEND_APPINSIGHTS_RESOURCE_ID
+      ids_equal "${FRONTEND_AI_ID}" "${FRONTEND_APPINSIGHTS_RESOURCE_ID}" ||
+        fail "frontend Application Insights resource changed after preflight"
+      ids_equal "${BACKEND_AI_ID}" "${BACKEND_APPINSIGHTS_RESOURCE_ID}" ||
+        fail "backend Application Insights resource changed after preflight"
+      target_ai_id="${BACKEND_AI_ID}"
+      other_ai_id="${FRONTEND_AI_ID}"
+      target_connection_string="${APPLICATIONINSIGHTS_CONNECTION_STRING}"
+      target_name="${BACKEND_APPINSIGHTS_NAME}"
+      ;;
+    frontend)
+      target_ai_id="${FRONTEND_AI_ID}"
+      other_ai_id="${BACKEND_AI_ID}"
+      target_connection_string="$(az resource show \
+        --ids "${FRONTEND_AI_ID}" \
+        --query properties.ConnectionString -o tsv)"
+      [[ -n "${target_connection_string}" ]] ||
+        fail "frontend Application Insights connection string is empty"
+      target_name="${FRONTEND_APPINSIGHTS_NAME}"
+      echo "::add-mask::${target_connection_string}"
+      ;;
+    *)
+      fail "unknown telemetry cutover target: ${target}"
+      ;;
+  esac
+
+  local old_connection_string
+  old_connection_string="$(az webapp config appsettings list \
+    --name "${BACKEND_APP_SERVICE}" \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv)"
+  [[ -n "${old_connection_string}" ]] &&
+    echo "::add-mask::${old_connection_string}"
+
+  local -a alert_ids=()
+  local -a old_alert_scopes=()
+  local alert_name alert_id alert_scope scope_count
+  for alert_name in "${BACKEND_ALERT_NAMES[@]}"; do
+    alert_id="$(az monitor scheduled-query show \
+      --resource-group "${AZURE_RESOURCE_GROUP}" \
+      --name "${alert_name}" \
+      --query id -o tsv)"
+    scope_count="$(az monitor scheduled-query show \
+      --resource-group "${AZURE_RESOURCE_GROUP}" \
+      --name "${alert_name}" \
+      --query "length(scopes)" -o tsv)"
+    alert_scope="$(az monitor scheduled-query show \
+      --resource-group "${AZURE_RESOURCE_GROUP}" \
+      --name "${alert_name}" \
+      --query "scopes[0]" -o tsv)"
+    [[ "${scope_count}" == "1" ]] ||
+      fail "${alert_name} must have exactly one Application Insights scope"
+    if ! ids_equal "${alert_scope}" "${FRONTEND_AI_ID}" &&
+       ! ids_equal "${alert_scope}" "${BACKEND_AI_ID}"; then
+      fail "${alert_name} has an unexpected scope: ${alert_scope}"
+    fi
+    alert_ids+=("${alert_id}")
+    old_alert_scopes+=("${alert_scope}")
+  done
+
+  local api_webtest_id old_api_webtest_tags frontend_link_key backend_link_key
+  local target_link_key other_link_key
+  api_webtest_id="$(az resource show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --name "${API_WEBTEST_NAME}" \
+    --resource-type Microsoft.Insights/webtests \
+    --query id -o tsv)"
+  old_api_webtest_tags="$(az resource show \
+    --ids "${api_webtest_id}" \
+    --query tags -o json)"
+  frontend_link_key="hidden-link:${FRONTEND_AI_ID}"
+  backend_link_key="hidden-link:${BACKEND_AI_ID}"
+  if [[ "${target}" == "backend" ]]; then
+    target_link_key="${backend_link_key}"
+    other_link_key="${frontend_link_key}"
+  else
+    target_link_key="${frontend_link_key}"
+    other_link_key="${backend_link_key}"
+  fi
+  jq -e \
+    --arg frontend "${frontend_link_key}" \
+    --arg backend "${backend_link_key}" \
+    '.[$frontend] == "Resource" or .[$backend] == "Resource"' \
+    <<< "${old_api_webtest_tags}" >/dev/null ||
+    fail "${API_WEBTEST_NAME} is not linked to either configured component"
+
+  local api_alert_id old_api_alert_json old_api_alert_component
+  local -a old_api_alert_scopes=()
+  api_alert_id="$(az monitor metrics alert show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --name "${API_WEBTEST_NAME}" \
+    --query id -o tsv)"
+  old_api_alert_json="$(az monitor metrics alert show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --name "${API_WEBTEST_NAME}" \
+    -o json)"
+  mapfile -t old_api_alert_scopes < <(
+    jq -r '.scopes[]' <<< "${old_api_alert_json}"
+  )
+  old_api_alert_component="$(
+    jq -r '.criteria.componentId' <<< "${old_api_alert_json}"
+  )"
+  [[ "${#old_api_alert_scopes[@]}" == "2" ]] ||
+    fail "${API_WEBTEST_NAME} alert must have exactly two scopes"
+  ids_equal "$(
+    jq -r '.criteria.webTestId' <<< "${old_api_alert_json}"
+  )" "${api_webtest_id}" ||
+    fail "${API_WEBTEST_NAME} alert criteria points to a different web test"
+  if ! ids_equal "${old_api_alert_component}" "${FRONTEND_AI_ID}" &&
+     ! ids_equal "${old_api_alert_component}" "${BACKEND_AI_ID}"; then
+    fail "${API_WEBTEST_NAME} alert has an unexpected component"
+  fi
+  local found_webtest=false found_component=false scope
+  for scope in "${old_api_alert_scopes[@]}"; do
+    ids_equal "${scope}" "${api_webtest_id}" && found_webtest=true
+    ids_equal "${scope}" "${old_api_alert_component}" && found_component=true
+  done
+  [[ "${found_webtest}" == "true" && "${found_component}" == "true" ]] ||
+    fail "${API_WEBTEST_NAME} alert scopes do not match its criteria"
+
+  rollback_cutover() {
+    local exit_code=$?
+    trap - ERR
+    set +e
+    echo "Telemetry cutover failed; restoring the prior routing and alert scopes" >&2
+
+    if [[ -n "${old_connection_string}" ]]; then
+      az webapp config appsettings set \
+        --name "${BACKEND_APP_SERVICE}" \
+        --resource-group "${AZURE_RESOURCE_GROUP}" \
+        --settings \
+          APPLICATIONINSIGHTS_CONNECTION_STRING="${old_connection_string}" \
+        --output none
+    else
+      az webapp config appsettings delete \
+        --name "${BACKEND_APP_SERVICE}" \
+        --resource-group "${AZURE_RESOURCE_GROUP}" \
+        --setting-names APPLICATIONINSIGHTS_CONNECTION_STRING \
+        --output none
+    fi
+
+    local index
+    for index in "${!alert_ids[@]}"; do
+      az resource update \
+        --ids "${alert_ids[$index]}" \
+        --set "properties.scopes[0]=${old_alert_scopes[$index]}" \
+        --output none
+    done
+
+    az rest \
+      --method patch \
+      --url "https://management.azure.com${api_webtest_id}?api-version=2022-06-15" \
+      --body "$(jq -cn \
+        --argjson tags "${old_api_webtest_tags}" \
+        '{tags: $tags}')" \
+      --output none
+    az resource update \
+      --ids "${api_alert_id}" \
+      --set \
+        "properties.scopes[0]=${old_api_alert_scopes[0]}" \
+        "properties.scopes[1]=${old_api_alert_scopes[1]}" \
+        "properties.criteria.componentId=${old_api_alert_component}" \
+      --output none
+    exit "${exit_code}"
+  }
+  trap rollback_cutover ERR
+
+  az webapp config appsettings set \
+    --name "${BACKEND_APP_SERVICE}" \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --settings \
+      APPLICATIONINSIGHTS_CONNECTION_STRING="${target_connection_string}" \
+    --output none
+
+  local index
+  for index in "${!alert_ids[@]}"; do
+    az resource update \
+      --ids "${alert_ids[$index]}" \
+      --set "properties.scopes[0]=${target_ai_id}" \
+      --output none
+  done
+
+  local new_api_webtest_tags
+  new_api_webtest_tags="$(jq -c \
+    --arg frontend "${frontend_link_key}" \
+    --arg backend "${backend_link_key}" \
+    --arg target "${target_link_key}" \
+    'del(.[$frontend], .[$backend]) | .[$target] = "Resource"' \
+    <<< "${old_api_webtest_tags}")"
+  az rest \
+    --method patch \
+    --url "https://management.azure.com${api_webtest_id}?api-version=2022-06-15" \
+    --body "$(jq -cn \
+      --argjson tags "${new_api_webtest_tags}" \
+      '{tags: $tags}')" \
+    --output none
+  az resource update \
+    --ids "${api_alert_id}" \
+    --set \
+      "properties.scopes[0]=${api_webtest_id}" \
+      "properties.scopes[1]=${target_ai_id}" \
+      "properties.criteria.componentId=${target_ai_id}" \
+    --output none
+
+  local live_connection_string
+  live_connection_string="$(az webapp config appsettings list \
+    --name "${BACKEND_APP_SERVICE}" \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv)"
+  [[ "${live_connection_string}" == "${target_connection_string}" ]] ||
+    fail "backend App Service telemetry routing does not match ${target_name}"
+
+  for alert_name in "${BACKEND_ALERT_NAMES[@]}"; do
+    alert_scope="$(az monitor scheduled-query show \
+      --resource-group "${AZURE_RESOURCE_GROUP}" \
+      --name "${alert_name}" \
+      --query "scopes[0]" -o tsv)"
+    ids_equal "${alert_scope}" "${target_ai_id}" ||
+      fail "${alert_name} is not scoped to ${target_name}"
+  done
+
+  az resource show \
+    --ids "${api_webtest_id}" \
+    --query tags -o json |
+    jq -e \
+      --arg target "${target_link_key}" \
+      --arg other "${other_link_key}" \
+      '.[$target] == "Resource" and has($other) == false' >/dev/null ||
+    fail "${API_WEBTEST_NAME} hidden-link did not migrate cleanly"
+
+  local live_api_alert_json
+  live_api_alert_json="$(az monitor metrics alert show \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --name "${API_WEBTEST_NAME}" \
+    -o json)"
+  jq -e \
+    --arg webtest "${api_webtest_id}" \
+    --arg target "${target_ai_id}" \
+    --arg other "${other_ai_id}" \
+    '
+      def lower: ascii_downcase;
+      (.criteria.webTestId | lower) == ($webtest | lower)
+      and (.criteria.componentId | lower) == ($target | lower)
+      and (.scopes | length) == 2
+      and any(.scopes[]; (lower == ($webtest | lower)))
+      and any(.scopes[]; (lower == ($target | lower)))
+      and all(.scopes[]; (lower != ($other | lower)))
+    ' <<< "${live_api_alert_json}" >/dev/null ||
+    fail "${API_WEBTEST_NAME} alert did not migrate cleanly"
+
+  trap - ERR
+}
+
+case "${1:-}" in
+  backend-preflight) backend_preflight ;;
+  backend-cutover) telemetry_cutover backend ;;
+  rollback-to-frontend) telemetry_cutover frontend ;;
+  frontend-resolve) frontend_resolve ;;
+  *)
+    echo "Usage: $0 {backend-preflight|backend-cutover|rollback-to-frontend|frontend-resolve}" >&2
+    exit 2
+    ;;
+esac

--- a/tests/test_appinsights_boundary.py
+++ b/tests/test_appinsights_boundary.py
@@ -1,0 +1,70 @@
+"""Static contracts for the frontend/backend Application Insights boundary."""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RESOURCE_MAP = ROOT / ".github" / "azure-observability.env"
+BACKEND_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-backend.yml"
+FRONTEND_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "deploy-frontend-appservice.yml"
+)
+BOUNDARY_SCRIPT = ROOT / "scripts" / "appinsights_boundary.sh"
+
+
+def _resource_names() -> dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in RESOURCE_MAP.read_text(encoding="utf-8").splitlines()
+        if line
+    )
+
+
+def test_appinsights_resources_are_distinct() -> None:
+    """Browser and backend telemetry must resolve to different components."""
+    resources = _resource_names()
+
+    assert resources["FRONTEND_APPINSIGHTS_NAME"]
+    assert resources["BACKEND_APPINSIGHTS_NAME"]
+    assert (
+        resources["FRONTEND_APPINSIGHTS_NAME"]
+        != resources["BACKEND_APPINSIGHTS_NAME"]
+    )
+
+
+def test_backend_workflow_enforces_server_only_ingestion() -> None:
+    """The backend workflow owns routing and rejects local-auth drift."""
+    workflow = BACKEND_WORKFLOW.read_text(encoding="utf-8")
+    script = BOUNDARY_SCRIPT.read_text(encoding="utf-8")
+
+    assert "vars.APPLICATIONINSIGHTS_CONNECTION_STRING" not in workflow
+    assert "backend-preflight" in workflow
+    assert "backend-cutover" in workflow
+    assert "properties.DisableLocalAuth=true" in script
+    assert "properties.WorkspaceResourceId" in script
+    assert "Monitoring Metrics Publisher" in script
+    assert "forged_browser_probe" in script
+    assert "rollback_cutover" in script
+    assert "rollback-to-frontend" in script
+    assert "praxys-db-health-unhealthy" in script
+    assert "wt-praxys-api-health" in script
+
+
+def test_frontend_workflow_resolves_only_frontend_ingestion() -> None:
+    """The browser build must never receive the backend connection string."""
+    workflow = FRONTEND_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "vars.VITE_APPINSIGHTS_CONNECTION_STRING" not in workflow
+    assert "frontend-resolve" in workflow
+
+
+def test_boundary_script_has_valid_bash_syntax() -> None:
+    """The deployment guard must remain parseable by the Actions Bash shell."""
+    if os.name == "nt":
+        pytest.skip("Windows resolves bash to WSL; Actions validation runs on Linux")
+    subprocess.run(["bash", "-n", str(BOUNDARY_SCRIPT)], check=True)

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,7 +1,8 @@
 # Frontend build-time env. Vite substitutes these at build into the bundle,
 # so the values ship to the browser — never put secrets here. For local dev,
-# copy to .env.local (gitignored) and fill in; for CI the deploy workflow
-# injects from repository variables.
+# copy to .env.local (gitignored) and fill in; CI resolves browser telemetry
+# directly from the frontend Azure component named in
+# .github/azure-observability.env.
 
 # Base URL for the Praxys API. Empty string → same-origin requests via the
 # SWA proxy. Set to a full https://... URL to hit a cross-origin App Service.
@@ -11,5 +12,6 @@ VITE_API_URL=
 # views, Core Web Vitals, fetch dependency timings). Leave unset locally
 # to disable telemetry. The connection string is not a secret — it's a
 # write-only ingestion token that ships in every client bundle by design.
-# Copy from the Application Insights resource → Overview blade.
+# Copy only from the frontend/RUM Application Insights resource. Never use
+# the backend component here.
 VITE_APPINSIGHTS_CONNECTION_STRING=


### PR DESCRIPTION
## Summary

- keep the already-public `appi-trainsight` component for browser RUM and route backend telemetry to the distinct `appi-praxys-backend` component
- enforce workspace linkage, managed-identity RBAC, disabled backend local auth, and an anonymous forged-event rejection on every deploy
- atomically migrate backend scheduled-query alerts plus the API availability test, with automatic failure rollback and an explicit reverse cutover
- fetch both connection strings from Azure through OIDC instead of GitHub variables
- update the operations handbook, alert inventory, query scopes, provisioning, verification, rollback, and cost guidance

## Live infrastructure

- `appi-praxys-backend` is provisioned in `log-trainsight`
- local authentication is disabled
- `trainsight-app` managed identity has `Monitoring Metrics Publisher`
- production routing and alert scopes will cut over through the merged backend workflow

## Validation

- full backend test suite
- production web build
- live backend/frontend deployment preflight
- anonymous backend ingestion probe returns HTTP 401
- rubber-duck review findings resolved
- dedicated code review: merge-qualified

Closes #417
