### PR TITLE
Deduplicate heat evidence for multi-provider activities

### DIFF
--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -466,36 +466,49 @@ def load_data_from_db(user_id: str, db: Session) -> dict[str, pd.DataFrame]:
 def load_heat_adaptation_inputs(
     user_id: str,
     db: Session,
+    activity_source: str,
     current_date: date,
     sample_max_interval_sec: float,
     lookback_days: int,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Load bounded environment, split power, and cadence-weighted sample power.
 
-    The heat tracker intentionally reads activity-level temperature/humidity
-    only as environmental context. Exercise intensity prefers timestamped
-    sample power, aggregated by exact power value in SQL to keep the request
-    bounded, with ``activity_splits.avg_power`` as fallback. A sample owns the
-    interval until the next timestamp only when that gap is positive and no
-    larger than ``sample_max_interval_sec``; larger gaps and the terminal sample
-    contribute no observed duration. Activity ``avg_power`` is never loaded for
-    this metric.
+    The selected activity provider is applied to parent activity rows and both
+    evidence joins so the same physical workout synced by multiple platforms
+    appears only once. Split/sample power provenance remains intact because a
+    Garmin activity may legitimately contain Stryd power. The heat tracker
+    intentionally reads activity-level temperature/humidity only as
+    environmental context. Exercise intensity prefers timestamped sample
+    power, aggregated by exact power value in SQL to keep the request bounded,
+    with ``activity_splits.avg_power`` as fallback. A sample owns the interval
+    until the next timestamp only when that gap is positive and no larger than
+    ``sample_max_interval_sec``; larger gaps and the terminal sample contribute
+    no observed duration. Activity ``avg_power`` is never loaded for this
+    metric.
     """
+    if not isinstance(activity_source, str) or not activity_source.strip():
+        raise ValueError("activity_source must be a non-empty provider name")
+    normalized_activity_source = activity_source.strip().casefold()
+
     cutoff = current_date - timedelta(days=max(1, lookback_days) - 1)
     activities = pd.read_sql(
         text(
-            "SELECT activity_id, date, activity_type, duration_sec, source, "
-            "environment_source, temperature_c, relative_humidity_pct "
-            "FROM activities "
-            "WHERE user_id = :uid AND date BETWEEN :cutoff AND :current_date "
-            "  AND activity_type IN ('running', 'trail_running') "
-            "ORDER BY date"
+            "SELECT a.activity_id, a.date, a.activity_type, a.duration_sec, "
+            "a.source, a.environment_source, a.temperature_c, "
+            "a.relative_humidity_pct "
+            "FROM activities AS a "
+            "WHERE a.user_id = :uid "
+            "  AND a.date BETWEEN :cutoff AND :current_date "
+            "  AND a.activity_type IN ('running', 'trail_running') "
+            "  AND LOWER(a.source) = :activity_source "
+            "ORDER BY a.date"
         ),
         db.bind,
         params={
             "uid": user_id,
             "cutoff": cutoff,
             "current_date": current_date,
+            "activity_source": normalized_activity_source,
         },
         parse_dates=["date"],
     )
@@ -511,13 +524,15 @@ def load_heat_adaptation_inputs(
             "  ON a.user_id = s.user_id AND a.activity_id = s.activity_id "
             "WHERE a.user_id = :uid "
             "  AND a.date BETWEEN :cutoff AND :current_date "
-            "  AND a.activity_type IN ('running', 'trail_running')"
+            "  AND a.activity_type IN ('running', 'trail_running') "
+            "  AND LOWER(a.source) = :activity_source"
         ),
         db.bind,
         params={
             "uid": user_id,
             "cutoff": cutoff,
             "current_date": current_date,
+            "activity_source": normalized_activity_source,
         },
     )
     sample_power = pd.read_sql(
@@ -534,7 +549,8 @@ def load_heat_adaptation_inputs(
             "    ON a.user_id = s.user_id AND a.activity_id = s.activity_id "
             "  WHERE a.user_id = :uid "
             "    AND a.date BETWEEN :cutoff AND :current_date "
-            "    AND a.activity_type IN ('running', 'trail_running')"
+            "    AND a.activity_type IN ('running', 'trail_running') "
+            "    AND LOWER(a.source) = :activity_source"
             ") "
             "SELECT activity_id, power_provider, power_watts, "
             "       SUM(CASE "
@@ -558,6 +574,7 @@ def load_heat_adaptation_inputs(
             "uid": user_id,
             "cutoff": cutoff,
             "current_date": current_date,
+            "activity_source": normalized_activity_source,
             "sample_max_interval_sec": sample_max_interval_sec,
         },
     )

--- a/api/daily_brief_freshness.py
+++ b/api/daily_brief_freshness.py
@@ -4,8 +4,8 @@
 DAILY_BRIEF_FRESHNESS_KEY = "daily_brief_freshness"
 
 # Cache/ETag salt for the deterministic /api/today representation.
-TODAY_RESPONSE_VERSION = "heat-adaptation-today-v11"
-TRAINING_RESPONSE_VERSION = "heat-adaptation-training-v10"
+TODAY_RESPONSE_VERSION = "heat-adaptation-today-v12"
+TRAINING_RESPONSE_VERSION = "heat-adaptation-training-v11"
 GOAL_RESPONSE_VERSION = "fixed-heat-model-goal-v1"
 SCIENCE_RESPONSE_VERSION = "fixed-heat-model-v1"
 PLAN_RESPONSE_VERSION = "connection-aware-plan-v2"

--- a/api/dashboard_cache.py
+++ b/api/dashboard_cache.py
@@ -26,7 +26,7 @@ Invalidation semantics — reuse L2's revision counters:
   scopes sorted alphabetically so two callers produce byte-identical
   strings, plus date and response-version salts where applicable.
   Example for ``today`` on 2026-04-26 with all-zero revisions:
-  ``"activities=0|config=0|fitness=0|plans=0|recovery=0|samples=0|splits=0|d=2026-04-26|v=heat-adaptation-today-v11"``.
+  ``"activities=0|config=0|fitness=0|plans=0|recovery=0|samples=0|splits=0|d=2026-04-26|v=heat-adaptation-today-v12"``.
   Any sync-writer or settings-route bump advances the relevant scope,
   so the cached row's source_version no longer matches and the next
   read recomputes.

--- a/api/deps.py
+++ b/api/deps.py
@@ -1810,39 +1810,27 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
         recovery_thresholds=recovery_params,
         hrv_only=hrv_only_mode,
     )
+    primary_activity_provider = (
+        config.preferences.get("activities") or "garmin"
+    )
     if user_id and db:
         heat_activities, heat_splits, heat_sample_power = (
             load_heat_adaptation_inputs(
                 user_id,
                 db,
+                activity_source=primary_activity_provider,
                 current_date=today,
                 sample_max_interval_sec=HEAT_SAMPLE_MAX_INTERVAL_SEC,
                 lookback_days=HEAT_LOOKBACK_DAYS,
             )
         )
     else:
-        primary_activity_provider = config.preferences.get("activities")
-        if (
-            thresholds.cp_power_provider
-            and thresholds.cp_power_provider != primary_activity_provider
-        ):
-            heat_activities, heat_splits, heat_sample_power = (
-                load_heat_adaptation_inputs_from_files(
-                    thresholds.cp_power_provider,
-                    data_dir,
-                )
+        heat_activities, heat_splits, heat_sample_power = (
+            load_heat_adaptation_inputs_from_files(
+                primary_activity_provider,
+                data_dir,
             )
-        else:
-            heat_activities = merged
-            heat_splits = data["splits"].copy()
-            if (
-                "power_provider" not in heat_splits.columns
-                and "power_source" in heat_splits.columns
-            ):
-                heat_splits = heat_splits.rename(
-                    columns={"power_source": "power_provider"},
-                )
-            heat_sample_power = pd.DataFrame()
+        )
     heat_adaptation = apply_heat_adaptation_guidance(
         compute_heat_adaptation(
             heat_activities,

--- a/api/packs.py
+++ b/api/packs.py
@@ -223,6 +223,10 @@ class RequestContext:
         activities, splits, sample_power = load_heat_adaptation_inputs(
             self.user_id,
             self.db,
+            activity_source=(
+                self.config.preferences.get("activities")
+                or "garmin"
+            ),
             current_date=self.today,
             sample_max_interval_sec=HEAT_SAMPLE_MAX_INTERVAL_SEC,
             lookback_days=HEAT_LOOKBACK_DAYS,

--- a/tests/test_dashboard_cache.py
+++ b/tests/test_dashboard_cache.py
@@ -218,10 +218,10 @@ def test_compute_source_version_is_deterministic(cache_client):
             "today is date-salted — date.today() must appear in source_version"
         )
         assert "splits=0" in a
-        assert "v=heat-adaptation-today-v11" in a
+        assert "v=heat-adaptation-today-v12" in a
         training = compute_source_version(db, user_id, "training")
         assert "samples=0" in training
-        assert "v=heat-adaptation-training-v10" in training
+        assert "v=heat-adaptation-training-v11" in training
         goal = compute_source_version(db, user_id, "goal")
         assert "v=fixed-heat-model-goal-v1" in goal
     finally:
@@ -340,7 +340,7 @@ def test_today_recomputes_prior_response_version_with_snapshot(cache_client):
     try:
         current_version = compute_source_version(db, user_id, "today")
         prior_version = current_version.replace(
-            "v=heat-adaptation-today-v11",
+            "v=heat-adaptation-today-v12",
             "v=heat-adaptation-today-v8",
         )
         assert prior_version != current_version

--- a/tests/test_etag.py
+++ b/tests/test_etag.py
@@ -133,8 +133,8 @@ def test_response_versions_cover_changed_endpoints():
     """Deployment salts invalidate pre-change cached endpoint bodies."""
     from api.etag import ENDPOINT_RESPONSE_VERSIONS
 
-    assert ENDPOINT_RESPONSE_VERSIONS["today"] == "heat-adaptation-today-v11"
-    assert ENDPOINT_RESPONSE_VERSIONS["training"] == "heat-adaptation-training-v10"
+    assert ENDPOINT_RESPONSE_VERSIONS["today"] == "heat-adaptation-today-v12"
+    assert ENDPOINT_RESPONSE_VERSIONS["training"] == "heat-adaptation-training-v11"
     assert ENDPOINT_RESPONSE_VERSIONS["goal"] == "fixed-heat-model-goal-v1"
     assert ENDPOINT_RESPONSE_VERSIONS["science"] == "fixed-heat-model-v1"
     assert ENDPOINT_RESPONSE_VERSIONS["plan"] == "connection-aware-plan-v2"

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -130,6 +130,22 @@ def _ctx(db_with_seeded_user):
     return RequestContext(user_id=user_id, db=db)
 
 
+def _set_activity_source(db, user_id: str, source: str) -> None:
+    from db.models import UserConfig as UserConfigModel
+
+    row = db.query(UserConfigModel).filter(
+        UserConfigModel.user_id == user_id,
+    ).first()
+    if row is None:
+        row = UserConfigModel(user_id=user_id)
+        db.add(row)
+    row.preferences = {
+        **(row.preferences or {}),
+        "activities": source,
+    }
+    db.commit()
+
+
 def _seed_heat_exposure(db, user_id):
     from db.models import Activity, ActivitySplit
 
@@ -234,6 +250,7 @@ def test_heat_input_loader_weights_sample_power_by_timestamp_cadence(
     activities, _, sample_power = load_heat_adaptation_inputs(
         user_id,
         db,
+        activity_source="stryd",
         current_date=date.today(),
         sample_max_interval_sec=HEAT_SAMPLE_MAX_INTERVAL_SEC,
         lookback_days=HEAT_LOOKBACK_DAYS,
@@ -293,6 +310,7 @@ def test_heat_input_loader_does_not_bridge_null_power_samples(
     _, _, sample_power = load_heat_adaptation_inputs(
         user_id,
         db,
+        activity_source="stryd",
         current_date=date.today(),
         sample_max_interval_sec=HEAT_SAMPLE_MAX_INTERVAL_SEC,
         lookback_days=HEAT_LOOKBACK_DAYS,
@@ -303,6 +321,166 @@ def test_heat_input_loader_does_not_bridge_null_power_samples(
     ].set_index("power_watts")["duration_sec"].to_dict()
     assert buckets == {180.0: 1}
     assert set(sample_power["power_provider"]) == {"stryd"}
+
+
+def test_heat_adaptation_uses_one_provider_for_duplicate_activity_rows(
+    db_with_seeded_user,
+):
+    """Garmin and Stryd copies of one run produce one heat-evidence session."""
+    from analysis.data_loader import load_heat_adaptation_inputs
+    from analysis.metrics import (
+        HEAT_LOOKBACK_DAYS,
+        HEAT_SAMPLE_MAX_INTERVAL_SEC,
+    )
+    from api.packs import RequestContext
+    from db.models import (
+        Activity,
+        ActivitySample,
+        ActivitySplit,
+    )
+
+    db, user_id = db_with_seeded_user
+    _set_activity_source(db, user_id, "stryd")
+    stryd_activity = (
+        db.query(Activity)
+        .filter(
+            Activity.user_id == user_id,
+            Activity.source == "stryd",
+        )
+        .order_by(Activity.date.desc())
+        .first()
+    )
+    assert stryd_activity is not None
+    stryd_activity.duration_sec = 3600.0
+    stryd_activity.temperature_c = 34.0
+    stryd_activity.relative_humidity_pct = 70.0
+    stryd_activity.environment_source = "stryd_activity_weather"
+    stryd_split = db.query(ActivitySplit).filter(
+        ActivitySplit.user_id == user_id,
+        ActivitySplit.activity_id == stryd_activity.activity_id,
+    ).one()
+    stryd_split.duration_sec = 3600.0
+    stryd_split.avg_power = 180.0
+
+    garmin_activity_id = "garmin-duplicate-run"
+    db.add(Activity(
+        user_id=user_id,
+        activity_id=garmin_activity_id,
+        date=stryd_activity.date,
+        activity_type="running",
+        distance_km=stryd_activity.distance_km,
+        duration_sec=3600.0,
+        temperature_c=34.0,
+        relative_humidity_pct=70.0,
+        environment_source="garmin_activity_weather",
+        source="garmin",
+    ))
+    db.add(ActivitySplit(
+        user_id=user_id,
+        activity_id=garmin_activity_id,
+        split_num=1,
+        duration_sec=3600.0,
+        avg_power=180.0,
+        power_source="garmin",
+    ))
+    db.add_all([
+        ActivitySample(
+            user_id=user_id,
+            activity_id=stryd_activity.activity_id,
+            source="stryd",
+            t_sec=0,
+            power_watts=180.0,
+        ),
+        ActivitySample(
+            user_id=user_id,
+            activity_id=stryd_activity.activity_id,
+            source="stryd",
+            t_sec=1,
+            power_watts=180.0,
+        ),
+        ActivitySample(
+            user_id=user_id,
+            activity_id=garmin_activity_id,
+            source="garmin",
+            t_sec=0,
+            power_watts=180.0,
+        ),
+        ActivitySample(
+            user_id=user_id,
+            activity_id=garmin_activity_id,
+            source="garmin",
+            t_sec=1,
+            power_watts=180.0,
+        ),
+    ])
+    db.commit()
+
+    activities, splits, sample_power = load_heat_adaptation_inputs(
+        user_id,
+        db,
+        activity_source="stryd",
+        current_date=date.today(),
+        sample_max_interval_sec=HEAT_SAMPLE_MAX_INTERVAL_SEC,
+        lookback_days=HEAT_LOOKBACK_DAYS,
+    )
+    selected_ids = set(activities["activity_id"])
+    assert garmin_activity_id not in selected_ids
+    assert set(activities["source"]) == {"stryd"}
+    assert set(splits["activity_id"]).issubset(selected_ids)
+    assert set(sample_power["activity_id"]).issubset(selected_ids)
+
+    status = RequestContext(user_id=user_id, db=db).heat_adaptation
+    assert [session["activity_id"] for session in status["sessions"]] == [
+        stryd_activity.activity_id,
+    ]
+    cadence_day = next(
+        day for day in status["cadence"]
+        if day["date"] == stryd_activity.date.isoformat()
+    )
+    assert cadence_day["session_count"] == 1
+    assert cadence_day["counted_session_count"] == 1
+
+
+def test_heat_adaptation_preserves_cross_provider_power_on_selected_activity(
+    db_with_seeded_user,
+):
+    """A selected Garmin activity can qualify with provenance-tagged Stryd power."""
+    from api.packs import RequestContext
+    from db.models import (
+        Activity,
+        ActivitySplit,
+    )
+
+    db, user_id = db_with_seeded_user
+    activity = (
+        db.query(Activity)
+        .filter(Activity.user_id == user_id)
+        .order_by(Activity.date.desc())
+        .first()
+    )
+    assert activity is not None
+    activity.source = "garmin"
+    activity.duration_sec = 3600.0
+    activity.temperature_c = 34.0
+    activity.relative_humidity_pct = 70.0
+    activity.environment_source = "garmin_activity_weather"
+    split = db.query(ActivitySplit).filter(
+        ActivitySplit.user_id == user_id,
+        ActivitySplit.activity_id == activity.activity_id,
+    ).one()
+    split.duration_sec = 3600.0
+    split.avg_power = 180.0
+    split.power_source = "stryd"
+    _set_activity_source(db, user_id, "garmin")
+
+    status = RequestContext(user_id=user_id, db=db).heat_adaptation
+
+    assert [session["activity_id"] for session in status["sessions"]] == [
+        activity.activity_id,
+    ]
+    assert status["sessions"][0]["power_provider"] == "stryd"
+    assert status["sessions"][0]["power_source_alignment"] == "matched"
+    assert status["sessions"][0]["qualifies"] is True
 
 
 def test_preferred_source_selector_uses_stable_lexical_tie_break():
@@ -499,6 +677,7 @@ def test_today_and_training_payloads_expose_heat_adaptation(
     from api.routes.training import _build_training_payload
 
     db, user_id = db_with_seeded_user
+    _set_activity_source(db, user_id, "stryd")
     _seed_heat_exposure(db, user_id)
 
     today_payload = _build_today_payload(user_id, db)
@@ -524,6 +703,7 @@ def test_training_payload_applies_restrictive_today_heat_guard(
     from db.models import TrainingPlan
 
     db, user_id = db_with_seeded_user
+    _set_activity_source(db, user_id, "stryd")
     _seed_heat_exposure(db, user_id)
     plan = db.query(TrainingPlan).filter(
         TrainingPlan.user_id == user_id,
@@ -551,6 +731,7 @@ def test_environment_evidence_does_not_change_existing_training_outputs(
     from api.routes.training import _build_training_payload
 
     db, user_id = db_with_seeded_user
+    _set_activity_source(db, user_id, "stryd")
     before_today = _build_today_payload(user_id, db)
     before_training = _build_training_payload(user_id, db)
 


### PR DESCRIPTION
## Summary
- restrict heat-adaptation parent activities to the user-selected activity provider so Garmin and Stryd copies of one run produce one evidence session
- preserve split/sample power provenance independently, including Garmin activities that legitimately carry Stryd power
- apply the same source selection to database, legacy file, cadence, and ledger paths
- bump Today and Training response versions so deployed caches cannot retain duplicate sessions

## Regression coverage
- duplicate Garmin/Stryd activity rows with Stryd selected yield one included ledger entry and one cadence session
- a selected Garmin activity with Stryd split power still aligns with Stryd CP and qualifies
- activity, split, and sample queries remain bounded to selected parent activity IDs

## Validation
- `python -m pytest tests/` — 1097 passed, 1 skipped
- API contract review — no findings
- final code review — no findings