### PR TITLE
Populate Garmin and COROS activity weather

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -6,8 +6,10 @@ environment variables when auth is disabled (local dev).
 import json
 import logging
 import os
+import re
 import threading
 import time
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
@@ -77,6 +79,54 @@ def _get_user_status(user_id: str) -> dict[str, dict]:
                 for s in _DEFAULT_SOURCES
             }
         return _sync_status[user_id]
+
+
+def _activity_ids_needing_environment(
+    user_id: str,
+    activity_ids: Iterable[str],
+    db: Session,
+) -> set[str]:
+    """Return activity IDs whose environment observation can still be filled."""
+    from db.models import Activity
+
+    candidate_ids = {
+        str(activity_id)
+        for activity_id in activity_ids
+        if activity_id
+    }
+    if not candidate_ids:
+        return set()
+
+    existing = db.query(Activity).filter(
+        Activity.user_id == user_id,
+        Activity.activity_id.in_(sorted(candidate_ids)),
+    ).all()
+    needed = set(candidate_ids)
+    for activity in existing:
+        temperature = activity.temperature_c
+        humidity = activity.relative_humidity_pct
+        source = activity.environment_source
+        if temperature is None and humidity is None:
+            continue
+        if temperature is not None and humidity is not None and source is None:
+            continue
+        needed.discard(activity.activity_id)
+    return needed
+
+
+def _exception_status_code(exc: BaseException) -> int | None:
+    """Extract an HTTP status from an exception response or provider message."""
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+    match = re.search(
+        r"(?:API Error|client error|status(?:_code)?|HTTP(?: error)?)"
+        r"\D*([1-5]\d{2})",
+        str(exc),
+        re.IGNORECASE,
+    )
+    return int(match.group(1)) if match else None
 
 
 def _get_data_dir() -> str:
@@ -545,10 +595,16 @@ def _sync_garmin(user_id: str, creds: dict, from_date: str | None,
     """Fetch Garmin data and write directly to DB."""
     from db import sync_writer
     from garminconnect import Garmin
+    from garminconnect.exceptions import (
+        GarminConnectAuthenticationError,
+        GarminConnectConnectionError,
+        GarminConnectTooManyRequestsError,
+    )
     from sync.garmin_sync import (
         parse_activities, parse_splits, parse_activity_stream,
         parse_daily_metrics, parse_lactate_threshold, parse_user_profile,
-        parse_heart_rates, parse_running_ftp, RATE_LIMIT_DELAY,
+        parse_activity_weather, parse_heart_rates, parse_running_ftp,
+        RATE_LIMIT_DELAY,
         GARMIN_MAX_CHART_SIZE,
     )
     import time
@@ -622,13 +678,72 @@ def _sync_garmin(user_id: str, creds: dict, from_date: str | None,
                 user_id, atype, e,
             )
     activity_rows = parse_activities(raw_activities)
+    status = _get_user_status(user_id)
+    weather_rows_by_id = {
+        str(row.get("activity_id")): row
+        for row in activity_rows
+        if row.get("activity_id")
+        and row.get("activity_type") in {"running", "trail_running"}
+    }
+    needed_weather_ids = _activity_ids_needing_environment(
+        user_id, weather_rows_by_id, db,
+    )
+    weather_rows = [
+        (activity_id, row)
+        for activity_id, row in weather_rows_by_id.items()
+        if activity_id in needed_weather_ids
+    ]
+    weather_failures = 0
+    weather_completed = 0
+    weather_abort: Exception | None = None
+    for idx, (aid, row) in enumerate(weather_rows):
+        with _sync_lock:
+            status["garmin"]["progress"] = (
+                f"Fetching weather: {idx + 1}/{len(weather_rows)}"
+            )
+        try:
+            weather = client.get_activity_weather(aid) or {}
+            row.update(parse_activity_weather(weather))
+        except (
+            GarminConnectAuthenticationError,
+            GarminConnectTooManyRequestsError,
+        ):
+            raise
+        except GarminConnectConnectionError as e:
+            status_code = _exception_status_code(e)
+            if status_code in {401, 403, 429}:
+                raise
+            if status_code not in {400, 404}:
+                weather_abort = e
+                break
+            weather_failures += 1
+            logger.debug("Weather for %s: skipped (%s)", aid, e)
+        except ValueError as e:
+            weather_failures += 1
+            logger.debug("Weather for %s: skipped (%s)", aid, e)
+        time.sleep(RATE_LIMIT_DELAY)
+        weather_completed += 1
+    if weather_abort is not None:
+        logger.warning(
+            "Garmin weather enrichment stopped after %d of %d eligible "
+            "activities (user %s): %s",
+            weather_completed,
+            len(weather_rows),
+            user_id,
+            weather_abort,
+        )
+    elif weather_rows and weather_failures >= max(3, len(weather_rows) // 2):
+        logger.warning(
+            "Garmin weather fetch failed for %d of %d eligible activities "
+            "(user %s) — heat-adaptation evidence will be incomplete",
+            weather_failures, len(weather_rows), user_id,
+        )
     act_count = sync_writer.write_activities(user_id, activity_rows, db)
 
     # Splits — per-activity lap data. Splits drive interval intensity analysis
     # (see CLAUDE.md: "Always use activity_splits.csv for intensity analysis").
     # Per-activity misses are logged at debug, but a systemic failure would
     # quietly lose intensity metrics, so we surface an aggregate warning.
-    status = _get_user_status(user_id)
     activity_ids = [str(a.get("activityId", "")) for a in raw_activities]
     total = len(activity_ids)
     all_splits = []
@@ -1097,9 +1212,11 @@ def _sync_coros(user_id: str, creds: dict, from_date: str | None,
         refresh_if_needed,
         fetch_activities,
         fetch_activity_detail,
+        fetch_activity_detail_data,
         fetch_daily_metrics,
         fetch_fitness_summary,
         parse_activities,
+        parse_activity_weather,
         parse_fit_laps,
         parse_fit_stream,
         parse_daily_metrics as parse_daily,
@@ -1158,6 +1275,75 @@ def _sync_coros(user_id: str, creds: dict, from_date: str | None,
     for row in activity_rows:
         row.setdefault("activity_type", "other")
         row.setdefault("source", "coros")
+    rows_by_id = {
+        str(row.get("activity_id")): row
+        for row in activity_rows
+        if row.get("activity_id")
+    }
+    weather_activities_by_id = {}
+    for raw_act in raw_activities:
+        act_id = str(raw_act.get("labelId") or raw_act.get("activityId") or "")
+        row = rows_by_id.get(act_id)
+        if row and row.get("activity_type") in {"running", "trail_running"}:
+            weather_activities_by_id[act_id] = raw_act
+    needed_weather_ids = _activity_ids_needing_environment(
+        user_id, weather_activities_by_id, db,
+    )
+    weather_activities = [
+        (activity_id, raw_activity)
+        for activity_id, raw_activity in weather_activities_by_id.items()
+        if activity_id in needed_weather_ids
+    ]
+    weather_failures = 0
+    weather_abort: Exception | None = None
+    from requests import RequestException
+
+    for idx, (act_id, raw_act) in enumerate(weather_activities):
+        with _sync_lock:
+            status.setdefault("coros", {})["progress"] = (
+                f"Fetching weather: {idx + 1}/{len(weather_activities)}"
+            )
+        try:
+            detail = fetch_activity_detail_data(
+                access_token,
+                region,
+                act_id,
+                raw_act.get("sportType"),
+            )
+            rows_by_id[act_id].update(parse_activity_weather(detail))
+        except RequestException as e:
+            status_code = _exception_status_code(e)
+            if status_code in {401, 403, 429}:
+                raise
+            if status_code not in {400, 404}:
+                weather_abort = e
+                break
+            weather_failures += 1
+            logger.debug("COROS weather for %s: skipped (%s)", act_id, e)
+        except RuntimeError as e:
+            if str(e).startswith("COROS auth error:"):
+                raise
+            weather_failures += 1
+            logger.debug("COROS weather for %s: skipped (%s)", act_id, e)
+        except ValueError as e:
+            weather_failures += 1
+            logger.debug("COROS weather for %s: skipped (%s)", act_id, e)
+        time_mod.sleep(0.3)
+    if weather_abort is not None:
+        logger.warning(
+            "COROS weather enrichment stopped for user %s: %s",
+            user_id,
+            weather_abort,
+        )
+    elif (
+        weather_activities
+        and weather_failures >= max(3, len(weather_activities) // 2)
+    ):
+        logger.warning(
+            "COROS weather fetch failed for %d of %d eligible activities "
+            "(user %s) — heat-adaptation evidence will be incomplete",
+            weather_failures, len(weather_activities), user_id,
+        )
     act_count = sync_writer.write_activities(user_id, activity_rows, db)
 
     # Splits and per-second samples from the same activity detail call.

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -155,9 +155,18 @@ render read-only with a source badge.
 
 ## Backfill semantics
 
-- `write_activities` / `write_splits` are **fill-only upserts** for a whitelisted set of columns (`avg_power`, `max_power`). If a row already exists and a column is NULL, a re-sync fills it; non-null values are preserved verbatim. This lets users benefit from parser improvements (e.g. native Garmin power) without deleting their existing data, *and* protects against clobbering Stryd-sourced power with a different Garmin reading in dual-sync scenarios.
+- `write_activities` / `write_splits` are **fill-only upserts** for a whitelisted set of columns (`avg_power`, `max_power`). Activity temperature, relative humidity, and provenance are also backfilled atomically: both values must come from one connector observation, and an existing pair is never mixed with or overwritten by a later source. This lets users benefit from parser improvements (e.g. native Garmin power or newly fetched activity weather) without deleting their existing data, *and* protects against clobbering Stryd-sourced power with a different Garmin reading in dual-sync scenarios.
 - `write_lactate_threshold` and `write_daily_metrics` are insert-only (existing rows skipped) — they're time-series of fresh values, so per-date idempotency is the right semantics.
 - Recovery (`recovery_data`) is update-capable per date (see `write_recovery`'s Garmin branch) so a partial first-sync row can be topped up on a later sync that returns HRV where the first didn't.
+
+## Activity weather support
+
+- Stryd activity summaries already provide temperature plus relative humidity.
+- Garmin requires a separate `get_activity_weather(activity_id)` call; its bare `temp` field is Fahrenheit and must be converted to Celsius.
+- COROS requires `POST /activity/detail/query`; `weather.temperature` and `weather.humidity` are both scaled by 10.
+- Strava exposes a Celsius temperature stream but no humidity field in its official API. Do not manufacture a complete heat-adaptation observation from Strava temperature alone.
+- Connector weather is fetched only for outdoor running/trail-running rows used by the heat-adaptation model. Treadmill and indoor activity must not inherit outdoor provider weather.
+- Re-sync skips weather calls once an activity already has a complete, attributed observation. Authentication and rate-limit errors still abort the connector sync so scheduler backoff protects the provider account; an individual missing weather observation remains non-fatal.
 
 ## Sync status observability
 

--- a/sync/coros_sync.py
+++ b/sync/coros_sync.py
@@ -15,6 +15,7 @@ import hashlib
 import io
 import json
 import logging
+import math
 import random
 import time
 from datetime import datetime, timezone
@@ -465,6 +466,71 @@ def fetch_activity_detail(
     except Exception as e:
         logger.warning("COROS FIT file download failed for %s: %s", activity_id, e)
         return b""
+
+
+def fetch_activity_detail_data(
+    access_token: str,
+    region: str,
+    activity_id: str,
+    sport_type: int | None = None,
+) -> dict:
+    """Fetch COROS JSON activity detail, including provider weather."""
+    url = f"{_base_url(region)}/activity/detail/query"
+    params: dict = {"labelId": activity_id}
+    if sport_type is not None:
+        params["sportType"] = sport_type
+
+    resp = requests.post(
+        url,
+        params=params,
+        headers=_headers(access_token),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    if not isinstance(body, dict):
+        return {}
+    if str(body.get("result")) not in ("0000", "0"):
+        msg = body.get("message", body.get("result"))
+        if "token" in str(msg).lower() or "auth" in str(msg).lower():
+            raise RuntimeError(f"COROS auth error: {msg}")
+        raise RuntimeError(f"COROS activity detail error: {msg}")
+    data = body.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def parse_activity_weather(detail: dict | None) -> dict[str, str]:
+    """Normalize COROS activity weather values from their ×10 wire units.
+
+    The reverse-engineered, live-verified detail schema documents
+    ``weather.temperature`` as Celsius ×10 and ``weather.humidity`` as
+    relative-humidity percent ×10:
+    https://github.com/0xNatal/coros/blob/main/docs/coros-api-reference.md
+    """
+    if not isinstance(detail, dict):
+        return {}
+    weather = detail.get("weather")
+    if not isinstance(weather, dict):
+        return {}
+    try:
+        raw_temperature = float(weather.get("temperature"))
+        raw_humidity = float(weather.get("humidity"))
+    except (TypeError, ValueError):
+        return {}
+    if not math.isfinite(raw_temperature) or not math.isfinite(raw_humidity):
+        return {}
+    if raw_temperature == 0 and raw_humidity == 0:
+        return {}
+
+    temperature_c = raw_temperature / 10
+    relative_humidity = raw_humidity / 10
+    if not -100 <= temperature_c <= 80 or not 0 <= relative_humidity <= 100:
+        return {}
+    return {
+        "temperature_c": str(round(temperature_c, 1)),
+        "relative_humidity_pct": str(round(relative_humidity, 1)),
+        "environment_source": "coros_activity_weather",
+    }
 
 
 def fetch_daily_metrics(

--- a/sync/garmin_sync.py
+++ b/sync/garmin_sync.py
@@ -1,6 +1,38 @@
 """Garmin Connect data parsing — fetch/parse layer for the sync API route."""
 
+import math
+
 RATE_LIMIT_DELAY = 0.5  # seconds between per-activity API calls
+
+
+def parse_activity_weather(weather: dict | None) -> dict[str, str]:
+    """Normalize Garmin's activity weather observation.
+
+    Garmin's activity weather endpoint returns ``temp`` in Fahrenheit and
+    ``relativeHumidity`` in percent:
+    https://github.com/co42/garmin-cli/blob/main/src/garmin/types/activity/weather.rs
+    """
+    if not isinstance(weather, dict):
+        return {}
+    try:
+        temperature_f = float(weather.get("temp"))
+        relative_humidity = float(weather.get("relativeHumidity"))
+    except (TypeError, ValueError):
+        return {}
+    if (
+        not math.isfinite(temperature_f)
+        or not math.isfinite(relative_humidity)
+        or not -148 <= temperature_f <= 176
+        or not 0 <= relative_humidity <= 100
+    ):
+        return {}
+
+    temperature_c = (temperature_f - 32) * 5 / 9
+    return {
+        "temperature_c": str(round(temperature_c, 1)),
+        "relative_humidity_pct": str(round(relative_humidity, 1)),
+        "environment_source": "garmin_activity_weather",
+    }
 
 
 def _garmin_speed_to_pace_sec_km(speed_value: float) -> float | None:

--- a/tests/test_coros_sync.py
+++ b/tests/test_coros_sync.py
@@ -1,18 +1,242 @@
 """Unit tests for COROS sync client parsers."""
 
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests import RequestException
+
 from sync.coros_sync import (
-    is_token_valid,
-    parse_activities,
-    parse_splits,
-    parse_daily_metrics,
-    parse_fitness_summary,
-    parse_sleep,
+    _compute_sleep_score,
     _format_date,
     _md5,
     _mobile_encrypt,
-    _compute_sleep_score,
+    fetch_activity_detail_data,
+    is_token_valid,
+    parse_activities,
+    parse_activity_weather,
+    parse_daily_metrics,
+    parse_fitness_summary,
+    parse_sleep,
+    parse_splits,
 )
-import time
+
+
+def test_fetch_activity_detail_data_uses_training_hub_detail_endpoint():
+    response = MagicMock()
+    response.json.return_value = {"result": "0000", "data": {"weather": {}}}
+
+    with patch("sync.coros_sync.requests.post", return_value=response) as post:
+        detail = fetch_activity_detail_data("token", "us", "act-1", 100)
+
+    assert detail == {"weather": {}}
+    post.assert_called_once()
+    _, kwargs = post.call_args
+    assert kwargs["params"] == {"labelId": "act-1", "sportType": 100}
+    assert kwargs["headers"]["accessToken"] == "token"
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_fetch_activity_detail_data_ignores_malformed_envelope():
+    response = MagicMock()
+    response.json.return_value = []
+
+    with patch("sync.coros_sync.requests.post", return_value=response):
+        assert fetch_activity_detail_data("token", "us", "act-1", 100) == {}
+
+
+def test_parse_activity_weather_scales_tenths():
+    weather = parse_activity_weather(
+        {"weather": {"temperature": 192, "humidity": 570}},
+    )
+
+    assert weather == {
+        "temperature_c": "19.2",
+        "relative_humidity_pct": "57.0",
+        "environment_source": "coros_activity_weather",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"weather": None},
+        {"weather": {"temperature": 192}},
+        {"weather": {"humidity": 570}},
+        {"weather": {"temperature": "bad", "humidity": 570}},
+        {"weather": {"temperature": 192, "humidity": 1200}},
+    ],
+)
+def test_parse_activity_weather_requires_a_valid_complete_pair(payload):
+    assert parse_activity_weather(payload) == {}
+
+
+def test_sync_coros_enriches_only_outdoor_runs_with_weather(monkeypatch):
+    weather_calls = []
+    written_rows = []
+    raw_activities = [
+        {"labelId": "2000", "sportType": 100, "date": 20260719},
+        {"labelId": "2001", "sportType": 100, "date": 20260720},
+        {"labelId": "2002", "sportType": 102, "date": 20260721},
+        {"labelId": "2003", "sportType": 101, "date": 20260722},
+    ]
+
+    def fetch_weather(access_token, region, activity_id, sport_type):
+        weather_calls.append((activity_id, sport_type))
+        if activity_id == "2002":
+            raise RequestException(
+                "weather unavailable",
+                response=SimpleNamespace(status_code=404),
+            )
+        return {"weather": {"temperature": 192, "humidity": 570}}
+
+    def capture_activities(user_id, rows, db):
+        written_rows.extend(rows)
+        return len(rows)
+
+    token_timestamp = int(time.time())
+    monkeypatch.setattr(
+        "sync.coros_sync.refresh_if_needed",
+        lambda creds, email, password: (creds, False),
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_activities",
+        lambda access_token, region, start, end: raw_activities,
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_activity_detail_data",
+        fetch_weather,
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_activity_detail",
+        lambda *args, **kwargs: b"",
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_daily_metrics",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.parse_daily_metrics",
+        lambda raw: [],
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_sleep",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.parse_sleep",
+        lambda raw: [],
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_fitness_summary",
+        lambda *args, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.parse_fitness_summary",
+        lambda raw: {},
+    )
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    monkeypatch.setattr("db.sync_writer.write_activities", capture_activities)
+    for name in (
+        "write_splits",
+        "write_samples",
+        "write_recovery",
+        "write_profile_thresholds",
+    ):
+        monkeypatch.setattr(f"db.sync_writer.{name}", lambda *args, **kwargs: 0)
+
+    class NullDB:
+        def query(self, model):
+            class Query:
+                def filter(self, *args):
+                    return self
+
+                def all(self):
+                    return [
+                        SimpleNamespace(
+                            activity_id="2000",
+                            temperature_c=25.0,
+                            relative_humidity_pct=50.0,
+                            environment_source="coros_activity_weather",
+                        ),
+                    ]
+
+            return Query()
+
+        def commit(self):
+            pass
+
+    from api.routes.sync import _sync_coros
+
+    result = _sync_coros(
+        "weather-user",
+        {
+            "email": "runner@example.com",
+            "password": "secret",
+            "access_token": "token",
+            "coros_user_id": "coros-user",
+            "timestamp": token_timestamp,
+            "mobile_access_token": "mobile-token",
+            "mobile_timestamp": token_timestamp,
+        },
+        None,
+        NullDB(),
+    )
+
+    assert result["activities"] == 4
+    assert weather_calls == [("2001", 100), ("2002", 102)]
+    rows_by_id = {row["activity_id"]: row for row in written_rows}
+    assert rows_by_id["2001"]["temperature_c"] == "19.2"
+    assert rows_by_id["2001"]["relative_humidity_pct"] == "57.0"
+    assert rows_by_id["2001"]["environment_source"] == "coros_activity_weather"
+    assert "temperature_c" not in rows_by_id["2000"]
+    assert "temperature_c" not in rows_by_id["2002"]
+    assert "temperature_c" not in rows_by_id["2003"]
+
+
+def test_sync_coros_weather_rate_limit_aborts_for_backoff(monkeypatch):
+    def rate_limited(*args, **kwargs):
+        raise RequestException(
+            "rate limited",
+            response=SimpleNamespace(status_code=429),
+        )
+
+    monkeypatch.setattr(
+        "sync.coros_sync.refresh_if_needed",
+        lambda creds, email, password: (creds, False),
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_activities",
+        lambda *args, **kwargs: [
+            {"labelId": "2001", "sportType": 100, "date": 20260720},
+        ],
+    )
+    monkeypatch.setattr(
+        "sync.coros_sync.fetch_activity_detail_data",
+        rate_limited,
+    )
+    monkeypatch.setattr(
+        "api.routes.sync._activity_ids_needing_environment",
+        lambda user_id, activity_ids, db: set(activity_ids),
+    )
+
+    from api.routes.sync import _sync_coros
+
+    with pytest.raises(RequestException):
+        _sync_coros(
+            "weather-user",
+            {
+                "email": "runner@example.com",
+                "password": "secret",
+                "access_token": "token",
+                "coros_user_id": "coros-user",
+                "timestamp": int(time.time()),
+            },
+            None,
+            object(),
+        )
 
 
 # --- Fixtures ---

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -1,7 +1,16 @@
+import contextlib
+from datetime import date
+from types import SimpleNamespace
+
 import pytest
+from garminconnect.exceptions import (
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
 
 from sync.garmin_sync import (
     parse_activities,
+    parse_activity_weather,
     parse_daily_metrics,
     parse_garmin_recovery,
     parse_heart_rates,
@@ -9,6 +18,238 @@ from sync.garmin_sync import (
     parse_splits,
     parse_user_profile,
 )
+
+
+def _garmin_connection_error(status_code):
+    return GarminConnectConnectionError(
+        f"API call client error ({status_code}): API Error {status_code}",
+    )
+
+
+def test_parse_activity_weather_converts_fahrenheit_to_celsius():
+    weather = parse_activity_weather({"temp": 86, "relativeHumidity": 72})
+
+    assert weather == {
+        "temperature_c": "30.0",
+        "relative_humidity_pct": "72.0",
+        "environment_source": "garmin_activity_weather",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"temp": 86},
+        {"relativeHumidity": 72},
+        {"temp": "not-a-number", "relativeHumidity": 72},
+        {"temp": 86, "relativeHumidity": 101},
+    ],
+)
+def test_parse_activity_weather_requires_a_valid_complete_pair(payload):
+    assert parse_activity_weather(payload) == {}
+
+
+def test_sync_garmin_enriches_only_outdoor_runs_with_weather(
+    tmp_path, monkeypatch,
+):
+    weather_calls = []
+    written_rows = []
+    raw_activities = [
+        {
+            "activityId": 1000,
+            "startTimeLocal": "2026-07-19 07:00:00",
+            "activityType": {"typeKey": "running"},
+        },
+        {
+            "activityId": 1001,
+            "startTimeLocal": "2026-07-20 07:00:00",
+            "activityType": {"typeKey": "running"},
+        },
+        {
+            "activityId": 1002,
+            "startTimeLocal": "2026-07-21 07:00:00",
+            "activityType": {"typeKey": "trail_running"},
+        },
+        {
+            "activityId": 1003,
+            "startTimeLocal": "2026-07-22 07:00:00",
+            "activityType": {"typeKey": "treadmill_running"},
+        },
+    ]
+
+    class FakeGarmin:
+        def __init__(self, email, password, is_cn=False):
+            self.client = type("Client", (), {})()
+
+        def login(self, token_dir):
+            pass
+
+        def get_activities_by_date(self, *args, **kwargs):
+            return raw_activities
+
+        def get_activity_weather(self, activity_id):
+            weather_calls.append(str(activity_id))
+            if str(activity_id) == "1002":
+                raise _garmin_connection_error(404)
+            return {"temp": 86, "relativeHumidity": 72}
+
+        def get_activity_splits(self, activity_id):
+            return {}
+
+        def get_activity_details(self, activity_id, maxchart):
+            return {}
+
+        def get_lactate_threshold(self, **kwargs):
+            return []
+
+        def get_user_profile(self):
+            return {}
+
+        def get_heart_rates(self, activity_date):
+            return {}
+
+        def connectapi(self, path):
+            return {}
+
+        def get_training_status(self, activity_date):
+            return {}
+
+        def get_training_readiness(self, activity_date):
+            return None
+
+        def get_race_predictions(self):
+            return None
+
+        def get_hrv_data(self, activity_date):
+            return None
+
+        def get_sleep_data(self, activity_date):
+            return None
+
+    def capture_activities(user_id, rows, db):
+        written_rows.extend(rows)
+        return len(rows)
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("garminconnect.Garmin", FakeGarmin)
+    monkeypatch.setattr("sync.garmin_sync.RATE_LIMIT_DELAY", 0)
+    monkeypatch.setattr("db.sync_writer.write_activities", capture_activities)
+    for name in (
+        "write_splits",
+        "write_samples",
+        "write_lactate_threshold",
+        "write_daily_metrics",
+        "write_recovery",
+        "write_profile_thresholds",
+    ):
+        monkeypatch.setattr(f"db.sync_writer.{name}", lambda *args, **kwargs: 0)
+
+    class FakeConfig:
+        source_options = {"garmin_activity_categories": ["running"]}
+
+    monkeypatch.setattr(
+        "analysis.config.load_config_from_db",
+        lambda user_id, db: FakeConfig(),
+    )
+
+    class NullDB:
+        def query(self, model):
+            class Query:
+                def filter(self, *args):
+                    return self
+
+                def all(self):
+                    return [
+                        SimpleNamespace(
+                            activity_id="1000",
+                            temperature_c=25.0,
+                            relative_humidity_pct=50.0,
+                            environment_source="garmin_activity_weather",
+                        ),
+                    ]
+
+            return Query()
+
+        def begin_nested(self):
+            return contextlib.nullcontext()
+
+    from api.routes.sync import _sync_garmin
+
+    result = _sync_garmin(
+        "weather-user",
+        {"email": "runner@example.com", "password": "secret"},
+        date.today().isoformat(),
+        NullDB(),
+    )
+
+    assert result["activities"] == 4
+    assert weather_calls == ["1001", "1002"]
+    rows_by_id = {row["activity_id"]: row for row in written_rows}
+    assert rows_by_id["1001"]["temperature_c"] == "30.0"
+    assert rows_by_id["1001"]["relative_humidity_pct"] == "72.0"
+    assert (
+        rows_by_id["1001"]["environment_source"]
+        == "garmin_activity_weather"
+    )
+    assert "temperature_c" not in rows_by_id["1000"]
+    assert "temperature_c" not in rows_by_id["1002"]
+    assert "temperature_c" not in rows_by_id["1003"]
+
+
+@pytest.mark.parametrize(
+    "weather_error",
+    [
+        GarminConnectTooManyRequestsError("rate limited"),
+        _garmin_connection_error(403),
+    ],
+)
+def test_sync_garmin_weather_systemic_error_aborts_for_backoff(
+    tmp_path, monkeypatch, weather_error,
+):
+    class RateLimitedGarmin:
+        def __init__(self, email, password, is_cn=False):
+            self.client = type("Client", (), {})()
+
+        def login(self, token_dir):
+            pass
+
+        def get_activities_by_date(self, *args, **kwargs):
+            return [
+                {
+                    "activityId": 1001,
+                    "startTimeLocal": "2026-07-20 07:00:00",
+                    "activityType": {"typeKey": "running"},
+                },
+            ]
+
+        def get_activity_weather(self, activity_id):
+            raise weather_error
+
+    class FakeConfig:
+        source_options = {"garmin_activity_categories": ["running"]}
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("garminconnect.Garmin", RateLimitedGarmin)
+    monkeypatch.setattr(
+        "analysis.config.load_config_from_db",
+        lambda user_id, db: FakeConfig(),
+    )
+    monkeypatch.setattr(
+        "api.routes.sync._activity_ids_needing_environment",
+        lambda user_id, activity_ids, db: set(activity_ids),
+    )
+
+    from api.routes.sync import _sync_garmin
+
+    with pytest.raises(type(weather_error)):
+        _sync_garmin(
+            "weather-user",
+            {"email": "runner@example.com", "password": "secret"},
+            date.today().isoformat(),
+            object(),
+        )
+
 
 SAMPLE_ACTIVITY = {
     "activityId": 12345678901,


### PR DESCRIPTION
## Summary

- fetch Garmin activity weather and normalize Fahrenheit plus relative humidity
- fetch COROS Training Hub activity detail weather and normalize its x10 wire units
- enrich only outdoor running and trail-running activities whose coherent environment pair can still be filled
- preserve optional missing observations while propagating authentication and rate-limit failures to connector backoff
- document provider coverage and add parser, orchestration, indoor-exclusion, persistence-skip, and backoff regressions

## Connector study

| Connector | Temperature | Humidity | Result |
| --- | --- | --- | --- |
| Stryd | Activity summary | Activity summary | Already supported by #446 |
| Garmin | `get_activity_weather()` | `relativeHumidity` | Added |
| COROS | Training Hub `/activity/detail/query` | Same weather object | Added |
| Strava | Celsius stream | Not exposed | No synthetic pair |

## Validation

- `python -m pytest tests/ -q` — 1194 passed, 3 skipped

Closes #447
