### PR TITLE
Document Actions PR permission after repo transfer

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -76,6 +76,9 @@ jobs:
   # (plus any additional refs you want to run from). The app needs
   # "Cognitive Services OpenAI User" on the Foundry resource — scope it there,
   # not at subscription level.
+  # PR creation also requires the organization and repository Actions settings
+  # to allow GITHUB_TOKEN to create pull requests. Repository transfers can
+  # inherit a disabled organization policy; see docs/ops/config-and-secrets.md.
   translate:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -47,6 +47,60 @@ transient — the next deploy overwrites them.**
 | `PRAXYS_DB_AUTH` (`entra` or unset) | Postgres auth mode: `entra` = AAD token via managed identity, no password. **Optional.** | App Service setting (backend) |
 | `PRAXYS_PG_SERVER` | Postgres Flexible Server name. **Reserved / currently unused** - the on-demand backup jobs it gated were removed (Burstable tier can't do on-demand backups; PITR covers backup). Kept for a future off-site backup job. | (reserved) |
 
+### GitHub Actions → Workflow permissions
+
+The i18n workflow uses `GITHUB_TOKEN` plus explicit `contents: write` and
+`pull-requests: write` job permissions to update `i18n/refresh-zh` and open its
+review PR. GitHub also has an independent **Allow GitHub Actions to create and
+approve pull requests** gate. A repository transfer into an organization can
+inherit that organization's disabled gate even when workflow YAML, secrets, and
+variables transfer successfully.
+
+Source of truth:
+
+- Organization prerequisite: `praxys-run → Settings → Actions → General →
+  Workflow permissions`.
+- Repository setting: `praxys-run/praxys → Settings → Actions → General →
+  Workflow permissions`.
+- Keep **Default workflow permissions** at `read`; the workflow grants only the
+  writes its job needs.
+- Enable PR creation for `praxys-run/praxys` only. Keep
+  `praxys-run/praxys-coach-plugin` and `praxys-run/praxys-ops-agent` disabled.
+
+Provision the current least-privilege state:
+
+```bash
+# The organization gate must allow repository-level opt-in.
+gh api -X PUT orgs/praxys-run/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+
+gh api -X PUT repos/praxys-run/praxys/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+
+# Explicitly retain the disabled state on repositories that do not create PRs.
+for repo in praxys-coach-plugin praxys-ops-agent; do
+  gh api -X PUT "repos/praxys-run/$repo/actions/permissions/workflow" \
+    -f default_workflow_permissions=read \
+    -F can_approve_pull_request_reviews=false
+done
+```
+
+Verify:
+
+```bash
+gh api orgs/praxys-run/actions/permissions/workflow
+for repo in praxys praxys-coach-plugin praxys-ops-agent; do
+  gh api "repos/praxys-run/$repo/actions/permissions/workflow"
+done
+```
+
+If `i18n.yml` pushes `i18n/refresh-zh` but fails at **Open pull request** with
+`GitHub Actions is not permitted to create or approve pull requests`, restore
+these gates and rerun the failed job. This setting was restored on 2026-07-24
+after the org migration exposed the missing post-transfer step.
+
 Application Insights resource names are tracked in
 `.github/azure-observability.env`, not repository variables. The deploy
 workflows use Azure OIDC to read each component's connection string at runtime;

--- a/docs/ops/org-migration.md
+++ b/docs/ops/org-migration.md
@@ -19,6 +19,10 @@ variables + webhooks + deploy keys remain** with the repo). The things that
   so we **pre-stage it additively before** the transfer.
 - **The feedback GitHub App** installation is on the `dddtc2005` *user*; an
   org-owned repo needs the app installed on the *org*.
+- **Actions PR creation policy** — the transferred repo inherits the target
+  organization's workflow-permission gate. `GITHUB_TOKEN` can still push an
+  automation branch while PR creation fails with `GitHub Actions is not
+  permitted to create or approve pull requests`.
 - **The submodule URL** and a pile of `dddtc2005/praxys` references in docs
   (redirects keep them working, but we update for correctness).
 
@@ -179,13 +183,42 @@ git submodule sync --recursive   # picks up the .gitmodules change from step 2.4
 > covers every worktree. Repeat for local clones of `praxys-coach-plugin` and
 > `praxys-ops-agent`.
 
+### 2.8 Restore Actions PR creation for `praxys` only 🤖
+
+The target org's Actions policy may block repository workflows from creating
+pull requests even though `contents: write` and `pull-requests: write` appear in
+the workflow. The org gate must permit repository opt-in; then enable the repo
+gate only where it is required by `.github/workflows/i18n.yml`.
+
+```bash
+gh api -X PUT orgs/praxys-run/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+
+gh api -X PUT repos/praxys-run/praxys/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+
+for repo in praxys-coach-plugin praxys-ops-agent; do
+  gh api -X PUT "repos/praxys-run/$repo/actions/permissions/workflow" \
+    -f default_workflow_permissions=read \
+    -F can_approve_pull_request_reviews=false
+done
+```
+
+The organization-level switch is a prerequisite for the repository override;
+the explicit `false` settings retain least privilege on the other two repos.
+See [config-and-secrets.md](./config-and-secrets.md) for the source of truth and
+verification commands.
+
 ---
 
 ## Phase 3 — Verify
 
 - 🤖 **Backend deploy** green (OIDC login step succeeds) → `https://api.praxys.run` healthy.
 - 🤖 **Frontend deploy** green → `https://www.praxys.run` serves.
-- 🤖 **i18n** workflow (push to main) logs in via OIDC.
+- 🤖 **i18n** workflow (push to main) logs in via OIDC **and its Open pull
+  request step succeeds**.
 - 🧑/🤖 **Feedback → issue**: submit a test in-app feedback (or re-run triage) → a
   new issue is filed in `praxys-run/praxys`.
 - 🤖 **Change loop**: label a throwaway bug `agent-ready` → `assign-copilot.yml`
@@ -221,6 +254,9 @@ git submodule sync --recursive   # picks up the .gitmodules change from step 2.4
 - **GitHub App**: if issue-filing breaks, re-check the org installation + the two
   variables (2.2–2.3); the app private key (`PRAXYS_GITHUB_APP_PRIVATE_KEY`) is
   unchanged.
+- **i18n PR creation**: if the translation branch updates but **Open pull
+  request** fails with `GitHub Actions is not permitted to create or approve
+  pull requests`, restore both permission gates in 2.8 and rerun the failed job.
 
 ## Free-org caveats (accepted)
 
@@ -241,4 +277,4 @@ git submodule sync --recursive   # picks up the .gitmodules change from step 2.4
 - [deploy.md](./deploy.md) — the deploy workflows that use OIDC.
 
 ---
-_Last reviewed: 2026-07-08 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-24 · Owner: @dddtc2005_


### PR DESCRIPTION
## Summary
- document the org-level Actions policy inherited during the repository transfer
- record the least-privilege state: PR creation enabled only for `praxys`, disabled for the plugin and ops-agent repos
- add provisioning, verification, and recovery commands to the ops handbook
- annotate the i18n workflow with its repository-policy prerequisite

## Root cause
Run [30062719968](https://github.com/praxys-run/praxys/actions/runs/30062719968) translated successfully and pushed `i18n/refresh-zh`, but failed because the migrated repository inherited the org setting that forbade `GITHUB_TOKEN` from creating pull requests.

## Live repair
- enabled the organization prerequisite while retaining default workflow permissions as `read`
- opted in only `praxys`; explicitly kept `praxys-coach-plugin` and `praxys-ops-agent` disabled
- reran the failed job; the complete workflow, including **Open pull request**, passed