### PR TITLE
Define managed plan ownership contract

### DIFF
--- a/alembic/versions/1a2b3c4d5e6f_add_plan_management_contract.py
+++ b/alembic/versions/1a2b3c4d5e6f_add_plan_management_contract.py
@@ -1,0 +1,32 @@
+"""add managed-plan ownership contract
+
+Revision ID: 1a2b3c4d5e6f
+Revises: a7b8c9d0e1f2
+Create Date: 2026-07-27
+
+Adds an explicit plan ownership/delivery-intent document without enabling
+external writes. Existing rows remain nullable and are normalized from legacy
+preferences by the application read path.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1a2b3c4d5e6f"
+down_revision: Union[str, Sequence[str], None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_config",
+        sa.Column("plan_management", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_config", "plan_management")

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -12,6 +12,8 @@ TrainingBase = Literal["power", "hr", "pace"]
 PlatformName = Literal["garmin", "stryd", "strava", "oura", "coros"]
 PlanSource = Literal["garmin", "stryd", "strava", "oura", "coros", "ai"]
 DataCategory = Literal["activities", "recovery", "fitness", "plan"]
+PlanManagementMode = Literal["external", "praxys"]
+PlanAdjustmentPolicy = Literal["suggest_only"]
 
 # Default zone boundaries as fractions of threshold value.
 # 4 boundaries define 5 zones (Z1..Z5).
@@ -40,6 +42,80 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCaps] = {
 }
 
 
+class PlanManagement(TypedDict):
+    """Ownership and delivery intent for future planned workouts."""
+
+    mode: PlanManagementMode
+    execution_target: str | None
+    delivery_enabled: bool
+    adjustment_policy: PlanAdjustmentPolicy
+
+
+def default_plan_management() -> PlanManagement:
+    """Return the safe default managed-plan contract."""
+    return {
+        "mode": "external",
+        "execution_target": None,
+        "delivery_enabled": False,
+        "adjustment_policy": "suggest_only",
+    }
+
+
+def normalize_plan_management(
+    value: object,
+    *,
+    legacy_plan_source: str | None = None,
+) -> PlanManagement:
+    """Normalize persisted managed-plan settings without auto-adopting a plan.
+
+    Missing legacy configs remain in external mode. A plan-capable provider in
+    ``preferences.plan`` may seed the execution target, but delivery always
+    stays disabled until a later explicit adoption flow enables it.
+    """
+    raw = value if isinstance(value, dict) else {}
+
+    mode = raw.get("mode", "external")
+    if mode not in {"external", "praxys"}:
+        logger.warning("Invalid plan management mode %r; using external", mode)
+        mode = "external"
+
+    raw_target = raw.get("execution_target")
+    if raw_target is None and not raw and legacy_plan_source != "ai":
+        raw_target = legacy_plan_source
+    target = str(raw_target).strip().casefold() if raw_target else None
+    if target:
+        caps = PLATFORM_CAPABILITIES.get(target)
+        if not caps or not caps.get("plan"):
+            logger.warning(
+                "Invalid plan execution target %r; clearing it",
+                raw_target,
+            )
+            target = None
+
+    delivery_enabled = raw.get("delivery_enabled", False)
+    if not isinstance(delivery_enabled, bool):
+        logger.warning(
+            "Invalid plan delivery_enabled %r; using false",
+            delivery_enabled,
+        )
+        delivery_enabled = False
+
+    adjustment_policy = raw.get("adjustment_policy", "suggest_only")
+    if adjustment_policy != "suggest_only":
+        logger.warning(
+            "Invalid plan adjustment policy %r; using suggest_only",
+            adjustment_policy,
+        )
+        adjustment_policy = "suggest_only"
+
+    return {
+        "mode": mode,
+        "execution_target": target,
+        "delivery_enabled": delivery_enabled,
+        "adjustment_policy": adjustment_policy,
+    }
+
+
 @dataclass
 class UserConfig:
     """Top-level user configuration stored as JSON."""
@@ -62,6 +138,10 @@ class UserConfig:
         "recovery": "oura",
         "plan": "stryd",
     })
+
+    # Explicit plan ownership. ``preferences.plan`` remains the legacy
+    # analytical read-source selector during the compatibility period.
+    plan_management: PlanManagement = field(default_factory=default_plan_management)
 
     training_base: TrainingBase = "power"
 
@@ -112,6 +192,7 @@ class UserConfig:
 
     def __post_init__(self) -> None:
         """Validate cross-field constraints."""
+        self.plan_management = normalize_plan_management(self.plan_management)
         # Validate preferences reference connected platforms with matching capabilities.
         # "ai" is a special plan source — not a platform, so skip platform checks for it.
         for category, platform in self.preferences.items():
@@ -134,6 +215,25 @@ class UserConfig:
             self.activity_routing["default"] = self.preferences.get(
                 "activities", "garmin"
             )
+
+
+def is_praxys_managed_plan(config: object) -> bool:
+    """Return whether Praxys owns the user's canonical future plan."""
+    plan_management = getattr(config, "plan_management", None)
+    return (
+        isinstance(plan_management, dict)
+        and plan_management.get("mode") == "praxys"
+    )
+
+
+def plan_analysis_source(config: object) -> str:
+    """Return the source analytical views should treat as canonical."""
+    if is_praxys_managed_plan(config):
+        return "ai"
+    preferences = getattr(config, "preferences", None)
+    if not isinstance(preferences, dict):
+        return ""
+    return str(preferences.get("plan") or "")
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +267,15 @@ def _migrate_config(data: dict) -> dict:
     prefs = data.get("preferences", {})
     if prefs.get("activities") and "activity_routing" not in data:
         data["activity_routing"] = {"default": prefs["activities"]}
+
+    if "plan_management" not in data:
+        legacy_target = prefs.get("plan")
+        if legacy_target not in data.get("connections", []):
+            legacy_target = None
+        data["plan_management"] = normalize_plan_management(
+            None,
+            legacy_plan_source=legacy_target,
+        )
 
     return data
 
@@ -208,6 +317,7 @@ def load_config_from_db(user_id: str, db) -> UserConfig:
     from db.models import UserConfig as UserConfigModel
 
     row = db.query(UserConfigModel).filter(UserConfigModel.user_id == user_id).first()
+    connections = _get_connections_from_db(user_id, db)
     if not row:
         # Fresh user with no saved settings yet. UserConfig()'s default
         # `connections` field contains ["garmin","stryd","oura"] — a leftover
@@ -215,7 +325,7 @@ def load_config_from_db(user_id: str, db) -> UserConfig:
         # page to show platforms as connected when the user has never linked
         # them. Always derive connections from the database instead.
         fresh = UserConfig()
-        fresh.connections = _get_connections_from_db(user_id, db)
+        fresh.connections = connections
         return fresh
 
     # Preferences: use stored preferences if set, otherwise derive from connections
@@ -223,12 +333,19 @@ def load_config_from_db(user_id: str, db) -> UserConfig:
     derived_prefs = _get_preferences_from_db(user_id, db)
     # Merge: stored prefs take priority, fill gaps from derived
     merged_prefs = {**derived_prefs, **stored_prefs}
+    plan_management = normalize_plan_management(
+        getattr(row, "plan_management", None),
+        legacy_plan_source=merged_prefs.get("plan"),
+    )
+    if plan_management["execution_target"] not in connections:
+        plan_management["execution_target"] = None
 
     return UserConfig(
         display_name=row.display_name or "",
         unit_system=getattr(row, "unit_system", "metric") or "metric",
-        connections=_get_connections_from_db(user_id, db),
+        connections=connections,
         preferences=merged_prefs,
+        plan_management=plan_management,
         training_base=row.training_base or "power",
         thresholds=row.thresholds or {},
         zones=row.zones or {k: list(v) for k, v in DEFAULT_ZONES.items()},
@@ -311,6 +428,7 @@ def save_config_to_db(user_id: str, config: UserConfig, db) -> None:
     row.unit_system = config.unit_system
     row.training_base = config.training_base
     row.preferences = config.preferences
+    row.plan_management = dict(config.plan_management)
     row.thresholds = config.thresholds
     row.zones = config.zones
     row.goal = config.goal

--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -183,7 +183,7 @@ def load_data(config: UserConfig, data_dir: str) -> dict[str, pd.DataFrame]:
     (e.g. Stryd power overlay on Garmin activities).
     Fitness is auto-merged from all connected fitness providers.
     """
-    from analysis.config import PLATFORM_CAPABILITIES
+    from analysis.config import PLATFORM_CAPABILITIES, plan_analysis_source
     from analysis.providers import (
         get_activity_provider,
         get_recovery_provider,
@@ -194,7 +194,7 @@ def load_data(config: UserConfig, data_dir: str) -> dict[str, pd.DataFrame]:
     connections = config.connections
     activity_source = config.preferences.get("activities", "garmin")
     recovery_source = config.preferences.get("recovery", "oura")
-    plan_source = config.preferences.get("plan", "")
+    plan_source = plan_analysis_source(config)
 
     # --- Activities: primary + enrichment from other connected sources ---
     activity_provider = get_activity_provider(activity_source)
@@ -389,6 +389,26 @@ def select_preferred_source(
             fallback_key,
         )
     return df.loc[source_keys == fallback_key].copy().reset_index(drop=True)
+
+
+def select_plan_for_analysis(
+    df: pd.DataFrame,
+    config: UserConfig,
+) -> pd.DataFrame:
+    """Select the canonical plan without blending ownership modes.
+
+    External mode preserves the legacy preferred-source fallback. Praxys mode
+    is strict: only Praxys-authored (``source='ai'``) rows are canonical, and
+    platform rows remain available separately for reconciliation.
+    """
+    from analysis.config import is_praxys_managed_plan
+
+    if not is_praxys_managed_plan(config):
+        return select_preferred_source(df, config.preferences.get("plan"))
+    if df.empty or "source" not in df.columns:
+        return df
+    source_keys = df["source"].fillna("").astype(str).str.strip().str.casefold()
+    return df.loc[source_keys == "ai"].copy().reset_index(drop=True)
 
 
 # ---------------------------------------------------------------------------

--- a/api/deps.py
+++ b/api/deps.py
@@ -8,11 +8,16 @@ from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
-from analysis.config import load_config
+from analysis.config import (
+    is_praxys_managed_plan,
+    load_config,
+    plan_analysis_source,
+)
 from analysis.data_loader import (
     load_data,
     load_heat_adaptation_inputs,
     load_heat_adaptation_inputs_from_files,
+    select_plan_for_analysis,
     select_preferred_source,
 )
 from analysis.providers.models import ThresholdEstimate
@@ -1568,7 +1573,7 @@ def _build_warnings(
         warnings.append(
             f"Modeled load balance below the coaching caution band (TSB = {current_tsb:.0f})"
         )
-    if config.preferences.get("plan") == "ai" and data_dir:
+    if plan_analysis_source(config) == "ai" and data_dir:
         from api.ai import check_plan_staleness
         warnings.extend(check_plan_staleness(data_dir, latest_cp_watts))
     return warnings
@@ -1646,9 +1651,7 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
         data["recovery"], config.preferences.get("recovery"),
     )
     all_plans = data["plan"].copy()
-    data["plan"] = select_preferred_source(
-        data["plan"], config.preferences.get("plan"),
-    )
+    data["plan"] = select_plan_for_analysis(data["plan"], config)
     merged = data["activities"]
 
     # Deduplicate activities by primary source preference.
@@ -1799,7 +1802,11 @@ def get_dashboard_data(user_id: str = None, db=None) -> dict:
 
     # Daily training signal
     planned_today, planned_detail = _get_todays_plan(
-        plan, today, fallback_plan=all_plans,
+        plan,
+        today,
+        fallback_plan=(
+            None if is_praxys_managed_plan(config) else all_plans
+        ),
     )
     # Recovery is standardized to a single HRV-based theory.
     hrv_only_mode = True

--- a/api/packs.py
+++ b/api/packs.py
@@ -20,10 +20,11 @@ from functools import cached_property
 
 import pandas as pd
 
-from analysis.config import load_config_from_db
+from analysis.config import is_praxys_managed_plan, load_config_from_db
 from analysis.data_loader import (
     load_data_from_db,
     load_heat_adaptation_inputs,
+    select_plan_for_analysis,
     select_preferred_source,
 )
 from analysis.metrics import (
@@ -201,11 +202,8 @@ class RequestContext:
 
     @cached_property
     def plan(self) -> pd.DataFrame:
-        """One preferred plan source for analysis and same-day guidance."""
-        return select_preferred_source(
-            self.all_plans,
-            self.config.preferences.get("plan"),
-        )
+        """Canonical plan source for analysis and same-day guidance."""
+        return select_plan_for_analysis(self.all_plans, self.config)
 
     @cached_property
     def thresholds(self) -> ThresholdEstimate:
@@ -575,7 +573,11 @@ def get_signal_pack(ctx: RequestContext) -> dict:
     guidance_recovery = _recovery_for_guidance(recovery_analysis)
 
     planned_today, planned_detail = _get_todays_plan(
-        ctx.plan, ctx.today, fallback_plan=ctx.all_plans,
+        ctx.plan,
+        ctx.today,
+        fallback_plan=(
+            None if is_praxys_managed_plan(ctx.config) else ctx.all_plans
+        ),
     )
     load_theory = ctx.science.get("load")
     recovery_theory = ctx.science.get("recovery")

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -8,12 +8,12 @@ import logging
 import os
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Literal
 
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,10 @@ from analysis.config import (
     save_config,
     load_config_from_db,
     save_config_to_db,
+    normalize_plan_management,
+    PlatformName,
     TrainingBase,
+    UserConfig,
     PLATFORM_CAPABILITIES,
 )
 from analysis.providers import available_providers
@@ -46,6 +49,17 @@ SUPPORTED_LANGUAGES = {"en", "zh"}
 _STRAVA_STATE_TTL_MINUTES = 10
 
 
+class PlanManagementUpdate(BaseModel):
+    """Partial managed-plan ownership update."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["external", "praxys"] | None = None
+    execution_target: PlatformName | None = None
+    delivery_enabled: bool | None = None
+    adjustment_policy: Literal["suggest_only"] | None = None
+
+
 class SettingsUpdate(BaseModel):
     """Partial update for user settings."""
 
@@ -55,12 +69,62 @@ class SettingsUpdate(BaseModel):
     # dict[str, Any] so the nested `threshold_sources` mapping
     # (e.g. {"threshold_sources": {"cp_estimate": "stryd"}}) flows through.
     preferences: dict[str, Any] | None = None
+    plan_management: PlanManagementUpdate | None = None
     training_base: TrainingBase | None = None
     thresholds: dict[str, Any] | None = None
     zones: dict[str, list[float]] | None = None
     goal: dict[str, Any] | None = None
     source_options: dict[str, Any] | None = None
     language: str | None = None
+
+
+def _legacy_execution_target(plan_source: object) -> str | None:
+    """Return a plan-capable provider from a legacy preference value."""
+    if not isinstance(plan_source, str):
+        return None
+    target = plan_source.strip().casefold()
+    caps = PLATFORM_CAPABILITIES.get(target)
+    return target if caps and caps.get("plan") else None
+
+
+def _apply_plan_management_update(
+    config: UserConfig,
+    update: PlanManagementUpdate,
+) -> None:
+    """Validate and merge an explicit managed-plan settings update."""
+    changes = update.model_dump(exclude_unset=True)
+    for required_field in ("mode", "delivery_enabled", "adjustment_policy"):
+        if required_field in changes and changes[required_field] is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"plan_management.{required_field} cannot be null",
+            )
+
+    candidate = {**config.plan_management, **changes}
+    if candidate.get("delivery_enabled"):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Managed-plan delivery is not available yet. "
+                "Plan ownership can be selected without enabling platform writes."
+            ),
+        )
+
+    target = candidate.get("execution_target")
+    if target is not None:
+        if target not in config.connections:
+            raise HTTPException(
+                status_code=400,
+                detail="Plan execution target must be a connected platform",
+            )
+        caps = PLATFORM_CAPABILITIES.get(target)
+        if not caps or not caps.get("plan"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{target} does not support plan delivery",
+            )
+
+    config.plan_management = normalize_plan_management(candidate)
 
 
 def _detect_thresholds_from_db(user_id: str, db) -> dict:
@@ -282,6 +346,20 @@ def update_settings(
         config.connections = body.connections
     if body.preferences is not None:
         config.preferences.update(body.preferences)
+        if (
+            body.plan_management is None
+            and config.plan_management["mode"] == "external"
+            and "plan" in body.preferences
+        ):
+            legacy_target = _legacy_execution_target(body.preferences["plan"])
+            if legacy_target not in config.connections:
+                legacy_target = None
+            config.plan_management = normalize_plan_management({
+                **config.plan_management,
+                "execution_target": legacy_target,
+            })
+    if body.plan_management is not None:
+        _apply_plan_management_update(config, body.plan_management)
     # `thresholds` updates are accepted-and-dropped: manual numeric overrides
     # are no longer supported; source selection lives in
     # ``preferences.threshold_sources``. Kept in the schema for API compat

--- a/db/models.py
+++ b/db/models.py
@@ -106,6 +106,7 @@ class UserConfig(Base):
     unit_system = Column(String(10), default="metric")
     training_base = Column(String(10), default="power")
     preferences = Column(JSON, default=dict)
+    plan_management = Column(JSON, default=dict)
     thresholds = Column(JSON, default=dict)
     zones = Column(JSON, default=dict)
     goal = Column(JSON, default=dict)

--- a/db/session.py
+++ b/db/session.py
@@ -382,6 +382,7 @@ _SQLITE_COMPAT_COLUMNS: dict[str, tuple[tuple[str, str], ...]] = {
         ("power_source", "VARCHAR(20)"),
     ),
     "user_config": (
+        ("plan_management", "JSON"),
         ("today_decision_check_claimed_at", "DATETIME"),
         ("today_decision_check_shown_at", "DATETIME"),
         ("today_decision_check_submitted_at", "DATETIME"),

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -817,6 +817,12 @@ Current configuration, platform capabilities, and detected thresholds.
   "config": {
     "connections": ["garmin", "stryd", "oura"],
     "preferences": { "activities": "garmin", "recovery": "oura", "plan": "ai" },
+    "plan_management": {
+      "mode": "external",
+      "execution_target": "stryd",
+      "delivery_enabled": false,
+      "adjustment_policy": "suggest_only"
+    },
     "training_base": "power",
     "thresholds": { "cp_watts": null, "lthr_bpm": null, "source": "auto" },
     "zones": { "power": [0.55, 0.75, 0.90, 1.05] },
@@ -844,9 +850,24 @@ Update settings (partial update).
 ```json
 {
   "training_base": "hr",
-  "goal": { "distance": "half_marathon", "target_time_sec": 5400 }
+  "goal": { "distance": "half_marathon", "target_time_sec": 5400 },
+  "plan_management": {
+    "mode": "praxys",
+    "execution_target": "stryd",
+    "delivery_enabled": false,
+    "adjustment_policy": "suggest_only"
+  }
 }
 ```
+
+`plan_management.mode` is `external` or `praxys`. Praxys mode makes
+Praxys-authored rows canonical but does not itself write to a platform.
+`execution_target` must be a connected plan-capable platform. During the
+foundation rollout, `delivery_enabled=true` returns 409 because automatic
+delivery has not shipped yet. `suggest_only` is the only adjustment policy.
+Legacy `preferences.plan` remains supported as the external-mode analytical
+source selector and may seed the execution target, but it never activates
+managed mode or delivery.
 
 ### GET /api/settings/connections
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -173,11 +173,18 @@ Activities can come from Garmin, Stryd, or Coros. `data_loader.py` merges them:
 - Secondary sources enrich with additional columns (e.g., Stryd adds power to Garmin activities)
 - Matching uses date + timestamp proximity (handles timezone differences)
 
-Analytical recovery and training-plan inputs are intentionally not blended. The
-configured provider wins when it has rows; otherwise Praxys selects one
-deterministic fallback by newest row, row count, then source name. The plan
-management endpoint still loads all AI and Stryd rows because it must compare
-them to derive sync state.
+Analytical recovery inputs are intentionally not blended: the configured
+provider wins when it has rows, otherwise Praxys selects one deterministic
+fallback by newest row, row count, then source name.
+
+Plan ownership is separate from provider preference. `config.plan_management`
+contains `mode`, `execution_target`, `delivery_enabled`, and
+`adjustment_policy`. External mode preserves the legacy
+`config.preferences.plan` preferred-source fallback. Praxys mode treats only
+Praxys-authored (`source='ai'`) rows as canonical; platform rows remain loaded
+for management and later reconciliation but never silently become the plan.
+The additive contract defaults to external mode with delivery disabled, so
+existing users are not enrolled in platform writes.
 
 ### LLM-backed Insights
 

--- a/scripts/migrate_csv_to_db.py
+++ b/scripts/migrate_csv_to_db.py
@@ -113,6 +113,7 @@ def migrate(data_dir: str, email: str = "local@praxys.dev", password: str = "cha
             cfg = UserConfig(
                 user_id=user_id,
                 training_base=config.training_base,
+                plan_management=config.plan_management,
                 thresholds=config.thresholds,
                 zones=config.zones or {k: list(v) for k, v in DEFAULT_ZONES.items()},
                 goal=config.goal,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from analysis.config import (
     load_config,
     save_config,
     _migrate_config,
+    default_plan_management,
     DEFAULT_ZONES,
 )
 
@@ -22,6 +23,10 @@ class TestUserConfigDefaults:
         assert config.preferences["activities"] == "garmin"
         assert config.preferences["recovery"] == "oura"
         assert config.preferences["plan"] == "stryd"
+
+    def test_default_plan_management_is_safe(self):
+        config = UserConfig()
+        assert config.plan_management == default_plan_management()
 
     def test_default_training_base(self):
         config = UserConfig()
@@ -55,19 +60,60 @@ class TestMigrateConfig:
         assert migrated["preferences"]["activities"] == "garmin"
         assert migrated["preferences"]["recovery"] == "oura"
         assert migrated["preferences"]["plan"] == "stryd"
+        assert migrated["plan_management"] == {
+            "mode": "external",
+            "execution_target": "stryd",
+            "delivery_enabled": False,
+            "adjustment_policy": "suggest_only",
+        }
 
-    def test_new_format_unchanged(self):
+    def test_new_format_gains_safe_plan_management_contract(self):
         new = {
             "connections": ["garmin"],
             "preferences": {"activities": "garmin"},
         }
         migrated = _migrate_config(new)
-        assert migrated == new
+        assert migrated["connections"] == ["garmin"]
+        assert migrated["preferences"] == {"activities": "garmin"}
+        assert migrated["plan_management"] == default_plan_management()
 
     def test_empty_sources_handled(self):
         old = {"sources": {"activities": "", "health": "", "plan": ""}}
         migrated = _migrate_config(old)
         assert migrated["connections"] == []
+
+    def test_legacy_ai_preference_does_not_auto_adopt_managed_mode(self):
+        migrated = _migrate_config({
+            "connections": ["stryd"],
+            "preferences": {
+                "activities": "stryd",
+                "recovery": "",
+                "plan": "ai",
+            },
+        })
+        assert migrated["preferences"]["plan"] == "ai"
+        assert migrated["plan_management"] == default_plan_management()
+
+    def test_disconnected_legacy_plan_provider_does_not_seed_target(self):
+        migrated = _migrate_config({
+            "connections": ["garmin"],
+            "preferences": {"activities": "garmin", "plan": "stryd"},
+        })
+        assert migrated["plan_management"] == default_plan_management()
+
+    def test_explicit_plan_management_is_not_rederived(self):
+        explicit = {
+            "mode": "praxys",
+            "execution_target": None,
+            "delivery_enabled": False,
+            "adjustment_policy": "suggest_only",
+        }
+        migrated = _migrate_config({
+            "connections": ["stryd"],
+            "preferences": {"plan": "stryd"},
+            "plan_management": explicit,
+        })
+        assert migrated["plan_management"] == explicit
 
 
 class TestLoadSaveConfig:
@@ -81,6 +127,7 @@ class TestLoadSaveConfig:
             loaded = load_config(path)
             assert loaded.training_base == "hr"
             assert loaded.connections == ["garmin"]
+            assert loaded.plan_management == default_plan_management()
 
     def test_load_missing_file_returns_defaults(self):
         config = load_config("/nonexistent/path/config.json")
@@ -101,6 +148,20 @@ class TestLoadSaveConfig:
                 data = json.load(f)
             assert "connections" in data
             assert "training_base" in data
+            assert data["plan_management"] == default_plan_management()
+
+    def test_plan_management_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "config.json")
+            config = UserConfig(plan_management={
+                "mode": "praxys",
+                "execution_target": "stryd",
+                "delivery_enabled": False,
+                "adjustment_policy": "suggest_only",
+            })
+            save_config(config, path)
+            loaded = load_config(path)
+            assert loaded.plan_management == config.plan_management
 
 
 class TestActivityRouting:

--- a/tests/test_db_session_url.py
+++ b/tests/test_db_session_url.py
@@ -101,6 +101,7 @@ def test_existing_sqlite_gets_additive_compatibility_columns(dbs, tmp_path):
         assert "today_decision_check_claimed_at" in columns_by_table["user_config"]
         assert "today_decision_check_shown_at" in columns_by_table["user_config"]
         assert "today_decision_check_submitted_at" in columns_by_table["user_config"]
+        assert "plan_management" in columns_by_table["user_config"]
         assert {
             "temperature_c",
             "relative_humidity_pct",

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -569,6 +569,41 @@ def test_request_context_honors_recovery_and_plan_preferences(
     assert ctx.plan.iloc[0]["workout_type"] == "easy"
 
 
+def test_request_context_praxys_mode_uses_only_praxys_rows(
+    db_with_seeded_user,
+):
+    """Managed mode never falls back to a platform-authored plan."""
+    from api.packs import RequestContext
+    from db.models import TrainingPlan, UserConfig as UserConfigModel
+
+    db, user_id = db_with_seeded_user
+    today = date.today()
+    db.add(UserConfigModel(
+        user_id=user_id,
+        preferences={"plan": "stryd"},
+        plan_management={
+            "mode": "praxys",
+            "execution_target": "stryd",
+            "delivery_enabled": False,
+            "adjustment_policy": "suggest_only",
+        },
+    ))
+    db.add(TrainingPlan(
+        user_id=user_id,
+        date=today,
+        workout_type="threshold",
+        planned_duration_min=50,
+        source="ai",
+    ))
+    db.commit()
+
+    ctx = RequestContext(user_id=user_id, db=db)
+
+    assert set(ctx.all_plans["source"]) == {"ai", "stryd"}
+    assert set(ctx.plan["source"]) == {"ai"}
+    assert ctx.plan.iloc[0]["workout_type"] == "threshold"
+
+
 def test_signal_pack_returns_required_keys(db_with_seeded_user):
     from api.packs import get_signal_pack
     ctx = _ctx(db_with_seeded_user)
@@ -639,6 +674,50 @@ def test_today_payload_fallback_to_synced_workout(
     assert payload["signal"]["recommendation"] == "follow_plan"
     assert payload["signal"]["plan"]["workout_type"] == "tempo"
     assert payload["signal"]["plan"]["duration_min"] == 45
+
+
+def test_today_payload_praxys_mode_does_not_fallback_to_synced_workout(
+    db_with_seeded_user,
+):
+    """A managed plan gap stays unscheduled instead of changing ownership."""
+    from api.routes.today import _build_today_payload
+    from db.models import TrainingPlan, UserConfig as UserConfigModel
+
+    db, user_id = db_with_seeded_user
+    today = date.today()
+    db.query(TrainingPlan).filter(
+        TrainingPlan.user_id == user_id,
+    ).delete(synchronize_session=False)
+    db.add(UserConfigModel(
+        user_id=user_id,
+        preferences={"plan": "ai"},
+        plan_management={
+            "mode": "praxys",
+            "execution_target": "stryd",
+            "delivery_enabled": False,
+            "adjustment_policy": "suggest_only",
+        },
+    ))
+    db.add(TrainingPlan(
+        user_id=user_id,
+        date=today,
+        workout_type="tempo",
+        planned_duration_min=45,
+        source="stryd",
+    ))
+    db.add(TrainingPlan(
+        user_id=user_id,
+        date=today + timedelta(days=2),
+        workout_type="easy",
+        planned_duration_min=40,
+        source="ai",
+    ))
+    db.commit()
+
+    payload = _build_today_payload(user_id, db)
+
+    assert payload["signal"]["recommendation"] == "unscheduled"
+    assert payload["signal"]["plan"] == {}
 
 
 def test_today_widgets_pack_returns_required_keys(db_with_seeded_user):

--- a/tests/test_pg_migration.py
+++ b/tests/test_pg_migration.py
@@ -70,6 +70,12 @@ def test_sqlite_to_postgres_roundtrip(tmp_path, monkeypatch):
             session.add_all([
                 m.UserConfig(
                     user_id=uid, display_name="Mig", preferences={"k": 1},
+                    plan_management={
+                        "mode": "external",
+                        "execution_target": None,
+                        "delivery_enabled": False,
+                        "adjustment_policy": "suggest_only",
+                    },
                     thresholds={"cp": 300}, zones={}, goal={}, science={},
                     activity_routing={}, source_options={},
                 ),
@@ -162,6 +168,11 @@ def test_sqlite_to_postgres_roundtrip(tmp_path, monkeypatch):
                 ).one()
                 assert ins[0]["zh"]["headline"] == "nihao"
                 assert ins[1] == ["r1", "r2"]
+                plan_management = c.execute(
+                    select(m.UserConfig.plan_management)
+                    .where(m.UserConfig.user_id == uid)
+                ).scalar()
+                assert plan_management["mode"] == "external"
                 act_date = c.execute(
                     select(m.Activity.date).where(m.Activity.user_id == uid)
                 ).scalar()

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -134,6 +134,161 @@ def test_get_settings_exposes_sync_interval_options(api_client):
     assert body["default_sync_interval_hours"] == 6
 
 
+def _seed_connection(user_id: str, platform: str) -> None:
+    """Insert a connected platform row for settings validation tests."""
+    from db import session as db_session
+    from db.models import UserConnection
+
+    db = db_session.SessionLocal()
+    try:
+        db.add(UserConnection(
+            user_id=user_id,
+            platform=platform,
+            status="connected",
+            preferences={"plan": platform == "stryd"},
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_get_settings_exposes_safe_plan_management_defaults(api_client):
+    client, _ = api_client
+    res = client.get("/api/settings")
+    assert res.status_code == 200, res.text
+    assert res.json()["config"]["plan_management"] == {
+        "mode": "external",
+        "execution_target": None,
+        "delivery_enabled": False,
+        "adjustment_policy": "suggest_only",
+    }
+
+
+def test_settings_roundtrip_explicit_praxys_ownership(api_client):
+    client, user_id = api_client
+    _seed_connection(user_id, "stryd")
+
+    res = client.put("/api/settings", json={
+        "plan_management": {
+            "mode": "praxys",
+            "execution_target": "stryd",
+            "delivery_enabled": False,
+            "adjustment_policy": "suggest_only",
+        },
+    })
+    assert res.status_code == 200, res.text
+    assert res.json()["config"]["plan_management"]["mode"] == "praxys"
+
+    got = client.get("/api/settings")
+    assert got.status_code == 200, got.text
+    assert got.json()["config"]["plan_management"] == {
+        "mode": "praxys",
+        "execution_target": "stryd",
+        "delivery_enabled": False,
+        "adjustment_policy": "suggest_only",
+    }
+
+
+def test_settings_rejects_unconnected_plan_target(api_client):
+    client, _ = api_client
+    res = client.put("/api/settings", json={
+        "plan_management": {"execution_target": "stryd"},
+    })
+    assert res.status_code == 400, res.text
+    assert "connected platform" in res.json()["detail"]
+
+
+def test_settings_rejects_delivery_enablement_before_delivery_exists(api_client):
+    client, user_id = api_client
+    _seed_connection(user_id, "stryd")
+    res = client.put("/api/settings", json={
+        "plan_management": {
+            "mode": "praxys",
+            "execution_target": "stryd",
+            "delivery_enabled": True,
+        },
+    })
+    assert res.status_code == 409, res.text
+    assert "not available yet" in res.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "plan_management",
+    [
+        {"mode": "automatic"},
+        {"adjustment_policy": "autonomous"},
+        {"unknown_field": True},
+    ],
+)
+def test_settings_strictly_validates_plan_management(
+    api_client,
+    plan_management,
+):
+    client, _ = api_client
+    res = client.put("/api/settings", json={
+        "plan_management": plan_management,
+    })
+    assert res.status_code == 422, res.text
+
+
+def test_legacy_plan_preference_seeds_target_without_adoption(api_client):
+    client, user_id = api_client
+    _seed_connection(user_id, "stryd")
+
+    res = client.put("/api/settings", json={
+        "preferences": {"plan": "stryd"},
+    })
+    assert res.status_code == 200, res.text
+    assert res.json()["config"]["plan_management"] == {
+        "mode": "external",
+        "execution_target": "stryd",
+        "delivery_enabled": False,
+        "adjustment_policy": "suggest_only",
+    }
+
+
+def test_legacy_full_preferences_save_does_not_target_disconnected_stryd(
+    api_client,
+):
+    client, _ = api_client
+    res = client.put("/api/settings", json={
+        "preferences": {
+            "activities": "garmin",
+            "recovery": "oura",
+            "plan": "stryd",
+        },
+    })
+    assert res.status_code == 200, res.text
+    assert res.json()["config"]["plan_management"]["execution_target"] is None
+
+
+def test_legacy_preferences_save_does_not_clobber_managed_target(api_client):
+    client, user_id = api_client
+    _seed_connection(user_id, "stryd")
+    adopted = client.put("/api/settings", json={
+        "plan_management": {
+            "mode": "praxys",
+            "execution_target": "stryd",
+        },
+    })
+    assert adopted.status_code == 200, adopted.text
+
+    saved = client.put("/api/settings", json={
+        "preferences": {
+            "activities": "garmin",
+            "recovery": "oura",
+            "plan": "ai",
+        },
+    })
+    assert saved.status_code == 200, saved.text
+    assert saved.json()["config"]["plan_management"] == {
+        "mode": "praxys",
+        "execution_target": "stryd",
+        "delivery_enabled": False,
+        "adjustment_policy": "suggest_only",
+    }
+
+
 # --- Threshold source selection (clean-break: no manual overrides) ---
 
 


### PR DESCRIPTION
## Summary

- add an explicit `plan_management` contract for ownership mode, execution target, delivery intent, and adjustment policy
- preserve legacy `preferences.plan` behavior for existing users while making explicit Praxys mode use only Praxys-authored rows
- keep all external delivery disabled and reject premature enablement
- add SQLite/PostgreSQL schema support, migration compatibility, API validation, documentation, and regression coverage

## Product boundary

This is the additive foundation only. It does not push, update, or delete workouts on an external platform. Existing users remain in external mode until they explicitly adopt a Praxys-managed plan in a later issue.

## Validation

- `python -m pytest tests/ -q --disable-warnings --ignore=tests/test_mcp_tools.py` — 1334 passed, 2 skipped
- isolated local-mode `python -m pytest tests/test_mcp_tools.py -q --disable-warnings` — 14 passed
- `python -m alembic heads` — `1a2b3c4d5e6f (head)`
- API contract review and final code review reported no remaining findings

Closes #475
Part of #474
