### PR TITLE
Persist plan revisions and platform delivery state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Garmin/Stryd/Oura APIs → sync/*.py → db/sync_writer.py → SQLite (trainsigh
 
 ### Data storage
 
-Sync pipelines write directly to SQLite (`trainsight.db`) via `db/sync_writer.py` — there are no live CSVs. Tables: `activities`, `activity_splits`, `recovery_data`, `fitness_data`, `training_plans`, `users`, `user_config`, `user_connections`. `data/sample/` holds synthetic CSVs used only by tests and seed scripts.
+Sync pipelines write directly to SQLite (`trainsight.db`) via `db/sync_writer.py` — there are no live CSVs. Core tables include `activities`, `activity_splits`, `recovery_data`, `fitness_data`, `training_plans`, `plan_revisions`, `plan_deliveries`, `plan_delivery_attempts`, `users`, `user_config`, and `user_connections`. `data/sample/` holds synthetic CSVs used only by tests and seed scripts.
 
 ## Scientific Rigor
 

--- a/alembic/versions/2b3c4d5e6f70_add_plan_revision_delivery_ledger.py
+++ b/alembic/versions/2b3c4d5e6f70_add_plan_revision_delivery_ledger.py
@@ -1,0 +1,159 @@
+"""add plan revision and delivery ledger
+
+Revision ID: 2b3c4d5e6f70
+Revises: 1a2b3c4d5e6f
+Create Date: 2026-07-28
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "2b3c4d5e6f70"
+down_revision: Union[str, Sequence[str], None] = "1a2b3c4d5e6f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plan_revisions",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("operation", sa.String(length=30), nullable=False),
+        sa.Column("actor_type", sa.String(length=20), nullable=False),
+        sa.Column("actor_id", sa.String(length=100), nullable=True),
+        sa.Column("origin", sa.String(length=80), nullable=False),
+        sa.Column("before_snapshot", sa.JSON(), nullable=False),
+        sa.Column("after_snapshot", sa.JSON(), nullable=False),
+        sa.Column("details", sa.JSON(), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "idempotency_key",
+            name="uq_plan_revision_user_idempotency",
+        ),
+    )
+    op.create_index(
+        "ix_plan_revisions_user_id",
+        "plan_revisions",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_plan_revisions_user_created",
+        "plan_revisions",
+        ["user_id", "created_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "plan_deliveries",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("canonical_key", sa.String(length=120), nullable=False),
+        sa.Column("workout_date", sa.Date(), nullable=False),
+        sa.Column("workout_version", sa.String(length=64), nullable=False),
+        sa.Column("target", sa.String(length=20), nullable=False),
+        sa.Column("state", sa.String(length=20), nullable=False),
+        sa.Column("external_id", sa.String(length=200), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("delivered_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint(
+            "state IN ('pending','delivering','synced','conflict','failed','removed')",
+            name="ck_plan_deliveries_state",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "target",
+            "canonical_key",
+            "workout_version",
+            name="uq_plan_delivery_version_target",
+        ),
+    )
+    op.create_index(
+        "ix_plan_deliveries_user_id",
+        "plan_deliveries",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_plan_deliveries_user_target_date",
+        "plan_deliveries",
+        ["user_id", "target", "workout_date"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_plan_deliveries_user_target_external",
+        "plan_deliveries",
+        ["user_id", "target", "external_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "plan_delivery_attempts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("delivery_id", sa.String(length=36), nullable=False),
+        sa.Column("attempt_number", sa.Integer(), nullable=False),
+        sa.Column("operation", sa.String(length=20), nullable=False),
+        sa.Column("state", sa.String(length=20), nullable=False),
+        sa.Column("external_id", sa.String(length=200), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("response", sa.JSON(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.CheckConstraint(
+            "state IN ('pending','delivering','synced','conflict','failed','removed')",
+            name="ck_plan_delivery_attempts_state",
+        ),
+        sa.CheckConstraint(
+            "operation IN ('deliver','remove','import')",
+            name="ck_plan_delivery_attempts_operation",
+        ),
+        sa.ForeignKeyConstraint(
+            ["delivery_id"],
+            ["plan_deliveries.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "delivery_id",
+            "attempt_number",
+            name="uq_plan_delivery_attempt_number",
+        ),
+    )
+    op.create_index(
+        "ix_plan_delivery_attempts_delivery_id",
+        "plan_delivery_attempts",
+        ["delivery_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_plan_delivery_attempts_delivery_id",
+        table_name="plan_delivery_attempts",
+    )
+    op.drop_table("plan_delivery_attempts")
+    op.drop_index(
+        "ix_plan_deliveries_user_target_external",
+        table_name="plan_deliveries",
+    )
+    op.drop_index(
+        "ix_plan_deliveries_user_target_date",
+        table_name="plan_deliveries",
+    )
+    op.drop_index("ix_plan_deliveries_user_id", table_name="plan_deliveries")
+    op.drop_table("plan_deliveries")
+    op.drop_index("ix_plan_revisions_user_created", table_name="plan_revisions")
+    op.drop_index("ix_plan_revisions_user_id", table_name="plan_revisions")
+    op.drop_table("plan_revisions")

--- a/api/account_deletion.py
+++ b/api/account_deletion.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+import glob
+import os
 from dataclasses import dataclass
 
 from fastapi import HTTPException
@@ -22,6 +24,9 @@ from db.models import (
     Feedback,
     FitnessData,
     Invitation,
+    PlanDelivery,
+    PlanDeliveryAttempt,
+    PlanRevision,
     RecoveryData,
     TrainingPlan,
     User,
@@ -30,6 +35,7 @@ from db.models import (
     WaitlistSignup,
 )
 from db.cache_revision import lock_revision_writes
+from db.plan_ledger import legacy_stryd_status_lock, lock_plan_writes
 from db.session import begin_serialized_write
 
 logger = logging.getLogger(__name__)
@@ -81,6 +87,16 @@ def _delete_user_owned_rows(db: Session, user_id: str) -> None:
         .with_for_update()
         .all()
     ]
+    delivery_ids = [
+        delivery_id
+        for (delivery_id,) in db.query(PlanDelivery.id)
+        .filter(PlanDelivery.user_id == user_id)
+        .all()
+    ]
+    if delivery_ids:
+        db.query(PlanDeliveryAttempt).filter(
+            PlanDeliveryAttempt.delivery_id.in_(delivery_ids)
+        ).delete(synchronize_session=False)
 
     for model in (
         ActivitySample,
@@ -89,6 +105,8 @@ def _delete_user_owned_rows(db: Session, user_id: str) -> None:
         RecoveryData,
         FitnessData,
         TrainingPlan,
+        PlanDelivery,
+        PlanRevision,
         UserConnection,
         UserConfig,
         AiInsightFeedback,
@@ -158,6 +176,32 @@ def _clear_tokenstore(user_id: str) -> None:
             "User %s deleted but Garmin tokenstore cleanup failed; orphan directory left on disk.",
             user_id,
         )
+
+
+def _clear_legacy_plan_status(db: Session, user_id: str) -> None:
+    """Remove pre-ledger Stryd status files and quarantine/import archives."""
+    from api.routes import plan as plan_route
+
+    lock_plan_writes(db, user_id)
+    path = plan_route._stryd_push_status_path(user_id)
+    try:
+        with legacy_stryd_status_lock(
+            os.path.dirname(path),
+            user_id,
+        ):
+            for candidate in [path, *glob.glob(f"{path}.*")]:
+                try:
+                    os.unlink(candidate)
+                except FileNotFoundError:
+                    continue
+                except OSError:
+                    logger.exception(
+                        "User %s deleted but legacy plan-status cleanup failed for %s.",
+                        user_id,
+                        candidate,
+                    )
+    finally:
+        db.rollback()
 
 
 def delete_user_account(
@@ -244,5 +288,6 @@ def delete_user_account(
 
     for deleted_user_id in deleted_user_ids:
         _clear_tokenstore(deleted_user_id)
+        _clear_legacy_plan_status(db, deleted_user_id)
 
     return AccountDeletionResult(email=email, deleted_user_ids=deleted_user_ids)

--- a/api/etag.py
+++ b/api/etag.py
@@ -63,9 +63,8 @@ logger = logging.getLogger(__name__)
 #   /api/history     — activities + splits only; goal/recovery edits do
 #                      NOT bust the History page.
 #   /api/science     — config only; sync writes do NOT bust Science.
-#   /api/plan        — plan rows plus config-derived connection state. Stryd push/delete handlers also bump
-#                      ``plans`` so the JSON-file ``stryd_status`` field
-#                      isn't served stale via 304 after a push.
+#   /api/plan        — plan rows, delivery-ledger state, and config-derived
+#                      connection state. Delivery transitions bump ``plans``.
 ENDPOINT_SCOPES: dict[str, tuple[str, ...]] = {
     "today":    ("activities", "splits", "samples", "recovery", "plans", "fitness", "config"),
     "training": ("activities", "splits", "samples", "recovery", "plans", "fitness", "config"),

--- a/api/routes/ai.py
+++ b/api/routes/ai.py
@@ -12,6 +12,7 @@ from api.auth import get_data_user_id, require_write_access
 from api.deps import get_dashboard_data
 from db.cache_revision import bump_revisions
 from db.models import TrainingPlan
+from db.plan_ledger import lock_plan_writes, plan_snapshot, record_plan_revision
 from db.session import get_db
 
 router = APIRouter()
@@ -112,26 +113,48 @@ def upload_plan(
             **kwargs,
         ))
 
-    if mode == "replace":
-        db.query(TrainingPlan).filter(
-            TrainingPlan.user_id == user_id,
-            TrainingPlan.source == "ai",
-            TrainingPlan.date >= date.today(),
-        ).delete(synchronize_session=False)
-    else:  # merge: clear only the dates we're about to write
-        target_dates = {p.date for p in parsed_rows if p.date is not None}
-        if target_dates:
-            db.query(TrainingPlan).filter(
+    target_dates = {p.date for p in parsed_rows if p.date is not None}
+    try:
+        db.rollback()
+        lock_plan_writes(db, user_id)
+        if mode == "replace":
+            affected = db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == user_id,
+                TrainingPlan.source == "ai",
+                TrainingPlan.date >= date.today(),
+            )
+        else:
+            affected = db.query(TrainingPlan).filter(
                 TrainingPlan.user_id == user_id,
                 TrainingPlan.source == "ai",
                 TrainingPlan.date.in_(target_dates),
-            ).delete(synchronize_session=False)
+            )
+        before_rows = affected.order_by(TrainingPlan.date, TrainingPlan.id).all()
+        before = [plan_snapshot(row) for row in before_rows]
+        for row in before_rows:
+            db.expunge(row)
+        affected.delete(synchronize_session=False)
 
-    for plan in parsed_rows:
-        db.add(plan)
+        for plan in parsed_rows:
+            db.add(plan)
 
-    bump_revisions(db, user_id, ["plans"])
-    db.commit()
+        record_plan_revision(
+            db,
+            user_id=user_id,
+            operation="upload",
+            actor_type="user",
+            actor_id=user_id,
+            origin="api.plan.upload",
+            before=before,
+            after=parsed_rows,
+            details={"mode": mode, "rows": len(parsed_rows)},
+        )
+        bump_revisions(db, user_id, ["plans"])
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
     return {"status": "saved", "rows": len(parsed_rows), "mode": mode}
 
 
@@ -154,12 +177,6 @@ def upsert_plan_day(
     except ValueError:
         raise HTTPException(400, "date must be YYYY-MM-DD")
 
-    db.query(TrainingPlan).filter(
-        TrainingPlan.user_id == user_id,
-        TrainingPlan.source == "ai",
-        TrainingPlan.date == d,
-    ).delete(synchronize_session=False)
-
     plan = TrainingPlan(
         user_id=user_id,
         date=d,
@@ -172,9 +189,36 @@ def upsert_plan_day(
         source="ai",
         meta={"uploaded_at": datetime.utcnow().isoformat()},
     )
-    db.add(plan)
-    bump_revisions(db, user_id, ["plans"])
-    db.commit()
+    try:
+        db.rollback()
+        lock_plan_writes(db, user_id)
+        existing = db.query(TrainingPlan).filter(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.source == "ai",
+            TrainingPlan.date == d,
+        )
+        before_rows = existing.order_by(TrainingPlan.id).all()
+        before = [plan_snapshot(row) for row in before_rows]
+        for row in before_rows:
+            db.expunge(row)
+        existing.delete(synchronize_session=False)
+        db.add(plan)
+        record_plan_revision(
+            db,
+            user_id=user_id,
+            operation="upsert",
+            actor_type="user",
+            actor_id=user_id,
+            origin="api.plan.upsert",
+            before=before,
+            after=[plan],
+            details={"date": plan_date},
+        )
+        bump_revisions(db, user_id, ["plans"])
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     db.refresh(plan)
     return _row_to_response(plan)
 
@@ -191,12 +235,34 @@ def delete_plan_day(
     except ValueError:
         raise HTTPException(400, "date must be YYYY-MM-DD")
 
-    deleted = db.query(TrainingPlan).filter(
-        TrainingPlan.user_id == user_id,
-        TrainingPlan.source == "ai",
-        TrainingPlan.date == d,
-    ).delete(synchronize_session=False)
-    if deleted:
-        bump_revisions(db, user_id, ["plans"])
-    db.commit()
+    try:
+        db.rollback()
+        lock_plan_writes(db, user_id)
+        existing = db.query(TrainingPlan).filter(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.source == "ai",
+            TrainingPlan.date == d,
+        )
+        before_rows = existing.order_by(TrainingPlan.id).all()
+        before = [plan_snapshot(row) for row in before_rows]
+        for row in before_rows:
+            db.expunge(row)
+        deleted = existing.delete(synchronize_session=False)
+        record_plan_revision(
+            db,
+            user_id=user_id,
+            operation="delete",
+            actor_type="user",
+            actor_id=user_id,
+            origin="api.plan.delete",
+            before=before,
+            after=[],
+            details={"date": plan_date, "rows": deleted},
+        )
+        if deleted:
+            bump_revisions(db, user_id, ["plans"])
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     return {"status": "deleted", "rows": deleted, "date": plan_date}

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 from datetime import date, datetime, timedelta, timezone
+from typing import Mapping
 
 import pandas as pd
 import requests
@@ -21,6 +22,22 @@ from api.deps import get_dashboard_data
 from api.etag import CACHE_CONTROL, ENDPOINT_SCOPES, ETagGuard, compute_etag
 from api.packs import RequestContext
 from db.cache_revision import bump_revisions
+from db.plan_ledger import (
+    begin_delivery_attempt,
+    complete_delivery_attempt,
+    delivery_status_for_snapshots,
+    find_delivery_by_external_id,
+    find_unverified_delivery_for_date,
+    get_or_create_delivery,
+    import_legacy_stryd_status,
+    legacy_stryd_status_path,
+    lock_plan_writes,
+    normalize_stryd_workout_id,
+    plan_snapshot,
+    remove_legacy_stryd_status,
+    write_legacy_stryd_status,
+)
+from db.models import TrainingPlan
 from db.session import get_db
 
 router = APIRouter()
@@ -30,19 +47,8 @@ _STRYD_PUSH_STATUS_DIR = os.path.join(_DATA_DIR, "ai", "stryd_push_status")
 
 
 def _stryd_push_status_path(user_id: str) -> str:
-    """Per-user push-status path.
-
-    Must be per-user: a shared file would let the GET /plan response
-    include every other user's workout IDs and push timestamps.
-    UUID user_ids keep filenames collision-free and filesystem-safe.
-
-    A legacy single-file layout at ``data/ai/stryd_push_status.json`` may
-    still exist on older deployments — this code does not read or migrate
-    it. Operators should delete that orphan file on deploy; leaving it in
-    place only means historical push-state that the UI won't show. No user
-    data is lost.
-    """
-    return os.path.join(_STRYD_PUSH_STATUS_DIR, f"{user_id}.json")
+    """Return the legacy per-user JSON path used by the one-time importer."""
+    return legacy_stryd_status_path(_STRYD_PUSH_STATUS_DIR, user_id)
 
 
 # Hard cap on how wide a window the client can request. Generous enough
@@ -174,12 +180,17 @@ def get_plan(
     plan from Stryd still see something here.
 
     Window framing is mixed into the ETag salt so two clients hitting
-    different windows can't bleed cache into each other. Stryd push
-    status comes from a per-user JSON file that lives outside the DB
-    revision counters; the push/delete handlers bump ``plans`` so a fresh
-    push is never served stale via 304.
+    different windows can't bleed cache into each other. The delivery ledger
+    is authoritative. A legacy per-user Stryd JSON file,
+    when present, is imported idempotently before the ETag is computed.
     """
     start_d, end_d = _resolve_window(start, end)
+    db.rollback()
+    import_legacy_stryd_status(
+        db,
+        user_id=user_id,
+        status_dir=_STRYD_PUSH_STATUS_DIR,
+    )
 
     etag = compute_etag(
         db, user_id, ENDPOINT_SCOPES["plan"],
@@ -192,8 +203,30 @@ def get_plan(
 
     ctx = RequestContext(user_id=user_id, db=db)
     plan_df = ctx.all_plans
-    push_status = _load_push_status(user_id)
     sync_target = _resolve_sync_target(ctx)
+    current_snapshots: dict[str, dict] = {}
+    if not plan_df.empty and "date" in plan_df.columns:
+        current_rows = (
+            plan_df[plan_df["source"] == "ai"]
+            if "source" in plan_df.columns
+            else plan_df
+        )
+        for _, current_row in current_rows.iterrows():
+            snapshot = plan_snapshot(current_row)
+            current_snapshots[str(snapshot["date"])] = snapshot
+    push_status = delivery_status_for_snapshots(
+        db,
+        user_id=user_id,
+        target="stryd",
+        current_snapshots=current_snapshots,
+    )
+    current_delivery_status = delivery_status_for_snapshots(
+        db,
+        user_id=user_id,
+        target="stryd",
+        current_snapshots=current_snapshots,
+        include_prior_versions=False,
+    )
 
     workouts: list[dict] = []
 
@@ -241,7 +274,7 @@ def get_plan(
                 for d, rows in stryd_by_date.items()
             }
             workout["sync_state"] = _compute_ai_sync_state(
-                workout["date"], push_status, stryd_match_by_date,
+                workout["date"], current_delivery_status, stryd_match_by_date,
             )
             ai_dates.add(workout["date"])
             workouts.append(workout)
@@ -302,59 +335,6 @@ def _row_to_workout(row, *, source: str) -> dict:
     return workout
 
 
-def _load_push_status(user_id: str) -> dict:
-    """Load a user's Stryd push status JSON.
-
-    Returns {} when the file is absent. On corruption, quarantines the file
-    (renames to ``*.corrupt-<timestamp>``) and returns {} — the subsequent
-    save would otherwise overwrite it with an empty dict and destroy any
-    recoverable content.
-    """
-    path = _stryd_push_status_path(user_id)
-    if not os.path.exists(path):
-        return {}
-    try:
-        with open(path) as f:
-            data = json.load(f)
-            if not isinstance(data, dict):
-                raise ValueError(f"Expected dict, got {type(data).__name__}")
-            return data
-    except (json.JSONDecodeError, ValueError, OSError) as e:
-        from datetime import datetime, timezone
-        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        quarantine = f"{path}.corrupt-{stamp}"
-        try:
-            os.replace(path, quarantine)
-            logger.error(
-                "Quarantined corrupt push status file for user=%s at %s: %s",
-                user_id, quarantine, e,
-            )
-        except OSError as rename_err:
-            logger.error(
-                "Corrupt push status file for user=%s at %s (quarantine failed: %s): %s",
-                user_id, path, rename_err, e,
-            )
-        return {}
-
-
-def _save_push_status(user_id: str, status: dict) -> None:
-    """Save a user's Stryd push status JSON atomically via temp file + rename."""
-    path = _stryd_push_status_path(user_id)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    tmp_path = path + ".tmp"
-    try:
-        with open(tmp_path, "w") as f:
-            json.dump(status, f, indent=2)
-        os.replace(tmp_path, path)
-    except OSError:
-        # Don't leave a half-written tmp file behind on rename failures.
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
-
-
 class PushStrydRequest(BaseModel):
     workout_dates: list[str]
 
@@ -374,6 +354,13 @@ def push_plan_to_stryd(
         _STRYD_WORKOUT_TYPES,
         build_workout_blocks,
         create_workout_api,
+    )
+
+    db.rollback()
+    import_legacy_stryd_status(
+        db,
+        user_id=current_user_id,
+        status_dir=_STRYD_PUSH_STATUS_DIR,
     )
 
     # Load Stryd credentials
@@ -428,36 +415,251 @@ def push_plan_to_stryd(
             detail="Cannot determine Critical Power from your data. Ensure recent activities with power data are synced before pushing to Stryd.",
         )
 
-    push_status = _load_push_status(current_user_id)
+    db.rollback()
     results = []
 
+    def _write_legacy_compat(
+        workout_date: str,
+        workout_id: str,
+        delivered_at: datetime | None,
+    ) -> None:
+        timestamp = delivered_at or datetime.now(timezone.utc)
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        try:
+            write_legacy_stryd_status(
+                db,
+                status_dir=_STRYD_PUSH_STATUS_DIR,
+                user_id=current_user_id,
+                workout_date=workout_date,
+                external_id=workout_id,
+                pushed_at=timestamp.isoformat(),
+            )
+        except Exception:
+            logger.exception(
+                "Delivery persisted but legacy status dual-write failed for user=%s date=%s",
+                current_user_id,
+                workout_date,
+            )
+
     for workout_date in request.workout_dates:
-        # Skip rest days
-        matching = plan_df[plan_df["date"].astype(str) == workout_date]
-        if matching.empty:
-            results.append({"date": workout_date, "status": "error", "error": "No workout found for this date"})
+        try:
+            lock_plan_writes(db, current_user_id)
+            current_data = get_dashboard_data(user_id=current_user_id, db=db)
+            current_all_plans = current_data.get("all_plans", pd.DataFrame())
+            if not isinstance(current_all_plans, pd.DataFrame) or current_all_plans.empty:
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": "No workout found for this date",
+                })
+                db.rollback()
+                continue
+            if "source" not in current_all_plans.columns:
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": "Training plan source is unavailable",
+                })
+                db.rollback()
+                continue
+            current_source = (
+                current_all_plans["source"]
+                .fillna("")
+                .astype(str)
+                .str.strip()
+                .str.casefold()
+            )
+            current_plan = current_all_plans[current_source == "ai"]
+            matching = current_plan[
+                current_plan["date"].astype(str) == workout_date
+            ]
+            if matching.empty:
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": "No workout found for this date",
+                })
+                db.rollback()
+                continue
+
+            row = matching.iloc[0]
+            workout_type = str(row.get("workout_type", ""))
+            if is_rest_workout(workout_type):
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": "Rest day — nothing to push",
+                })
+                db.rollback()
+                continue
+            workout = plan_snapshot(row)
+
+            delivery, delivery_created = get_or_create_delivery(
+                db,
+                user_id=current_user_id,
+                target="stryd",
+                snapshot=workout,
+            )
+            existing_stryd_rows = current_all_plans[
+                (current_source == "stryd")
+                & (current_all_plans["date"].astype(str) == workout_date)
+            ]
+            if (
+                not existing_stryd_rows.empty
+                and not (delivery.state == "synced" and delivery.external_id)
+            ):
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": (
+                        "A Stryd workout already exists on this date and must "
+                        "be reconciled before delivery"
+                    ),
+                })
+                if delivery_created:
+                    db.delete(delivery)
+                    db.commit()
+                else:
+                    db.rollback()
+                continue
+            unverified = find_unverified_delivery_for_date(
+                db,
+                user_id=current_user_id,
+                target="stryd",
+                workout_date=date.fromisoformat(workout_date),
+            )
+            if unverified is not None:
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": (
+                        "Delivery outcome is uncertain; sync Stryd before retrying"
+                    ),
+                })
+                if delivery_created:
+                    db.delete(delivery)
+                    db.commit()
+                else:
+                    db.rollback()
+                continue
+            delivery, attempt, disposition = begin_delivery_attempt(
+                db,
+                delivery,
+                operation="deliver",
+            )
+            if disposition == "already_complete":
+                external_id = str(delivery.external_id)
+                delivered_at = delivery.delivered_at
+                db.rollback()
+                _write_legacy_compat(
+                    workout_date,
+                    external_id,
+                    delivered_at,
+                )
+                results.append({
+                    "date": workout_date,
+                    "status": "success",
+                    "workout_id": external_id,
+                })
+                continue
+            if disposition == "reconciliation_required":
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": (
+                        "Delivery outcome is uncertain; sync Stryd before retrying"
+                    ),
+                })
+                if delivery_created:
+                    db.delete(delivery)
+                    db.commit()
+                else:
+                    db.rollback()
+                continue
+            assert attempt is not None
+            delivery_id = delivery.id
+            attempt_id = attempt.id
+            bump_revisions(db, current_user_id, ["plans"])
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.exception(
+                "Failed to start Stryd delivery for user=%s date=%s",
+                current_user_id,
+                workout_date,
+            )
+            results.append({
+                "date": workout_date,
+                "status": "error",
+                "error": f"Could not start delivery: {exc}",
+            })
             continue
 
-        row = matching.iloc[0]
-        workout_type = str(row.get("workout_type", ""))
+        def _record_failure(message: str) -> None:
+            try:
+                complete_delivery_attempt(
+                    db,
+                    user_id=current_user_id,
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    attempt_state="failed",
+                    error=message,
+                )
+                bump_revisions(db, current_user_id, ["plans"])
+                db.commit()
+            except Exception:
+                db.rollback()
+                logger.exception(
+                    "Failed to persist Stryd delivery failure for user=%s date=%s",
+                    current_user_id,
+                    workout_date,
+                )
 
-        # Skip rest days
-        if is_rest_workout(workout_type):
-            results.append({"date": workout_date, "status": "error", "error": "Rest day — nothing to push"})
-            continue
-
-        workout = row.to_dict()
-        # Convert date objects to strings for the dict
-        for k, v in workout.items():
-            if hasattr(v, "isoformat"):
-                workout[k] = v.isoformat()
+        def _record_conflict(detail: str) -> None:
+            message = (
+                "Stryd delivery outcome is uncertain; sync Stryd before retrying"
+            )
+            try:
+                complete_delivery_attempt(
+                    db,
+                    user_id=current_user_id,
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    attempt_state="conflict",
+                    error=f"{message}: {detail}",
+                )
+                bump_revisions(db, current_user_id, ["plans"])
+                db.commit()
+            except Exception:
+                db.rollback()
+                logger.exception(
+                    "Failed to persist ambiguous Stryd delivery for user=%s date=%s",
+                    current_user_id,
+                    workout_date,
+                )
 
         try:
             blocks = build_workout_blocks(workout, cp_watts)
             stryd_type = _STRYD_WORKOUT_TYPES.get(workout_type.lower(), "")
             title = f"{workout_type.replace('_', ' ').title()}"
-            description = str(row.get("workout_description", ""))
+            description = str(workout.get("workout_description") or "")
+        except Exception as exc:
+            logger.error(
+                "Failed to prepare Stryd workout for %s: %s: %s",
+                workout_date,
+                type(exc).__name__,
+                exc,
+            )
+            _record_failure(str(exc))
+            results.append({
+                "date": workout_date,
+                "status": "error",
+                "error": str(exc),
+            })
+            continue
 
+        try:
             result = create_workout_api(
                 user_id=stryd_user_id,
                 token=token,
@@ -467,42 +669,103 @@ def push_plan_to_stryd(
                 workout_type=stryd_type,
                 description=description,
             )
-
-            workout_id = str(result.get("id", ""))
-            push_status[workout_date] = {
-                "workout_id": workout_id,
-                "pushed_at": datetime.now(timezone.utc).isoformat(),
-                "status": "pushed",
-            }
-            results.append({"date": workout_date, "status": "success", "workout_id": workout_id})
-
+        except (requests.Timeout, requests.ConnectionError) as e:
+            _record_conflict(str(e))
+            results.append({
+                "date": workout_date,
+                "status": "error",
+                "error": (
+                    "Stryd delivery outcome is uncertain; sync Stryd before retrying"
+                ),
+            })
+            continue
         except requests.HTTPError as e:
             detail = str(e)
+            status_code = e.response.status_code if e.response is not None else None
             if e.response is not None:
                 try:
                     detail = e.response.json().get("message", detail)
                 except (ValueError, AttributeError):
                     pass
-            results.append({"date": workout_date, "status": "error", "error": f"Stryd API error: {detail}"})
+            if status_code is None or status_code == 408 or status_code >= 500:
+                _record_conflict(detail)
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": (
+                        "Stryd delivery outcome is uncertain; sync Stryd before retrying"
+                    ),
+                })
+                continue
+            message = f"Stryd API error: {detail}"
+            _record_failure(message)
+            results.append({"date": workout_date, "status": "error", "error": message})
+            continue
         except Exception as e:
-            logger.error("Failed to push workout for %s: %s: %s", workout_date, type(e).__name__, e)
-            results.append({"date": workout_date, "status": "error", "error": str(e)})
+            logger.error(
+                "Ambiguous Stryd response for %s: %s: %s",
+                workout_date,
+                type(e).__name__,
+                e,
+            )
+            _record_conflict(str(e))
+            results.append({
+                "date": workout_date,
+                "status": "error",
+                "error": (
+                    "Stryd delivery outcome is uncertain; sync Stryd before retrying"
+                ),
+            })
+            continue
 
-    try:
-        _save_push_status(current_user_id, push_status)
-    except OSError as e:
-        logger.warning("Failed to save push status: %s", e)
-    else:
-        # Bump ``plans`` so /api/plan's ETag flips and the new push status is
-        # served on the next read instead of a stale 304. ``stryd_status``
-        # lives in a JSON file outside the DB scopes, so without this bump
-        # the L2 cache layer would have no signal that the response changed.
+        raw_workout_id = result.get("id") if isinstance(result, Mapping) else None
+        workout_id = normalize_stryd_workout_id(raw_workout_id)
+        if not workout_id:
+            _record_conflict("Stryd response did not include a workout id")
+            results.append({
+                "date": workout_date,
+                "status": "error",
+                "error": (
+                    "Stryd delivery outcome is uncertain; sync Stryd before retrying"
+                ),
+            })
+            continue
         try:
+            complete_delivery_attempt(
+                db,
+                user_id=current_user_id,
+                delivery_id=delivery_id,
+                attempt_id=attempt_id,
+                attempt_state="synced",
+                external_id=workout_id,
+                response=result,
+            )
             bump_revisions(db, current_user_id, ["plans"])
             db.commit()
-        except Exception as e:
-            logger.warning("Failed to bump cache revision after push: %s", e)
+        except Exception:
             db.rollback()
+            logger.exception(
+                "Stryd accepted workout but ledger commit failed for user=%s date=%s id=%s",
+                current_user_id,
+                workout_date,
+                workout_id,
+            )
+            results.append({
+                "date": workout_date,
+                "status": "error",
+                "error": "Stryd accepted the workout, but delivery state could not be finalized",
+            })
+            continue
+        results.append({
+            "date": workout_date,
+            "status": "success",
+            "workout_id": workout_id,
+        })
+        _write_legacy_compat(
+            workout_date,
+            workout_id,
+            datetime.now(timezone.utc),
+        )
 
     return {"results": results}
 
@@ -516,45 +779,194 @@ def delete_stryd_workout(
     """Delete a previously pushed workout from Stryd."""
     from sync.stryd_sync import _login_api, delete_workout_api
 
+    normalized_workout_id = normalize_stryd_workout_id(workout_id)
+    if normalized_workout_id is None:
+        raise HTTPException(status_code=400, detail="Invalid Stryd workout id")
+    workout_id = normalized_workout_id
+
+    db.rollback()
+    import_legacy_stryd_status(
+        db,
+        user_id=current_user_id,
+        status_dir=_STRYD_PUSH_STATUS_DIR,
+    )
+    lock_plan_writes(db, current_user_id)
+    delivery = find_delivery_by_external_id(
+        db,
+        user_id=current_user_id,
+        target="stryd",
+        external_id=workout_id,
+    )
+    if delivery is None:
+        db.rollback()
+        raise HTTPException(
+            status_code=404,
+            detail="No Stryd delivery found for this user and workout",
+        )
+
+    previous_state = delivery.state
+    if previous_state == "delivering" and delivery.external_id:
+        # A stale remove attempt can be retried after its lease expires.
+        # Restore the known pre-remove state if the repeated DELETE fails.
+        previous_state = "synced"
+    try:
+        delivery, attempt, disposition = begin_delivery_attempt(
+            db,
+            delivery,
+            operation="remove",
+        )
+        if disposition == "already_complete":
+            db.rollback()
+            try:
+                remove_legacy_stryd_status(
+                    db,
+                    status_dir=_STRYD_PUSH_STATUS_DIR,
+                    user_id=current_user_id,
+                    external_id=workout_id,
+                )
+            except Exception:
+                logger.exception(
+                    "Legacy removal cleanup failed for user=%s workout=%s",
+                    current_user_id,
+                    workout_id,
+                )
+            return {"deleted": True, "workout_id": workout_id}
+        if disposition == "reconciliation_required":
+            db.rollback()
+            raise HTTPException(
+                status_code=409,
+                detail="Stryd workout delivery is already being updated",
+            )
+        assert attempt is not None
+        delivery_id = delivery.id
+        attempt_id = attempt.id
+        bump_revisions(db, current_user_id, ["plans"])
+        db.commit()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        db.rollback()
+        logger.exception(
+            "Failed to start Stryd removal for user=%s workout=%s",
+            current_user_id,
+            workout_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Could not start Stryd workout removal",
+        ) from exc
+
+    def _record_removal_failure(message: str) -> bool:
+        try:
+            updated = complete_delivery_attempt(
+                db,
+                user_id=current_user_id,
+                delivery_id=delivery_id,
+                attempt_id=attempt_id,
+                attempt_state="failed",
+                delivery_state=previous_state,
+                error=message,
+            )
+            current_delivery = find_delivery_by_external_id(
+                db,
+                user_id=current_user_id,
+                target="stryd",
+                external_id=workout_id,
+            )
+            removed_won = (
+                not updated
+                and current_delivery is not None
+                and current_delivery.state == "removed"
+            )
+            bump_revisions(db, current_user_id, ["plans"])
+            db.commit()
+            return removed_won
+        except Exception:
+            db.rollback()
+            logger.exception(
+                "Failed to persist Stryd removal failure for user=%s workout=%s",
+                current_user_id,
+                workout_id,
+            )
+            return False
+
     load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "sync", ".env"))
     email = os.environ.get("STRYD_EMAIL")
     password = os.environ.get("STRYD_PASSWORD")
     if not email or not password:
-        raise HTTPException(status_code=400, detail="STRYD_EMAIL / STRYD_PASSWORD not configured")
+        _record_removal_failure("STRYD_EMAIL / STRYD_PASSWORD not configured")
+        raise HTTPException(
+            status_code=400,
+            detail="STRYD_EMAIL / STRYD_PASSWORD not configured",
+        )
 
     try:
         stryd_user_id, token = _login_api(email, password)
     except Exception as e:
         logger.error("Stryd login failed: %s", e)
-        raise HTTPException(status_code=502, detail="Stryd login failed. Check your credentials in sync/.env")
+        if _record_removal_failure(str(e)):
+            return {"deleted": True, "workout_id": workout_id}
+        raise HTTPException(
+            status_code=502,
+            detail="Stryd login failed. Check your credentials in sync/.env",
+        )
 
+    already_absent = False
     try:
         delete_workout_api(stryd_user_id, token, workout_id)
     except requests.HTTPError as e:
         if e.response is not None and e.response.status_code == 404:
-            pass  # Already deleted on Stryd — proceed to clean local status
+            already_absent = True
         else:
+            if _record_removal_failure(str(e)):
+                return {"deleted": True, "workout_id": workout_id}
             raise HTTPException(status_code=502, detail=f"Stryd delete failed: {e}")
     except Exception as e:
         logger.error("Stryd delete failed: %s", e)
+        if _record_removal_failure(str(e)):
+            return {"deleted": True, "workout_id": workout_id}
         raise HTTPException(status_code=502, detail="Failed to delete from Stryd")
 
-    # Remove from push status
-    push_status = _load_push_status(current_user_id)
-    to_remove = [d for d, info in push_status.items() if info.get("workout_id") == workout_id]
-    for d in to_remove:
-        del push_status[d]
-    _save_push_status(current_user_id, push_status)
-
-    # Bump ``plans`` so /api/plan's ETag flips and the cleared push status is
-    # served on the next read instead of a stale 304. Mirror the bump in
-    # push_plan_to_stryd — ``stryd_status`` lives outside the DB scopes.
-    if to_remove:
-        try:
-            bump_revisions(db, current_user_id, ["plans"])
-            db.commit()
-        except Exception as e:
-            logger.warning("Failed to bump cache revision after delete: %s", e)
-            db.rollback()
+    try:
+        complete_delivery_attempt(
+            db,
+            user_id=current_user_id,
+            delivery_id=delivery_id,
+            attempt_id=attempt_id,
+            attempt_state="removed",
+            external_id=workout_id,
+            response={"already_absent": already_absent},
+        )
+        db.query(TrainingPlan).filter(
+            TrainingPlan.user_id == current_user_id,
+            TrainingPlan.source == "stryd",
+            TrainingPlan.external_id == workout_id,
+        ).delete(synchronize_session=False)
+        bump_revisions(db, current_user_id, ["plans"])
+        db.commit()
+    except Exception as exc:
+        db.rollback()
+        logger.exception(
+            "Stryd workout deleted but ledger finalization failed for user=%s workout=%s",
+            current_user_id,
+            workout_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Stryd workout was deleted, but delivery state could not be finalized",
+        ) from exc
+    try:
+        remove_legacy_stryd_status(
+            db,
+            status_dir=_STRYD_PUSH_STATUS_DIR,
+            user_id=current_user_id,
+            external_id=workout_id,
+        )
+    except Exception:
+        logger.exception(
+            "Stryd removal persisted but legacy status dual-write failed for user=%s workout=%s",
+            current_user_id,
+            workout_id,
+        )
 
     return {"deleted": True, "workout_id": workout_id}

--- a/db/cache_revision.py
+++ b/db/cache_revision.py
@@ -15,7 +15,7 @@ and the bump points in ``db/sync_writer.py`` + the config-mutation routes):
     samples     — ActivitySample rows
     recovery    — RecoveryData rows (Oura sleep/HRV/RHR + Garmin variants)
     fitness     — FitnessData rows (CP, LTHR, threshold pace, max/rest HR)
-    plans       — TrainingPlan rows (Stryd push, AI plan upload/upsert/delete)
+    plans       — TrainingPlan rows plus plan revision/delivery ledger state
     config      — UserConfig rows (settings, science choice, goal updates)
 
 A counter beats a timestamp because two writes within the same wall-clock

--- a/db/models.py
+++ b/db/models.py
@@ -481,6 +481,131 @@ class TrainingPlan(Base):
     )
 
 
+class PlanRevision(Base):
+    """Append-only audit event for a canonical plan mutation."""
+
+    __tablename__ = "plan_revisions"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    operation = Column(String(30), nullable=False)
+    actor_type = Column(String(20), nullable=False)
+    actor_id = Column(String(100), nullable=True)
+    origin = Column(String(80), nullable=False)
+    before_snapshot = Column(JSON, nullable=False, default=list)
+    after_snapshot = Column(JSON, nullable=False, default=list)
+    details = Column(JSON, nullable=False, default=dict)
+    idempotency_key = Column(String(128), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "idempotency_key",
+            name="uq_plan_revision_user_idempotency",
+        ),
+        Index("ix_plan_revisions_user_created", "user_id", "created_at"),
+    )
+
+
+class PlanDelivery(Base):
+    """Current provider-neutral delivery state for one workout version."""
+
+    __tablename__ = "plan_deliveries"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    canonical_key = Column(String(120), nullable=False)
+    workout_date = Column(Date, nullable=False)
+    workout_version = Column(String(64), nullable=False)
+    target = Column(String(20), nullable=False)
+    state = Column(String(20), nullable=False, default="pending")
+    external_id = Column(String(200), nullable=True)
+    last_error = Column(Text, nullable=True)
+    delivered_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "state IN ('pending','delivering','synced','conflict','failed','removed')",
+            name="ck_plan_deliveries_state",
+        ),
+        UniqueConstraint(
+            "user_id",
+            "target",
+            "canonical_key",
+            "workout_version",
+            name="uq_plan_delivery_version_target",
+        ),
+        Index(
+            "ix_plan_deliveries_user_target_date",
+            "user_id",
+            "target",
+            "workout_date",
+        ),
+        Index(
+            "ix_plan_deliveries_user_target_external",
+            "user_id",
+            "target",
+            "external_id",
+        ),
+    )
+
+
+class PlanDeliveryAttempt(Base):
+    """Append-only attempt history for a plan delivery or removal."""
+
+    __tablename__ = "plan_delivery_attempts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    delivery_id = Column(
+        String(36),
+        ForeignKey("plan_deliveries.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    attempt_number = Column(Integer, nullable=False)
+    operation = Column(String(20), nullable=False)
+    state = Column(String(20), nullable=False)
+    external_id = Column(String(200), nullable=True)
+    error = Column(Text, nullable=True)
+    response = Column(JSON, nullable=True)
+    started_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    completed_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "state IN ('pending','delivering','synced','conflict','failed','removed')",
+            name="ck_plan_delivery_attempts_state",
+        ),
+        CheckConstraint(
+            "operation IN ('deliver','remove','import')",
+            name="ck_plan_delivery_attempts_operation",
+        ),
+        UniqueConstraint(
+            "delivery_id",
+            "attempt_number",
+            name="uq_plan_delivery_attempt_number",
+        ),
+    )
+
+
 class SystemAnnouncement(Base):
     """Admin-configurable site-wide notification banners.
 

--- a/db/plan_ledger.py
+++ b/db/plan_ledger.py
@@ -1,0 +1,997 @@
+"""Durable plan revision and provider-neutral delivery bookkeeping."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import re
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Iterator, Mapping, Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from db.cache_revision import bump_revisions, lock_revision_writes
+from db.models import (
+    PlanDelivery,
+    PlanDeliveryAttempt,
+    PlanRevision,
+    User,
+)
+from db.session import begin_serialized_write
+
+logger = logging.getLogger(__name__)
+
+PLAN_DELIVERY_STATES = frozenset(
+    {"pending", "delivering", "synced", "conflict", "failed", "removed"}
+)
+DELIVERY_ATTEMPT_LEASE = timedelta(minutes=5)
+
+_SNAPSHOT_FIELDS = (
+    "date",
+    "workout_type",
+    "planned_duration_min",
+    "planned_distance_km",
+    "target_power_min",
+    "target_power_max",
+    "target_hr_min",
+    "target_hr_max",
+    "target_pace_min",
+    "target_pace_max",
+    "workout_description",
+    "source",
+    "start_time",
+    "meta",
+)
+_LEGACY_LOCK_STATE = threading.local()
+
+
+def lock_plan_writes(db: Session, user_id: str) -> None:
+    """Serialize plan DB and compatibility-file writes for one user."""
+    if db.get_bind().dialect.name == "sqlite" and not db.in_transaction():
+        begin_serialized_write(db)
+    lock_revision_writes(db, user_id)
+
+
+def normalize_stryd_workout_id(raw_id: object) -> str | None:
+    """Return a safe Stryd provider ID, or ``None`` for malformed values."""
+    if isinstance(raw_id, int):
+        if isinstance(raw_id, bool) or raw_id <= 0:
+            return None
+        candidate = str(raw_id)
+    elif isinstance(raw_id, str):
+        candidate = raw_id.strip()
+    else:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,200}", candidate):
+        return None
+    return candidate
+
+
+def _user_exists(db: Session, user_id: str) -> bool:
+    return db.execute(
+        select(User.id).where(User.id == user_id)
+    ).scalar_one_or_none() is not None
+
+
+@contextmanager
+def legacy_stryd_status_lock(
+    status_dir: str,
+    user_id: str,
+) -> Iterator[None]:
+    """Cross-process lock for one user's legacy compatibility files."""
+    os.makedirs(status_dir, exist_ok=True)
+    digest = hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+    lock_path = os.path.join(status_dir, f".{digest}.lock")
+    held = getattr(_LEGACY_LOCK_STATE, "paths", set())
+    if lock_path in held:
+        yield
+        return
+
+    deadline = time.monotonic() + 10.0
+    while True:
+        try:
+            fd = os.open(
+                lock_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+            try:
+                os.write(fd, str(os.getpid()).encode("ascii"))
+            finally:
+                os.close(fd)
+            break
+        except FileExistsError:
+            try:
+                if time.time() - os.path.getmtime(lock_path) > 60.0:
+                    os.unlink(lock_path)
+                    continue
+            except FileNotFoundError:
+                continue
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"timed out acquiring legacy status lock for user {user_id}"
+                )
+            time.sleep(0.05)
+
+    held = set(held)
+    held.add(lock_path)
+    _LEGACY_LOCK_STATE.paths = held
+    try:
+        yield
+    finally:
+        held.remove(lock_path)
+        _LEGACY_LOCK_STATE.paths = held
+        try:
+            os.unlink(lock_path)
+        except FileNotFoundError:
+            pass
+
+
+def _atomic_write_legacy_status(path: str, payload: Mapping[str, Any]) -> None:
+    """Atomically replace one legacy JSON snapshot without shared temp names."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(path),
+        prefix=f"{os.path.basename(path)}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_field(record: Any, field: str) -> Any:
+    if isinstance(record, Mapping):
+        return record.get(field)
+    return getattr(record, field, None)
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if value.__class__.__name__ in {"NAType", "NaTType"}:
+        return None
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_value(item) for item in value]
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return _json_value(item())
+        except (TypeError, ValueError):
+            pass
+    return str(value)
+
+
+def plan_snapshot(record: Any) -> dict[str, Any]:
+    """Return a JSON-safe canonical snapshot of one training-plan row."""
+    snapshot = {
+        field: _json_value(_read_field(record, field))
+        for field in _SNAPSHOT_FIELDS
+    }
+    snapshot["source"] = snapshot.get("source") or "ai"
+    return snapshot
+
+
+def canonical_workout_key(snapshot: Mapping[str, Any]) -> str:
+    """Return the stable logical key used across versions of one workout slot."""
+    workout_date = str(snapshot.get("date") or "")
+    if not workout_date:
+        raise ValueError("plan snapshot must include a date")
+    source = str(snapshot.get("source") or "ai").strip().lower()
+    return f"{source}:{workout_date}"
+
+
+def legacy_unknown_version(snapshot: Mapping[str, Any]) -> str:
+    """Return the sentinel version for an unverified legacy push record."""
+    return f"legacy-unknown:{canonical_workout_key(snapshot)}"
+
+
+def workout_version(snapshot: Mapping[str, Any]) -> str:
+    """Hash delivery-relevant workout content into an immutable version id."""
+    normalized = plan_snapshot(snapshot)
+    normalized.pop("meta", None)
+    payload = json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def record_plan_revision(
+    db: Session,
+    *,
+    user_id: str,
+    operation: str,
+    actor_type: str,
+    actor_id: str | None,
+    origin: str,
+    before: Sequence[Any],
+    after: Sequence[Any],
+    details: Mapping[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> PlanRevision:
+    """Stage one append-only plan revision in the caller's transaction."""
+    revision = PlanRevision(
+        user_id=user_id,
+        operation=operation,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        origin=origin,
+        before_snapshot=[plan_snapshot(row) for row in before],
+        after_snapshot=[plan_snapshot(row) for row in after],
+        details=_json_value(dict(details or {})),
+        idempotency_key=idempotency_key,
+    )
+    db.add(revision)
+    db.flush()
+    return revision
+
+
+def get_or_create_delivery(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    snapshot: Mapping[str, Any] | Any,
+    workout_version_override: str | None = None,
+) -> tuple[PlanDelivery, bool]:
+    """Return the stable delivery row for a workout version and target."""
+    lock_plan_writes(db, user_id)
+    normalized = plan_snapshot(snapshot)
+    workout_date = date.fromisoformat(str(normalized["date"]))
+    key = canonical_workout_key(normalized)
+    version = workout_version_override or workout_version(normalized)
+    existing = db.execute(
+        select(PlanDelivery).where(
+            PlanDelivery.user_id == user_id,
+            PlanDelivery.target == target,
+            PlanDelivery.canonical_key == key,
+            PlanDelivery.workout_version == version,
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing, False
+
+    delivery = PlanDelivery(
+        user_id=user_id,
+        canonical_key=key,
+        workout_date=workout_date,
+        workout_version=version,
+        target=target,
+        state="pending",
+    )
+    try:
+        with db.begin_nested():
+            db.add(delivery)
+            db.flush()
+    except IntegrityError:
+        delivery = db.execute(
+            select(PlanDelivery).where(
+                PlanDelivery.user_id == user_id,
+                PlanDelivery.target == target,
+                PlanDelivery.canonical_key == key,
+                PlanDelivery.workout_version == version,
+            )
+        ).scalar_one()
+        return delivery, False
+    return delivery, True
+
+
+def begin_delivery_attempt(
+    db: Session,
+    delivery: PlanDelivery,
+    *,
+    operation: str,
+) -> tuple[PlanDelivery, PlanDeliveryAttempt | None, str]:
+    """Stage a delivery attempt and report whether external work should start."""
+    if operation not in {"deliver", "remove"}:
+        raise ValueError(f"unsupported delivery operation: {operation}")
+    lock_plan_writes(db, delivery.user_id)
+
+    # A user-row lock serializes different content versions of the same
+    # canonical slot. PlanDelivery's uniqueness is version-scoped, so locking
+    # only the selected row would let two concurrent versions POST together.
+    db.execute(
+        select(User.id)
+        .where(User.id == delivery.user_id)
+        .with_for_update()
+    ).scalar_one_or_none()
+    slot_rows = db.execute(
+        select(PlanDelivery)
+        .where(
+            PlanDelivery.user_id == delivery.user_id,
+            PlanDelivery.target == delivery.target,
+            PlanDelivery.canonical_key == delivery.canonical_key,
+        )
+        .order_by(PlanDelivery.created_at.asc(), PlanDelivery.id.asc())
+        .with_for_update()
+    ).scalars().all()
+    locked = next(row for row in slot_rows if row.id == delivery.id)
+
+    if operation == "deliver" and any(
+        row.id != locked.id
+        and (
+            row.state in {"delivering", "conflict"}
+            or (row.state == "synced" and row.external_id is not None)
+        )
+        for row in slot_rows
+    ):
+        return locked, None, "reconciliation_required"
+
+    if operation == "deliver" and locked.state == "synced" and locked.external_id:
+        return locked, None, "already_complete"
+    if operation == "remove" and locked.state == "removed":
+        return locked, None, "already_complete"
+    if locked.state == "delivering":
+        latest_attempt = db.execute(
+            select(PlanDeliveryAttempt)
+            .where(PlanDeliveryAttempt.delivery_id == locked.id)
+            .order_by(
+                PlanDeliveryAttempt.attempt_number.desc(),
+                PlanDeliveryAttempt.id.desc(),
+            )
+        ).scalars().first()
+        now = datetime.utcnow()
+        lease_expired = (
+            latest_attempt is not None
+            and latest_attempt.operation == "remove"
+            and latest_attempt.state == "delivering"
+            and latest_attempt.started_at <= now - DELIVERY_ATTEMPT_LEASE
+        )
+        if operation != "remove" or not lease_expired:
+            return locked, None, "reconciliation_required"
+        latest_attempt.state = "failed"
+        latest_attempt.error = "Removal attempt lease expired; superseded by retry"
+        latest_attempt.completed_at = now
+    if operation == "deliver" and locked.state == "conflict":
+        return locked, None, "reconciliation_required"
+
+    latest_number = db.execute(
+        select(func.coalesce(func.max(PlanDeliveryAttempt.attempt_number), 0))
+        .where(PlanDeliveryAttempt.delivery_id == locked.id)
+    ).scalar_one()
+    attempt = PlanDeliveryAttempt(
+        delivery_id=locked.id,
+        attempt_number=int(latest_number) + 1,
+        operation=operation,
+        state="delivering",
+        started_at=datetime.utcnow(),
+    )
+    locked.state = "delivering"
+    locked.last_error = None
+    locked.updated_at = datetime.utcnow()
+    db.add(attempt)
+    db.flush()
+    return locked, attempt, "started"
+
+
+def complete_delivery_attempt(
+    db: Session,
+    *,
+    user_id: str,
+    delivery_id: str,
+    attempt_id: int,
+    attempt_state: str,
+    delivery_state: str | None = None,
+    external_id: str | None = None,
+    error: str | None = None,
+    response: Mapping[str, Any] | None = None,
+) -> bool:
+    """Stage a terminal result if this attempt still owns the delivery."""
+    if attempt_state not in PLAN_DELIVERY_STATES:
+        raise ValueError(f"unsupported attempt state: {attempt_state}")
+    final_delivery_state = delivery_state or attempt_state
+    if final_delivery_state not in PLAN_DELIVERY_STATES:
+        raise ValueError(f"unsupported delivery state: {final_delivery_state}")
+    lock_plan_writes(db, user_id)
+    locked_delivery = db.execute(
+        select(PlanDelivery)
+        .where(
+            PlanDelivery.id == delivery_id,
+            PlanDelivery.user_id == user_id,
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one()
+    locked_attempt = db.execute(
+        select(PlanDeliveryAttempt)
+        .where(
+            PlanDeliveryAttempt.id == attempt_id,
+            PlanDeliveryAttempt.delivery_id == delivery_id,
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one()
+    latest_attempt_id = db.execute(
+        select(PlanDeliveryAttempt.id)
+        .where(PlanDeliveryAttempt.delivery_id == locked_delivery.id)
+        .order_by(
+            PlanDeliveryAttempt.attempt_number.desc(),
+            PlanDeliveryAttempt.id.desc(),
+        )
+    ).scalars().first()
+    if (
+        locked_attempt.id != latest_attempt_id
+        or locked_attempt.state != "delivering"
+    ):
+        late_removal_success = (
+            locked_attempt.operation == "remove"
+            and attempt_state == "removed"
+            and external_id is not None
+            and locked_delivery.external_id == external_id
+        )
+        if locked_attempt.state == "delivering" or late_removal_success:
+            now = datetime.utcnow()
+            locked_attempt.state = attempt_state
+            locked_attempt.external_id = external_id or locked_attempt.external_id
+            locked_attempt.error = error
+            locked_attempt.response = (
+                _json_value(dict(response or {})) if response is not None else None
+            )
+            locked_attempt.completed_at = now
+            if late_removal_success:
+                locked_delivery.state = "removed"
+                locked_delivery.last_error = None
+                locked_delivery.updated_at = now
+        return False
+
+    now = datetime.utcnow()
+    locked_attempt.state = attempt_state
+    locked_attempt.external_id = external_id or locked_attempt.external_id
+    locked_attempt.error = error
+    locked_attempt.response = (
+        _json_value(dict(response or {})) if response is not None else None
+    )
+    locked_attempt.completed_at = now
+
+    if (
+        locked_attempt.operation == "remove"
+        and attempt_state == "failed"
+        and locked_delivery.state == "removed"
+    ):
+        return False
+
+    locked_delivery.state = final_delivery_state
+    locked_delivery.external_id = external_id or locked_delivery.external_id
+    locked_delivery.last_error = error
+    locked_delivery.updated_at = now
+    if final_delivery_state == "synced":
+        locked_delivery.delivered_at = now
+    return True
+
+
+def find_delivery_by_external_id(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    external_id: str,
+) -> PlanDelivery | None:
+    """Find the newest delivery row associated with a provider workout id."""
+    return db.execute(
+        select(PlanDelivery)
+        .where(
+            PlanDelivery.user_id == user_id,
+            PlanDelivery.target == target,
+            PlanDelivery.external_id == external_id,
+        )
+        .order_by(PlanDelivery.updated_at.desc(), PlanDelivery.created_at.desc())
+    ).scalars().first()
+
+
+def find_unverified_delivery_for_date(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    workout_date: date,
+) -> PlanDelivery | None:
+    """Find a synced delivery whose content version is not verified."""
+    return db.execute(
+        select(PlanDelivery)
+        .where(
+            PlanDelivery.user_id == user_id,
+            PlanDelivery.target == target,
+            PlanDelivery.workout_date == workout_date,
+            PlanDelivery.state == "synced",
+            PlanDelivery.workout_version.like("legacy-unknown:%"),
+        )
+        .order_by(PlanDelivery.updated_at.desc(), PlanDelivery.created_at.desc())
+    ).scalars().first()
+
+
+def delivery_status_for_snapshots(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    current_snapshots: Mapping[str, Mapping[str, Any]],
+    include_prior_versions: bool = True,
+) -> dict[str, dict[str, str]]:
+    """Project synced delivery rows into the legacy date-keyed status shape."""
+    current_versions = {
+        date_key: workout_version(snapshot)
+        for date_key, snapshot in current_snapshots.items()
+    }
+    rows = db.execute(
+        select(PlanDelivery)
+        .where(
+            PlanDelivery.user_id == user_id,
+            PlanDelivery.target == target,
+            PlanDelivery.state == "synced",
+            PlanDelivery.external_id.is_not(None),
+        )
+        .order_by(PlanDelivery.updated_at.asc(), PlanDelivery.created_at.asc())
+    ).scalars()
+
+    status: dict[str, dict[str, str]] = {}
+    priorities: dict[str, int] = {}
+    for delivery in rows:
+        date_key = delivery.workout_date.isoformat()
+        current_version = current_versions.get(date_key)
+        if (
+            not include_prior_versions
+            and delivery.workout_version != current_version
+        ):
+            continue
+        priority = int(current_version == delivery.workout_version)
+        if priority < priorities.get(date_key, -1):
+            continue
+        entry = {
+            "workout_id": str(delivery.external_id),
+            "status": "pushed",
+        }
+        pushed_at = delivery.delivered_at or delivery.updated_at
+        if pushed_at is not None:
+            if pushed_at.tzinfo is None:
+                pushed_at = pushed_at.replace(tzinfo=timezone.utc)
+            entry["pushed_at"] = pushed_at.isoformat()
+        status[date_key] = entry
+        priorities[date_key] = priority
+    return status
+
+
+def legacy_stryd_status_path(status_dir: str, user_id: str) -> str:
+    """Return the old per-user Stryd push-status JSON path."""
+    return os.path.join(status_dir, f"{user_id}.json")
+
+
+def write_legacy_stryd_status(
+    db: Session,
+    *,
+    status_dir: str,
+    user_id: str,
+    workout_date: str,
+    external_id: str,
+    pushed_at: str,
+) -> None:
+    """Dual-write a successful delivery for mixed-version deployments."""
+    external_id = normalize_stryd_workout_id(external_id)
+    if external_id is None:
+        raise ValueError("invalid Stryd workout id")
+    lock_plan_writes(db, user_id)
+    if not _user_exists(db, user_id):
+        db.rollback()
+        raise LookupError(f"user {user_id} no longer exists")
+    active_delivery = db.execute(
+        select(PlanDelivery.id).where(
+            PlanDelivery.user_id == user_id,
+            PlanDelivery.target == "stryd",
+            PlanDelivery.canonical_key == f"ai:{workout_date}",
+            PlanDelivery.external_id == external_id,
+            PlanDelivery.state == "synced",
+            ~PlanDelivery.workout_version.startswith("legacy-unknown:"),
+        )
+    ).scalars().first()
+    if active_delivery is None:
+        db.rollback()
+        logger.info(
+            "Skipped stale legacy Stryd status write for user %s and workout %s",
+            user_id,
+            external_id,
+        )
+        return
+    with legacy_stryd_status_lock(status_dir, user_id):
+        path = legacy_stryd_status_path(status_dir, user_id)
+        payload: dict[str, Any] = {}
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            if not isinstance(loaded, dict):
+                db.rollback()
+                raise ValueError(f"expected object in {path}")
+            payload = loaded
+        payload[workout_date] = {
+            "workout_id": external_id,
+            "pushed_at": pushed_at,
+            "status": "pushed",
+        }
+        try:
+            _atomic_write_legacy_status(path, payload)
+        except Exception:
+            db.rollback()
+            raise
+        import_legacy_stryd_status(db, user_id=user_id, status_dir=status_dir)
+
+
+def remove_legacy_stryd_status(
+    db: Session,
+    *,
+    status_dir: str,
+    user_id: str,
+    external_id: str,
+) -> None:
+    """Dual-write a provider removal into the legacy compatibility file."""
+    external_id = normalize_stryd_workout_id(external_id)
+    if external_id is None:
+        raise ValueError("invalid Stryd workout id")
+    lock_plan_writes(db, user_id)
+    if not _user_exists(db, user_id):
+        db.rollback()
+        raise LookupError(f"user {user_id} no longer exists")
+    with legacy_stryd_status_lock(status_dir, user_id):
+        path = legacy_stryd_status_path(status_dir, user_id)
+        if not os.path.exists(path):
+            db.rollback()
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            if not isinstance(loaded, dict):
+                raise ValueError(f"expected object in {path}")
+        except Exception:
+            db.rollback()
+            raise
+        payload = {
+            date_key: entry
+            for date_key, entry in loaded.items()
+            if not (
+                isinstance(entry, Mapping)
+                and str(entry.get("workout_id") or "") == external_id
+            )
+        }
+        try:
+            _atomic_write_legacy_status(path, payload)
+        except Exception:
+            db.rollback()
+            raise
+        import_legacy_stryd_status(db, user_id=user_id, status_dir=status_dir)
+
+
+def _parse_legacy_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def _archive_legacy_file(path: str, suffix: str) -> None:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    destination = f"{path}.{suffix}-{stamp}"
+    try:
+        os.replace(path, destination)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("Failed to archive legacy plan status %s: %s", path, exc)
+
+
+def _legacy_entries_from_revision(revision: PlanRevision | None) -> dict[str, dict[str, Any]]:
+    """Return the normalized compatibility snapshot stored on an import event."""
+    if revision is None or not isinstance(revision.details, Mapping):
+        return {}
+    entries = revision.details.get("entries")
+    if not isinstance(entries, Mapping):
+        return {}
+    return {
+        str(date_key): dict(entry)
+        for date_key, entry in entries.items()
+        if isinstance(entry, Mapping)
+    }
+
+
+def _append_legacy_attempt(
+    db: Session,
+    delivery: PlanDelivery,
+    *,
+    state: str,
+    external_id: str,
+    completed_at: datetime,
+    action: str,
+) -> None:
+    """Append one compatibility-file transition to a delivery's history."""
+    latest_number = db.execute(
+        select(func.coalesce(func.max(PlanDeliveryAttempt.attempt_number), 0))
+        .where(PlanDeliveryAttempt.delivery_id == delivery.id)
+    ).scalar_one()
+    db.add(
+        PlanDeliveryAttempt(
+            delivery_id=delivery.id,
+            attempt_number=int(latest_number) + 1,
+            operation="import",
+            state=state,
+            external_id=external_id,
+            response={"legacy_import": True, "action": action},
+            started_at=completed_at,
+            completed_at=completed_at,
+        )
+    )
+    db.flush()
+
+
+def import_legacy_stryd_status(
+    db: Session,
+    *,
+    user_id: str,
+    status_dir: str,
+) -> str:
+    """Reconcile one user's current legacy Stryd JSON snapshot into the ledger."""
+    path = legacy_stryd_status_path(status_dir, user_id)
+    if not os.path.exists(path):
+        return "missing"
+    lock_plan_writes(db, user_id)
+    if not _user_exists(db, user_id):
+        db.rollback()
+        return "missing_user"
+    with legacy_stryd_status_lock(status_dir, user_id):
+        if not os.path.exists(path):
+            db.rollback()
+            return "missing"
+        return _import_legacy_stryd_status_locked(
+            db,
+            user_id=user_id,
+            path=path,
+        )
+
+
+def _import_legacy_stryd_status_locked(
+    db: Session,
+    *,
+    user_id: str,
+    path: str,
+) -> str:
+    """Reconcile a compatibility snapshot while its file lock is held."""
+
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read()
+        payload = json.loads(raw.decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected object, got {type(payload).__name__}")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        logger.error(
+            "Quarantining corrupt legacy Stryd status for user=%s path=%s: %s",
+            user_id,
+            path,
+            exc,
+        )
+        _archive_legacy_file(path, "corrupt")
+        db.rollback()
+        return "corrupt"
+
+    previous_revision = db.execute(
+        select(PlanRevision)
+        .where(
+            PlanRevision.user_id == user_id,
+            PlanRevision.origin == "legacy.stryd_push_status",
+        )
+        .order_by(PlanRevision.created_at.desc(), PlanRevision.id.desc())
+    ).scalars().first()
+    previous_entries = _legacy_entries_from_revision(previous_revision)
+
+    parsed: list[tuple[str, dict[str, Any], str, datetime | None]] = []
+    normalized_entries: dict[str, dict[str, Any]] = {}
+    skipped = 0
+    for date_key, entry in payload.items():
+        if not isinstance(entry, Mapping):
+            skipped += 1
+            continue
+        try:
+            workout_date = date.fromisoformat(str(date_key))
+        except ValueError:
+            skipped += 1
+            continue
+        external_id = normalize_stryd_workout_id(entry.get("workout_id"))
+        legacy_state = str(entry.get("status") or "pushed").strip().lower()
+        if not external_id or legacy_state not in {"pushed", "synced", "success"}:
+            skipped += 1
+            continue
+
+        snapshot = plan_snapshot(
+            {
+                "date": workout_date,
+                "source": "ai",
+                "workout_type": None,
+            }
+        )
+        pushed_at = _parse_legacy_timestamp(entry.get("pushed_at"))
+        normalized_entry: dict[str, Any] = {
+            "workout_id": external_id,
+            "status": "pushed",
+        }
+        if pushed_at is not None:
+            normalized_entry["pushed_at"] = pushed_at.replace(
+                tzinfo=timezone.utc
+            ).isoformat()
+        normalized_entries[workout_date.isoformat()] = normalized_entry
+        parsed.append((workout_date.isoformat(), snapshot, external_id, pushed_at))
+
+    if (
+        previous_revision is not None
+        and normalized_entries == previous_entries
+    ):
+        db.rollback()
+        return "already_imported"
+    normalized_payload = json.dumps(
+        normalized_entries,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    digest = hashlib.sha256(normalized_payload).hexdigest()
+    previous_token = previous_revision.id if previous_revision is not None else "initial"
+    idempotency_key = (
+        f"legacy-stryd-status:{digest}:after:{previous_token}"
+    )
+
+    try:
+        record_plan_revision(
+            db,
+            user_id=user_id,
+            operation="legacy_import",
+            actor_type="system",
+            actor_id=None,
+            origin="legacy.stryd_push_status",
+            before=[],
+            after=[snapshot for _, snapshot, _, _ in parsed],
+            details={
+                "imported": len(parsed),
+                "skipped": skipped,
+                "entries": normalized_entries,
+            },
+            idempotency_key=idempotency_key,
+        )
+        changed = False
+        completed_at = datetime.utcnow()
+
+        # Old workers can delete or replace a date in the compatibility file.
+        # Reconcile the prior imported snapshot before applying the new one.
+        for date_key, previous_entry in previous_entries.items():
+            previous_external_id = str(
+                previous_entry.get("workout_id") or ""
+            ).strip()
+            current_external_id = str(
+                normalized_entries.get(date_key, {}).get("workout_id") or ""
+            ).strip()
+            if not previous_external_id or current_external_id == previous_external_id:
+                continue
+            previous_delivery = find_delivery_by_external_id(
+                db,
+                user_id=user_id,
+                target="stryd",
+                external_id=previous_external_id,
+            )
+            if previous_delivery is None or previous_delivery.state == "removed":
+                continue
+            previous_delivery.state = "removed"
+            previous_delivery.last_error = None
+            previous_delivery.updated_at = completed_at
+            _append_legacy_attempt(
+                db,
+                previous_delivery,
+                state="removed",
+                external_id=previous_external_id,
+                completed_at=completed_at,
+                action="removed",
+            )
+            changed = True
+
+        for _, snapshot, external_id, pushed_at in parsed:
+            existing_external = find_delivery_by_external_id(
+                db,
+                user_id=user_id,
+                target="stryd",
+                external_id=external_id,
+            )
+            if existing_external is not None:
+                if not existing_external.workout_version.startswith(
+                    "legacy-unknown:"
+                ):
+                    continue
+                restored_at = pushed_at or completed_at
+                existing_external.state = "synced"
+                existing_external.last_error = None
+                existing_external.delivered_at = (
+                    pushed_at
+                    or existing_external.delivered_at
+                    or completed_at
+                )
+                existing_external.updated_at = restored_at
+                _append_legacy_attempt(
+                    db,
+                    existing_external,
+                    state="synced",
+                    external_id=external_id,
+                    completed_at=restored_at,
+                    action="restored",
+                )
+                changed = True
+                continue
+            delivery, created = get_or_create_delivery(
+                db,
+                user_id=user_id,
+                target="stryd",
+                snapshot=snapshot,
+                workout_version_override=legacy_unknown_version(snapshot),
+            )
+            if (
+                not created
+                and delivery.state == "synced"
+                and delivery.external_id == external_id
+            ):
+                continue
+            imported_at = pushed_at or completed_at
+            delivery.state = "synced"
+            delivery.external_id = external_id
+            delivery.last_error = None
+            delivery.delivered_at = pushed_at or delivery.delivered_at
+            delivery.updated_at = imported_at
+            _append_legacy_attempt(
+                db,
+                delivery,
+                state="synced",
+                external_id=external_id,
+                completed_at=imported_at,
+                action="created" if created else "replaced",
+            )
+            changed = True
+        if changed:
+            bump_revisions(db, user_id, ["plans"])
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        marker = db.execute(
+            select(PlanRevision.id).where(
+                PlanRevision.user_id == user_id,
+                PlanRevision.idempotency_key == idempotency_key,
+            )
+        ).scalar_one_or_none()
+        if marker is None:
+            raise
+        return "already_imported"
+    except Exception:
+        db.rollback()
+        raise
+
+    return "imported"

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -694,12 +694,15 @@ Paginated activity history.
 
 ### GET /api/plan
 
-The user's AI plan within a window, plus per-row Stryd sync state and the
-caller's Stryd push history.
+The user's plan within a window, plus per-row Stryd sync state. `sync_state` is
+authoritative for the current Praxys-authored version. `stryd_status` keeps the
+legacy date-keyed response shape and may retain a prior successful workout ID so
+clients can delete it before replacing an edited version; its source of truth is
+the database delivery ledger rather than JSON files.
 
-The canonical plan is the AI-authored one (`source='ai'`); Stryd plan rows
-in the same window are surfaced as a `sync_state` flag on each AI row and
-as `stryd_only_dates` for Stryd entries with no AI counterpart.
+The canonical plan is the AI-authored one (`source='ai'`). Stryd rows in the
+same window inform each AI row's `sync_state`; dates with no AI counterpart are
+returned as `source='stryd'` workout rows.
 
 **Query params:**
 - `start` *(YYYY-MM-DD, default = today)* — window start.
@@ -725,7 +728,6 @@ as `stryd_only_dates` for Stryd entries with no AI counterpart.
     "2026-04-11": { "workout_id": "stryd_123", "pushed_at": "...", "status": "pushed" }
   },
   "sync_target": "stryd",
-  "stryd_only_dates": ["2026-04-13"],
   "window": { "start": "2026-04-11", "end": "2026-04-25" }
 }
 ```
@@ -745,6 +747,14 @@ as `stryd_only_dates` for Stryd entries with no AI counterpart.
 
 Push only Praxys-authored plan rows (`source = "ai"`) to the Stryd calendar. Imported Stryd rows are never eligible, even when they are the analytically preferred plan source.
 
+Delivery identity is `(user, target, canonical workout key, workout content
+version)`. Retrying a definite provider rejection appends an attempt to the same
+delivery row. Ambiguous post-send outcomes require reconciliation, and an edited
+version cannot be delivered until the prior provider workout is removed.
+Retrying an already-synced version returns its existing workout id without
+creating a duplicate on Stryd. If a different Stryd workout already exists on
+the requested date, delivery is blocked before the provider create call.
+
 **Request body:**
 ```json
 { "workout_dates": ["2026-04-11", "2026-04-12"] }
@@ -754,14 +764,19 @@ Push only Praxys-authored plan rows (`source = "ai"`) to the Stryd calendar. Imp
 ```json
 {
   "results": [
-    { "date": "2026-04-11", "status": "pushed", "workout_id": "stryd_123" }
+    { "date": "2026-04-11", "status": "success", "workout_id": "stryd_123" }
   ]
 }
 ```
 
 ### DELETE /api/plan/stryd-workout/{workout_id}
 
-Remove a workout from Stryd calendar.
+Remove a workout from Stryd calendar and transition its delivery-ledger row to
+`removed`. Removal attempts remain auditable; a failed removal keeps the prior
+successful delivery state. An interrupted removal can be retried after its lease
+expires; attempt fencing prevents a late superseded result from undoing the
+newer outcome. The workout ID must belong to the caller's delivery ledger;
+unknown IDs return `404` before any Stryd request.
 
 ### POST /api/plan/upload
 
@@ -778,6 +793,9 @@ planned_distance_km,target_power_min,target_power_max,workout_description`.
   for partial edits like shifting a single workout.
 
 **Response:** `{ "status": "saved", "rows": <int>, "mode": "replace"|"merge" }`
+
+The plan-row mutation, cache-revision bump, and append-only `upload` revision
+event (actor, origin, before snapshot, after snapshot) commit atomically.
 
 ### PUT /api/plan/{date}
 
@@ -800,10 +818,14 @@ day so you don't have to round-trip the whole future window.
 
 **Response:** the upserted row (`id`, `date`, `workout_type`, …, `source`).
 
+The row and its append-only `upsert` revision event commit atomically.
+
 ### DELETE /api/plan/{date}
 
 Delete the AI plan workout(s) for the given date (`YYYY-MM-DD`). Idempotent —
 deleting a missing date returns `{ "status": "deleted", "rows": 0 }`.
+Every request appends a `delete` revision event with its before snapshot and an
+empty after snapshot; a real deletion and its event commit atomically.
 
 ## Settings
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -78,6 +78,9 @@ Training data is stored in a SQLite database (`DATA_DIR/trainsight.db`) via SQLA
 | `RecoveryData` | `recovery_data` | Sleep and readiness data (HRV, sleep score, resting HR, body temp) |
 | `FitnessData` | `fitness_data` | Per-metric fitness tracking (VO2max, CP estimate, LTHR, max HR) |
 | `TrainingPlan` | `training_plans` | Planned workouts from Stryd or AI (targets, description, meta) |
+| `PlanRevision` | `plan_revisions` | Append-only plan mutation events with actor/origin and before/after snapshots |
+| `PlanDelivery` | `plan_deliveries` | Provider-neutral current state for one canonical workout content version and target |
+| `PlanDeliveryAttempt` | `plan_delivery_attempts` | Append-only deliver/remove/import attempt history |
 
 **Session management** (`db/session.py`):
 - `init_db()` creates both sync and async engines, runs `create_all()`, then applies lightweight schema migrations
@@ -185,6 +188,22 @@ Praxys-authored (`source='ai'`) rows as canonical; platform rows remain loaded
 for management and later reconciliation but never silently become the plan.
 The additive contract defaults to external mode with delivery disabled, so
 existing users are not enrolled in platform writes.
+
+Plan mutations write immutable `PlanRevision` events in the same transaction as
+their `TrainingPlan` changes. Platform delivery rows are keyed by a stable
+logical workout slot plus a SHA-256 fingerprint of delivery-relevant content;
+attempts append beneath that identity, so a retry cannot duplicate a successful
+delivery of the same version. The former per-user Stryd push-status JSON is
+lazy-reconciled through an ordered snapshot cursor. During rolling deployment it
+is retained and dual-written after successful push/delete operations so old
+workers remain compatible; additions, replacements, and removals are reflected
+without certifying unknown content as the current version. Corrupt files are
+quarantined and never converted into successful delivery state. A verified
+ledger row is authoritative over a stale legacy snapshot, including after
+removal, so an old worker cannot resurrect a deleted delivery. Per-user database
+locks plus a cross-process file lock serialize cursor/file changes on both
+PostgreSQL and SQLite, and dual-writes verify the user still exists so an
+in-flight request cannot recreate status after account deletion.
 
 ### LLM-backed Insights
 

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -101,6 +101,9 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         Feedback,
         FitnessData,
         Invitation,
+        PlanDelivery,
+        PlanDeliveryAttempt,
+        PlanRevision,
         RecoveryData,
         TrainingPlan,
         User,
@@ -128,6 +131,34 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         db.add(RecoveryData(user_id=user_id, date=date(2026, 6, 1), source="oura"))
         db.add(FitnessData(user_id=user_id, date=date(2026, 6, 1), metric_type="cp_estimate", value=300))
         db.add(TrainingPlan(user_id=user_id, date=date(2026, 6, 2), source="ai", workout_type="easy"))
+        revision = PlanRevision(
+            user_id=user_id,
+            operation="upsert",
+            actor_type="user",
+            actor_id=user_id,
+            origin="test",
+            before_snapshot=[],
+            after_snapshot=[],
+            details={},
+        )
+        delivery = PlanDelivery(
+            user_id=user_id,
+            canonical_key="ai:2026-06-02",
+            workout_date=date(2026, 6, 2),
+            workout_version="a" * 64,
+            target="stryd",
+            state="synced",
+            external_id="stryd-delete-me",
+        )
+        db.add_all([revision, delivery])
+        db.flush()
+        db.add(PlanDeliveryAttempt(
+            delivery_id=delivery.id,
+            attempt_number=1,
+            operation="deliver",
+            state="synced",
+            external_id="stryd-delete-me",
+        ))
         db.add(AiInsight(user_id=user_id, insight_type="daily_brief"))
         db.add(AiInsightFeedback(
             user_id=user_id,
@@ -203,6 +234,9 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
         Feedback,
         FitnessData,
         Invitation,
+        PlanDelivery,
+        PlanDeliveryAttempt,
+        PlanRevision,
         RecoveryData,
         TrainingPlan,
         User,
@@ -224,12 +258,15 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
             DashboardCache,
             Feedback,
             FitnessData,
+            PlanDelivery,
+            PlanRevision,
             RecoveryData,
             TrainingPlan,
             UserConfig,
             UserConnection,
         ):
             assert db.query(model).filter(model.user_id.in_(["delete-me", "demo-user"])).count() == 0
+        assert db.query(PlanDeliveryAttempt).count() == 0
         assert db.query(AgentDecision).count() == 0
         assert db.query(AgentOutcome).count() == 0
         assert db.query(Invitation).filter(
@@ -298,6 +335,32 @@ def test_inactive_account_can_retry_cleanup(account_client, monkeypatch):
         assert db.query(User).filter(User.id.in_(["delete-me", "demo-user"])).count() == 0
     finally:
         db.close()
+
+
+def test_delete_me_removes_legacy_plan_status_files(
+    account_client,
+    monkeypatch,
+    tmp_path,
+):
+    import glob
+    import os
+
+    client, db_session = account_client
+    _seed_account_rows(db_session)
+
+    from api.routes import plan as plan_route
+
+    monkeypatch.setattr(plan_route, "_STRYD_PUSH_STATUS_DIR", str(tmp_path))
+    path = plan_route._stryd_push_status_path("delete-me")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    for candidate in (path, f"{path}.imported-old", f"{path}.corrupt-old"):
+        with open(candidate, "w", encoding="utf-8") as handle:
+            handle.write("{}")
+
+    response = client.delete("/api/me")
+    assert response.status_code == 200, response.text
+    assert not os.path.exists(path)
+    assert glob.glob(f"{path}.*") == []
 
 
 def test_delete_access_accepts_valid_token_for_inactive_user(account_client):
@@ -604,6 +667,9 @@ def test_delete_user_account_no_dangling_fk_under_enforcement(monkeypatch):
         Base,
         Feedback,
         Invitation,
+        PlanDelivery,
+        PlanDeliveryAttempt,
+        PlanRevision,
         User,
         UserConfig,
         WaitlistSignup,
@@ -644,6 +710,34 @@ def test_delete_user_account_no_dangling_fk_under_enforcement(monkeypatch):
         db.add(UserConfig(user_id="target", display_name="T"))
         db.add(Activity(user_id="target", activity_id="a1", date=date(2026, 6, 1)))
         db.add(Feedback(user_id="target", kind="bug", message="hi", status="new"))
+        revision = PlanRevision(
+            user_id="target",
+            operation="upsert",
+            actor_type="user",
+            actor_id="target",
+            origin="test",
+            before_snapshot=[],
+            after_snapshot=[],
+            details={},
+        )
+        delivery = PlanDelivery(
+            user_id="target",
+            canonical_key="ai:2026-06-02",
+            workout_date=date(2026, 6, 2),
+            workout_version="b" * 64,
+            target="stryd",
+            state="synced",
+            external_id="stryd-target",
+        )
+        db.add_all([revision, delivery])
+        db.flush()
+        db.add(PlanDeliveryAttempt(
+            delivery_id=delivery.id,
+            attempt_number=1,
+            operation="deliver",
+            state="synced",
+            external_id="stryd-target",
+        ))
         made = Invitation(code="TS-MADE-9999", created_by="target", is_active=True)
         used = Invitation(code="TS-USED-9999", created_by="admin", used_by="target", is_active=True)
         db.add_all([made, used])
@@ -671,6 +765,9 @@ def test_delete_user_account_no_dangling_fk_under_enforcement(monkeypatch):
         assert used_row.is_active is False
         # Invitation the user *created* is deleted (created_by is NOT NULL).
         assert db.query(Invitation).filter(Invitation.code == "TS-MADE-9999").count() == 0
+        assert db.query(PlanRevision).filter(PlanRevision.user_id == "target").count() == 0
+        assert db.query(PlanDelivery).filter(PlanDelivery.user_id == "target").count() == 0
+        assert db.query(PlanDeliveryAttempt).count() == 0
         # Waitlist lead kept with its (now-deleted) invitation link nulled.
         wl = db.query(WaitlistSignup).filter(WaitlistSignup.email == "w1@x.test").one()
         assert wl.invitation_id is None

--- a/tests/test_pg_migration.py
+++ b/tests/test_pg_migration.py
@@ -117,6 +117,34 @@ def test_sqlite_to_postgres_roundtrip(tmp_path, monkeypatch):
                     planned_distance_km=8.0, source="ai",
                     start_time=datetime(2026, 6, 2, 6, 0, 0), meta={"cp": 300},
                 ),
+                m.PlanRevision(
+                    id="22222222-2222-2222-2222-222222222222",
+                    user_id=uid,
+                    operation="upsert",
+                    actor_type="user",
+                    actor_id=uid,
+                    origin="migration-test",
+                    before_snapshot=[],
+                    after_snapshot=[{"date": "2026-06-02", "source": "ai"}],
+                    details={"reason": "test"},
+                ),
+                m.PlanDelivery(
+                    id="33333333-3333-3333-3333-333333333333",
+                    user_id=uid,
+                    canonical_key="ai:2026-06-02",
+                    workout_date=date(2026, 6, 2),
+                    workout_version="c" * 64,
+                    target="stryd",
+                    state="synced",
+                    external_id="stryd-migration",
+                ),
+                m.PlanDeliveryAttempt(
+                    delivery_id="33333333-3333-3333-3333-333333333333",
+                    attempt_number=1,
+                    operation="deliver",
+                    state="synced",
+                    external_id="stryd-migration",
+                ),
                 m.Invitation(code="MIGCODE1", created_by=uid, is_active=True, note="t"),
                 m.Invitation(
                     code="MIGORPHAN", created_by=uid,
@@ -173,6 +201,14 @@ def test_sqlite_to_postgres_roundtrip(tmp_path, monkeypatch):
                     .where(m.UserConfig.user_id == uid)
                 ).scalar()
                 assert plan_management["mode"] == "external"
+                delivery_state = c.execute(
+                    select(m.PlanDelivery.state)
+                    .where(m.PlanDelivery.user_id == uid)
+                ).scalar()
+                assert delivery_state == "synced"
+                assert c.execute(
+                    select(func.count()).select_from(m.PlanDeliveryAttempt)
+                ).scalar() == 1
                 act_date = c.execute(
                     select(m.Activity.date).where(m.Activity.user_id == uid)
                 ).scalar()

--- a/tests/test_plan_endpoints.py
+++ b/tests/test_plan_endpoints.py
@@ -117,6 +117,31 @@ def _list_plan_rows(user_id: str) -> list[dict]:
         db.close()
 
 
+def _list_revisions(user_id: str) -> list[dict]:
+    from db import session as db_session
+    from db.models import PlanRevision
+
+    db = db_session.SessionLocal()
+    try:
+        rows = db.query(PlanRevision).filter(
+            PlanRevision.user_id == user_id,
+        ).order_by(PlanRevision.created_at, PlanRevision.id).all()
+        return [
+            {
+                "operation": row.operation,
+                "actor_type": row.actor_type,
+                "actor_id": row.actor_id,
+                "origin": row.origin,
+                "before": row.before_snapshot,
+                "after": row.after_snapshot,
+                "details": row.details,
+            }
+            for row in rows
+        ]
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # POST /api/plan/upload — replace mode (default, backwards-compat)
 # ---------------------------------------------------------------------------
@@ -313,3 +338,62 @@ def test_upload_rejects_invalid_mode(api_client):
     })
     # FastAPI returns 422 for query validation failures
     assert res.status_code == 422
+
+
+def test_plan_mutations_append_before_and_after_revisions(api_client):
+    client, user_id = api_client
+    target = (date.today() + timedelta(days=8)).isoformat()
+
+    upload = client.post("/api/plan/upload?mode=merge", json={
+        "csv": "date,workout_type,workout_description\n"
+               f"{target},easy,Initial workout\n",
+    })
+    assert upload.status_code == 200, upload.text
+
+    upsert = client.put(f"/api/plan/{target}", json={
+        "workout_type": "threshold",
+        "workout_description": "Adjusted workout",
+    })
+    assert upsert.status_code == 200, upsert.text
+
+    delete = client.delete(f"/api/plan/{target}")
+    assert delete.status_code == 200, delete.text
+
+    revisions = _list_revisions(user_id)
+    assert [row["operation"] for row in revisions] == [
+        "upload",
+        "upsert",
+        "delete",
+    ]
+    assert all(row["actor_type"] == "user" for row in revisions)
+    assert all(row["actor_id"] == user_id for row in revisions)
+    assert revisions[0]["origin"] == "api.plan.upload"
+    assert revisions[0]["before"] == []
+    assert revisions[0]["after"][0]["workout_description"] == "Initial workout"
+    assert revisions[1]["before"][0]["workout_type"] == "easy"
+    assert revisions[1]["after"][0]["workout_type"] == "threshold"
+    assert revisions[2]["before"][0]["workout_description"] == "Adjusted workout"
+    assert revisions[2]["after"] == []
+
+
+def test_revision_failure_rolls_back_plan_change(api_client, monkeypatch):
+    client, user_id = api_client
+    target = (date.today() + timedelta(days=9)).isoformat()
+    _seed_plan(user_id, [(target, "easy", "Keep this row")])
+
+    def _fail_revision(*args, **kwargs):
+        raise RuntimeError("revision write failed")
+
+    monkeypatch.setattr("api.routes.ai.record_plan_revision", _fail_revision)
+    with pytest.raises(RuntimeError, match="revision write failed"):
+        client.put(f"/api/plan/{target}", json={
+            "workout_type": "threshold",
+            "workout_description": "Must roll back",
+        })
+
+    assert _list_plan_rows(user_id) == [{
+        "date": target,
+        "workout_type": "easy",
+        "workout_description": "Keep this row",
+    }]
+    assert _list_revisions(user_id) == []

--- a/tests/test_plan_ledger.py
+++ b/tests/test_plan_ledger.py
@@ -1,0 +1,79 @@
+"""Unit and schema tests for the managed-plan revision/delivery ledger."""
+from datetime import date
+
+
+def test_workout_version_is_content_stable_and_meta_independent():
+    from db.plan_ledger import workout_version
+
+    base = {
+        "date": date(2026, 8, 10),
+        "source": "ai",
+        "workout_type": "threshold",
+        "planned_duration_min": 60,
+        "workout_description": "2 x 20 minutes",
+        "meta": {"uploaded_at": "2026-07-28T01:00:00"},
+    }
+    same_content = {
+        **base,
+        "meta": {"uploaded_at": "2026-07-28T02:00:00"},
+    }
+    changed = {
+        **base,
+        "workout_description": "3 x 15 minutes",
+    }
+
+    assert workout_version(base) == workout_version(same_content)
+    assert workout_version(base) != workout_version(changed)
+
+
+def test_sqlite_init_adds_ledger_tables_to_existing_database(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine, inspect
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("PRAXYS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    from db import session as db_session
+    from db.models import TrainingPlan, User
+
+    sqlite_path = tmp_path / "trainsight.db"
+    legacy = create_engine(f"sqlite:///{sqlite_path}")
+    User.__table__.create(legacy)
+    TrainingPlan.__table__.create(legacy)
+    legacy.dispose()
+
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    try:
+        db_session.init_db()
+        tables = set(inspect(db_session.engine).get_table_names())
+        assert {
+            "plan_revisions",
+            "plan_deliveries",
+            "plan_delivery_attempts",
+        }.issubset(tables)
+    finally:
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+
+
+def test_alembic_head_includes_plan_ledger():
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    config = Config("alembic.ini")
+    script = ScriptDirectory.from_config(config)
+    assert script.get_current_head() == "2b3c4d5e6f70"

--- a/tests/test_plan_sync_state.py
+++ b/tests/test_plan_sync_state.py
@@ -49,6 +49,18 @@ def api_client(monkeypatch):
     from db.session import get_db
 
     user_id = "test-user-plan-sync-state"
+    from db.models import User
+
+    seed_db = db_session.SessionLocal()
+    try:
+        seed_db.add(User(
+            id=user_id,
+            email="plan-sync-state@example.test",
+            hashed_password="test",
+        ))
+        seed_db.commit()
+    finally:
+        seed_db.close()
 
     def _override_user():
         return user_id
@@ -102,6 +114,55 @@ def _seed_rows(user_id: str, rows: list[dict]) -> None:
                 external_id=r.get("external_id"),
                 planned_duration_min=r.get("planned_duration_min"),
             ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_synced_delivery(
+    user_id: str,
+    workout_date: date,
+    workout_type: str,
+    external_id: str,
+    *,
+    workout_description: str = "",
+) -> None:
+    """Persist one successful Stryd delivery for the current AI version."""
+    from db import session as db_session
+    from db.plan_ledger import (
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+    )
+
+    db = db_session.SessionLocal()
+    try:
+        delivery, _ = get_or_create_delivery(
+            db,
+            user_id=user_id,
+            target="stryd",
+            snapshot={
+                "date": workout_date,
+                "source": "ai",
+                "workout_type": workout_type,
+                "workout_description": workout_description,
+            },
+        )
+        delivery, attempt, disposition = begin_delivery_attempt(
+            db,
+            delivery,
+            operation="deliver",
+        )
+        assert disposition == "started"
+        assert attempt is not None
+        complete_delivery_attempt(
+            db,
+            user_id=user_id,
+            delivery_id=delivery.id,
+            attempt_id=attempt.id,
+            attempt_state="synced",
+            external_id=external_id,
+        )
         db.commit()
     finally:
         db.close()
@@ -163,13 +224,9 @@ def test_ai_row_takes_precedence_when_date_collides(api_client):
 
 def test_sync_state_synced_when_external_id_matches_push_log(api_client):
     """An AI row + Stryd row at the same date with matching ids → ``synced``."""
-    from api.routes.plan import _save_push_status
-
     client, user_id = api_client
     target = date.today() + timedelta(days=3)
-    _save_push_status(user_id, {
-        target.isoformat(): {"workout_id": "stryd-abc", "status": "pushed"},
-    })
+    _seed_synced_delivery(user_id, target, "threshold", "stryd-abc")
     _seed_rows(user_id, [
         {"date": target, "source": "ai", "workout_type": "threshold"},
         {
@@ -188,13 +245,9 @@ def test_sync_state_mismatch_when_external_id_diverges(api_client):
     This is the case the UI must catch before re-pushing — typically the
     user edited the workout directly inside Stryd's calendar.
     """
-    from api.routes.plan import _save_push_status
-
     client, user_id = api_client
     target = date.today() + timedelta(days=4)
-    _save_push_status(user_id, {
-        target.isoformat(): {"workout_id": "stryd-old", "status": "pushed"},
-    })
+    _seed_synced_delivery(user_id, target, "intervals", "stryd-old")
     _seed_rows(user_id, [
         {"date": target, "source": "ai", "workout_type": "intervals"},
         {
@@ -214,13 +267,9 @@ def test_sync_state_synced_when_pushed_but_stryd_not_yet_resynced(api_client):
     that don't share the frontend's optimistic ``pushStatus`` map
     (mini-program, MCP). Otherwise they'd offer to push again.
     """
-    from api.routes.plan import _save_push_status
-
     client, user_id = api_client
     target = date.today() + timedelta(days=6)
-    _save_push_status(user_id, {
-        target.isoformat(): {"workout_id": "stryd-just-pushed", "status": "pushed"},
-    })
+    _seed_synced_delivery(user_id, target, "easy", "stryd-just-pushed")
     _seed_rows(user_id, [
         {"date": target, "source": "ai", "workout_type": "easy"},
     ])
@@ -234,13 +283,9 @@ def test_sync_state_uses_workout_type_match_when_multiple_stryd_rows(api_client)
     pick the row whose ``workout_type`` matches the AI row, not
     arbitrarily the last-iterated one.
     """
-    from api.routes.plan import _save_push_status
-
     client, user_id = api_client
     target = date.today() + timedelta(days=2)
-    _save_push_status(user_id, {
-        target.isoformat(): {"workout_id": "stryd-threshold", "status": "pushed"},
-    })
+    _seed_synced_delivery(user_id, target, "threshold", "stryd-threshold")
     _seed_rows(user_id, [
         # AI plan: a threshold workout.
         {"date": target, "source": "ai", "workout_type": "threshold"},
@@ -270,6 +315,30 @@ def test_sync_state_not_synced_when_no_stryd_row(api_client):
     ])
     body = client.get("/api/plan").json()
     assert body["workouts"][0]["sync_state"] == "not_synced"
+
+
+def test_changed_workout_version_preserves_prior_external_id_for_replacement(
+    api_client,
+):
+    client, user_id = api_client
+    target = date.today() + timedelta(days=5)
+    _seed_synced_delivery(
+        user_id,
+        target,
+        "easy",
+        "stryd-old-version",
+        workout_description="Original prescription",
+    )
+    _seed_rows(user_id, [{
+        "date": target,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Adjusted prescription",
+    }])
+
+    body = client.get("/api/plan").json()
+    assert body["workouts"][0]["sync_state"] == "not_synced"
+    assert body["stryd_status"][target.isoformat()]["workout_id"] == "stryd-old-version"
 
 
 def test_stryd_only_row_surfaces_with_source_tag(api_client):

--- a/tests/test_stryd_push_status_endpoints.py
+++ b/tests/test_stryd_push_status_endpoints.py
@@ -1,14 +1,8 @@
-"""Endpoint-level tests for Stryd push-status isolation.
-
-Helper-level tests (tests/test_stryd_push_status_isolation.py) prove that
-_load_push_status/_save_push_status scope by user_id correctly. These
-tests additionally prove the three plan.py endpoints thread the calling
-user's user_id into those helpers — if a refactor dropped user_id at any
-call site, the helper unit tests would keep passing and the regression
-would slip through.
-"""
+"""Endpoint-level tests for durable Stryd delivery-state isolation."""
+import json
 import os
 import tempfile
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -46,9 +40,26 @@ def api_client(monkeypatch, tmp_path):
     from db.session import get_db
 
     current_user_id = {"value": "alice"}
+    ensured_users: set[str] = set()
 
     def _override_current_user():
-        return current_user_id["value"]
+        user_id = current_user_id["value"]
+        if user_id not in ensured_users:
+            from db.models import User
+
+            db = db_session.SessionLocal()
+            try:
+                if db.get(User, user_id) is None:
+                    db.add(User(
+                        id=user_id,
+                        email=f"{user_id}@example.test",
+                        hashed_password="test",
+                    ))
+                    db.commit()
+                ensured_users.add(user_id)
+            finally:
+                db.close()
+        return user_id
 
     def _override_db():
         db = db_session.SessionLocal()
@@ -82,16 +93,106 @@ def api_client(monkeypatch, tmp_path):
         tmpdir.cleanup()
 
 
+def _seed_synced_delivery(
+    user_id: str,
+    workout_date: str,
+    external_id: str,
+    *,
+    workout_type: str = "easy_run",
+) -> None:
+    from db import session as db_session
+    from db.plan_ledger import (
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+    )
+
+    db = db_session.SessionLocal()
+    try:
+        delivery, _ = get_or_create_delivery(
+            db,
+            user_id=user_id,
+            target="stryd",
+            snapshot={
+                "date": workout_date,
+                "source": "ai",
+                "workout_type": workout_type,
+                "workout_description": "",
+            },
+        )
+        delivery, attempt, disposition = begin_delivery_attempt(
+            db,
+            delivery,
+            operation="deliver",
+        )
+        assert disposition == "started"
+        assert attempt is not None
+        complete_delivery_attempt(
+            db,
+            user_id=user_id,
+            delivery_id=delivery.id,
+            attempt_id=attempt.id,
+            attempt_state="synced",
+            external_id=external_id,
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _delivery_rows(user_id: str) -> list[dict]:
+    from db import session as db_session
+    from db.models import PlanDelivery
+
+    db = db_session.SessionLocal()
+    try:
+        rows = db.query(PlanDelivery).filter(
+            PlanDelivery.user_id == user_id,
+        ).order_by(PlanDelivery.created_at).all()
+        return [
+            {
+                "external_id": row.external_id,
+                "state": row.state,
+                "date": row.workout_date.isoformat(),
+            }
+            for row in rows
+        ]
+    finally:
+        db.close()
+
+
+def _attempt_rows(user_id: str) -> list[dict]:
+    from db import session as db_session
+    from db.models import PlanDelivery, PlanDeliveryAttempt
+
+    db = db_session.SessionLocal()
+    try:
+        rows = db.query(PlanDeliveryAttempt).join(
+            PlanDelivery,
+            PlanDelivery.id == PlanDeliveryAttempt.delivery_id,
+        ).filter(
+            PlanDelivery.user_id == user_id,
+        ).order_by(PlanDeliveryAttempt.attempt_number).all()
+        return [
+            {
+                "number": row.attempt_number,
+                "operation": row.operation,
+                "state": row.state,
+            }
+            for row in rows
+        ]
+    finally:
+        db.close()
+
+
 def test_plan_stryd_status_returns_only_current_users_data(api_client):
     """User B's /plan GET must not surface user A's push status writes via
     the embedded `stryd_status` field. (This used to be its own
     /plan/stryd-status route; the isolation invariant must survive the
     merge into /plan.)
     """
-    from api.routes.plan import _save_push_status
-
-    _save_push_status("alice", {"2026-05-01": {"workout_id": "alice-only"}})
-    _save_push_status("bob", {"2026-06-15": {"workout_id": "bob-only"}})
+    _seed_synced_delivery("alice", "2026-05-01", "alice-only")
+    _seed_synced_delivery("bob", "2026-06-15", "bob-only")
 
     # No need to stub the data layer — the test DB is fresh, so the L1 plan
     # pack naturally returns an empty workouts list. The legacy stub on
@@ -102,7 +203,7 @@ def test_plan_stryd_status_returns_only_current_users_data(api_client):
     api_client["current"]["value"] = "bob"
     res = api_client["client"].get("/api/plan")
     assert res.status_code == 200, res.text
-    assert res.json()["stryd_status"] == {"2026-06-15": {"workout_id": "bob-only"}}
+    assert res.json()["stryd_status"]["2026-06-15"]["workout_id"] == "bob-only"
 
     api_client["current"]["value"] = "alice"
     # Bypass the cache by sending an If-None-Match the server doesn't have —
@@ -112,7 +213,7 @@ def test_plan_stryd_status_returns_only_current_users_data(api_client):
     res = api_client["client"].get(
         "/api/plan", headers={"If-None-Match": '"never-matches"'},
     )
-    assert res.json()["stryd_status"] == {"2026-05-01": {"workout_id": "alice-only"}}
+    assert res.json()["stryd_status"]["2026-05-01"]["workout_id"] == "alice-only"
 
 
 def test_plan_get_does_not_call_get_dashboard_data(api_client, monkeypatch):
@@ -160,10 +261,8 @@ def test_plan_get_returns_304_on_warm_revalidation(api_client):
 
 
 def test_plan_get_etag_flips_after_stryd_push(api_client, monkeypatch):
-    """A Stryd push writes to a JSON file outside the DB scopes, so the
-    ETag wouldn't bust on its own. The push handler must bump the ``plans``
-    scope so the next GET delivers the updated ``stryd_status`` instead of
-    serving a stale 304.
+    """A Stryd push changes delivery state outside the plan rows, so the push
+    handler must bump the ``plans`` scope and avoid serving a stale 304.
     """
     monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
     monkeypatch.setenv("STRYD_PASSWORD", "stub")
@@ -213,7 +312,9 @@ def test_plan_get_etag_flips_after_stryd_push(api_client, monkeypatch):
 
 
 def test_push_endpoint_persists_under_calling_user(api_client, monkeypatch):
-    """POST /plan/push-stryd must write to the caller's file, not a shared one."""
+    """POST writes the caller's ledger and rolling-deploy compatibility file."""
+    from api.routes import plan as plan_mod
+
     monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
     monkeypatch.setenv("STRYD_PASSWORD", "stub")
     monkeypatch.setattr(
@@ -252,13 +353,20 @@ def test_push_endpoint_persists_under_calling_user(api_client, monkeypatch):
     )
     assert res.status_code == 200, res.text
 
-    from api.routes.plan import _load_push_status
-    # Carol's file got the update.
-    carol_status = _load_push_status("carol")
-    assert "2026-05-07" in carol_status
-    assert carol_status["2026-05-07"]["workout_id"] == "new-workout-for-2026-05-07"
-    # Alice's file (previously empty) is untouched — no leak.
-    assert _load_push_status("alice") == {}
+    assert _delivery_rows("carol") == [{
+        "external_id": "new-workout-for-2026-05-07",
+        "state": "synced",
+        "date": "2026-05-07",
+    }]
+    assert _delivery_rows("alice") == []
+    with open(
+        plan_mod._stryd_push_status_path("carol"),
+        encoding="utf-8",
+    ) as handle:
+        compatibility_status = json.load(handle)
+    assert compatibility_status["2026-05-07"]["workout_id"] == (
+        "new-workout-for-2026-05-07"
+    )
 
 
 def test_push_selects_ai_row_from_all_plan_sources(api_client, monkeypatch):
@@ -283,7 +391,7 @@ def test_push_selects_ai_row_from_all_plan_sources(api_client, monkeypatch):
     workout_date = "2026-05-08"
     all_plans = pd.DataFrame([
         {
-            "date": workout_date,
+            "date": "2026-05-09",
             "source": "stryd",
             "workout_type": "tempo_stryd",
             "planned_duration_min": 40,
@@ -318,14 +426,615 @@ def test_push_selects_ai_row_from_all_plan_sources(api_client, monkeypatch):
     assert captured["workout_type"] == "threshold"
 
 
+def test_push_rereads_current_plan_before_starting_delivery(api_client, monkeypatch):
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    captured: dict = {}
+
+    def _capture_blocks(workout, cp):
+        captured.update(workout)
+        return []
+
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", _capture_blocks)
+    monkeypatch.setattr(
+        "sync.stryd_sync.create_workout_api",
+        lambda **kwargs: {"id": "fresh-version-id"},
+    )
+    workout_date = "2026-05-09"
+    calls = {"dashboard": 0}
+
+    def _dashboard(user_id, db):
+        calls["dashboard"] += 1
+        description = (
+            "Stale pre-lock version"
+            if calls["dashboard"] == 1
+            else "Current locked version"
+        )
+        plan_df = pd.DataFrame([{
+            "date": workout_date,
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": description,
+        }])
+        return {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        }
+
+    monkeypatch.setattr("api.routes.plan.get_dashboard_data", _dashboard)
+    api_client["current"]["value"] = "locked-plan-user"
+
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["results"][0]["status"] == "success"
+    assert calls["dashboard"] >= 2
+    assert captured["workout_description"] == "Current locked version"
+
+
+def test_successful_delivery_is_idempotent_for_same_workout_version(
+    api_client,
+    monkeypatch,
+):
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "stable-stryd-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-04"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Version one",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    api_client["current"]["value"] = "idempotent-user"
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert first.json()["results"][0]["status"] == "success"
+    assert second.json()["results"][0] == {
+        "date": workout_date,
+        "status": "success",
+        "workout_id": "stable-stryd-id",
+    }
+    assert calls["create"] == 1
+    assert len(_delivery_rows("idempotent-user")) == 1
+    assert _attempt_rows("idempotent-user") == [{
+        "number": 1,
+        "operation": "deliver",
+        "state": "synced",
+    }]
+
+
+def test_failed_retry_reuses_delivery_and_appends_attempt(api_client, monkeypatch):
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        if calls["create"] == 1:
+            import requests
+
+            response = requests.Response()
+            response.status_code = 400
+            response._content = b'{"message":"invalid workout"}'
+            raise requests.HTTPError("invalid workout", response=response)
+        return {"id": "retry-stryd-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-05"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Retry me",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    api_client["current"]["value"] = "retry-user"
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    third = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert first.json()["results"][0]["status"] == "error"
+    assert second.json()["results"][0]["status"] == "success"
+    assert third.json()["results"][0]["status"] == "success"
+    assert calls["create"] == 2
+    assert len(_delivery_rows("retry-user")) == 1
+    assert _attempt_rows("retry-user") == [
+        {"number": 1, "operation": "deliver", "state": "failed"},
+        {"number": 2, "operation": "deliver", "state": "synced"},
+    ]
+
+
+def test_ambiguous_failure_requires_reconciliation_before_retry(
+    api_client,
+    monkeypatch,
+):
+    import requests
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    calls = {"create": 0}
+
+    def _timeout(**kwargs):
+        calls["create"] += 1
+        raise requests.Timeout("response timed out")
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _timeout)
+    workout_date = "2026-08-06"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Ambiguous result",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    api_client["current"]["value"] = "ambiguous-user"
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert "uncertain" in first.json()["results"][0]["error"]
+    assert "uncertain" in second.json()["results"][0]["error"]
+    assert calls["create"] == 1
+    assert _delivery_rows("ambiguous-user")[0]["state"] == "conflict"
+    assert _attempt_rows("ambiguous-user") == [{
+        "number": 1,
+        "operation": "deliver",
+        "state": "conflict",
+    }]
+
+
+@pytest.mark.parametrize(
+    "provider_outcome",
+    [
+        "gateway_error",
+        "missing_id",
+        "object_id",
+        "reserved_id",
+        "oversized_integer_id",
+    ],
+)
+def test_post_send_uncertainty_is_not_retried(
+    api_client,
+    monkeypatch,
+    provider_outcome,
+):
+    import requests
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        if provider_outcome == "missing_id":
+            return {"status": "created"}
+        if provider_outcome == "object_id":
+            return {"id": {"unexpected": "object"}}
+        if provider_outcome == "reserved_id":
+            return {"id": "abc?target=other"}
+        if provider_outcome == "oversized_integer_id":
+            return {"id": 10 ** 200}
+        response = requests.Response()
+        response.status_code = 503
+        response._content = b'{"message":"gateway unavailable"}'
+        raise requests.HTTPError("gateway unavailable", response=response)
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-08"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Uncertain response",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    api_client["current"]["value"] = f"uncertain-{provider_outcome}"
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert "uncertain" in first.json()["results"][0]["error"]
+    assert "uncertain" in second.json()["results"][0]["error"]
+    assert calls["create"] == 1
+    assert _delivery_rows(f"uncertain-{provider_outcome}")[0]["state"] == "conflict"
+
+
+def test_delete_rejects_unsafe_provider_id_before_external_call(api_client):
+    api_client["current"]["value"] = "unsafe-delete-user"
+    response = api_client["client"].delete(
+        "/api/plan/stryd-workout/abc%25target",
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid Stryd workout id"
+
+
+def test_delete_requires_callers_delivery_before_external_call(
+    api_client,
+    monkeypatch,
+):
+    calls = {"login": 0, "delete": 0}
+
+    def _login(email, password):
+        calls["login"] += 1
+        return "sid", "token"
+
+    def _delete(*args):
+        calls["delete"] += 1
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", _delete)
+    api_client["current"]["value"] = "no-delivery-user"
+
+    response = api_client["client"].delete(
+        "/api/plan/stryd-workout/not-owned",
+    )
+
+    assert response.status_code == 404
+    assert calls == {"login": 0, "delete": 0}
+
+
+def test_existing_stryd_row_blocks_duplicate_provider_create(
+    api_client,
+    monkeypatch,
+):
+    workout_date = "2026-08-09"
+    all_plans = pd.DataFrame([
+        {
+            "date": workout_date,
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": "Canonical workout",
+        },
+        {
+            "date": workout_date,
+            "source": "stryd",
+            "workout_type": "easy",
+            "workout_description": "Existing provider workout",
+            "external_id": "existing-provider-id",
+        },
+    ])
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "duplicate-id"}
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": all_plans[all_plans["source"] == "ai"],
+            "all_plans": all_plans,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+    api_client["current"]["value"] = "provider-row-user"
+
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    result = response.json()["results"][0]
+    assert "reconciled" in result["error"]
+    assert calls["create"] == 0
+    assert _delivery_rows("provider-row-user") == []
+
+
+def test_conflict_blocks_delivery_of_edited_version(api_client, monkeypatch):
+    import requests
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    calls = {"create": 0}
+
+    def _timeout(**kwargs):
+        calls["create"] += 1
+        raise requests.Timeout("response timed out")
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _timeout)
+    workout_date = "2026-08-09"
+    description = {"value": "Version one"}
+
+    def _dashboard(user_id, db):
+        plan_df = pd.DataFrame([{
+            "date": workout_date,
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": description["value"],
+        }])
+        return {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        }
+
+    monkeypatch.setattr("api.routes.plan.get_dashboard_data", _dashboard)
+    api_client["current"]["value"] = "edited-conflict-user"
+
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    description["value"] = "Version two"
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert "uncertain" in first.json()["results"][0]["error"]
+    assert "uncertain" in second.json()["results"][0]["error"]
+    assert calls["create"] == 1
+    assert _delivery_rows("edited-conflict-user") == [{
+        "external_id": None,
+        "state": "conflict",
+        "date": workout_date,
+    }]
+
+
+def test_synced_prior_version_must_be_removed_before_replacement(
+    api_client,
+    monkeypatch,
+):
+    workout_date = "2026-08-10"
+    user_id = "edited-synced-user"
+    _seed_synced_delivery(
+        user_id,
+        workout_date,
+        "prior-version-id",
+        workout_type="easy",
+    )
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "duplicate-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Edited content",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+    api_client["current"]["value"] = user_id
+
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert "uncertain" in response.json()["results"][0]["error"]
+    assert calls["create"] == 0
+    assert _delivery_rows(user_id) == [{
+        "external_id": "prior-version-id",
+        "state": "synced",
+        "date": workout_date,
+    }]
+
+
+def test_push_imports_legacy_status_before_external_call(api_client, monkeypatch):
+    from api.routes import plan as plan_mod
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "should-not-run"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    monkeypatch.setattr("sync.stryd_sync.build_workout_blocks", lambda workout, cp: [])
+    workout_date = "2026-08-07"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Legacy status",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    api_client["current"]["value"] = "legacy-before-push"
+    path = plan_mod._stryd_push_status_path("legacy-before-push")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump({
+            workout_date: {
+                "workout_id": "legacy-existing-id",
+                "status": "pushed",
+            }
+        }, handle)
+
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert "uncertain" in response.json()["results"][0]["error"]
+    assert calls["create"] == 0
+    assert _delivery_rows("legacy-before-push")[0]["state"] == "synced"
+
+
 def test_delete_endpoint_touches_only_calling_users_status(api_client, monkeypatch):
     """DELETE /plan/stryd-workout/{id} must not remove entries from another user's status."""
-    from api.routes.plan import _save_push_status, _load_push_status
+    from api.routes import plan as plan_mod
+    from db import session as db_session
+    from db.models import TrainingPlan, User
 
-    # Two users pushed the same Stryd workout_id (hypothetically — unusual, but
-    # if it happened, deleting as one user must not scrub the other's record).
-    _save_push_status("alice", {"2026-05-01": {"workout_id": "shared-id"}})
-    _save_push_status("bob", {"2026-05-01": {"workout_id": "shared-id"}})
+    _seed_synced_delivery("alice", "2026-05-01", "shared-id")
+    _seed_synced_delivery("bob", "2026-05-01", "shared-id")
+    db = db_session.SessionLocal()
+    try:
+        for user_id in ("alice", "bob"):
+            if db.get(User, user_id) is None:
+                db.add(User(
+                    id=user_id,
+                    email=f"{user_id}@example.test",
+                    hashed_password="test",
+                ))
+            db.add(TrainingPlan(
+                user_id=user_id,
+                date=datetime(2026, 5, 1).date(),
+                source="stryd",
+                workout_type="easy",
+                external_id="shared-id",
+            ))
+        db.commit()
+    finally:
+        db.close()
+    for user_id in ("alice", "bob"):
+        path = plan_mod._stryd_push_status_path(user_id)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump({
+                "2026-05-01": {
+                    "workout_id": "shared-id",
+                    "status": "pushed",
+                }
+            }, handle)
 
     monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
     monkeypatch.setenv("STRYD_PASSWORD", "stub")
@@ -338,7 +1047,63 @@ def test_delete_endpoint_touches_only_calling_users_status(api_client, monkeypat
     res = api_client["client"].delete("/api/plan/stryd-workout/shared-id")
     assert res.status_code == 200
 
-    # Bob's record is gone...
-    assert _load_push_status("bob") == {}
-    # ...but Alice's is preserved.
-    assert _load_push_status("alice") == {"2026-05-01": {"workout_id": "shared-id"}}
+    assert _delivery_rows("bob")[0]["state"] == "removed"
+    assert _delivery_rows("alice")[0]["state"] == "synced"
+    db = db_session.SessionLocal()
+    try:
+        assert db.query(TrainingPlan).filter_by(user_id="bob").count() == 0
+        assert db.query(TrainingPlan).filter_by(user_id="alice").count() == 1
+    finally:
+        db.close()
+    with open(
+        plan_mod._stryd_push_status_path("bob"),
+        encoding="utf-8",
+    ) as handle:
+        assert json.load(handle) == {}
+    assert os.path.exists(plan_mod._stryd_push_status_path("alice"))
+
+
+def test_stale_removal_attempt_can_be_retried(api_client, monkeypatch):
+    from db import session as db_session
+    from db.models import PlanDelivery
+    from db.plan_ledger import DELIVERY_ATTEMPT_LEASE, begin_delivery_attempt
+
+    user_id = "stale-remove-user"
+    _seed_synced_delivery(user_id, "2026-05-02", "stale-remove-id")
+    db = db_session.SessionLocal()
+    try:
+        delivery = db.query(PlanDelivery).filter_by(user_id=user_id).one()
+        delivery, attempt, disposition = begin_delivery_attempt(
+            db,
+            delivery,
+            operation="remove",
+        )
+        assert disposition == "started"
+        assert attempt is not None
+        attempt.started_at = (
+            datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    monkeypatch.setenv("STRYD_EMAIL", "stub@example.com")
+    monkeypatch.setenv("STRYD_PASSWORD", "stub")
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("sid", "token"),
+    )
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", lambda *args: None)
+    api_client["current"]["value"] = user_id
+
+    response = api_client["client"].delete(
+        "/api/plan/stryd-workout/stale-remove-id",
+    )
+
+    assert response.status_code == 200, response.text
+    assert _delivery_rows(user_id)[0]["state"] == "removed"
+    assert _attempt_rows(user_id) == [
+        {"number": 1, "operation": "deliver", "state": "synced"},
+        {"number": 2, "operation": "remove", "state": "failed"},
+        {"number": 3, "operation": "remove", "state": "removed"},
+    ]

--- a/tests/test_stryd_push_status_isolation.py
+++ b/tests/test_stryd_push_status_isolation.py
@@ -1,97 +1,749 @@
-"""Stryd push-status must be isolated per user.
-
-A single shared `stryd_push_status.json` used to leak one user's workout IDs
-and push timestamps to every other caller of ``GET /api/plan/stryd-status``.
-Scoping by user_id at the storage layer is the fix; these tests lock the
-invariant down behaviorally.
-"""
+"""Legacy Stryd push-status import and per-user isolation."""
+import glob
+import json
 import os
+from datetime import datetime, timedelta
 
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _tmpdir_data(tmp_path, monkeypatch):
-    """Redirect the module's _DATA_DIR into a scratch directory per test."""
-    from api.routes import plan as plan_mod
+@pytest.fixture
+def ledger_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("PRAXYS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
 
-    scratch = tmp_path / "data"
-    scratch.mkdir()
-    monkeypatch.setattr(plan_mod, "_DATA_DIR", str(scratch))
-    monkeypatch.setattr(
-        plan_mod, "_STRYD_PUSH_STATUS_DIR",
-        os.path.join(str(scratch), "ai", "stryd_push_status"),
-    )
-    yield
+    from db import session as db_session
+
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    db = db_session.SessionLocal()
+    from db.models import User
+
+    for user_id in (
+        "alice",
+        "corrupt-user",
+        "invalid-user",
+        "rolling-user",
+        "repeat-user",
+        "verified-rolling-user",
+        "fenced-remove-user",
+    ):
+        db.add(User(
+            id=user_id,
+            email=f"{user_id}@example.test",
+            hashed_password="test",
+        ))
+    db.commit()
+    status_dir = tmp_path / "ai" / "stryd_push_status"
+    status_dir.mkdir(parents=True)
+    try:
+        yield db, status_dir
+    finally:
+        db.close()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
 
 
-def test_path_is_unique_per_user():
-    from api.routes.plan import _stryd_push_status_path
+def _write_status(status_dir, user_id: str, payload) -> str:
+    from db.plan_ledger import legacy_stryd_status_path
 
-    a = _stryd_push_status_path("user-a")
-    b = _stryd_push_status_path("user-b")
+    path = legacy_stryd_status_path(str(status_dir), user_id)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+    return path
+
+
+def test_path_is_unique_per_user(ledger_db):
+    _, status_dir = ledger_db
+    from db.plan_ledger import legacy_stryd_status_path
+
+    a = legacy_stryd_status_path(str(status_dir), "user-a")
+    b = legacy_stryd_status_path(str(status_dir), "user-b")
     assert a != b
     assert a.endswith("user-a.json")
     assert b.endswith("user-b.json")
 
 
-def test_save_and_load_roundtrip_per_user():
-    from api.routes.plan import _load_push_status, _save_push_status
+def test_import_is_idempotent_and_preserves_status_shape(ledger_db):
+    db, status_dir = ledger_db
+    from db.models import PlanDelivery, PlanDeliveryAttempt, PlanRevision
+    from db.plan_ledger import (
+        delivery_status_for_snapshots,
+        import_legacy_stryd_status,
+    )
 
-    _save_push_status("alice", {"2026-05-01": {"workout_id": "alice-w1"}})
-    assert _load_push_status("alice") == {"2026-05-01": {"workout_id": "alice-w1"}}
+    path = _write_status(
+        status_dir,
+        "alice",
+        {
+            "2026-05-01": {
+                "workout_id": "alice-w1",
+                "pushed_at": "2026-04-30T12:00:00+00:00",
+                "status": "pushed",
+            }
+        },
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="alice",
+        status_dir=str(status_dir),
+    ) == "imported"
+    assert os.path.exists(path)
+    assert glob.glob(f"{path}.imported-*") == []
+
+    status = delivery_status_for_snapshots(
+        db,
+        user_id="alice",
+        target="stryd",
+        current_snapshots={},
+    )
+    assert status["2026-05-01"]["workout_id"] == "alice-w1"
+    assert status["2026-05-01"]["status"] == "pushed"
+    assert db.query(PlanDelivery).filter_by(user_id="alice").count() == 1
+    assert db.query(PlanDeliveryAttempt).count() == 1
+    assert db.query(PlanRevision).filter_by(
+        user_id="alice",
+        operation="legacy_import",
+    ).count() == 1
+    assert os.path.exists(path)
+
+    _write_status(
+        status_dir,
+        "alice",
+        {
+            "2026-05-01": {
+                "workout_id": "alice-w1",
+                "pushed_at": "2026-04-30T12:00:00+00:00",
+                "status": "pushed",
+            }
+        },
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="alice",
+        status_dir=str(status_dir),
+    ) == "already_imported"
+    assert db.query(PlanDelivery).filter_by(user_id="alice").count() == 1
+    assert db.query(PlanDeliveryAttempt).count() == 1
+    assert db.query(PlanRevision).filter_by(
+        user_id="alice",
+        operation="legacy_import",
+    ).count() == 1
 
 
-def test_one_users_save_is_invisible_to_another():
-    """The core regression: one user's writes must NOT leak via another's read."""
-    from api.routes.plan import _load_push_status, _save_push_status
+def test_one_users_import_is_invisible_to_another(ledger_db):
+    db, status_dir = ledger_db
+    from db.plan_ledger import (
+        delivery_status_for_snapshots,
+        import_legacy_stryd_status,
+    )
 
-    _save_push_status("alice", {"2026-05-01": {"workout_id": "alice-w1"}})
-    assert _load_push_status("bob") == {}, "Bob must not see Alice's push history"
+    _write_status(
+        status_dir,
+        "alice",
+        {"2026-05-01": {"workout_id": "alice-w1"}},
+    )
+    import_legacy_stryd_status(db, user_id="alice", status_dir=str(status_dir))
+
+    assert delivery_status_for_snapshots(
+        db,
+        user_id="alice",
+        target="stryd",
+        current_snapshots={},
+    )["2026-05-01"]["workout_id"] == "alice-w1"
+    assert delivery_status_for_snapshots(
+        db,
+        user_id="bob",
+        target="stryd",
+        current_snapshots={},
+    ) == {}
 
 
-def test_missing_user_returns_empty_dict():
-    """Never-pushed users must see an empty status without raising."""
-    from api.routes.plan import _load_push_status
+def test_missing_user_returns_empty_status(ledger_db):
+    db, status_dir = ledger_db
+    from db.plan_ledger import (
+        delivery_status_for_snapshots,
+        import_legacy_stryd_status,
+    )
 
-    assert _load_push_status("never-pushed") == {}
+    assert import_legacy_stryd_status(
+        db,
+        user_id="never-pushed",
+        status_dir=str(status_dir),
+    ) == "missing"
+    assert delivery_status_for_snapshots(
+        db,
+        user_id="never-pushed",
+        target="stryd",
+        current_snapshots={},
+    ) == {}
 
 
-def test_corrupt_file_quarantines_rather_than_overwriting(tmp_path):
-    """A corrupt file must be preserved under a quarantine name, not silently
-    overwritten by the next save. Returning {} keeps the endpoint responsive
-    without destroying recoverable history."""
-    import glob
+def test_deleted_user_legacy_file_cannot_recreate_ledger_state(ledger_db):
+    db, status_dir = ledger_db
+    from db.models import PlanDelivery, PlanRevision
+    from db.plan_ledger import (
+        import_legacy_stryd_status,
+        write_legacy_stryd_status,
+    )
 
-    from api.routes import plan as plan_mod
-    from api.routes.plan import _load_push_status
+    path = _write_status(
+        status_dir,
+        "deleted-user",
+        {"2026-05-01": {"workout_id": "deleted-id"}},
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="deleted-user",
+        status_dir=str(status_dir),
+    ) == "missing_user"
+    assert db.query(PlanDelivery).filter_by(user_id="deleted-user").count() == 0
+    assert db.query(PlanRevision).filter_by(user_id="deleted-user").count() == 0
 
-    path = plan_mod._stryd_push_status_path("corrupt-user")
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
-        f.write("{this is not json")
+    with pytest.raises(LookupError):
+        write_legacy_stryd_status(
+            db,
+            status_dir=str(status_dir),
+            user_id="deleted-user",
+            workout_date="2026-05-02",
+            external_id="new-id",
+            pushed_at="2026-05-01T12:00:00+00:00",
+        )
+    with open(path, encoding="utf-8") as handle:
+        assert json.load(handle) == {
+            "2026-05-01": {"workout_id": "deleted-id"}
+        }
 
-    assert _load_push_status("corrupt-user") == {}
-    # Original file is gone, renamed with a .corrupt-<stamp> suffix.
+
+def test_corrupt_file_is_quarantined_without_inventing_success(ledger_db):
+    db, status_dir = ledger_db
+    from db.models import PlanDelivery
+    from db.plan_ledger import import_legacy_stryd_status, legacy_stryd_status_path
+
+    path = legacy_stryd_status_path(str(status_dir), "corrupt-user")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("{this is not json")
+
+    assert import_legacy_stryd_status(
+        db,
+        user_id="corrupt-user",
+        status_dir=str(status_dir),
+    ) == "corrupt"
     assert not os.path.exists(path)
-    quarantines = glob.glob(f"{path}.corrupt-*")
-    assert len(quarantines) == 1
+    assert len(glob.glob(f"{path}.corrupt-*")) == 1
+    assert db.query(PlanDelivery).filter_by(user_id="corrupt-user").count() == 0
 
 
-def test_save_cleans_up_tmp_file_on_rename_failure(tmp_path, monkeypatch):
-    """If os.replace raises, the .tmp must not leak on disk."""
-    from api.routes import plan as plan_mod
-    from api.routes.plan import _save_push_status
+def test_invalid_entries_are_skipped_without_success_rows(ledger_db):
+    db, status_dir = ledger_db
+    from db.models import PlanDelivery, PlanRevision
+    from db.plan_ledger import import_legacy_stryd_status
 
-    user_id = "user-rename-fail"
-    target = plan_mod._stryd_push_status_path(user_id)
+    _write_status(
+        status_dir,
+        "invalid-user",
+        {
+            "not-a-date": {"workout_id": "x"},
+            "2026-05-01": {"status": "failed"},
+            "2026-05-02": "not-an-object",
+            "2026-05-03": {"workout_id": "unsafe?id"},
+        },
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="invalid-user",
+        status_dir=str(status_dir),
+    ) == "imported"
+    assert db.query(PlanDelivery).filter_by(user_id="invalid-user").count() == 0
+    revision = db.query(PlanRevision).filter_by(user_id="invalid-user").one()
+    assert revision.details == {"imported": 0, "skipped": 4, "entries": {}}
 
-    def _boom(src, dst):
-        raise OSError("simulated rename failure")
 
-    monkeypatch.setattr("os.replace", _boom)
+def test_changed_legacy_snapshot_reconciles_replacements_and_removals(ledger_db):
+    db, status_dir = ledger_db
+    from db.models import PlanDelivery, PlanDeliveryAttempt
+    from db.plan_ledger import (
+        delivery_status_for_snapshots,
+        import_legacy_stryd_status,
+    )
 
-    with pytest.raises(OSError):
-        _save_push_status(user_id, {"2026-05-01": {"workout_id": "x"}})
+    _write_status(
+        status_dir,
+        "rolling-user",
+        {
+            "2026-05-01": {"workout_id": "old-a"},
+            "2026-05-02": {"workout_id": "old-b"},
+        },
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="rolling-user",
+        status_dir=str(status_dir),
+    ) == "imported"
 
-    assert not os.path.exists(target + ".tmp"), "orphan .tmp was left behind"
+    _write_status(
+        status_dir,
+        "rolling-user",
+        {"2026-05-01": {"workout_id": "new-a"}},
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="rolling-user",
+        status_dir=str(status_dir),
+    ) == "imported"
+
+    status = delivery_status_for_snapshots(
+        db,
+        user_id="rolling-user",
+        target="stryd",
+        current_snapshots={},
+    )
+    assert status == {
+        "2026-05-01": {
+            "workout_id": "new-a",
+            "status": "pushed",
+            "pushed_at": status["2026-05-01"]["pushed_at"],
+        }
+    }
+    rows = db.query(PlanDelivery).filter_by(user_id="rolling-user").order_by(
+        PlanDelivery.workout_date,
+    ).all()
+    assert [(row.external_id, row.state) for row in rows] == [
+        ("new-a", "synced"),
+        ("old-b", "removed"),
+    ]
+    attempts = db.query(PlanDeliveryAttempt).order_by(
+        PlanDeliveryAttempt.delivery_id,
+        PlanDeliveryAttempt.attempt_number,
+    ).all()
+    assert sum(attempt.state == "removed" for attempt in attempts) == 2
+    assert sum(attempt.state == "synced" for attempt in attempts) == 3
+
+
+def test_legacy_snapshot_cursor_handles_historical_digest_repeats(ledger_db):
+    db, status_dir = ledger_db
+    from db.models import PlanDelivery
+    from db.plan_ledger import import_legacy_stryd_status
+
+    snapshot_a = {"2026-05-01": {"workout_id": "a"}}
+    snapshot_ab = {
+        **snapshot_a,
+        "2026-05-02": {"workout_id": "b"},
+    }
+    for payload in (snapshot_a, snapshot_ab, snapshot_a):
+        _write_status(status_dir, "repeat-user", payload)
+        assert import_legacy_stryd_status(
+            db,
+            user_id="repeat-user",
+            status_dir=str(status_dir),
+        ) == "imported"
+
+    rows = db.query(PlanDelivery).filter_by(user_id="repeat-user").order_by(
+        PlanDelivery.workout_date,
+    ).all()
+    assert [(row.external_id, row.state) for row in rows] == [
+        ("a", "synced"),
+        ("b", "removed"),
+    ]
+
+
+def test_old_worker_delete_marks_verified_delivery_removed(ledger_db):
+    db, status_dir = ledger_db
+    from db.plan_ledger import (
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+        import_legacy_stryd_status,
+        write_legacy_stryd_status,
+    )
+
+    delivery, _ = get_or_create_delivery(
+        db,
+        user_id="verified-rolling-user",
+        target="stryd",
+        snapshot={
+            "date": "2026-05-03",
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": "Verified version",
+        },
+    )
+    delivery, attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="deliver",
+    )
+    assert disposition == "started"
+    assert attempt is not None
+    complete_delivery_attempt(
+        db,
+        user_id="verified-rolling-user",
+        delivery_id=delivery.id,
+        attempt_id=attempt.id,
+        attempt_state="synced",
+        external_id="verified-id",
+    )
+    db.commit()
+    write_legacy_stryd_status(
+        db,
+        status_dir=str(status_dir),
+        user_id="verified-rolling-user",
+        workout_date="2026-05-03",
+        external_id="verified-id",
+        pushed_at="2026-05-02T12:00:00+00:00",
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="verified-rolling-user",
+        status_dir=str(status_dir),
+    ) == "already_imported"
+
+    _write_status(status_dir, "verified-rolling-user", {})
+    assert import_legacy_stryd_status(
+        db,
+        user_id="verified-rolling-user",
+        status_dir=str(status_dir),
+    ) == "imported"
+    db.refresh(delivery)
+    assert delivery.state == "removed"
+
+    _write_status(
+        status_dir,
+        "verified-rolling-user",
+        {"2026-05-03": {"workout_id": "verified-id"}},
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id="verified-rolling-user",
+        status_dir=str(status_dir),
+    ) == "imported"
+    db.refresh(delivery)
+    assert delivery.state == "removed"
+    rows = db.query(type(delivery)).filter_by(
+        user_id="verified-rolling-user",
+    ).all()
+    assert sorted(
+        (row.workout_version.startswith("legacy-unknown:"), row.state)
+        for row in rows
+    ) == [(False, "removed")]
+
+
+def test_superseded_removal_cannot_overwrite_successful_retry(ledger_db):
+    db, _ = ledger_db
+    from db.plan_ledger import (
+        DELIVERY_ATTEMPT_LEASE,
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+    )
+
+    delivery, _ = get_or_create_delivery(
+        db,
+        user_id="fenced-remove-user",
+        target="stryd",
+        snapshot={
+            "date": "2026-05-04",
+            "source": "ai",
+            "workout_type": "easy",
+        },
+    )
+    delivery, deliver_attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="deliver",
+    )
+    assert disposition == "started"
+    assert deliver_attempt is not None
+    assert complete_delivery_attempt(
+        db,
+        user_id="fenced-remove-user",
+        delivery_id=delivery.id,
+        attempt_id=deliver_attempt.id,
+        attempt_state="synced",
+        external_id="fenced-id",
+    )
+    db.commit()
+
+    delivery, first_remove, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="remove",
+    )
+    assert disposition == "started"
+    assert first_remove is not None
+    first_remove.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    db.commit()
+
+    delivery, retry_remove, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="remove",
+    )
+    assert disposition == "started"
+    assert retry_remove is not None
+    db.commit()
+    assert complete_delivery_attempt(
+        db,
+        user_id="fenced-remove-user",
+        delivery_id=delivery.id,
+        attempt_id=retry_remove.id,
+        attempt_state="removed",
+        external_id="fenced-id",
+    )
+    db.commit()
+
+    assert not complete_delivery_attempt(
+        db,
+        user_id="fenced-remove-user",
+        delivery_id=delivery.id,
+        attempt_id=first_remove.id,
+        attempt_state="failed",
+        delivery_state="synced",
+        error="late failure",
+    )
+    db.commit()
+    db.refresh(delivery)
+    assert delivery.state == "removed"
+
+
+def test_late_removal_success_dominates_retry_failure(ledger_db):
+    db, _ = ledger_db
+    from db.plan_ledger import (
+        DELIVERY_ATTEMPT_LEASE,
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+    )
+
+    user_id = "fenced-remove-user"
+    delivery, _ = get_or_create_delivery(
+        db,
+        user_id=user_id,
+        target="stryd",
+        snapshot={
+            "date": "2026-05-05",
+            "source": "ai",
+            "workout_type": "easy",
+        },
+    )
+    delivery, deliver_attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="deliver",
+    )
+    assert disposition == "started"
+    assert deliver_attempt is not None
+    assert complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=deliver_attempt.id,
+        attempt_state="synced",
+        external_id="late-success-id",
+    )
+    db.commit()
+
+    delivery, first_remove, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="remove",
+    )
+    assert disposition == "started"
+    assert first_remove is not None
+    first_remove.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    db.commit()
+
+    delivery, retry_remove, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="remove",
+    )
+    assert disposition == "started"
+    assert retry_remove is not None
+    db.commit()
+
+    assert not complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=first_remove.id,
+        attempt_state="removed",
+        external_id="late-success-id",
+    )
+    db.commit()
+    assert not complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=retry_remove.id,
+        attempt_state="failed",
+        delivery_state="synced",
+        error="retry failed after prior success",
+    )
+    db.commit()
+
+    db.refresh(delivery)
+    assert delivery.state == "removed"
+
+
+def test_stale_legacy_success_does_not_resurrect_removed_delivery(ledger_db):
+    db, status_dir = ledger_db
+    from db.plan_ledger import (
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+        legacy_stryd_status_path,
+        write_legacy_stryd_status,
+    )
+
+    user_id = "rolling-user"
+    delivery, _ = get_or_create_delivery(
+        db,
+        user_id=user_id,
+        target="stryd",
+        snapshot={
+            "date": "2026-05-06",
+            "source": "ai",
+            "workout_type": "easy",
+        },
+    )
+    delivery, deliver_attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="deliver",
+    )
+    assert disposition == "started"
+    assert deliver_attempt is not None
+    assert complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=deliver_attempt.id,
+        attempt_state="synced",
+        external_id="removed-before-legacy-id",
+    )
+    db.commit()
+
+    delivery, remove_attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="remove",
+    )
+    assert disposition == "started"
+    assert remove_attempt is not None
+    assert complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=remove_attempt.id,
+        attempt_state="removed",
+        external_id="removed-before-legacy-id",
+    )
+    db.commit()
+
+    write_legacy_stryd_status(
+        db,
+        status_dir=str(status_dir),
+        user_id=user_id,
+        workout_date="2026-05-06",
+        external_id="removed-before-legacy-id",
+        pushed_at="2026-05-05T12:00:00+00:00",
+    )
+
+    assert not os.path.exists(
+        legacy_stryd_status_path(str(status_dir), user_id)
+    )
+    rows = db.query(type(delivery)).filter_by(user_id=user_id).all()
+    assert [(row.workout_version.startswith("legacy-unknown:"), row.state) for row in rows] == [
+        (False, "removed")
+    ]
+
+
+def test_raw_stale_legacy_snapshot_does_not_resurrect_removed_delivery(ledger_db):
+    db, status_dir = ledger_db
+    from db.plan_ledger import (
+        begin_delivery_attempt,
+        complete_delivery_attempt,
+        get_or_create_delivery,
+        import_legacy_stryd_status,
+    )
+
+    user_id = "repeat-user"
+    delivery, _ = get_or_create_delivery(
+        db,
+        user_id=user_id,
+        target="stryd",
+        snapshot={
+            "date": "2026-05-07",
+            "source": "ai",
+            "workout_type": "easy",
+        },
+    )
+    delivery, deliver_attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="deliver",
+    )
+    assert disposition == "started"
+    assert deliver_attempt is not None
+    assert complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=deliver_attempt.id,
+        attempt_state="synced",
+        external_id="raw-stale-id",
+    )
+    db.commit()
+    delivery, remove_attempt, disposition = begin_delivery_attempt(
+        db,
+        delivery,
+        operation="remove",
+    )
+    assert disposition == "started"
+    assert remove_attempt is not None
+    assert complete_delivery_attempt(
+        db,
+        user_id=user_id,
+        delivery_id=delivery.id,
+        attempt_id=remove_attempt.id,
+        attempt_state="removed",
+        external_id="raw-stale-id",
+    )
+    db.commit()
+
+    _write_status(
+        status_dir,
+        user_id,
+        {"2026-05-07": {"workout_id": "raw-stale-id", "status": "pushed"}},
+    )
+    assert import_legacy_stryd_status(
+        db,
+        user_id=user_id,
+        status_dir=str(status_dir),
+    ) == "imported"
+
+    rows = db.query(type(delivery)).filter_by(user_id=user_id).all()
+    assert [(row.workout_version.startswith("legacy-unknown:"), row.state) for row in rows] == [
+        (False, "removed")
+    ]

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -394,6 +394,9 @@ export default function UpcomingPlanCard() {
   const [pushErrors, setPushErrors] = useState<Record<string, string>>({});
   const [pushing, setPushing] = useState(false);
   const [pushingDates, setPushingDates] = useState<Set<string>>(new Set());
+  const [optimisticPushedDates, setOptimisticPushedDates] = useState<Set<string>>(
+    new Set(),
+  );
 
   // Stryd connection status — read from SettingsContext rather than firing
   // a second /api/settings request.
@@ -413,6 +416,7 @@ export default function UpcomingPlanCard() {
   useEffect(() => {
     if (data?.stryd_status) {
       setPushStatus(data.stryd_status);
+      setOptimisticPushedDates(new Set());
     }
   }, [data?.stryd_status]);
 
@@ -425,13 +429,16 @@ export default function UpcomingPlanCard() {
       // already on Stryd by definition.
       if (workout.source === 'stryd') return 'native';
       // Server-derived sync_state is the source of truth for AI rows.
-      // The local `pushStatus` map only matters for optimistic updates
-      // between a successful push and the next /api/plan refetch.
+      if (optimisticPushedDates.has(date)) return 'pushed';
       if (workout.sync_state === 'mismatch') return 'mismatch';
-      if (workout.sync_state === 'synced' || pushStatus[date]) return 'pushed';
+      if (workout.sync_state === 'synced') return 'pushed';
+      // Compatibility fallback for an older backend that does not emit
+      // sync_state yet. On the current contract, a historical pushStatus ID
+      // must not certify a revised workout as synced.
+      if (workout.sync_state === undefined && pushStatus[date]) return 'pushed';
       return 'none';
     },
-    [pushingDates, pushErrors, pushStatus],
+    [pushingDates, pushErrors, pushStatus, optimisticPushedDates],
   );
 
   const handlePushResults = useCallback(
@@ -466,6 +473,13 @@ export default function UpcomingPlanCard() {
 
         return next;
       });
+      setOptimisticPushedDates((prev) => {
+        const next = new Set(prev);
+        for (const result of results) {
+          if (result.status === 'success') next.add(result.date);
+        }
+        return next;
+      });
     },
     [],
   );
@@ -492,7 +506,7 @@ export default function UpcomingPlanCard() {
         // If already pushed, delete the old workout from Stryd first
         const existing = pushStatus[date];
         if (existing?.workout_id) {
-          const resp = await fetch(`${API_BASE}/api/plan/stryd-workout/${existing.workout_id}`, { method: 'DELETE', headers: getAuthHeaders() });
+          const resp = await fetch(`${API_BASE}/api/plan/stryd-workout/${encodeURIComponent(existing.workout_id)}`, { method: 'DELETE', headers: getAuthHeaders() });
           if (!resp.ok) {
             const err = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }));
             throw new Error(err.detail || `HTTP ${resp.status}`);
@@ -501,6 +515,11 @@ export default function UpcomingPlanCard() {
           setPushStatus((prev) => {
             const next = { ...prev };
             delete next[date];
+            return next;
+          });
+          setOptimisticPushedDates((prev) => {
+            const next = new Set(prev);
+            next.delete(date);
             return next;
           });
         }
@@ -526,13 +545,8 @@ export default function UpcomingPlanCard() {
     [pushingDates, pushStatus, handlePushResults],
   );
 
-  // Push all unpushed AI workouts. Mirrors the ``aiPushable`` filter
-  // used to render the count beside the button — both must agree, or
-  // the button will offer to push N rows then push N±k after a
-  // round-trip. Specifically: must be ``source='ai'`` (Stryd-native
-  // rows would create *duplicates* on Stryd if pushed back),
-  // non-rest, and either not yet synced (``not_synced``) or diverged
-  // (``mismatch`` — re-push to overwrite).
+  // Push all unsynced AI workouts. Historical IDs are deleted one at a time
+  // before replacement, so an edited version never creates a duplicate.
   const pushAll = useCallback(async () => {
     if (!data) return;
 
@@ -541,7 +555,7 @@ export default function UpcomingPlanCard() {
         (w) => w.source === 'ai'
           && w.workout_type.toLowerCase() !== 'rest'
           && (w.sync_state === 'not_synced' || w.sync_state === 'mismatch')
-          && !pushStatus[w.date],
+          && !optimisticPushedDates.has(w.date),
       )
       .map((w) => w.date);
 
@@ -552,19 +566,56 @@ export default function UpcomingPlanCard() {
     setPushErrors({});
 
     try {
-      const { results } = await pushDatesToStryd(datesToPush);
-      handlePushResults(results, datesToPush);
-    } catch (e) {
-      const newErrors: Record<string, string> = {};
-      for (const d of datesToPush) {
-        newErrors[d] = e instanceof Error ? e.message : 'Push failed';
+      for (const date of datesToPush) {
+        let deleted = false;
+        try {
+          const existing = pushStatus[date];
+          if (existing?.workout_id) {
+            const response = await fetch(
+              `${API_BASE}/api/plan/stryd-workout/${encodeURIComponent(existing.workout_id)}`,
+              { method: 'DELETE', headers: getAuthHeaders() },
+            );
+            if (!response.ok) {
+              const error = await response.json().catch(
+                () => ({ detail: `HTTP ${response.status}` }),
+              );
+              throw new Error(error.detail || `HTTP ${response.status}`);
+            }
+            deleted = true;
+            setPushStatus((prev) => {
+              const next = { ...prev };
+              delete next[date];
+              return next;
+            });
+          }
+
+          const { results } = await pushDatesToStryd([date]);
+          const adjustedResults = deleted
+            ? results.map((result) => (
+                result.status === 'error'
+                  ? {
+                      ...result,
+                      error: `${result.error} (the previous Stryd workout was deleted before the new one failed — click Sync to upload again)`,
+                    }
+                  : result
+              ))
+            : results;
+          handlePushResults(adjustedResults, [date]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Push failed';
+          setPushErrors((prev) => ({
+            ...prev,
+            [date]: deleted
+              ? `${message} (the previous Stryd workout was deleted before the new one failed — click Sync to upload again)`
+              : message,
+          }));
+        }
       }
-      setPushErrors(newErrors);
     } finally {
       setPushing(false);
       setPushingDates(new Set());
     }
-  }, [data, pushStatus, handlePushResults]);
+  }, [data, pushStatus, optimisticPushedDates, handlePushResults]);
 
   if (loading) {
     return (
@@ -600,7 +651,7 @@ export default function UpcomingPlanCard() {
     (w) => w.source === 'ai'
       && w.workout_type.toLowerCase() !== 'rest'
       && (w.sync_state === 'not_synced' || w.sync_state === 'mismatch')
-      && !pushStatus[w.date],
+      && !optimisticPushedDates.has(w.date),
   );
   const unpushedCount = aiPushable.length;
   const allSynced = unpushedCount === 0

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -41,7 +41,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:620
+#: src/components/UpcomingPlanCard.tsx:671
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -646,7 +646,7 @@ msgstr "All {0} linked ticket(s) already up to date."
 msgid "All components operational"
 msgstr "All components operational"
 
-#: src/components/UpcomingPlanCard.tsx:639
+#: src/components/UpcomingPlanCard.tsx:690
 msgid "All synced"
 msgstr "All synced"
 
@@ -1997,7 +1997,7 @@ msgstr "Failed to load settings"
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:586
+#: src/components/UpcomingPlanCard.tsx:637
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -3509,7 +3509,7 @@ msgstr "No Workout Scheduled"
 msgid "No workout scheduled."
 msgstr "No workout scheduled."
 
-#: src/components/UpcomingPlanCard.tsx:664
+#: src/components/UpcomingPlanCard.tsx:715
 msgid "No workouts scheduled in this window."
 msgstr "No workouts scheduled in this window."
 
@@ -4154,7 +4154,7 @@ msgid "Push this workout to your Stryd calendar."
 msgstr "Push this workout to your Stryd calendar."
 
 #: src/components/UpcomingPlanCard.tsx:231
-#: src/components/UpcomingPlanCard.tsx:644
+#: src/components/UpcomingPlanCard.tsx:695
 msgid "Push to Stryd"
 msgstr "Push to Stryd"
 
@@ -4162,7 +4162,7 @@ msgstr "Push to Stryd"
 #~ msgid "Pushing..."
 #~ msgstr "Pushing..."
 
-#: src/components/UpcomingPlanCard.tsx:634
+#: src/components/UpcomingPlanCard.tsx:685
 msgid "Pushing…"
 msgstr "Pushing…"
 
@@ -4651,7 +4651,7 @@ msgid "Resting HR"
 msgstr "Resting HR"
 
 #: src/components/UpcomingPlanCard.tsx:186
-#: src/components/UpcomingPlanCard.tsx:589
+#: src/components/UpcomingPlanCard.tsx:640
 #: src/pages/admin/AdminFeedback.tsx:347
 #: src/pages/admin/AdminRouteState.tsx:36
 #: src/pages/admin/AdminUsers.tsx:544
@@ -5699,7 +5699,7 @@ msgstr "Trusted sync and connection outcomes from the backend telemetry boundary
 #~ msgid "Trusted Today signals"
 #~ msgstr "Trusted Today signals"
 
-#: src/components/UpcomingPlanCard.tsx:658
+#: src/components/UpcomingPlanCard.tsx:709
 msgid "Try a longer window above."
 msgstr "Try a longer window above."
 
@@ -5764,7 +5764,7 @@ msgstr "Unverified"
 msgid "Up to date"
 msgstr "Up to date"
 
-#: src/components/UpcomingPlanCard.tsx:613
+#: src/components/UpcomingPlanCard.tsx:664
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -41,7 +41,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:620
+#: src/components/UpcomingPlanCard.tsx:671
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -645,7 +645,7 @@ msgstr "{0} 个关联工单均已是最新状态。"
 msgid "All components operational"
 msgstr "所有组件运行正常"
 
-#: src/components/UpcomingPlanCard.tsx:639
+#: src/components/UpcomingPlanCard.tsx:690
 msgid "All synced"
 msgstr "全部已同步"
 
@@ -2004,7 +2004,7 @@ msgstr "加载设置失败"
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:586
+#: src/components/UpcomingPlanCard.tsx:637
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -3576,7 +3576,7 @@ msgstr "今日无训练安排"
 msgid "No workout scheduled."
 msgstr "今日无训练安排。"
 
-#: src/components/UpcomingPlanCard.tsx:664
+#: src/components/UpcomingPlanCard.tsx:715
 msgid "No workouts scheduled in this window."
 msgstr "这段时间内暂无训练安排。"
 
@@ -4241,7 +4241,7 @@ msgid "Push this workout to your Stryd calendar."
 msgstr "将这次训练推送到 Stryd 日历。"
 
 #: src/components/UpcomingPlanCard.tsx:231
-#: src/components/UpcomingPlanCard.tsx:644
+#: src/components/UpcomingPlanCard.tsx:695
 msgid "Push to Stryd"
 msgstr "推送到 Stryd"
 
@@ -4249,7 +4249,7 @@ msgstr "推送到 Stryd"
 #~ msgid "Pushing..."
 #~ msgstr "正在推送..."
 
-#: src/components/UpcomingPlanCard.tsx:634
+#: src/components/UpcomingPlanCard.tsx:685
 msgid "Pushing…"
 msgstr "推送中…"
 
@@ -4766,7 +4766,7 @@ msgid "Resting HR"
 msgstr "静息心率"
 
 #: src/components/UpcomingPlanCard.tsx:186
-#: src/components/UpcomingPlanCard.tsx:589
+#: src/components/UpcomingPlanCard.tsx:640
 #: src/pages/admin/AdminFeedback.tsx:347
 #: src/pages/admin/AdminRouteState.tsx:36
 #: src/pages/admin/AdminUsers.tsx:544
@@ -5861,7 +5861,7 @@ msgstr "来自后端可信遥测边界的同步与连接结果。"
 #~ msgid "Trusted Today signals"
 #~ msgstr "受信任的今日信号"
 
-#: src/components/UpcomingPlanCard.tsx:658
+#: src/components/UpcomingPlanCard.tsx:709
 msgid "Try a longer window above."
 msgstr "试试上方更长的时间窗口。"
 
@@ -5926,7 +5926,7 @@ msgstr "未验证"
 msgid "Up to date"
 msgstr "最新"
 
-#: src/components/UpcomingPlanCard.tsx:613
+#: src/components/UpcomingPlanCard.tsx:664
 msgid "Upcoming Plan"
 msgstr "近期计划"
 
@@ -6290,12 +6290,10 @@ msgstr "Praxys 邀请"
 #. placeholder {0}: result.code
 #. placeholder {1}: result.invite_url
 #: src/pages/admin/AdminUsers.tsx:830
-msgid ""
-"Your Praxys invitation code: {0}\n"
+msgid "Your Praxys invitation code: {0}\n"
 "\n"
 "Finish registering here: {1}"
-msgstr ""
-"Praxys 邀请码：{0}\n"
+msgstr "Praxys 邀请码：{0}\n"
 "\n"
 "注册链接：{1}"
 


### PR DESCRIPTION
## Summary

- add append-only plan revision events that commit atomically with upload, upsert, and delete mutations
- add provider-neutral delivery and attempt ledgers with content-version identity, retry fencing, and ambiguous-outcome handling
- move `/api/plan` Stryd status to the database while safely reconciling and dual-writing legacy per-user JSON during rolling deployment
- harden caller isolation, provider-row duplicate prevention, account deletion, stale removal races, and verified-ledger authority over legacy snapshots
- keep the existing API response shape and make the frontend's `sync_state` reflect the exact current workout version

## Validation

- `python -m pytest tests/ -q` — 1365 passed, 3 skipped
- changed backend tests — 79 passed, 1 skipped
- `cd web && npm run build`
- Python compile check and single Alembic-head assertion (`2b3c4d5e6f70`)
- final code review and API-contract review reported no findings

Closes #476
