### PR TITLE
Document zero-approval merge policy

### DIFF
--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -148,15 +148,19 @@ Protect `main` so the coding agent cannot ship or bypass checks:
   backend pytest and the web production build. Add it once that workflow has run
   on a PR so the check name is selectable.
 
-The repository ruleset currently requires one approval and squash merge, with an
-`Always` bypass for the repo-admin role so the solo maintainer can merge a green
-PR without a formal self-approval. That makes review maintainer-controlled, not
-mechanically universal. Do not grant the coding agent that bypass.
+Repository ruleset `default` (id `15208143`) requires a pull request and
+squash-only merge, and blocks branch deletion and non-fast-forward updates. Its
+`required_approving_review_count` is `0`: human review is encouraged for risky,
+security-sensitive, or science-affecting changes, but it is not a mandatory
+merge gate for the solo-maintainer workflow. The classic `backend-tests` status
+check remains required with admin enforcement.
 
-Future no-review merges must use a separate policy-owned identity or ruleset path
-that is limited to promoted change classes and still requires all checks. Do not
-reuse the broad repo-admin bypass, and do not let the implementation agent label
-its own PR as eligible.
+The ruleset retains an `Always` bypass for the repository-role admin. Normal
+green PRs do not need that bypass now that no approval is required; keep it as a
+maintainer capability and never grant it to the coding agent. Any future
+policy-owned auto-merge path must remain independently allowlisted and
+check-gated rather than reusing this broad bypass, and the implementation agent
+must not label its own PR as eligible.
 
 ```bash
 gh api repos/praxys-run/praxys/branches/main/protection --jq '{checks:.required_status_checks}'
@@ -269,17 +273,19 @@ hidden in issue text. Defenses, in layers:
   `copilot-swe-agent` bot on a `copilot/*` branch, reviewable line-by-line. A
   zip / "patched build" / diff attached by a non-collaborator is **never** our
   flow — do not download, unzip, run, or apply it.
-- **The merge path is policy-owned** (§4). Today the maintainer decides. A future
-  no-review path must be independently allowlisted and check-gated; the coding
-  agent never self-approves or receives a broad bypass.
+- **The merge path is policy-owned** (§4). Today the maintainer decides whether
+  a green PR is ready; human review is encouraged for risky, security-sensitive,
+  or science-affecting changes but is not a mandatory gate. Any automated merge
+  path must be independently allowlisted and check-gated; the coding agent never
+  receives the broad admin bypass.
 - **The trigger is write-gated.** `agent-ready` can only be added by the triage
   bot or a maintainer — a drive-by account cannot start the loop. Keep it that
   way (don't let automation add the label from untrusted input).
 - **Least-privilege, expiring token** for assignment (§3); the agent runs in
   GitHub's sandbox with its firewall on — don't disable it.
-- **Protect `.github/**`** with CODEOWNERS + required review so a PR can't
-  quietly weaken a workflow or exfiltrate secrets; pin actions, keep
-  `permissions:` minimal, never expose secrets to fork/PR code.
+- **Treat `.github/**` changes as high risk.** Keep CODEOWNERS as an ownership
+  signal and obtain human review before merging workflow or policy changes; pin
+  actions, keep `permissions:` minimal, and never expose secrets to fork/PR code.
 
 **Treat all user-supplied text as untrusted (prompt-injection):** issue bodies,
 comments, and screenshot-derived text can carry "ignore your instructions…"
@@ -383,4 +389,4 @@ gh run list --workflow=assign-copilot.yml -R praxys-run/praxys --limit 5
 - Design: praxys-run/praxys#362 (the change loop); #361 (backend pytest gate); #377 (self-improvement).
 
 ---
-_Last reviewed: 2026-07-25 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-26 · Owner: @dddtc2005_

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -72,7 +72,7 @@
 ## Repo governance
 
 - **Owner:** the repos live in the **`praxys-run`** org (GitHub **Free**; public repos keep branch protection + unlimited Actions minutes). Migrated from the `dddtc2005` personal account on 2026-07-10 — see [org-migration.md](./org-migration.md).
-- **`main` protection is two layers.** (1) **Classic branch protection**: required status check `backend-tests` (`ci-backend.yml`, #361) blocks merge on a failing `pytest`, **admins included** (`enforce_admins`); managed via `repos/praxys-run/praxys/branches/main/protection`. (2) **Repo ruleset `default`** (id `15208143`): **squash-only** merges + **1 required review**, with a **repo-admin `Always` bypass** so the solo maintainer self-merges a green PR; managed via the rulesets API. ⚠️ **Transfer gotcha:** moving a repo between accounts **wipes the ruleset's `bypass_actors`** — after the org migration the bypass list was empty (deadlocking solo self-merge) and had to be restored (`PUT repos/praxys-run/praxys/rulesets/15208143`, requires `admin:org` scope + the full ruleset body).
+- **`main` protection is two layers.** (1) **Classic branch protection**: required status check `backend-tests` (`ci-backend.yml`, #361) blocks merge on a failing `pytest`, **admins included** (`enforce_admins`); managed via `repos/praxys-run/praxys/branches/main/protection`. (2) **Repo ruleset `default`** (id `15208143`): a pull request is required, merges are **squash-only**, and deletion plus non-fast-forward updates are blocked. Since 2026-07-26, `required_approving_review_count` is **`0`**: human review remains encouraged for risky, security-sensitive, or science-affecting changes, but it is not a mandatory merge gate for the solo-maintainer workflow. The ruleset retains the repository-role admin `Always` bypass as a maintainer capability; normal green PRs do not need it. Managed via the rulesets API. ⚠️ **Transfer gotcha:** moving a repo between accounts **wipes the ruleset's `bypass_actors`** — after the org migration the bypass list was empty (then deadlocking solo self-merge under the former one-approval policy) and had to be restored (`PUT repos/praxys-run/praxys/rulesets/15208143`, requires `admin:org` scope + the full ruleset body). Transfers must still restore the bypass deliberately if this admin capability is meant to remain.
 
 ## Related
 
@@ -80,4 +80,4 @@
 - `docs/deployment.md` (one-time Azure setup) · `docs/perf-baselines/azure-provisioning.md`
 
 ---
-_Last reviewed: 2026-07-18 · Owner: @dddtc2005_
+_Last reviewed: 2026-07-26 · Owner: @dddtc2005_


### PR DESCRIPTION
## Summary
- document ruleset `default` id `15208143` with zero required approving reviews
- preserve the PR-only squash path, deletion/non-fast-forward protections, classic `backend-tests` gate, admin enforcement, and repository-role admin bypass
- clarify that human review remains encouraged for risky, security-sensitive, and science-affecting changes without being a mandatory solo-maintainer merge gate
- preserve the repository-transfer bypass restoration warning

## Validation
- compared the documentation against the live ruleset and classic branch-protection APIs
- `git diff --check`