### PR TITLE
Wait for App Service SCM before backend deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -260,6 +260,37 @@ jobs:
         shell: bash
         run: bash scripts/appinsights_boundary.sh backend-cutover
 
+      - name: Wait for App Service deployment endpoint to settle
+        timeout-minutes: 8
+        shell: bash
+        run: |
+          set -euo pipefail
+          # App-setting and site-config writes recycle the SCM container.
+          # Starting ZipDeploy during that recycle aborts the deployment.
+          sleep 90
+          stable_probes=0
+          for attempt in {1..12}; do
+            deployment_id=""
+            if deployment_id="$(timeout 20s az webapp log deployment list \
+              --name trainsight-app \
+              --resource-group rg-trainsight \
+              --query "[0].id" \
+              -o tsv 2>/dev/null)" &&
+              [[ -n "${deployment_id}" ]]; then
+              stable_probes=$((stable_probes + 1))
+              if (( stable_probes >= 3 )); then
+                echo "App Service deployment endpoint is stable."
+                exit 0
+              fi
+            else
+              stable_probes=0
+            fi
+            echo "Waiting for App Service deployment endpoint (${attempt}/12)."
+            sleep 10
+          done
+          echo "App Service deployment endpoint did not stabilize." >&2
+          exit 1
+
       # NB: no pre-deploy on-demand DB snapshot. praxys-pg is a Burstable-tier
       # Flexible Server, which does not support customer on-demand backups; the
       # server's continuous PITR (14-day) provides the pre-deploy restore point

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -73,6 +73,15 @@ Each workflow also serializes every production deployment, including `main`
 pushes and release tags, without cancelling the active run. A newer run remains
 queued and deploys last, so an older package cannot overwrite it.
 
+Backend App Service setting, site-config, and telemetry-cutover writes recycle
+the SCM container. `deploy-backend.yml` therefore waits at least 90 seconds and
+requires three consecutive successful reads from the App Service deployment
+endpoint before invoking ZipDeploy. Do not remove or shorten this settle gate:
+deploying during the recycle is rejected with
+`Deployment has been stopped due to SCM container restart`. Each probe has a
+20-second command timeout and the full gate is capped at eight minutes so a
+stalled SCM endpoint cannot monopolize the serialized production lane.
+
 ### Azure App Service → Application settings (backend `trainsight-app`)
 Source of truth = `deploy-backend.yml`. Literals set inline: `DATA_DIR=/home/data`,
 `WEBSITES_PORT=8000`, `SCM_DO_BUILD_DURING_DEPLOYMENT=true`,

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -24,8 +24,14 @@ Automatic on merge to `main` (for the paths above). The workflow:
 2. Stamps `api/_build_version.txt`.
 3. Waits for a compatible live frontend `deployed_sha`.
 4. Uses OIDC to enforce the telemetry boundary, sync App Service settings (see
-   [config-and-secrets.md](./config-and-secrets.md)), and run
+   [config-and-secrets.md](./config-and-secrets.md)).
+5. Waits for the App Service SCM deployment endpoint to remain healthy across
+   three probes after the configuration recycle, then runs
    `azure/webapps-deploy`.
+
+The settle gate is load-bearing: App Service management writes recycle the SCM
+container, and starting ZipDeploy during that recycle aborts the deployment
+with `Deployment has been stopped due to SCM container restart`.
 
 Force a deploy without a code change: re-run the latest `deploy-backend.yml` run
 (`gh run rerun <id>`), or push an `api-YYYY.MM.MICRO` tag for a versioned release.

--- a/tests/test_appinsights_boundary.py
+++ b/tests/test_appinsights_boundary.py
@@ -60,6 +60,12 @@ def test_backend_workflow_enforces_server_only_ingestion() -> None:
     assert "praxys-frontend.azurewebsites.net/healthz" in workflow
     assert ".deployed_sha" in workflow
     assert "Deployed frontend commit is not yet compatible" in workflow
+    assert "Wait for App Service deployment endpoint to settle" in workflow
+    assert "sleep 90" in workflow
+    assert "az webapp log deployment list" in workflow
+    assert "stable_probes >= 3" in workflow
+    assert "timeout-minutes: 8" in workflow
+    assert "timeout 20s az webapp" in workflow
     assert "group: deploy-backend-production" in workflow
     assert "cancel-in-progress: false" in workflow
     assert "Monitoring Metrics Publisher" in script


### PR DESCRIPTION
## Summary
- wait at least 90 seconds after backend App Service management writes
- require three consecutive successful SCM deployment-endpoint probes before ZipDeploy
- bound each probe to 20 seconds and the full gate to eight minutes
- document the production failure mode and keep the guard covered by workflow contract tests

## Why
The first backend rollout after #437 was aborted by App Service because configuration and telemetry-cutover writes recycled the SCM container while `azure/webapps-deploy` was starting. Production was recovered with a clean ZIP deployment after the management operations settled.

## Validation
- `tests/test_appinsights_boundary.py`: 3 passed, 1 skipped
- workflow YAML and diff checks passed
- focused deployment review found no remaining issues

Follow-up to #437.