### PR TITLE
Refactor Stryd plan delivery behind per-user adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,15 @@ PRAXYS_LOCAL_ENCRYPTION_KEY=
 # PRAXYS_JWT_SECRET=
 # PRAXYS_ENV=development
 
+# Optional local-only compatibility for Stryd workout delivery.
+# Production and normal local accounts always use the encrypted per-user
+# connection saved through Settings. The backend reads STRYD_EMAIL /
+# STRYD_PASSWORD only when PRAXYS_ENV=development AND the authenticated
+# Praxys user ID exactly matches PRAXYS_STRYD_ENV_USER_ID.
+# PRAXYS_STRYD_ENV_USER_ID=
+# STRYD_EMAIL=
+# STRYD_PASSWORD=
+
 # Optional: Admin email — this email can register without an invitation code
 # and is always granted admin privileges. Not needed if you're the first user.
 # PRAXYS_ADMIN_EMAIL=

--- a/alembic/versions/3c4d5e6f7081_add_delivery_identity_fields.py
+++ b/alembic/versions/3c4d5e6f7081_add_delivery_identity_fields.py
@@ -1,0 +1,43 @@
+"""add delivery plan and provider account identity
+
+Revision ID: 3c4d5e6f7081
+Revises: 2b3c4d5e6f70
+Create Date: 2026-07-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "3c4d5e6f7081"
+down_revision: Union[str, Sequence[str], None] = "2b3c4d5e6f70"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "plan_deliveries",
+        sa.Column("plan_version", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "plan_deliveries",
+        sa.Column(
+            "provider_account_id",
+            sa.String(length=200),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE plan_deliveries "
+            "SET plan_version = workout_version "
+            "WHERE plan_version IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("plan_deliveries", "provider_account_id")
+    op.drop_column("plan_deliveries", "plan_version")

--- a/api/plan_delivery/__init__.py
+++ b/api/plan_delivery/__init__.py
@@ -1,0 +1,91 @@
+"""Provider-neutral managed-plan delivery service."""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from sqlalchemy.orm import Session
+
+from api.plan_delivery.base import (
+    PlanDeliveryAdapter,
+    PreparedWorkoutDelivery,
+    ProviderAuthenticationError,
+)
+from api.plan_delivery.credentials import (
+    DeliveryCredentialsInvalid,
+    DeliveryCredentialsUnavailable,
+    resolve_delivery_credentials,
+)
+from api.plan_delivery.service import (
+    DeliveryAccountMismatchError,
+    DeliveryAccountVerificationError,
+    DeliveryBusyError,
+    DeliveryFinalizationError,
+    DeliveryNotFoundError,
+    DeliveryRemovalFailedError,
+    DeliveryResult,
+    DeliveryStartError,
+    PlanDeliveryService,
+    RemovalResult,
+)
+from api.plan_delivery.stryd import StrydPlanDeliveryAdapter
+
+
+class UnsupportedDeliveryTargetError(ValueError):
+    """No delivery adapter is registered for the requested target."""
+
+
+AdapterFactory = Callable[[Mapping[str, Any]], PlanDeliveryAdapter]
+
+_ADAPTER_TYPES: dict[str, AdapterFactory] = {
+    StrydPlanDeliveryAdapter.target: StrydPlanDeliveryAdapter,
+}
+
+
+def register_plan_delivery_adapter(
+    target: str,
+    adapter_type: AdapterFactory,
+) -> None:
+    """Register a provider adapter without changing delivery callers."""
+    _ADAPTER_TYPES[target] = adapter_type
+
+
+def load_plan_delivery_adapter(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+) -> PlanDeliveryAdapter:
+    """Build a delivery adapter using only the caller's credentials."""
+    adapter_type = _ADAPTER_TYPES.get(target)
+    if adapter_type is None:
+        raise UnsupportedDeliveryTargetError(
+            f"Unsupported plan delivery target: {target}"
+        )
+    credentials = resolve_delivery_credentials(
+        db,
+        user_id=user_id,
+        target=target,
+    )
+    return adapter_type(credentials)
+
+
+__all__ = [
+    "DeliveryAccountMismatchError",
+    "DeliveryAccountVerificationError",
+    "DeliveryBusyError",
+    "DeliveryCredentialsInvalid",
+    "DeliveryCredentialsUnavailable",
+    "DeliveryFinalizationError",
+    "DeliveryNotFoundError",
+    "DeliveryRemovalFailedError",
+    "DeliveryResult",
+    "DeliveryStartError",
+    "PlanDeliveryAdapter",
+    "PlanDeliveryService",
+    "PreparedWorkoutDelivery",
+    "ProviderAuthenticationError",
+    "RemovalResult",
+    "UnsupportedDeliveryTargetError",
+    "load_plan_delivery_adapter",
+    "register_plan_delivery_adapter",
+]

--- a/api/plan_delivery/base.py
+++ b/api/plan_delivery/base.py
@@ -1,0 +1,109 @@
+"""Provider-neutral contracts for external workout delivery."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class PreparedWorkoutDelivery:
+    """Immutable delivery identity paired with its exact provider request."""
+
+    version: str
+    request: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ProviderCreateResult:
+    """Confirmed provider workout creation."""
+
+    external_id: str
+    provider_account_id: str
+    response: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ProviderRemoveResult:
+    """Confirmed provider workout removal."""
+
+    already_absent: bool = False
+
+
+class PlanDeliveryProviderError(RuntimeError):
+    """Base class for provider delivery failures."""
+
+
+class ProviderAuthenticationError(PlanDeliveryProviderError):
+    """The provider rejected or could not complete authentication."""
+
+
+class ProviderRequestError(PlanDeliveryProviderError):
+    """Praxys could not prepare a valid provider request."""
+
+
+class ProviderRejectedError(PlanDeliveryProviderError):
+    """The provider definitely rejected a request."""
+
+
+class ProviderOutcomeUnknownError(PlanDeliveryProviderError):
+    """The request may have reached the provider, so retry requires reconciliation."""
+
+
+class ProviderRemovalError(PlanDeliveryProviderError):
+    """The provider removal request failed."""
+
+
+class ProviderReadError(PlanDeliveryProviderError):
+    """The provider calendar could not be read."""
+
+
+@runtime_checkable
+class PlanDeliveryAdapter(Protocol):
+    """Provider operations required by managed-plan delivery.
+
+    Replacement is deliberately composed as a confirmed delete followed by a
+    create so callers can persist and surface partial outcomes between steps.
+    """
+
+    target: str
+    display_name: str
+
+    @property
+    def account_id(self) -> str:
+        """Return the authenticated provider account identity."""
+        ...
+
+    def authenticate(self) -> None:
+        """Authenticate once and cache the provider session for this adapter."""
+        ...
+
+    def prepare_workout(
+        self,
+        workout: Mapping[str, Any],
+        *,
+        threshold_value: float,
+    ) -> PreparedWorkoutDelivery:
+        """Prepare and fingerprint the exact provider request once."""
+        ...
+
+    def create_workout(
+        self,
+        prepared: PreparedWorkoutDelivery,
+    ) -> ProviderCreateResult:
+        """Create one workout and return its confirmed provider identity."""
+        ...
+
+    def delete_workout(self, external_id: str) -> ProviderRemoveResult:
+        """Delete one provider workout."""
+        ...
+
+    def fetch_calendar(
+        self,
+        *,
+        threshold_value: float | None = None,
+        days_ahead: int = 14,
+        days_back: int = 0,
+        timezone_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch normalized upcoming workouts from the provider calendar."""
+        ...

--- a/api/plan_delivery/credentials.py
+++ b/api/plan_delivery/credentials.py
@@ -1,0 +1,89 @@
+"""Credential resolution for provider workout delivery."""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from dotenv import dotenv_values
+from sqlalchemy.orm import Session
+
+from db.connection_credentials import (
+    CredentialAccessError,
+    load_connection_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DeliveryCredentialsUnavailable(RuntimeError):
+    """No credentials are available for the requested delivery target."""
+
+
+class DeliveryCredentialsInvalid(RuntimeError):
+    """Stored credentials require the user to reconnect the platform."""
+
+
+def _legacy_stryd_credentials(user_id: str) -> dict[str, str] | None:
+    """Return explicitly pinned local-development Stryd credentials."""
+    environment = (
+        os.environ.get("PRAXYS_ENV")
+        or os.environ.get("TRAINSIGHT_ENV")
+        or ""
+    ).strip().casefold()
+    if environment != "development":
+        return None
+
+    values: dict[str, Any] = {}
+    legacy_path = Path(__file__).resolve().parents[2] / "sync" / ".env"
+    if legacy_path.exists():
+        values.update(dotenv_values(legacy_path))
+
+    def configured(name: str) -> str:
+        value = os.environ.get(name)
+        if value is None:
+            value = values.get(name)
+        return str(value or "").strip()
+
+    pinned_user_id = configured("PRAXYS_STRYD_ENV_USER_ID")
+    if pinned_user_id != user_id:
+        return None
+
+    email = configured("STRYD_EMAIL")
+    password = configured("STRYD_PASSWORD")
+    if not email or not password:
+        return None
+    logger.warning(
+        "Using local-only environment Stryd credentials for pinned user=%s",
+        user_id,
+    )
+    return {"email": email, "password": password}
+
+
+def resolve_delivery_credentials(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+) -> dict[str, Any]:
+    """Resolve credentials without ever borrowing another user's connection."""
+    try:
+        credentials = load_connection_credentials(
+            db,
+            user_id=user_id,
+            platform=target,
+        )
+    except CredentialAccessError as exc:
+        raise DeliveryCredentialsInvalid(str(exc)) from exc
+    if credentials is not None:
+        return credentials
+
+    if target == "stryd":
+        legacy = _legacy_stryd_credentials(user_id)
+        if legacy is not None:
+            return legacy
+
+    raise DeliveryCredentialsUnavailable(
+        f"No credentials available for {target}"
+    )

--- a/api/plan_delivery/service.py
+++ b/api/plan_delivery/service.py
@@ -1,0 +1,532 @@
+"""Ledger-backed orchestration for provider workout delivery."""
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Callable, Mapping
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from api.plan_delivery.base import (
+    PlanDeliveryAdapter,
+    ProviderAuthenticationError,
+    ProviderOutcomeUnknownError,
+    ProviderReadError,
+    ProviderRejectedError,
+    ProviderRemovalError,
+    ProviderRequestError,
+)
+from api.plan_delivery.credentials import (
+    DeliveryCredentialsInvalid,
+    DeliveryCredentialsUnavailable,
+)
+from db.cache_revision import bump_revisions
+from db.models import TrainingPlan
+from db.plan_ledger import (
+    begin_delivery_attempt,
+    complete_delivery_attempt,
+    find_delivery_by_external_id,
+    find_unverified_delivery_for_date,
+    get_or_create_delivery,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    """One manual delivery outcome."""
+
+    status: str
+    external_id: str | None = None
+    error: str | None = None
+    delivered_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class RemovalResult:
+    """One manual removal outcome."""
+
+    external_id: str
+    already_absent: bool = False
+
+
+class DeliveryNotFoundError(LookupError):
+    """The caller does not own a matching delivery record."""
+
+
+class DeliveryBusyError(RuntimeError):
+    """Another attempt currently owns the delivery."""
+
+
+class DeliveryStartError(RuntimeError):
+    """The delivery attempt could not be started durably."""
+
+
+class DeliveryAccountMismatchError(RuntimeError):
+    """The delivery belongs to a different provider account."""
+
+
+class DeliveryAccountVerificationError(RuntimeError):
+    """The provider account for a migrated delivery could not be verified."""
+
+
+class DeliveryRemovalFailedError(RuntimeError):
+    """The provider workout could not be removed."""
+
+
+class DeliveryFinalizationError(RuntimeError):
+    """The provider changed but the durable ledger could not be finalized."""
+
+
+class PlanDeliveryService:
+    """Coordinate provider calls with durable per-user delivery state."""
+
+    def __init__(
+        self,
+        *,
+        db: Session,
+        user_id: str,
+        target: str,
+        adapter_loader: Callable[[], PlanDeliveryAdapter],
+    ):
+        self.db = db
+        self.user_id = user_id
+        self.target = target
+        self._adapter_loader = adapter_loader
+        self._loaded_adapter: PlanDeliveryAdapter | None = None
+
+    def _adapter(self) -> PlanDeliveryAdapter:
+        if self._loaded_adapter is None:
+            self._loaded_adapter = self._adapter_loader()
+        return self._loaded_adapter
+
+    def authenticate(self) -> None:
+        """Authenticate the configured provider before a batch operation."""
+        self._adapter().authenticate()
+
+    def _cleanup_new_delivery(self, delivery, created: bool) -> None:
+        if created:
+            self.db.delete(delivery)
+            self.db.commit()
+        else:
+            self.db.rollback()
+
+    def _record_terminal_attempt(
+        self,
+        *,
+        delivery_id: str,
+        attempt_id: int,
+        state: str,
+        error: str | None = None,
+        external_id: str | None = None,
+        response: Mapping[str, Any] | None = None,
+        provider_account_id: str | None = None,
+        delivery_state: str | None = None,
+        commit: bool = True,
+    ) -> bool:
+        updated = complete_delivery_attempt(
+            self.db,
+            user_id=self.user_id,
+            delivery_id=delivery_id,
+            attempt_id=attempt_id,
+            attempt_state=state,
+            delivery_state=delivery_state,
+            external_id=external_id,
+            error=error,
+            response=response,
+            provider_account_id=provider_account_id,
+        )
+        bump_revisions(self.db, self.user_id, ["plans"])
+        if commit:
+            self.db.commit()
+        return updated
+
+    def deliver(
+        self,
+        snapshot: Mapping[str, Any],
+        *,
+        threshold_value: float,
+        observed_external_ids: Collection[str] | None,
+    ) -> DeliveryResult:
+        """Deliver one canonical workout version to the configured target."""
+        workout_date = str(snapshot["date"])
+        provider_name = self.target.capitalize()
+        try:
+            adapter = self._adapter()
+            prepared = adapter.prepare_workout(
+                snapshot,
+                threshold_value=threshold_value,
+            )
+            adapter.authenticate()
+            provider_account_id = adapter.account_id
+        except ProviderRequestError as exc:
+            return DeliveryResult(status="error", error=str(exc))
+
+        try:
+            delivery, delivery_created = get_or_create_delivery(
+                self.db,
+                user_id=self.user_id,
+                target=self.target,
+                snapshot=snapshot,
+                workout_version_override=prepared.version,
+            )
+            if (
+                delivery.provider_account_id
+                and delivery.provider_account_id != provider_account_id
+            ):
+                self._cleanup_new_delivery(delivery, delivery_created)
+                return DeliveryResult(
+                    status="error",
+                    error=(
+                        f"This {provider_name} delivery belongs to a "
+                        f"different {provider_name} account"
+                    ),
+                )
+            observed_ids = {
+                str(external_id).strip()
+                for external_id in observed_external_ids or ()
+                if str(external_id).strip()
+            }
+            if observed_external_ids is not None:
+                observed_deliveries_owned = bool(observed_ids) and all(
+                    (
+                        owned := find_delivery_by_external_id(
+                            self.db,
+                            user_id=self.user_id,
+                            target=self.target,
+                            external_id=external_id,
+                        )
+                    ) is not None
+                    and owned.state != "removed"
+                    and owned.workout_date == delivery.workout_date
+                    and owned.canonical_key == delivery.canonical_key
+                    and (
+                        owned.provider_account_id is None
+                        or owned.provider_account_id == provider_account_id
+                    )
+                    for external_id in observed_ids
+                )
+                if not observed_deliveries_owned:
+                    self._cleanup_new_delivery(delivery, delivery_created)
+                    return DeliveryResult(
+                        status="error",
+                        error=(
+                            f"A different {provider_name} workout exists on "
+                            "this date and must be reconciled before delivery"
+                        ),
+                    )
+
+            unverified = find_unverified_delivery_for_date(
+                self.db,
+                user_id=self.user_id,
+                target=self.target,
+                workout_date=delivery.workout_date,
+            )
+            if unverified is not None:
+                self._cleanup_new_delivery(delivery, delivery_created)
+                return DeliveryResult(
+                    status="error",
+                    error=(
+                        f"Delivery outcome is uncertain; sync {provider_name} before retrying"
+                    ),
+                )
+
+            delivery, attempt, disposition = begin_delivery_attempt(
+                self.db,
+                delivery,
+                operation="deliver",
+            )
+            if disposition == "already_complete":
+                external_id = str(delivery.external_id)
+                delivered_at = delivery.delivered_at
+                self.db.commit()
+                return DeliveryResult(
+                    status="success",
+                    external_id=external_id,
+                    delivered_at=delivered_at,
+                )
+            if disposition == "reconciliation_required":
+                self._cleanup_new_delivery(delivery, delivery_created)
+                return DeliveryResult(
+                    status="error",
+                    error=(
+                        f"Delivery outcome is uncertain; sync {provider_name} before retrying"
+                    ),
+                )
+            if disposition == "replacement_required":
+                self._cleanup_new_delivery(delivery, delivery_created)
+                return DeliveryResult(
+                    status="error",
+                    error=(
+                        f"The existing Praxys-managed {provider_name} workout "
+                        "must be removed before replacement"
+                    ),
+                )
+            assert attempt is not None
+            delivery_id = delivery.id
+            attempt_id = attempt.id
+            bump_revisions(self.db, self.user_id, ["plans"])
+            self.db.commit()
+        except (SQLAlchemyError, ValueError) as exc:
+            self.db.rollback()
+            logger.exception(
+                "Failed to start %s delivery for user=%s date=%s",
+                self.target,
+                self.user_id,
+                workout_date,
+            )
+            return DeliveryResult(
+                status="error",
+                error=f"Could not start delivery: {exc}",
+            )
+
+        try:
+            provider_result = adapter.create_workout(prepared)
+            if provider_result.provider_account_id != provider_account_id:
+                raise ProviderOutcomeUnknownError(
+                    f"{provider_name} account changed during delivery"
+                )
+        except (ProviderRequestError, ProviderRejectedError) as exc:
+            try:
+                self._record_terminal_attempt(
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    state="failed",
+                    error=str(exc),
+                )
+            except SQLAlchemyError:
+                self.db.rollback()
+                logger.exception(
+                    "Failed to persist %s delivery failure for user=%s date=%s",
+                    self.target,
+                    self.user_id,
+                    workout_date,
+                )
+            return DeliveryResult(status="error", error=str(exc))
+        except ProviderOutcomeUnknownError as exc:
+            message = (
+                f"{provider_name} delivery outcome is uncertain; "
+                f"sync {provider_name} before retrying"
+            )
+            try:
+                self._record_terminal_attempt(
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    state="conflict",
+                    error=f"{message}: {exc}",
+                )
+            except SQLAlchemyError:
+                self.db.rollback()
+                logger.exception(
+                    "Failed to persist ambiguous %s delivery for user=%s date=%s",
+                    self.target,
+                    self.user_id,
+                    workout_date,
+                )
+            return DeliveryResult(status="error", error=message)
+
+        try:
+            self._record_terminal_attempt(
+                delivery_id=delivery_id,
+                attempt_id=attempt_id,
+                state="synced",
+                external_id=provider_result.external_id,
+                response=provider_result.response,
+                provider_account_id=provider_result.provider_account_id,
+            )
+        except SQLAlchemyError:
+            self.db.rollback()
+            logger.exception(
+                "%s accepted workout but ledger commit failed for user=%s date=%s id=%s",
+                self.target,
+                self.user_id,
+                workout_date,
+                provider_result.external_id,
+            )
+            return DeliveryResult(
+                status="error",
+                error=(
+                    f"{provider_name} accepted the workout, but delivery state could not "
+                    "be finalized"
+                ),
+            )
+        return DeliveryResult(
+            status="success",
+            external_id=provider_result.external_id,
+            delivered_at=datetime.utcnow(),
+        )
+
+    def remove(self, external_id: str) -> RemovalResult:
+        """Remove one caller-owned provider workout and finalize its ledger."""
+        provider_name = self.target.capitalize()
+        delivery = find_delivery_by_external_id(
+            self.db,
+            user_id=self.user_id,
+            target=self.target,
+            external_id=external_id,
+        )
+        if delivery is None:
+            self.db.rollback()
+            raise DeliveryNotFoundError(
+                f"No {provider_name} delivery found for this user and workout"
+            )
+        if delivery.state == "removed":
+            self.db.rollback()
+            return RemovalResult(external_id=external_id)
+
+        adapter = self._adapter()
+        adapter.authenticate()
+        provider_account_id = adapter.account_id
+        if delivery.provider_account_id is None:
+            days_until_workout = (delivery.workout_date - date.today()).days
+            if days_until_workout < -2 or days_until_workout > 365:
+                self.db.rollback()
+                raise DeliveryAccountMismatchError(
+                    f"This migrated {provider_name} delivery must be "
+                    "reconciled before removal"
+                )
+            try:
+                calendar = adapter.fetch_calendar(
+                    days_ahead=max(14, days_until_workout + 3),
+                    days_back=3,
+                )
+            except ProviderReadError as exc:
+                self.db.rollback()
+                raise DeliveryAccountVerificationError(
+                    f"Could not verify the {provider_name} account before "
+                    "removal"
+                ) from exc
+            verified = any(
+                str(row.get("external_id") or "").strip() == external_id
+                for row in calendar
+            )
+            if not verified:
+                self.db.rollback()
+                raise DeliveryAccountMismatchError(
+                    f"This migrated {provider_name} delivery could not be "
+                    "verified on the connected account"
+                )
+            delivery.provider_account_id = provider_account_id
+        elif delivery.provider_account_id != provider_account_id:
+            self.db.rollback()
+            raise DeliveryAccountMismatchError(
+                f"This {provider_name} delivery belongs to a different "
+                f"{provider_name} account"
+            )
+
+        previous_state = delivery.state
+        if previous_state == "delivering" and delivery.external_id:
+            previous_state = "synced"
+        try:
+            delivery, attempt, disposition = begin_delivery_attempt(
+                self.db,
+                delivery,
+                operation="remove",
+            )
+            if disposition == "already_complete":
+                self.db.rollback()
+                return RemovalResult(external_id=external_id)
+            if disposition == "reconciliation_required":
+                self.db.rollback()
+                raise DeliveryBusyError(
+                    f"{provider_name} workout delivery is already being updated"
+                )
+            assert attempt is not None
+            delivery_id = delivery.id
+            attempt_id = attempt.id
+            bump_revisions(self.db, self.user_id, ["plans"])
+            self.db.commit()
+        except DeliveryBusyError:
+            raise
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            logger.exception(
+                "Failed to start %s removal for user=%s workout=%s",
+                self.target,
+                self.user_id,
+                external_id,
+            )
+            raise DeliveryStartError(
+                f"Could not start {provider_name} workout removal"
+            ) from exc
+
+        def record_failure(message: str) -> bool:
+            try:
+                updated = self._record_terminal_attempt(
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    state="failed",
+                    delivery_state=previous_state,
+                    error=message,
+                )
+                current = find_delivery_by_external_id(
+                    self.db,
+                    user_id=self.user_id,
+                    target=self.target,
+                    external_id=external_id,
+                )
+                return (
+                    not updated
+                    and current is not None
+                    and current.state == "removed"
+                )
+            except SQLAlchemyError:
+                self.db.rollback()
+                logger.exception(
+                    "Failed to persist %s removal failure for user=%s workout=%s",
+                    self.target,
+                    self.user_id,
+                    external_id,
+                )
+                return False
+
+        try:
+            provider_result = adapter.delete_workout(external_id)
+        except (
+            DeliveryCredentialsUnavailable,
+            DeliveryCredentialsInvalid,
+            ProviderAuthenticationError,
+        ) as exc:
+            if record_failure(str(exc)):
+                return RemovalResult(external_id=external_id)
+            raise
+        except ProviderRemovalError as exc:
+            if record_failure(str(exc)):
+                return RemovalResult(external_id=external_id)
+            raise DeliveryRemovalFailedError(str(exc)) from exc
+
+        try:
+            self._record_terminal_attempt(
+                delivery_id=delivery_id,
+                attempt_id=attempt_id,
+                state="removed",
+                external_id=external_id,
+                response={"already_absent": provider_result.already_absent},
+                commit=False,
+            )
+            self.db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == self.user_id,
+                TrainingPlan.source == self.target,
+                TrainingPlan.external_id == external_id,
+            ).delete(synchronize_session=False)
+            self.db.commit()
+        except SQLAlchemyError as exc:
+            self.db.rollback()
+            logger.exception(
+                "%s workout deleted but ledger finalization failed for user=%s workout=%s",
+                self.target,
+                self.user_id,
+                external_id,
+            )
+            raise DeliveryFinalizationError(
+                f"{provider_name} workout was deleted, but delivery state "
+                "could not be finalized"
+            ) from exc
+        return RemovalResult(
+            external_id=external_id,
+            already_absent=provider_result.already_absent,
+        )

--- a/api/plan_delivery/stryd.py
+++ b/api/plan_delivery/stryd.py
@@ -1,0 +1,297 @@
+"""Stryd implementation of the provider-neutral delivery contract."""
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from typing import Any, Mapping
+
+import requests
+
+from api.plan_delivery.base import (
+    ProviderAuthenticationError,
+    ProviderCreateResult,
+    ProviderOutcomeUnknownError,
+    PreparedWorkoutDelivery,
+    ProviderReadError,
+    ProviderRejectedError,
+    ProviderRemoveResult,
+    ProviderRemovalError,
+    ProviderRequestError,
+)
+from db.plan_ledger import normalize_stryd_workout_id
+from sync import stryd_sync
+
+
+class StrydPlanDeliveryAdapter:
+    """Create, remove, and read Stryd workouts for one user's credentials."""
+
+    target = "stryd"
+    display_name = "Stryd"
+
+    def __init__(self, credentials: Mapping[str, Any]):
+        email = credentials.get("email")
+        password = credentials.get("password")
+        if not isinstance(email, str) or not email.strip():
+            raise ProviderAuthenticationError(
+                "Stryd credentials are missing an email"
+            )
+        if not isinstance(password, str) or not password:
+            raise ProviderAuthenticationError(
+                "Stryd credentials are missing a password"
+            )
+        self._email = email.strip()
+        self._password = password
+        self._provider_user_id: str | None = None
+        self._token: str | None = None
+
+    @property
+    def account_id(self) -> str:
+        """Return the authenticated Stryd account identity."""
+        self.authenticate()
+        assert self._provider_user_id is not None
+        return self._provider_user_id
+
+    def authenticate(self) -> None:
+        """Authenticate once for all operations performed by this adapter."""
+        if self._provider_user_id and self._token:
+            return
+        try:
+            provider_user_id, token = stryd_sync._login_api(
+                self._email,
+                self._password,
+            )
+        except (
+            requests.RequestException,
+            KeyError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise ProviderAuthenticationError("Stryd login failed") from exc
+        if not provider_user_id or not token:
+            raise ProviderAuthenticationError(
+                "Stryd login did not return a usable session"
+            )
+        self._provider_user_id = str(provider_user_id)
+        self._token = str(token)
+
+    def _session(self) -> tuple[str, str]:
+        self.authenticate()
+        assert self._provider_user_id is not None
+        assert self._token is not None
+        return self._provider_user_id, self._token
+
+    @staticmethod
+    def _http_detail(error: requests.HTTPError) -> str:
+        detail = str(error)
+        if error.response is not None:
+            try:
+                body = error.response.json()
+            except ValueError:
+                body = None
+            if isinstance(body, dict) and body.get("message"):
+                detail = str(body["message"])
+        return detail
+
+    @staticmethod
+    def _prepare_workout(
+        workout: Mapping[str, Any],
+        threshold_value: float,
+    ) -> dict[str, Any]:
+        try:
+            raw_blocks = stryd_sync.build_workout_blocks(
+                dict(workout),
+                threshold_value,
+            )
+            blocks_without_ids = StrydPlanDeliveryAdapter._without_uuids(
+                raw_blocks
+            )
+            block_seed = json.dumps(
+                blocks_without_ids,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+            blocks = StrydPlanDeliveryAdapter._stable_uuids(
+                raw_blocks,
+                seed=block_seed,
+            )
+            workout_type = str(workout.get("workout_type") or "")
+            provider_type = stryd_sync._STRYD_WORKOUT_TYPES.get(
+                workout_type.casefold(),
+                "",
+            )
+            return {
+                "workout_date": str(workout["date"]),
+                "title": workout_type.replace("_", " ").title(),
+                "blocks": blocks,
+                "workout_type": provider_type,
+                "description": str(
+                    workout.get("workout_description") or ""
+                ),
+            }
+        except (ArithmeticError, KeyError, TypeError, ValueError) as exc:
+            raise ProviderRequestError(str(exc)) from exc
+
+    @staticmethod
+    def _without_uuids(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {
+                str(key): StrydPlanDeliveryAdapter._without_uuids(item)
+                for key, item in value.items()
+                if key != "uuid"
+            }
+        if isinstance(value, list):
+            return [
+                StrydPlanDeliveryAdapter._without_uuids(item)
+                for item in value
+            ]
+        return value
+
+    @staticmethod
+    def _stable_uuids(
+        value: Any,
+        *,
+        seed: str,
+        path: str = "$",
+    ) -> Any:
+        if isinstance(value, Mapping):
+            result = {
+                str(key): StrydPlanDeliveryAdapter._stable_uuids(
+                    item,
+                    seed=seed,
+                    path=f"{path}.{key}",
+                )
+                for key, item in value.items()
+                if key != "uuid"
+            }
+            if "uuid" in value:
+                result["uuid"] = str(
+                    uuid.uuid5(
+                        uuid.NAMESPACE_URL,
+                        f"praxys-stryd:{seed}:{path}",
+                    )
+                )
+            return result
+        if isinstance(value, list):
+            return [
+                StrydPlanDeliveryAdapter._stable_uuids(
+                    item,
+                    seed=seed,
+                    path=f"{path}[{index}]",
+                )
+                for index, item in enumerate(value)
+            ]
+        return value
+
+    def prepare_workout(
+        self,
+        workout: Mapping[str, Any],
+        *,
+        threshold_value: float,
+    ) -> PreparedWorkoutDelivery:
+        """Prepare and hash one deterministic Stryd create request."""
+        payload = self._prepare_workout(workout, threshold_value)
+        try:
+            encoded = json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise ProviderRequestError(str(exc)) from exc
+        return PreparedWorkoutDelivery(
+            version=hashlib.sha256(encoded).hexdigest(),
+            request=payload,
+        )
+
+    def create_workout(
+        self,
+        prepared: PreparedWorkoutDelivery,
+    ) -> ProviderCreateResult:
+        """Create a structured Stryd workout."""
+        provider_user_id, token = self._session()
+
+        try:
+            response = stryd_sync.create_workout_api(
+                user_id=provider_user_id,
+                token=token,
+                **prepared.request,
+            )
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            raise ProviderOutcomeUnknownError(str(exc)) from exc
+        except requests.HTTPError as exc:
+            status_code = (
+                exc.response.status_code if exc.response is not None else None
+            )
+            detail = self._http_detail(exc)
+            if status_code is None or status_code == 408 or status_code >= 500:
+                raise ProviderOutcomeUnknownError(detail) from exc
+            raise ProviderRejectedError(f"Stryd API error: {detail}") from exc
+        except requests.RequestException as exc:
+            raise ProviderOutcomeUnknownError(str(exc)) from exc
+        except (TypeError, ValueError) as exc:
+            raise ProviderOutcomeUnknownError(str(exc)) from exc
+
+        if not isinstance(response, Mapping):
+            raise ProviderOutcomeUnknownError(
+                "Stryd response was not an object"
+            )
+        external_id = normalize_stryd_workout_id(response.get("id"))
+        if external_id is None:
+            raise ProviderOutcomeUnknownError(
+                "Stryd response did not include a workout id"
+            )
+        return ProviderCreateResult(
+            external_id=external_id,
+            provider_account_id=provider_user_id,
+            response=dict(response),
+        )
+
+    def delete_workout(self, external_id: str) -> ProviderRemoveResult:
+        """Delete a Stryd workout, treating an existing 404 as success."""
+        provider_user_id, token = self._session()
+        try:
+            stryd_sync.delete_workout_api(
+                provider_user_id,
+                token,
+                external_id,
+            )
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return ProviderRemoveResult(already_absent=True)
+            raise ProviderRemovalError(str(exc)) from exc
+        except requests.RequestException as exc:
+            raise ProviderRemovalError(str(exc)) from exc
+        return ProviderRemoveResult()
+
+    def fetch_calendar(
+        self,
+        *,
+        threshold_value: float | None = None,
+        days_ahead: int = 14,
+        days_back: int = 0,
+        timezone_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch normalized Stryd calendar workouts."""
+        provider_user_id, token = self._session()
+        try:
+            return stryd_sync.fetch_training_plan_api(
+                provider_user_id,
+                token,
+                cp_watts=threshold_value,
+                days_ahead=days_ahead,
+                days_back=days_back,
+                tz_name=timezone_name,
+            )
+        except (
+            requests.RequestException,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise ProviderReadError(str(exc)) from exc

--- a/api/routes/plan.py
+++ b/api/routes/plan.py
@@ -1,16 +1,15 @@
 """Upcoming training plan endpoint with Stryd push integration."""
 import json
 import logging
+import math
 import os
 from datetime import date, datetime, timedelta, timezone
-from typing import Mapping
 
 import pandas as pd
-import requests
-from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -21,14 +20,23 @@ from api.daily_brief_freshness import PLAN_RESPONSE_VERSION
 from api.deps import get_dashboard_data
 from api.etag import CACHE_CONTROL, ENDPOINT_SCOPES, ETagGuard, compute_etag
 from api.packs import RequestContext
+from api.plan_delivery import (
+    DeliveryAccountMismatchError,
+    DeliveryAccountVerificationError,
+    DeliveryBusyError,
+    DeliveryCredentialsInvalid,
+    DeliveryCredentialsUnavailable,
+    DeliveryFinalizationError,
+    DeliveryNotFoundError,
+    DeliveryRemovalFailedError,
+    DeliveryStartError,
+    PlanDeliveryService,
+    ProviderAuthenticationError,
+    load_plan_delivery_adapter,
+)
 from db.cache_revision import bump_revisions
 from db.plan_ledger import (
-    begin_delivery_attempt,
-    complete_delivery_attempt,
     delivery_status_for_snapshots,
-    find_delivery_by_external_id,
-    find_unverified_delivery_for_date,
-    get_or_create_delivery,
     import_legacy_stryd_status,
     legacy_stryd_status_path,
     lock_plan_writes,
@@ -37,7 +45,6 @@ from db.plan_ledger import (
     remove_legacy_stryd_status,
     write_legacy_stryd_status,
 )
-from db.models import TrainingPlan
 from db.session import get_db
 
 router = APIRouter()
@@ -339,6 +346,31 @@ class PushStrydRequest(BaseModel):
     workout_dates: list[str]
 
 
+def _resolve_stryd_delivery_cp(data: dict) -> float | None:
+    """Resolve the CP value used to build Stryd workout blocks."""
+    latest_cp = data.get("latest_cp")
+    try:
+        parsed_latest = float(latest_cp)
+    except (TypeError, ValueError):
+        parsed_latest = 0.0
+    if math.isfinite(parsed_latest) and parsed_latest > 0:
+        return parsed_latest
+
+    activities = data.get("activities", pd.DataFrame())
+    if not isinstance(activities, pd.DataFrame) or activities.empty:
+        return None
+    if "cp_estimate" not in activities.columns:
+        return None
+    valid_cp = activities["cp_estimate"].dropna()
+    if valid_cp.empty:
+        return None
+    try:
+        cp_watts = float(valid_cp.iloc[-1])
+    except (TypeError, ValueError):
+        return None
+    return cp_watts if math.isfinite(cp_watts) and cp_watts > 0 else None
+
+
 @router.post("/plan/push-stryd")
 def push_plan_to_stryd(
     request: PushStrydRequest,
@@ -349,13 +381,6 @@ def push_plan_to_stryd(
 
     Converts AI plan workouts to Stryd structured format and uploads them.
     """
-    from sync.stryd_sync import (
-        _login_api,
-        _STRYD_WORKOUT_TYPES,
-        build_workout_blocks,
-        create_workout_api,
-    )
-
     db.rollback()
     import_legacy_stryd_status(
         db,
@@ -363,19 +388,34 @@ def push_plan_to_stryd(
         status_dir=_STRYD_PUSH_STATUS_DIR,
     )
 
-    # Load Stryd credentials
-    load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "sync", ".env"))
-    email = os.environ.get("STRYD_EMAIL")
-    password = os.environ.get("STRYD_PASSWORD")
-    if not email or not password:
-        raise HTTPException(status_code=400, detail="STRYD_EMAIL / STRYD_PASSWORD not configured")
-
-    # Login to Stryd
+    service = PlanDeliveryService(
+        db=db,
+        user_id=current_user_id,
+        target="stryd",
+        adapter_loader=lambda: load_plan_delivery_adapter(
+            db,
+            user_id=current_user_id,
+            target="stryd",
+        ),
+    )
     try:
-        stryd_user_id, token = _login_api(email, password)
-    except Exception as e:
-        logger.error("Stryd login failed: %s", e)
-        raise HTTPException(status_code=502, detail="Stryd login failed. Check your credentials in sync/.env")
+        service.authenticate()
+    except DeliveryCredentialsUnavailable as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="No Stryd credentials. Connect Stryd in Settings first.",
+        ) from exc
+    except DeliveryCredentialsInvalid as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Stored Stryd credentials are unavailable. Reconnect Stryd.",
+        ) from exc
+    except ProviderAuthenticationError as exc:
+        logger.error("Stryd login failed for user=%s", current_user_id)
+        raise HTTPException(
+            status_code=502,
+            detail="Stryd login failed. Reconnect Stryd and try again.",
+        ) from exc
 
     # Analytical views use one preferred plan source, but pushing must always
     # select the AI-authored rows from the complete source set.
@@ -393,22 +433,7 @@ def push_plan_to_stryd(
     if plan_df.empty:
         raise HTTPException(status_code=404, detail="No AI-authored training plan found")
 
-    # Get current CP for block building
-    cp_watts = None
-    latest_cp = data.get("latest_cp")
-    if latest_cp and float(latest_cp) > 0:
-        cp_watts = float(latest_cp)
-    # Fallback: try from latest activities
-    if not cp_watts:
-        activities = data.get("activities", pd.DataFrame())
-        if not isinstance(activities, pd.DataFrame) or activities.empty:
-            pass
-        else:
-            cp_col = "cp_estimate" if "cp_estimate" in activities.columns else None
-            if cp_col:
-                valid_cp = activities[cp_col].dropna()
-                if not valid_cp.empty:
-                    cp_watts = float(valid_cp.iloc[-1])
+    cp_watts = _resolve_stryd_delivery_cp(data)
     if not cp_watts:
         raise HTTPException(
             status_code=422,
@@ -435,7 +460,14 @@ def push_plan_to_stryd(
                 external_id=workout_id,
                 pushed_at=timestamp.isoformat(),
             )
-        except Exception:
+        except (
+            OSError,
+            ValueError,
+            LookupError,
+            json.JSONDecodeError,
+            SQLAlchemyError,
+        ):
+            db.rollback()
             logger.exception(
                 "Delivery persisted but legacy status dual-write failed for user=%s date=%s",
                 current_user_id,
@@ -482,6 +514,15 @@ def push_plan_to_stryd(
                 })
                 db.rollback()
                 continue
+            current_cp_watts = _resolve_stryd_delivery_cp(current_data)
+            if not current_cp_watts:
+                results.append({
+                    "date": workout_date,
+                    "status": "error",
+                    "error": "Critical Power became unavailable before delivery",
+                })
+                db.rollback()
+                continue
 
             row = matching.iloc[0]
             workout_type = str(row.get("workout_type", ""))
@@ -494,98 +535,30 @@ def push_plan_to_stryd(
                 db.rollback()
                 continue
             workout = plan_snapshot(row)
-
-            delivery, delivery_created = get_or_create_delivery(
-                db,
-                user_id=current_user_id,
-                target="stryd",
-                snapshot=workout,
-            )
             existing_stryd_rows = current_all_plans[
                 (current_source == "stryd")
                 & (current_all_plans["date"].astype(str) == workout_date)
             ]
-            if (
-                not existing_stryd_rows.empty
-                and not (delivery.state == "synced" and delivery.external_id)
-            ):
-                results.append({
-                    "date": workout_date,
-                    "status": "error",
-                    "error": (
-                        "A Stryd workout already exists on this date and must "
-                        "be reconciled before delivery"
-                    ),
-                })
-                if delivery_created:
-                    db.delete(delivery)
-                    db.commit()
-                else:
-                    db.rollback()
-                continue
-            unverified = find_unverified_delivery_for_date(
-                db,
-                user_id=current_user_id,
-                target="stryd",
-                workout_date=date.fromisoformat(workout_date),
-            )
-            if unverified is not None:
-                results.append({
-                    "date": workout_date,
-                    "status": "error",
-                    "error": (
-                        "Delivery outcome is uncertain; sync Stryd before retrying"
-                    ),
-                })
-                if delivery_created:
-                    db.delete(delivery)
-                    db.commit()
-                else:
-                    db.rollback()
-                continue
-            delivery, attempt, disposition = begin_delivery_attempt(
-                db,
-                delivery,
-                operation="deliver",
-            )
-            if disposition == "already_complete":
-                external_id = str(delivery.external_id)
-                delivered_at = delivery.delivered_at
-                db.rollback()
-                _write_legacy_compat(
-                    workout_date,
-                    external_id,
-                    delivered_at,
+            observed_external_ids: tuple[str, ...] | None
+            if existing_stryd_rows.empty:
+                observed_external_ids = None
+            elif "external_id" not in existing_stryd_rows.columns:
+                observed_external_ids = ()
+            else:
+                observed_external_ids = tuple(
+                    external_id
+                    for raw_id in existing_stryd_rows["external_id"]
+                    if (external_id := normalize_stryd_workout_id(raw_id))
                 )
-                results.append({
-                    "date": workout_date,
-                    "status": "success",
-                    "workout_id": external_id,
-                })
-                continue
-            if disposition == "reconciliation_required":
-                results.append({
-                    "date": workout_date,
-                    "status": "error",
-                    "error": (
-                        "Delivery outcome is uncertain; sync Stryd before retrying"
-                    ),
-                })
-                if delivery_created:
-                    db.delete(delivery)
-                    db.commit()
-                else:
-                    db.rollback()
-                continue
-            assert attempt is not None
-            delivery_id = delivery.id
-            attempt_id = attempt.id
-            bump_revisions(db, current_user_id, ["plans"])
-            db.commit()
-        except Exception as exc:
+            outcome = service.deliver(
+                workout,
+                threshold_value=current_cp_watts,
+                observed_external_ids=observed_external_ids,
+            )
+        except SQLAlchemyError as exc:
             db.rollback()
             logger.exception(
-                "Failed to start Stryd delivery for user=%s date=%s",
+                "Failed to read current plan for Stryd delivery user=%s date=%s",
                 current_user_id,
                 workout_date,
             )
@@ -596,176 +569,17 @@ def push_plan_to_stryd(
             })
             continue
 
-        def _record_failure(message: str) -> None:
-            try:
-                complete_delivery_attempt(
-                    db,
-                    user_id=current_user_id,
-                    delivery_id=delivery_id,
-                    attempt_id=attempt_id,
-                    attempt_state="failed",
-                    error=message,
-                )
-                bump_revisions(db, current_user_id, ["plans"])
-                db.commit()
-            except Exception:
-                db.rollback()
-                logger.exception(
-                    "Failed to persist Stryd delivery failure for user=%s date=%s",
-                    current_user_id,
-                    workout_date,
-                )
-
-        def _record_conflict(detail: str) -> None:
-            message = (
-                "Stryd delivery outcome is uncertain; sync Stryd before retrying"
-            )
-            try:
-                complete_delivery_attempt(
-                    db,
-                    user_id=current_user_id,
-                    delivery_id=delivery_id,
-                    attempt_id=attempt_id,
-                    attempt_state="conflict",
-                    error=f"{message}: {detail}",
-                )
-                bump_revisions(db, current_user_id, ["plans"])
-                db.commit()
-            except Exception:
-                db.rollback()
-                logger.exception(
-                    "Failed to persist ambiguous Stryd delivery for user=%s date=%s",
-                    current_user_id,
-                    workout_date,
-                )
-
-        try:
-            blocks = build_workout_blocks(workout, cp_watts)
-            stryd_type = _STRYD_WORKOUT_TYPES.get(workout_type.lower(), "")
-            title = f"{workout_type.replace('_', ' ').title()}"
-            description = str(workout.get("workout_description") or "")
-        except Exception as exc:
-            logger.error(
-                "Failed to prepare Stryd workout for %s: %s: %s",
+        result = {"date": workout_date, "status": outcome.status}
+        if outcome.status == "success" and outcome.external_id:
+            result["workout_id"] = outcome.external_id
+            _write_legacy_compat(
                 workout_date,
-                type(exc).__name__,
-                exc,
+                outcome.external_id,
+                outcome.delivered_at,
             )
-            _record_failure(str(exc))
-            results.append({
-                "date": workout_date,
-                "status": "error",
-                "error": str(exc),
-            })
-            continue
-
-        try:
-            result = create_workout_api(
-                user_id=stryd_user_id,
-                token=token,
-                workout_date=workout_date,
-                title=title,
-                blocks=blocks,
-                workout_type=stryd_type,
-                description=description,
-            )
-        except (requests.Timeout, requests.ConnectionError) as e:
-            _record_conflict(str(e))
-            results.append({
-                "date": workout_date,
-                "status": "error",
-                "error": (
-                    "Stryd delivery outcome is uncertain; sync Stryd before retrying"
-                ),
-            })
-            continue
-        except requests.HTTPError as e:
-            detail = str(e)
-            status_code = e.response.status_code if e.response is not None else None
-            if e.response is not None:
-                try:
-                    detail = e.response.json().get("message", detail)
-                except (ValueError, AttributeError):
-                    pass
-            if status_code is None or status_code == 408 or status_code >= 500:
-                _record_conflict(detail)
-                results.append({
-                    "date": workout_date,
-                    "status": "error",
-                    "error": (
-                        "Stryd delivery outcome is uncertain; sync Stryd before retrying"
-                    ),
-                })
-                continue
-            message = f"Stryd API error: {detail}"
-            _record_failure(message)
-            results.append({"date": workout_date, "status": "error", "error": message})
-            continue
-        except Exception as e:
-            logger.error(
-                "Ambiguous Stryd response for %s: %s: %s",
-                workout_date,
-                type(e).__name__,
-                e,
-            )
-            _record_conflict(str(e))
-            results.append({
-                "date": workout_date,
-                "status": "error",
-                "error": (
-                    "Stryd delivery outcome is uncertain; sync Stryd before retrying"
-                ),
-            })
-            continue
-
-        raw_workout_id = result.get("id") if isinstance(result, Mapping) else None
-        workout_id = normalize_stryd_workout_id(raw_workout_id)
-        if not workout_id:
-            _record_conflict("Stryd response did not include a workout id")
-            results.append({
-                "date": workout_date,
-                "status": "error",
-                "error": (
-                    "Stryd delivery outcome is uncertain; sync Stryd before retrying"
-                ),
-            })
-            continue
-        try:
-            complete_delivery_attempt(
-                db,
-                user_id=current_user_id,
-                delivery_id=delivery_id,
-                attempt_id=attempt_id,
-                attempt_state="synced",
-                external_id=workout_id,
-                response=result,
-            )
-            bump_revisions(db, current_user_id, ["plans"])
-            db.commit()
-        except Exception:
-            db.rollback()
-            logger.exception(
-                "Stryd accepted workout but ledger commit failed for user=%s date=%s id=%s",
-                current_user_id,
-                workout_date,
-                workout_id,
-            )
-            results.append({
-                "date": workout_date,
-                "status": "error",
-                "error": "Stryd accepted the workout, but delivery state could not be finalized",
-            })
-            continue
-        results.append({
-            "date": workout_date,
-            "status": "success",
-            "workout_id": workout_id,
-        })
-        _write_legacy_compat(
-            workout_date,
-            workout_id,
-            datetime.now(timezone.utc),
-        )
+        elif outcome.error:
+            result["error"] = outcome.error
+        results.append(result)
 
     return {"results": results}
 
@@ -777,8 +591,6 @@ def delete_stryd_workout(
     db: Session = Depends(get_db),
 ) -> dict:
     """Delete a previously pushed workout from Stryd."""
-    from sync.stryd_sync import _login_api, delete_workout_api
-
     normalized_workout_id = normalize_stryd_workout_id(workout_id)
     if normalized_workout_id is None:
         raise HTTPException(status_code=400, detail="Invalid Stryd workout id")
@@ -790,171 +602,58 @@ def delete_stryd_workout(
         user_id=current_user_id,
         status_dir=_STRYD_PUSH_STATUS_DIR,
     )
-    lock_plan_writes(db, current_user_id)
-    delivery = find_delivery_by_external_id(
-        db,
+    service = PlanDeliveryService(
+        db=db,
         user_id=current_user_id,
         target="stryd",
-        external_id=workout_id,
-    )
-    if delivery is None:
-        db.rollback()
-        raise HTTPException(
-            status_code=404,
-            detail="No Stryd delivery found for this user and workout",
-        )
-
-    previous_state = delivery.state
-    if previous_state == "delivering" and delivery.external_id:
-        # A stale remove attempt can be retried after its lease expires.
-        # Restore the known pre-remove state if the repeated DELETE fails.
-        previous_state = "synced"
-    try:
-        delivery, attempt, disposition = begin_delivery_attempt(
-            db,
-            delivery,
-            operation="remove",
-        )
-        if disposition == "already_complete":
-            db.rollback()
-            try:
-                remove_legacy_stryd_status(
-                    db,
-                    status_dir=_STRYD_PUSH_STATUS_DIR,
-                    user_id=current_user_id,
-                    external_id=workout_id,
-                )
-            except Exception:
-                logger.exception(
-                    "Legacy removal cleanup failed for user=%s workout=%s",
-                    current_user_id,
-                    workout_id,
-                )
-            return {"deleted": True, "workout_id": workout_id}
-        if disposition == "reconciliation_required":
-            db.rollback()
-            raise HTTPException(
-                status_code=409,
-                detail="Stryd workout delivery is already being updated",
-            )
-        assert attempt is not None
-        delivery_id = delivery.id
-        attempt_id = attempt.id
-        bump_revisions(db, current_user_id, ["plans"])
-        db.commit()
-    except HTTPException:
-        raise
-    except Exception as exc:
-        db.rollback()
-        logger.exception(
-            "Failed to start Stryd removal for user=%s workout=%s",
-            current_user_id,
-            workout_id,
-        )
-        raise HTTPException(
-            status_code=500,
-            detail="Could not start Stryd workout removal",
-        ) from exc
-
-    def _record_removal_failure(message: str) -> bool:
-        try:
-            updated = complete_delivery_attempt(
-                db,
-                user_id=current_user_id,
-                delivery_id=delivery_id,
-                attempt_id=attempt_id,
-                attempt_state="failed",
-                delivery_state=previous_state,
-                error=message,
-            )
-            current_delivery = find_delivery_by_external_id(
-                db,
-                user_id=current_user_id,
-                target="stryd",
-                external_id=workout_id,
-            )
-            removed_won = (
-                not updated
-                and current_delivery is not None
-                and current_delivery.state == "removed"
-            )
-            bump_revisions(db, current_user_id, ["plans"])
-            db.commit()
-            return removed_won
-        except Exception:
-            db.rollback()
-            logger.exception(
-                "Failed to persist Stryd removal failure for user=%s workout=%s",
-                current_user_id,
-                workout_id,
-            )
-            return False
-
-    load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "sync", ".env"))
-    email = os.environ.get("STRYD_EMAIL")
-    password = os.environ.get("STRYD_PASSWORD")
-    if not email or not password:
-        _record_removal_failure("STRYD_EMAIL / STRYD_PASSWORD not configured")
-        raise HTTPException(
-            status_code=400,
-            detail="STRYD_EMAIL / STRYD_PASSWORD not configured",
-        )
-
-    try:
-        stryd_user_id, token = _login_api(email, password)
-    except Exception as e:
-        logger.error("Stryd login failed: %s", e)
-        if _record_removal_failure(str(e)):
-            return {"deleted": True, "workout_id": workout_id}
-        raise HTTPException(
-            status_code=502,
-            detail="Stryd login failed. Check your credentials in sync/.env",
-        )
-
-    already_absent = False
-    try:
-        delete_workout_api(stryd_user_id, token, workout_id)
-    except requests.HTTPError as e:
-        if e.response is not None and e.response.status_code == 404:
-            already_absent = True
-        else:
-            if _record_removal_failure(str(e)):
-                return {"deleted": True, "workout_id": workout_id}
-            raise HTTPException(status_code=502, detail=f"Stryd delete failed: {e}")
-    except Exception as e:
-        logger.error("Stryd delete failed: %s", e)
-        if _record_removal_failure(str(e)):
-            return {"deleted": True, "workout_id": workout_id}
-        raise HTTPException(status_code=502, detail="Failed to delete from Stryd")
-
-    try:
-        complete_delivery_attempt(
+        adapter_loader=lambda: load_plan_delivery_adapter(
             db,
             user_id=current_user_id,
-            delivery_id=delivery_id,
-            attempt_id=attempt_id,
-            attempt_state="removed",
-            external_id=workout_id,
-            response={"already_absent": already_absent},
-        )
-        db.query(TrainingPlan).filter(
-            TrainingPlan.user_id == current_user_id,
-            TrainingPlan.source == "stryd",
-            TrainingPlan.external_id == workout_id,
-        ).delete(synchronize_session=False)
-        bump_revisions(db, current_user_id, ["plans"])
-        db.commit()
-    except Exception as exc:
-        db.rollback()
-        logger.exception(
-            "Stryd workout deleted but ledger finalization failed for user=%s workout=%s",
-            current_user_id,
-            workout_id,
-        )
+            target="stryd",
+        ),
+    )
+    try:
+        service.remove(workout_id)
+    except DeliveryNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except DeliveryBusyError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except DeliveryAccountMismatchError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except DeliveryAccountVerificationError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except DeliveryCredentialsUnavailable as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="No Stryd credentials. Connect Stryd in Settings first.",
+        ) from exc
+    except DeliveryCredentialsInvalid as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Stored Stryd credentials are unavailable. Reconnect Stryd.",
+        ) from exc
+    except ProviderAuthenticationError as exc:
+        logger.error("Stryd login failed for user=%s", current_user_id)
+        raise HTTPException(
+            status_code=502,
+            detail="Stryd login failed. Reconnect Stryd and try again.",
+        ) from exc
+    except DeliveryStartError as exc:
         raise HTTPException(
             status_code=500,
-            detail="Stryd workout was deleted, but delivery state could not be finalized",
+            detail=str(exc),
         ) from exc
+    except DeliveryRemovalFailedError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Stryd delete failed: {exc}",
+        ) from exc
+    except DeliveryFinalizationError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=str(exc),
+        ) from exc
+
     try:
         remove_legacy_stryd_status(
             db,
@@ -962,7 +661,8 @@ def delete_stryd_workout(
             user_id=current_user_id,
             external_id=workout_id,
         )
-    except Exception:
+    except (OSError, ValueError, json.JSONDecodeError):
+        db.rollback()
         logger.exception(
             "Stryd removal persisted but legacy status dual-write failed for user=%s workout=%s",
             current_user_id,

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -329,27 +329,27 @@ def complete_garmin_mfa(user_id: str, code: str) -> dict:
 def _get_credentials(user_id: str, platform: str, db: Session) -> dict | None:
     """Get decrypted credentials for a user's platform connection.
 
-    Returns credential dict or None if not connected. Falls back to env vars
-    when auth is disabled (dev mode).
+    Returns credential dict or None if not connected.
     """
-    from db.models import UserConnection
+    from db.connection_credentials import (
+        CredentialAccessError,
+        load_connection_credentials,
+    )
 
-    conn = db.query(UserConnection).filter(
-        UserConnection.user_id == user_id,
-        UserConnection.platform == platform,
-    ).first()
-
-    if conn and conn.encrypted_credentials and conn.wrapped_dek:
-        from db.crypto import get_vault
-        vault = get_vault()
-        try:
-            creds_json = vault.decrypt(conn.encrypted_credentials, conn.wrapped_dek)
-            return json.loads(creds_json)
-        except Exception as e:
-            logger.warning("Failed to decrypt credentials for %s/%s: %s",
-                           user_id, platform, e)
-
-    return None
+    try:
+        return load_connection_credentials(
+            db,
+            user_id=user_id,
+            platform=platform,
+        )
+    except CredentialAccessError as exc:
+        logger.warning(
+            "Failed to decode credentials for user=%s platform=%s: %s",
+            user_id,
+            platform,
+            exc,
+        )
+        return None
 
 
 def _persist_credentials(user_id: str, platform: str, creds: dict, db: Session) -> None:

--- a/db/connection_credentials.py
+++ b/db/connection_credentials.py
@@ -1,0 +1,63 @@
+"""Shared access to encrypted per-user platform credentials."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from azure.core.exceptions import AzureError
+from cryptography.fernet import InvalidToken
+from sqlalchemy.orm import Session
+
+from db.crypto import get_vault
+from db.models import UserConnection
+
+
+class CredentialAccessError(RuntimeError):
+    """Stored platform credentials exist but cannot be decoded safely."""
+
+
+def load_connection_credentials(
+    db: Session,
+    *,
+    user_id: str,
+    platform: str,
+) -> dict[str, Any] | None:
+    """Return decrypted credentials for one user's platform connection."""
+    connection = db.query(UserConnection).filter(
+        UserConnection.user_id == user_id,
+        UserConnection.platform == platform,
+    ).first()
+    if (
+        connection is None
+        or not connection.encrypted_credentials
+        or not connection.wrapped_dek
+    ):
+        return None
+
+    try:
+        raw = get_vault().decrypt(
+            connection.encrypted_credentials,
+            connection.wrapped_dek,
+        )
+    except (
+        AzureError,
+        InvalidToken,
+        TypeError,
+        UnicodeDecodeError,
+        ValueError,
+    ) as exc:
+        raise CredentialAccessError(
+            f"Stored {platform} credentials could not be decrypted"
+        ) from exc
+
+    try:
+        credentials = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError) as exc:
+        raise CredentialAccessError(
+            f"Stored {platform} credentials are malformed"
+        ) from exc
+    if not isinstance(credentials, dict):
+        raise CredentialAccessError(
+            f"Stored {platform} credentials must be an object"
+        )
+    return credentials

--- a/db/models.py
+++ b/db/models.py
@@ -527,10 +527,15 @@ class PlanDelivery(Base):
     )
     canonical_key = Column(String(120), nullable=False)
     workout_date = Column(Date, nullable=False)
+    # Provider-payload fingerprint. This legacy column name is retained so
+    # existing uniqueness constraints continue to fence duplicate writes.
     workout_version = Column(String(64), nullable=False)
+    # Canonical Praxys plan-content version used by API sync-state projection.
+    plan_version = Column(String(64), nullable=True)
     target = Column(String(20), nullable=False)
     state = Column(String(20), nullable=False, default="pending")
     external_id = Column(String(200), nullable=True)
+    provider_account_id = Column(String(200), nullable=True)
     last_error = Column(Text, nullable=True)
     delivered_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/db/plan_ledger.py
+++ b/db/plan_ledger.py
@@ -259,13 +259,15 @@ def get_or_create_delivery(
     target: str,
     snapshot: Mapping[str, Any] | Any,
     workout_version_override: str | None = None,
+    plan_version_override: str | None = None,
 ) -> tuple[PlanDelivery, bool]:
     """Return the stable delivery row for a workout version and target."""
     lock_plan_writes(db, user_id)
     normalized = plan_snapshot(snapshot)
     workout_date = date.fromisoformat(str(normalized["date"]))
     key = canonical_workout_key(normalized)
-    version = workout_version_override or workout_version(normalized)
+    plan_version = plan_version_override or workout_version(normalized)
+    version = workout_version_override or plan_version
     existing = db.execute(
         select(PlanDelivery).where(
             PlanDelivery.user_id == user_id,
@@ -275,6 +277,8 @@ def get_or_create_delivery(
         )
     ).scalar_one_or_none()
     if existing is not None:
+        if existing.plan_version != plan_version:
+            existing.plan_version = plan_version
         return existing, False
 
     delivery = PlanDelivery(
@@ -282,6 +286,7 @@ def get_or_create_delivery(
         canonical_key=key,
         workout_date=workout_date,
         workout_version=version,
+        plan_version=plan_version,
         target=target,
         state="pending",
     )
@@ -298,6 +303,8 @@ def get_or_create_delivery(
                 PlanDelivery.workout_version == version,
             )
         ).scalar_one()
+        if delivery.plan_version != plan_version:
+            delivery.plan_version = plan_version
         return delivery, False
     return delivery, True
 
@@ -333,15 +340,19 @@ def begin_delivery_attempt(
     ).scalars().all()
     locked = next(row for row in slot_rows if row.id == delivery.id)
 
-    if operation == "deliver" and any(
-        row.id != locked.id
-        and (
-            row.state in {"delivering", "conflict"}
-            or (row.state == "synced" and row.external_id is not None)
-        )
-        for row in slot_rows
-    ):
-        return locked, None, "reconciliation_required"
+    if operation == "deliver":
+        if any(
+            row.id != locked.id and row.state in {"delivering", "conflict"}
+            for row in slot_rows
+        ):
+            return locked, None, "reconciliation_required"
+        if any(
+            row.id != locked.id
+            and row.state == "synced"
+            and row.external_id is not None
+            for row in slot_rows
+        ):
+            return locked, None, "replacement_required"
 
     if operation == "deliver" and locked.state == "synced" and locked.external_id:
         return locked, None, "already_complete"
@@ -401,6 +412,7 @@ def complete_delivery_attempt(
     external_id: str | None = None,
     error: str | None = None,
     response: Mapping[str, Any] | None = None,
+    provider_account_id: str | None = None,
 ) -> bool:
     """Stage a terminal result if this attempt still owns the delivery."""
     if attempt_state not in PLAN_DELIVERY_STATES:
@@ -478,6 +490,8 @@ def complete_delivery_attempt(
 
     locked_delivery.state = final_delivery_state
     locked_delivery.external_id = external_id or locked_delivery.external_id
+    if provider_account_id is not None:
+        locked_delivery.provider_account_id = provider_account_id
     locked_delivery.last_error = error
     locked_delivery.updated_at = now
     if final_delivery_state == "synced":
@@ -554,12 +568,15 @@ def delivery_status_for_snapshots(
     for delivery in rows:
         date_key = delivery.workout_date.isoformat()
         current_version = current_versions.get(date_key)
+        delivery_plan_version = (
+            delivery.plan_version or delivery.workout_version
+        )
         if (
             not include_prior_versions
-            and delivery.workout_version != current_version
+            and delivery_plan_version != current_version
         ):
             continue
-        priority = int(current_version == delivery.workout_version)
+        priority = int(current_version == delivery_plan_version)
         if priority < priorities.get(date_key, -1):
             continue
         entry = {
@@ -954,6 +971,7 @@ def _import_legacy_stryd_status_locked(
                 target="stryd",
                 snapshot=snapshot,
                 workout_version_override=legacy_unknown_version(snapshot),
+                plan_version_override=legacy_unknown_version(snapshot),
             )
             if (
                 not created

--- a/db/session.py
+++ b/db/session.py
@@ -387,6 +387,10 @@ _SQLITE_COMPAT_COLUMNS: dict[str, tuple[tuple[str, str], ...]] = {
         ("today_decision_check_shown_at", "DATETIME"),
         ("today_decision_check_submitted_at", "DATETIME"),
     ),
+    "plan_deliveries": (
+        ("plan_version", "VARCHAR(64)"),
+        ("provider_account_id", "VARCHAR(200)"),
+    ),
 }
 
 
@@ -405,6 +409,12 @@ def _ensure_sqlite_compat_columns(engine_obj) -> None:
                     f'ALTER TABLE "{table}" ADD COLUMN "{column}" {ddl_type}'
                 )
                 logger.info("Added SQLite compatibility column %s.%s", table, column)
+            if table == "plan_deliveries":
+                conn.exec_driver_sql(
+                    'UPDATE "plan_deliveries" '
+                    'SET "plan_version" = "workout_version" '
+                    'WHERE "plan_version" IS NULL'
+                )
 
 
 def _ensure_schema(engine_obj, backend: str) -> None:

--- a/db/sync_scheduler.py
+++ b/db/sync_scheduler.py
@@ -4,12 +4,13 @@ Runs as a daemon thread started on app boot. Every CHECK_INTERVAL seconds,
 scans user_connections for stale entries and triggers sync for each.
 Syncs are staggered (one at a time, small delay between) to avoid rate limits.
 """
-import json
 import logging
 import os
 import threading
 import time
 from datetime import datetime, timedelta
+
+from db.connection_credentials import CredentialAccessError
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,9 @@ def classify_sync_failure(exc: BaseException) -> tuple[str, bool]:
       browser before reconnecting. The marker survives the library's
       "All login strategies exhausted: …" wrapping because the wrapped
       response dict is preserved in the message.
+    * ``CredentialAccessError`` — the encrypted connection exists but its
+      envelope cannot be opened or decoded. Waiting cannot repair stored
+      ciphertext; the user must reconnect to replace it.
 
     Anything else is treated as transient — the caller applies exponential
     backoff and tries again later.
@@ -85,6 +89,8 @@ def classify_sync_failure(exc: BaseException) -> tuple[str, bool]:
     msg = str(exc) or ""
 
     if cls_name == "GarminConnectAuthenticationError":
+        return ("auth_required", True)
+    if isinstance(exc, CredentialAccessError):
         return ("auth_required", True)
     if "CAPTCHA_REQUIRED" in msg:
         return ("auth_required", True)
@@ -347,21 +353,26 @@ def _sync_connection(user_id: str, platform: str, db):
 
     Uses the sync route's fetch + DB write functions (no CSV intermediate).
     """
+    from db.connection_credentials import load_connection_credentials
     from db.models import UserConnection
-    from db.crypto import get_vault
 
     conn = db.query(UserConnection).filter(
         UserConnection.user_id == user_id,
         UserConnection.platform == platform,
     ).first()
-    if not conn or not conn.encrypted_credentials:
+    if not conn:
         logger.warning("No credentials for user=%s platform=%s", user_id, platform)
         return
 
-    # Decrypt credentials
-    vault = get_vault()
-    creds_json = vault.decrypt(conn.encrypted_credentials, conn.wrapped_dek)
-    creds = json.loads(creds_json)
+    credentials = load_connection_credentials(
+        db,
+        user_id=user_id,
+        platform=platform,
+    )
+    if credentials is None:
+        logger.warning("No credentials for user=%s platform=%s", user_id, platform)
+        return
+    creds = credentials
 
     # Use the sync route's direct DB write functions
     from api.routes.sync import (

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -735,9 +735,9 @@ returned as `source='stryd'` workout rows.
 `sync_state` is one of:
 - `synced` — Stryd has a matching workout whose id equals the one we
   logged on push (a re-push is a no-op).
-- `mismatch` — Stryd has a workout on this date but we don't recognise
-  its id (user-edited on Stryd, or never pushed). The UI confirms before
-  overwriting.
+- `mismatch` — Stryd has a workout on this date but Praxys does not recognise
+  its ID as the current managed delivery. The backend will not overwrite an
+  unowned workout; clients should ask the user to resolve the conflict.
 - `not_synced` — No Stryd workout on this date.
 
 `sync_target` is `"stryd"` when the user has a Stryd connection, else
@@ -747,13 +747,23 @@ returned as `source='stryd'` workout rows.
 
 Push only Praxys-authored plan rows (`source = "ai"`) to the Stryd calendar. Imported Stryd rows are never eligible, even when they are the analytically preferred plan source.
 
-Delivery identity is `(user, target, canonical workout key, workout content
-version)`. Retrying a definite provider rejection appends an attempt to the same
-delivery row. Ambiguous post-send outcomes require reconciliation, and an edited
-version cannot be delivered until the prior provider workout is removed.
-Retrying an already-synced version returns its existing workout id without
-creating a duplicate on Stryd. If a different Stryd workout already exists on
-the requested date, delivery is blocked before the provider create call.
+The endpoint authenticates with the caller's encrypted Stryd
+`UserConnection`; global environment credentials are never shared across
+users. Missing or unreadable stored credentials return `400` with a reconnect
+instruction, and a provider login rejection returns `502`. The only environment
+fallback is local development with an explicit
+`PRAXYS_STRYD_ENV_USER_ID=<authenticated-user-id>` pin.
+
+Delivery identity is `(user, target, canonical workout key, provider-payload
+fingerprint)`. The fingerprint covers the exact transformed request, including
+CP-derived workout blocks; the canonical Praxys content version is tracked
+separately for UI sync state. Retrying a definite provider rejection appends an
+attempt to the same delivery row. Ambiguous post-send outcomes require
+reconciliation, and an edited payload cannot be delivered until the prior
+Praxys-managed provider workout is removed. Retrying an already-synced payload
+returns its existing workout ID without creating a duplicate. When calendar
+data is present, the observed provider ID must match a caller-owned ledger ID;
+an external workout is blocked before the provider create call.
 
 **Request body:**
 ```json
@@ -777,6 +787,16 @@ successful delivery state. An interrupted removal can be retried after its lease
 expires; attempt fencing prevents a late superseded result from undoing the
 newer outcome. The workout ID must belong to the caller's delivery ledger;
 unknown IDs return `404` before any Stryd request.
+
+Removal uses the same caller-owned encrypted connection. Unknown IDs are
+rejected before credentials are loaded. New deliveries also persist the
+authenticated provider account identity, so reconnecting a different Stryd
+account blocks deletion with `409`. Credential/authentication failures occur
+before the provider attempt; provider and finalization failures remain explicit
+and never return a success-shaped fallback. Migrated rows that predate stored
+provider-account identity are verified against the live current-account
+calendar before their first removal; a missing/moved ID requires reconciliation
+instead of treating a cross-account `404` as success.
 
 ### POST /api/plan/upload
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -29,6 +29,7 @@ Garmin/Stryd/Oura APIs
    ├── users.py          FastAPI-Users integration
    ├── deps.py           Data layer (get_dashboard_data())
    ├── ai.py             AI context builder + plan validation
+   ├── plan_delivery/    Provider-neutral workout delivery + adapters
    └── routes/           Thin endpoint handlers
         |
    ┌────┴────────────┐
@@ -79,7 +80,7 @@ Training data is stored in a SQLite database (`DATA_DIR/trainsight.db`) via SQLA
 | `FitnessData` | `fitness_data` | Per-metric fitness tracking (VO2max, CP estimate, LTHR, max HR) |
 | `TrainingPlan` | `training_plans` | Planned workouts from Stryd or AI (targets, description, meta) |
 | `PlanRevision` | `plan_revisions` | Append-only plan mutation events with actor/origin and before/after snapshots |
-| `PlanDelivery` | `plan_deliveries` | Provider-neutral current state for one canonical workout content version and target |
+| `PlanDelivery` | `plan_deliveries` | Provider-neutral state for one canonical workout/provider-payload version, including plan-version and provider-account fencing |
 | `PlanDeliveryAttempt` | `plan_delivery_attempts` | Append-only deliver/remove/import attempt history |
 
 **Session management** (`db/session.py`):
@@ -87,9 +88,11 @@ Training data is stored in a SQLite database (`DATA_DIR/trainsight.db`) via SQLA
 - `get_db()` is a FastAPI dependency yielding sync sessions
 - `get_async_db()` yields async sessions for FastAPI-Users
 
-### Auto-Migration
+### Schema Migration
 
-`init_db()` in `db/session.py` includes a lightweight migration system that runs on every startup. After `create_all()` (which only creates new tables), it inspects existing tables for missing columns and runs `ALTER TABLE ... ADD COLUMN` statements. This avoids needing a full Alembic setup for simple schema additions. New columns are registered in the `_migrations` list inside `init_db()`.
+SQLite development databases use `create_all()` plus narrow additive
+compatibility columns in `db/session.py`. PostgreSQL deployments run Alembic
+to the current head during startup.
 
 ### Authentication
 
@@ -114,6 +117,20 @@ Platform credentials (Garmin/Stryd passwords, Oura tokens) are stored encrypted 
 4. Both `encrypted_credentials` and `wrapped_dek` are stored as binary columns on `UserConnection`
 
 If `KEY_VAULT_URL` is set, the `CredentialVault` initializes an Azure `CryptographyClient`. Otherwise, it falls back to local Fernet encryption. If neither is configured, it generates an ephemeral key and logs a warning (credentials will not survive restarts).
+
+### Plan Delivery Boundary
+
+`api/plan_delivery/` separates provider-neutral orchestration from Stryd API
+details. The service authenticates before starting a durable attempt, scopes
+credentials and ledger rows to the authenticated Praxys user, and records a
+fingerprint of the exact provider payload (including CP-derived workout
+blocks). The canonical Praxys plan version remains separate so API sync state
+does not depend on provider-specific serialization.
+
+Successful creates persist the authenticated provider account ID. A later
+delete is refused if the user has reconnected a different provider account.
+Replacement is intentionally a confirmed delete followed by create so a
+partial failure is explicit and recoverable rather than success-shaped.
 
 ### Admin System
 
@@ -193,7 +210,13 @@ Plan mutations write immutable `PlanRevision` events in the same transaction as
 their `TrainingPlan` changes. Platform delivery rows are keyed by a stable
 logical workout slot plus a SHA-256 fingerprint of delivery-relevant content;
 attempts append beneath that identity, so a retry cannot duplicate a successful
-delivery of the same version. The former per-user Stryd push-status JSON is
+delivery of the same version. Provider writes run through
+`api/plan_delivery/`: the service owns ledger transitions and fencing, while
+provider adapters own authentication plus create/delete/calendar operations.
+Adapters receive credentials resolved from the caller's encrypted
+`UserConnection`; the Stryd adapter never reads another user's connection.
+
+The former per-user Stryd push-status JSON is
 lazy-reconciled through an ordered snapshot cursor. During rolling deployment it
 is retained and dual-written after successful push/delete operations so old
 workers remain compatible; additions, replacements, and removals are reflected

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -32,7 +32,7 @@ transient — the next deploy overwrites them.**
 | `WECHAT_MINIAPP_UPLOAD_KEY` | Mini program CI upload key | `miniapp-publish.yml` |
 | `COPILOT_ASSIGN_TOKEN` | **Required for workflow auto-assign** — fine-grained PAT (*Issues: write*, this repo only, with expiry). Agent assignment needs a user token; the built-in `GITHUB_TOKEN` is forbidden (issue #400). Manual UI assignment doesn't need it. | `assign-copilot.yml` |
 | `PRAXYS_GITHUB_APP_PRIVATE_KEY` | Feedback GitHub App private key. The app has Issues read/write and Pull requests read; tokens are minted on demand. | App Service setting (backend) |
-| `PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY` | Independent selective-review App key. The App has Contents write + Pull requests write solely to approve qualifying PRs and enable normal auto-merge. | `selective-review.yml` |
+| `PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY` | Independent selective-review App key. The App has Contents write + Pull requests write solely to approve qualifying PRs and enable normal auto-merge. Optional while every PR is review-required; mandatory only for an autonomous candidate or stale policy-state cleanup. | `selective-review.yml` |
 
 ### GitHub Actions → Variables
 `… → Variables` (non-secret; build variables are inlined into the SPA and ship to browsers)
@@ -52,7 +52,8 @@ transient — the next deploy overwrites them.**
 | `PRAXYS_PG_SERVER` | Postgres Flexible Server name. **Reserved / currently unused** - the on-demand backup jobs it gated were removed (Burstable tier can't do on-demand backups; PITR covers backup). Kept for a future off-site backup job. | (reserved) |
 | `PRAXYS_GITHUB_APP_ID` / `PRAXYS_GITHUB_APP_INSTALLATION_ID` | Feedback GitHub App identifiers. | App Service setting (backend) |
 | `PRAXYS_FEEDBACK_GITHUB_REPO` / `PRAXYS_FEEDBACK_GITHUB_LABELS` / `PRAXYS_FEEDBACK_GITHUB_ASSIGNEES` | Feedback issue target and optional issue metadata. | App Service setting (backend) |
-| `PRAXYS_REVIEW_POLICY_APP_ID` | App ID for the independent selective-review GitHub App. | `selective-review.yml` |
+| `PRAXYS_REVIEW_POLICY_APP_ID` | App ID for the independent selective-review GitHub App. Optional on ordinary review-required runs. | `selective-review.yml` |
+| `PRAXYS_REVIEW_POLICY_APP_SLUG` | Expected URL slug for the independent App, without `[bot]`; lets pre-credential evaluation recognize only that App's prior blocking reviews and verifies the minted identity. | `selective-review.yml`, `selective-review-emergency-stop.yml` |
 | `PRAXYS_SELECTIVE_REVIEW_ENABLED` | Master enable; absent/anything except `true` keeps every PR review-required. | `selective-review.yml` |
 | `PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH` | Emergency stop; `true` disables approval even when the master enable and class promotion are active. | `selective-review.yml` |
 
@@ -171,6 +172,21 @@ comes from the secrets/variables above.
 Local only; never committed. See [`.env.example`](../../.env.example) for the full
 annotated list. Minimum: `PRAXYS_LOCAL_ENCRYPTION_KEY` (Fernet); `PRAXYS_ENV=development`
 to boot without a JWT secret.
+
+Platform credentials used by sync and plan delivery are encrypted per user in
+`user_connections`; production does not read global `STRYD_EMAIL` /
+`STRYD_PASSWORD` values for API writes. A legacy local-only fallback is
+available when all three conditions hold:
+
+- `PRAXYS_ENV=development` in the root `.env` or process environment (the
+  server intentionally does not accept this opt-in from `sync/.env`);
+- `PRAXYS_STRYD_ENV_USER_ID` exactly matches the authenticated Praxys user ID;
+- `STRYD_EMAIL` and `STRYD_PASSWORD` are present in the process environment or
+  `sync/.env`.
+
+The explicit user-ID pin prevents one local account from borrowing another
+account's environment credentials. Do not add these values to
+`deploy-backend.yml`, GitHub Actions, or App Service settings.
 
 ### Application Insights trust boundary (#417)
 
@@ -401,8 +417,11 @@ to the Copilot coding agent. These are **repo settings, not deploy-managed**:
   `PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH=true` stops approval immediately. The
   independent App identity is
   `PRAXYS_REVIEW_POLICY_APP_ID` +
+  `PRAXYS_REVIEW_POLICY_APP_SLUG` +
   `PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY`; workflows derive the exact bot login
-  from the minted token's App slug. Provisioning:
+  from the minted token and verify it against the configured slug. These App
+  values may remain absent while the committed policy is unpromoted/default-off;
+  review-required runs do not inspect them. Provisioning:
   [setup-review-policy-app.md](./setup-review-policy-app.md).
 - The repository setting **Allow auto-merge** is enabled once for
   `selective-review.yml`. Auto-merge remains squash-only and obeys the active

--- a/sync/.env.example
+++ b/sync/.env.example
@@ -3,7 +3,12 @@ GARMIN_EMAIL=your_email@example.com
 GARMIN_PASSWORD=your_password
 GARMIN_IS_CN=true  # Set to "true" for Garmin Connect China (connect.garmin.cn)
 
-# Stryd (user ID is auto-derived from login)
+# Stryd legacy local credentials (user ID is auto-derived from login).
+# API workout delivery normally uses the encrypted per-user connection stored
+# through Settings. To use these values for a local development account, set
+# PRAXYS_ENV=development in the root .env or process environment, then pin the
+# exact Praxys user ID below. This file cannot opt the server into dev mode.
+PRAXYS_STRYD_ENV_USER_ID=
 STRYD_EMAIL=your_stryd_email
 STRYD_PASSWORD=your_stryd_password
 

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -335,6 +335,7 @@ def fetch_training_plan_api(
     cp_watts: float | None = None,
     days_ahead: int = 14,
     tz_name: str | None = None,
+    days_back: int = 0,
 ) -> list[dict]:
     """Fetch upcoming planned workouts from the Stryd calendar API.
 
@@ -345,11 +346,13 @@ def fetch_training_plan_api(
     Args:
         cp_watts: Current CP in watts (for converting % targets to absolute watts).
                   If None, power targets are omitted.
+        days_back: Extra server-calendar days to include before today.
     """
     today = date.today()
+    start = today - timedelta(days=max(days_back, 0))
     end = today + timedelta(days=days_ahead)
 
-    from_ts = int(datetime.combine(today, datetime.min.time()).timestamp())
+    from_ts = int(datetime.combine(start, datetime.min.time()).timestamp())
     to_ts = int(datetime.combine(end, datetime.max.time()).timestamp())
 
     url = STRYD_CALENDAR_API.format(user_id=user_id)

--- a/tests/test_plan_delivery_adapter.py
+++ b/tests/test_plan_delivery_adapter.py
@@ -1,0 +1,218 @@
+"""Provider-neutral plan-delivery adapter tests."""
+import pytest
+import requests
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.plan_delivery.base import (
+    PlanDeliveryAdapter,
+    ProviderAuthenticationError,
+)
+from api.plan_delivery.service import PlanDeliveryService
+from api.plan_delivery.stryd import StrydPlanDeliveryAdapter
+
+
+def test_stryd_adapter_implements_contract_and_reuses_login(monkeypatch):
+    calls = {"login": 0, "calendar": 0, "delete": 0}
+
+    def _login(email: str, password: str) -> tuple[str, str]:
+        calls["login"] += 1
+        assert (email, password) == ("runner@example.test", "secret")
+        return "provider-user", "provider-token"
+
+    def _calendar(
+        user_id: str,
+        token: str,
+        *,
+        cp_watts: float | None,
+        days_ahead: int,
+        days_back: int,
+        tz_name: str | None,
+    ) -> list[dict]:
+        calls["calendar"] += 1
+        assert (user_id, token) == ("provider-user", "provider-token")
+        assert (cp_watts, days_ahead, days_back, tz_name) == (
+            280.0,
+            21,
+            0,
+            "Asia/Shanghai",
+        )
+        return [{"date": "2026-08-01", "external_id": "calendar-id"}]
+
+    def _delete(user_id: str, token: str, external_id: str) -> bool:
+        calls["delete"] += 1
+        assert (user_id, token, external_id) == (
+            "provider-user",
+            "provider-token",
+            "calendar-id",
+        )
+        return True
+
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    monkeypatch.setattr("sync.stryd_sync.fetch_training_plan_api", _calendar)
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", _delete)
+
+    adapter = StrydPlanDeliveryAdapter({
+        "email": "runner@example.test",
+        "password": "secret",
+    })
+
+    assert isinstance(adapter, PlanDeliveryAdapter)
+    assert adapter.fetch_calendar(
+        threshold_value=280.0,
+        days_ahead=21,
+        timezone_name="Asia/Shanghai",
+    ) == [{"date": "2026-08-01", "external_id": "calendar-id"}]
+    assert adapter.account_id == "provider-user"
+    assert adapter.delete_workout("calendar-id").already_absent is False
+    assert calls == {"login": 1, "calendar": 1, "delete": 1}
+
+
+def test_stryd_adapter_treats_missing_delete_as_already_absent(monkeypatch):
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("provider-user", "provider-token"),
+    )
+
+    def _missing(user_id: str, token: str, external_id: str) -> bool:
+        response = requests.Response()
+        response.status_code = 404
+        raise requests.HTTPError("not found", response=response)
+
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", _missing)
+    adapter = StrydPlanDeliveryAdapter({
+        "email": "runner@example.test",
+        "password": "secret",
+    })
+
+    assert adapter.delete_workout("missing-id").already_absent is True
+
+
+def test_stryd_adapter_sends_the_prepared_payload_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("provider-user", "provider-token"),
+    )
+    captured: dict = {}
+
+    def _create(**kwargs):
+        captured.update(kwargs)
+        return {"id": "created-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    adapter = StrydPlanDeliveryAdapter({
+        "email": "runner@example.test",
+        "password": "secret",
+    })
+    prepared = adapter.prepare_workout(
+        {
+            "date": "2026-08-02",
+            "workout_type": "threshold",
+            "planned_duration_min": 60,
+            "workout_description": "WU 10min, 3x3min @275-290W w/ 3min, CD 10min",
+        },
+        threshold_value=280.0,
+    )
+
+    result = adapter.create_workout(prepared)
+
+    assert result.external_id == "created-id"
+    assert result.provider_account_id == "provider-user"
+    assert {
+        key: value
+        for key, value in captured.items()
+        if key not in {"user_id", "token"}
+    } == prepared.request
+
+
+def test_stryd_prepared_payload_is_stable_and_tracks_threshold():
+    adapter = StrydPlanDeliveryAdapter({
+        "email": "runner@example.test",
+        "password": "secret",
+    })
+    workout = {
+        "date": "2026-08-02",
+        "workout_type": "threshold",
+        "planned_duration_min": 60,
+        "workout_description": "20min @250-270W",
+    }
+
+    first = adapter.prepare_workout(workout, threshold_value=280.0)
+    repeated = adapter.prepare_workout(workout, threshold_value=280.0)
+    changed = adapter.prepare_workout(workout, threshold_value=285.0)
+
+    assert first == repeated
+    assert first.version != changed.version
+
+
+def test_delivery_authenticates_before_starting_ledger_attempt(tmp_path):
+    from db.models import Base, PlanDelivery, PlanDeliveryAttempt, User
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'delivery.db'}")
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    db.add(User(
+        id="auth-failure-user",
+        email="auth-failure@example.test",
+        hashed_password="test",
+    ))
+    db.commit()
+
+    class AuthFailureAdapter:
+        target = "stryd"
+        display_name = "Stryd"
+
+        @property
+        def account_id(self) -> str:
+            raise AssertionError("account_id must not be read after failed auth")
+
+        def authenticate(self) -> None:
+            raise ProviderAuthenticationError("login failed")
+
+        def prepare_workout(self, workout, *, threshold_value):
+            from api.plan_delivery.base import PreparedWorkoutDelivery
+
+            return PreparedWorkoutDelivery(
+                version="a" * 64,
+                request={},
+            )
+
+        def create_workout(self, prepared):
+            raise AssertionError("create must not run")
+
+        def delete_workout(self, external_id):
+            raise AssertionError("delete must not run")
+
+        def fetch_calendar(
+            self,
+            *,
+            threshold_value=None,
+            days_ahead=14,
+            days_back=0,
+            timezone_name=None,
+        ):
+            raise AssertionError("calendar must not run")
+
+    service = PlanDeliveryService(
+        db=db,
+        user_id="auth-failure-user",
+        target="stryd",
+        adapter_loader=AuthFailureAdapter,
+    )
+
+    try:
+        with pytest.raises(ProviderAuthenticationError):
+            service.deliver(
+                {
+                    "date": "2026-08-03",
+                    "source": "ai",
+                    "workout_type": "easy",
+                },
+                threshold_value=280.0,
+                observed_external_ids=None,
+            )
+        assert db.query(PlanDelivery).count() == 0
+        assert db.query(PlanDeliveryAttempt).count() == 0
+    finally:
+        db.close()
+        engine.dispose()

--- a/tests/test_plan_ledger.py
+++ b/tests/test_plan_ledger.py
@@ -76,4 +76,85 @@ def test_alembic_head_includes_plan_ledger():
 
     config = Config("alembic.ini")
     script = ScriptDirectory.from_config(config)
-    assert script.get_current_head() == "2b3c4d5e6f70"
+    assert script.get_current_head() == "3c4d5e6f7081"
+
+
+def test_sqlite_init_backfills_delivery_identity_columns(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine, inspect, text
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("PRAXYS_DATABASE_URL", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    sqlite_path = tmp_path / "trainsight.db"
+    legacy = create_engine(f"sqlite:///{sqlite_path}")
+    with legacy.begin() as conn:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE plan_deliveries (
+                id VARCHAR(36) PRIMARY KEY,
+                user_id VARCHAR(36) NOT NULL,
+                canonical_key VARCHAR(120) NOT NULL,
+                workout_date DATE NOT NULL,
+                workout_version VARCHAR(64) NOT NULL,
+                target VARCHAR(20) NOT NULL,
+                state VARCHAR(20) NOT NULL,
+                external_id VARCHAR(200),
+                last_error TEXT,
+                delivered_at DATETIME,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            INSERT INTO plan_deliveries (
+                id, user_id, canonical_key, workout_date, workout_version,
+                target, state, created_at, updated_at
+            ) VALUES (
+                'legacy-delivery', 'legacy-user', 'ai:2026-08-04',
+                '2026-08-04', 'legacy-version', 'stryd', 'pending',
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
+            """
+        )
+    legacy.dispose()
+
+    from db import session as db_session
+
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    try:
+        db_session.init_db()
+        columns = {
+            column["name"]
+            for column in inspect(db_session.engine).get_columns(
+                "plan_deliveries"
+            )
+        }
+        assert {"plan_version", "provider_account_id"}.issubset(columns)
+        with db_session.engine.connect() as conn:
+            plan_version = conn.execute(
+                text(
+                    "SELECT plan_version FROM plan_deliveries "
+                    "WHERE id = 'legacy-delivery'"
+                )
+            ).scalar_one()
+        assert plan_version == "legacy-version"
+    finally:
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None

--- a/tests/test_stryd_push_status_endpoints.py
+++ b/tests/test_stryd_push_status_endpoints.py
@@ -2,7 +2,7 @@
 import json
 import os
 import tempfile
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -45,7 +45,8 @@ def api_client(monkeypatch, tmp_path):
     def _override_current_user():
         user_id = current_user_id["value"]
         if user_id not in ensured_users:
-            from db.models import User
+            from db.crypto import get_vault
+            from db.models import User, UserConnection
 
             db = db_session.SessionLocal()
             try:
@@ -54,6 +55,21 @@ def api_client(monkeypatch, tmp_path):
                         id=user_id,
                         email=f"{user_id}@example.test",
                         hashed_password="test",
+                    ))
+                if db.query(UserConnection).filter_by(
+                    user_id=user_id,
+                    platform="stryd",
+                ).first() is None:
+                    encrypted, wrapped_dek = get_vault().encrypt(json.dumps({
+                        "email": f"{user_id}@stryd.test",
+                        "password": f"password-{user_id}",
+                    }))
+                    db.add(UserConnection(
+                        user_id=user_id,
+                        platform="stryd",
+                        encrypted_credentials=encrypted,
+                        wrapped_dek=wrapped_dek,
+                        status="connected",
                     ))
                     db.commit()
                 ensured_users.add(user_id)
@@ -93,12 +109,72 @@ def api_client(monkeypatch, tmp_path):
         tmpdir.cleanup()
 
 
+def _store_stryd_credentials(
+    user_id: str,
+    *,
+    email: str,
+    password: str,
+) -> None:
+    from db import session as db_session
+    from db.crypto import get_vault
+    from db.models import UserConnection
+
+    db = db_session.SessionLocal()
+    try:
+        encrypted, wrapped_dek = get_vault().encrypt(json.dumps({
+            "email": email,
+            "password": password,
+        }))
+        connection = db.query(UserConnection).filter_by(
+            user_id=user_id,
+            platform="stryd",
+        ).one()
+        connection.encrypted_credentials = encrypted
+        connection.wrapped_dek = wrapped_dek
+        connection.status = "connected"
+        db.commit()
+    finally:
+        db.close()
+
+
+def _delete_stryd_credentials(user_id: str) -> None:
+    from db import session as db_session
+    from db.models import UserConnection
+
+    db = db_session.SessionLocal()
+    try:
+        db.query(UserConnection).filter_by(
+            user_id=user_id,
+            platform="stryd",
+        ).delete(synchronize_session=False)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _corrupt_stryd_credentials(user_id: str) -> None:
+    from db import session as db_session
+    from db.models import UserConnection
+
+    db = db_session.SessionLocal()
+    try:
+        connection = db.query(UserConnection).filter_by(
+            user_id=user_id,
+            platform="stryd",
+        ).one()
+        connection.encrypted_credentials = b"not-a-fernet-token"
+        db.commit()
+    finally:
+        db.close()
+
+
 def _seed_synced_delivery(
     user_id: str,
     workout_date: str,
     external_id: str,
     *,
     workout_type: str = "easy_run",
+    provider_account_id: str | None = None,
 ) -> None:
     from db import session as db_session
     from db.plan_ledger import (
@@ -134,6 +210,7 @@ def _seed_synced_delivery(
             attempt_id=attempt.id,
             attempt_state="synced",
             external_id=external_id,
+            provider_account_id=provider_account_id,
         )
         db.commit()
     finally:
@@ -309,6 +386,233 @@ def test_plan_get_etag_flips_after_stryd_push(api_client, monkeypatch):
         "ETag did not flip after Stryd push — stryd_status served stale via 304"
     )
     assert "2026-05-07" in after.json()["stryd_status"]
+
+
+def test_push_uses_calling_users_encrypted_stryd_credentials(
+    api_client,
+    monkeypatch,
+):
+    workout_date = "2026-05-07"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "workout_type": "easy",
+        "planned_duration_min": 45,
+        "workout_description": "easy",
+        "target_power_min": 200,
+        "target_power_max": 230,
+        "source": "ai",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [],
+    )
+    logins: list[tuple[str, str]] = []
+
+    def _login(email: str, password: str) -> tuple[str, str]:
+        logins.append((email, password))
+        return f"provider-{email}", f"token-{email}"
+
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    monkeypatch.setattr(
+        "sync.stryd_sync.create_workout_api",
+        lambda **kwargs: {"id": f"id-{kwargs['user_id']}"},
+    )
+    monkeypatch.setenv("STRYD_EMAIL", "global@example.test")
+    monkeypatch.setenv("STRYD_PASSWORD", "global-password")
+
+    for user_id, email, password in (
+        ("credential-alice", "alice@stryd.test", "alice-secret"),
+        ("credential-bob", "bob@stryd.test", "bob-secret"),
+    ):
+        api_client["current"]["value"] = user_id
+        assert api_client["client"].get("/api/plan").status_code == 200
+        _store_stryd_credentials(
+            user_id,
+            email=email,
+            password=password,
+        )
+        response = api_client["client"].post(
+            "/api/plan/push-stryd",
+            json={"workout_dates": [workout_date]},
+        )
+        assert response.status_code == 200, response.text
+
+    assert logins == [
+        ("alice@stryd.test", "alice-secret"),
+        ("bob@stryd.test", "bob-secret"),
+    ]
+
+
+def test_unpinned_global_stryd_credentials_are_not_used(
+    api_client,
+    monkeypatch,
+):
+    user_id = "no-stryd-credentials"
+    api_client["current"]["value"] = user_id
+    assert api_client["client"].get("/api/plan").status_code == 200
+    _delete_stryd_credentials(user_id)
+
+    monkeypatch.setenv("PRAXYS_ENV", "development")
+    monkeypatch.delenv("PRAXYS_STRYD_ENV_USER_ID", raising=False)
+    monkeypatch.setenv("STRYD_EMAIL", "global@example.test")
+    monkeypatch.setenv("STRYD_PASSWORD", "global-password")
+    monkeypatch.setattr(
+        "api.plan_delivery.credentials.dotenv_values",
+        lambda path: {},
+    )
+    calls = {"login": 0}
+
+    def _login(email: str, password: str) -> tuple[str, str]:
+        calls["login"] += 1
+        return "provider-user", "token"
+
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": ["2026-05-07"]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "No Stryd credentials. Connect Stryd in Settings first."
+    )
+    assert calls["login"] == 0
+
+
+def test_unreadable_stored_stryd_credentials_require_reconnect(
+    api_client,
+    monkeypatch,
+):
+    user_id = "corrupt-stryd-credentials"
+    api_client["current"]["value"] = user_id
+    assert api_client["client"].get("/api/plan").status_code == 200
+    _corrupt_stryd_credentials(user_id)
+    calls = {"login": 0}
+
+    def _login(email: str, password: str) -> tuple[str, str]:
+        calls["login"] += 1
+        return "provider-user", "token"
+
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": ["2026-05-07"]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Stored Stryd credentials are unavailable. Reconnect Stryd."
+    )
+    assert calls["login"] == 0
+
+
+def test_key_vault_credential_failure_requires_reconnect(
+    api_client,
+    monkeypatch,
+):
+    from azure.core.exceptions import AzureError
+
+    user_id = "key-vault-failure-user"
+    api_client["current"]["value"] = user_id
+    assert api_client["client"].get("/api/plan").status_code == 200
+
+    class FailingVault:
+        def decrypt(self, encrypted_data, wrapped_dek):
+            raise AzureError("key vault unavailable")
+
+    monkeypatch.setattr(
+        "db.connection_credentials.get_vault",
+        lambda: FailingVault(),
+    )
+    calls = {"login": 0}
+
+    def _login(email: str, password: str) -> tuple[str, str]:
+        calls["login"] += 1
+        return "provider-user", "token"
+
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": ["2026-05-07"]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Stored Stryd credentials are unavailable. Reconnect Stryd."
+    )
+    assert calls["login"] == 0
+
+
+def test_pinned_development_user_can_use_legacy_stryd_environment(
+    api_client,
+    monkeypatch,
+):
+    user_id = "legacy-local-user"
+    workout_date = "2026-05-07"
+    api_client["current"]["value"] = user_id
+    assert api_client["client"].get("/api/plan").status_code == 200
+    _delete_stryd_credentials(user_id)
+
+    monkeypatch.setenv("PRAXYS_ENV", "development")
+    monkeypatch.setenv("PRAXYS_STRYD_ENV_USER_ID", user_id)
+    monkeypatch.setenv("STRYD_EMAIL", "local@example.test")
+    monkeypatch.setenv("STRYD_PASSWORD", "local-password")
+    monkeypatch.setattr(
+        "api.plan_delivery.credentials.dotenv_values",
+        lambda path: {},
+    )
+    captured: dict[str, str] = {}
+
+    def _login(email: str, password: str) -> tuple[str, str]:
+        captured.update(email=email, password=password)
+        return "local-provider-user", "local-token"
+
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "workout_type": "easy",
+        "planned_duration_min": 45,
+        "workout_description": "easy",
+        "source": "ai",
+    }])
+    monkeypatch.setattr("sync.stryd_sync._login_api", _login)
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [],
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.create_workout_api",
+        lambda **kwargs: {"id": "legacy-local-id"},
+    )
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["results"][0]["workout_id"] == "legacy-local-id"
+    assert captured == {
+        "email": "local@example.test",
+        "password": "local-password",
+    }
 
 
 def test_push_endpoint_persists_under_calling_user(api_client, monkeypatch):
@@ -539,6 +843,309 @@ def test_successful_delivery_is_idempotent_for_same_workout_version(
         "operation": "deliver",
         "state": "synced",
     }]
+
+
+def test_changed_threshold_requires_owned_workout_replacement(
+    api_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("threshold-account", "token"),
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [{"target_power": cp}],
+    )
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "threshold-version-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-04"
+    cp = {"value": 260.0}
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Threshold-sensitive payload",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": cp["value"],
+            "activities": pd.DataFrame(),
+        },
+    )
+
+    api_client["current"]["value"] = "threshold-version-user"
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    cp["value"] = 270.0
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert first.json()["results"][0]["status"] == "success"
+    assert "removed before replacement" in (
+        second.json()["results"][0]["error"]
+    )
+    assert calls["create"] == 1
+    assert len(_delivery_rows("threshold-version-user")) == 1
+
+
+def test_synced_delivery_requires_exact_observed_external_id(
+    api_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("exact-id-account", "token"),
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [],
+    )
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "owned-external-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-04"
+    provider_id = {"value": None}
+
+    def _dashboard(user_id, db):
+        rows = [{
+            "date": workout_date,
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": "Exact identity",
+        }]
+        if provider_id["value"] is not None:
+            rows.append({
+                "date": workout_date,
+                "source": "stryd",
+                "workout_type": "easy",
+                "external_id": provider_id["value"],
+            })
+        plan_df = pd.DataFrame(rows)
+        return {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        }
+
+    monkeypatch.setattr("api.routes.plan.get_dashboard_data", _dashboard)
+    api_client["current"]["value"] = "exact-id-user"
+
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    provider_id["value"] = "different-external-id"
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert first.json()["results"][0]["status"] == "success"
+    assert "different Stryd workout" in second.json()["results"][0]["error"]
+    assert calls["create"] == 1
+
+
+def test_synced_delivery_rejects_extra_unowned_calendar_id(
+    api_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("extra-id-account", "token"),
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [],
+    )
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "owned-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-04"
+    include_calendar = {"value": False}
+
+    def _dashboard(user_id, db):
+        rows = [{
+            "date": workout_date,
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": "Extra identity",
+        }]
+        if include_calendar["value"]:
+            rows.extend([
+                {
+                    "date": workout_date,
+                    "source": "stryd",
+                    "workout_type": "easy",
+                    "external_id": "owned-id",
+                },
+                {
+                    "date": workout_date,
+                    "source": "stryd",
+                    "workout_type": "easy",
+                    "external_id": "unowned-id",
+                },
+            ])
+        plan_df = pd.DataFrame(rows)
+        return {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        }
+
+    monkeypatch.setattr("api.routes.plan.get_dashboard_data", _dashboard)
+    api_client["current"]["value"] = "extra-id-user"
+
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    include_calendar["value"] = True
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert first.json()["results"][0]["status"] == "success"
+    assert "different Stryd workout" in second.json()["results"][0]["error"]
+    assert calls["create"] == 1
+
+
+def test_calendar_id_owned_on_other_date_does_not_authorize_delivery(
+    api_client,
+    monkeypatch,
+):
+    user_id = "moved-calendar-id-user"
+    moved_id = "moved-owned-id"
+    _seed_synced_delivery(
+        user_id,
+        "2026-08-03",
+        moved_id,
+        provider_account_id="moved-id-account",
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("moved-id-account", "token"),
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [],
+    )
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "duplicate-id"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-04"
+    plan_df = pd.DataFrame([
+        {
+            "date": workout_date,
+            "source": "ai",
+            "workout_type": "easy",
+            "workout_description": "Moved provider row",
+        },
+        {
+            "date": workout_date,
+            "source": "stryd",
+            "workout_type": "easy",
+            "external_id": moved_id,
+        },
+    ])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+    api_client["current"]["value"] = user_id
+
+    response = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert "different Stryd workout" in response.json()["results"][0]["error"]
+    assert calls["create"] == 0
+
+
+def test_identical_push_rejects_reconnected_provider_account(
+    api_client,
+    monkeypatch,
+):
+    account_id = {"value": "original-provider-account"}
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: (account_id["value"], "token"),
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.build_workout_blocks",
+        lambda workout, cp: [],
+    )
+    calls = {"create": 0}
+
+    def _create(**kwargs):
+        calls["create"] += 1
+        return {"id": "old-account-workout"}
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _create)
+    workout_date = "2026-08-04"
+    plan_df = pd.DataFrame([{
+        "date": workout_date,
+        "source": "ai",
+        "workout_type": "easy",
+        "workout_description": "Account fenced",
+    }])
+    monkeypatch.setattr(
+        "api.routes.plan.get_dashboard_data",
+        lambda user_id, db: {
+            "plan": plan_df,
+            "all_plans": plan_df,
+            "latest_cp": 260.0,
+            "activities": pd.DataFrame(),
+        },
+    )
+    api_client["current"]["value"] = "account-fenced-push-user"
+
+    first = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+    account_id["value"] = "different-provider-account"
+    second = api_client["client"].post(
+        "/api/plan/push-stryd",
+        json={"workout_dates": [workout_date]},
+    )
+
+    assert first.json()["results"][0]["status"] == "success"
+    assert "different Stryd account" in second.json()["results"][0]["error"]
+    assert calls["create"] == 1
 
 
 def test_failed_retry_reuses_delivery_and_appends_attempt(api_client, monkeypatch):
@@ -934,7 +1541,7 @@ def test_synced_prior_version_must_be_removed_before_replacement(
         json={"workout_dates": [workout_date]},
     )
 
-    assert "uncertain" in response.json()["results"][0]["error"]
+    assert "removed before replacement" in response.json()["results"][0]["error"]
     assert calls["create"] == 0
     assert _delivery_rows(user_id) == [{
         "external_id": "prior-version-id",
@@ -1004,8 +1611,18 @@ def test_delete_endpoint_touches_only_calling_users_status(api_client, monkeypat
     from db import session as db_session
     from db.models import TrainingPlan, User
 
-    _seed_synced_delivery("alice", "2026-05-01", "shared-id")
-    _seed_synced_delivery("bob", "2026-05-01", "shared-id")
+    _seed_synced_delivery(
+        "alice",
+        "2026-05-01",
+        "shared-id",
+        provider_account_id="stryd-user-id",
+    )
+    _seed_synced_delivery(
+        "bob",
+        "2026-05-01",
+        "shared-id",
+        provider_account_id="stryd-user-id",
+    )
     db = db_session.SessionLocal()
     try:
         for user_id in ("alice", "bob"):
@@ -1063,13 +1680,158 @@ def test_delete_endpoint_touches_only_calling_users_status(api_client, monkeypat
     assert os.path.exists(plan_mod._stryd_push_status_path("alice"))
 
 
+def test_delete_rejects_reconnected_different_provider_account(
+    api_client,
+    monkeypatch,
+):
+    user_id = "provider-account-fence-user"
+    external_id = "provider-account-workout"
+    _seed_synced_delivery(
+        user_id,
+        "2026-05-03",
+        external_id,
+        provider_account_id="original-provider-account",
+    )
+    calls = {"delete": 0}
+
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("different-provider-account", "token"),
+    )
+
+    def _delete(*args):
+        calls["delete"] += 1
+
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", _delete)
+    api_client["current"]["value"] = user_id
+
+    response = api_client["client"].delete(
+        f"/api/plan/stryd-workout/{external_id}",
+    )
+
+    assert response.status_code == 409
+    assert "different Stryd account" in response.json()["detail"]
+    assert calls["delete"] == 0
+    assert _delivery_rows(user_id)[0]["state"] == "synced"
+    assert _attempt_rows(user_id) == [{
+        "number": 1,
+        "operation": "deliver",
+        "state": "synced",
+    }]
+
+
+def test_delete_verifies_migrated_delivery_on_current_calendar(
+    api_client,
+    monkeypatch,
+):
+    from db import session as db_session
+    from db.models import PlanDelivery
+
+    user_id = "migrated-removal-user"
+    external_id = "migrated-removal-id"
+    workout_date = (date.today() + timedelta(days=2)).isoformat()
+    _seed_synced_delivery(user_id, workout_date, external_id)
+    calls = {"calendar": 0, "delete": 0}
+
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("verified-current-account", "token"),
+    )
+
+    def _calendar(
+        provider_user_id,
+        token,
+        *,
+        cp_watts,
+        days_ahead,
+        days_back,
+        tz_name,
+    ):
+        calls["calendar"] += 1
+        assert days_ahead >= 14
+        assert days_back == 3
+        shifted_date = (
+            date.fromisoformat(workout_date) - timedelta(days=1)
+        ).isoformat()
+        return [{"date": shifted_date, "external_id": external_id}]
+
+    def _delete(*args):
+        calls["delete"] += 1
+
+    monkeypatch.setattr(
+        "sync.stryd_sync.fetch_training_plan_api",
+        _calendar,
+    )
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", _delete)
+    api_client["current"]["value"] = user_id
+
+    response = api_client["client"].delete(
+        f"/api/plan/stryd-workout/{external_id}",
+    )
+
+    assert response.status_code == 200, response.text
+    assert calls == {"calendar": 1, "delete": 1}
+    db = db_session.SessionLocal()
+    try:
+        delivery = db.query(PlanDelivery).filter_by(user_id=user_id).one()
+        assert delivery.state == "removed"
+        assert delivery.provider_account_id == "verified-current-account"
+    finally:
+        db.close()
+
+
+def test_delete_rejects_unverified_migrated_delivery(
+    api_client,
+    monkeypatch,
+):
+    user_id = "unverified-migrated-removal-user"
+    external_id = "unverified-migrated-id"
+    workout_date = (date.today() + timedelta(days=2)).isoformat()
+    _seed_synced_delivery(user_id, workout_date, external_id)
+    calls = {"delete": 0}
+
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("different-current-account", "token"),
+    )
+    monkeypatch.setattr(
+        "sync.stryd_sync.fetch_training_plan_api",
+        lambda *args, **kwargs: [],
+    )
+
+    def _delete(*args):
+        calls["delete"] += 1
+
+    monkeypatch.setattr("sync.stryd_sync.delete_workout_api", _delete)
+    api_client["current"]["value"] = user_id
+
+    response = api_client["client"].delete(
+        f"/api/plan/stryd-workout/{external_id}",
+    )
+
+    assert response.status_code == 409
+    assert "could not be verified" in response.json()["detail"]
+    assert calls["delete"] == 0
+    assert _delivery_rows(user_id)[0]["state"] == "synced"
+    assert _attempt_rows(user_id) == [{
+        "number": 1,
+        "operation": "deliver",
+        "state": "synced",
+    }]
+
+
 def test_stale_removal_attempt_can_be_retried(api_client, monkeypatch):
     from db import session as db_session
     from db.models import PlanDelivery
     from db.plan_ledger import DELIVERY_ATTEMPT_LEASE, begin_delivery_attempt
 
     user_id = "stale-remove-user"
-    _seed_synced_delivery(user_id, "2026-05-02", "stale-remove-id")
+    _seed_synced_delivery(
+        user_id,
+        "2026-05-02",
+        "stale-remove-id",
+        provider_account_id="sid",
+    )
     db = db_session.SessionLocal()
     try:
         delivery = db.query(PlanDelivery).filter_by(user_id=user_id).one()

--- a/tests/test_stryd_sync.py
+++ b/tests/test_stryd_sync.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -97,6 +98,26 @@ def test_fetch_training_plan_tz_name_fallback_on_utc_server(mock_get):
     )
     rows = fetch_training_plan_api("u", "t", tz_name="Asia/Shanghai")
     assert rows[0]["date"] == "2026-06-30"
+
+
+@patch("sync.stryd_sync.requests.get")
+def test_fetch_training_plan_days_back_expands_lower_bound(mock_get):
+    """A buffered verification query must include the full prior UTC day."""
+    mock_get.return_value = MagicMock(
+        json=MagicMock(return_value={"workouts": []}),
+        raise_for_status=MagicMock(),
+    )
+
+    fetch_training_plan_api("u", "t", days_back=3)
+
+    params = mock_get.call_args.kwargs["params"]
+    expected_start = int(
+        datetime.combine(
+            date.today() - timedelta(days=3),
+            datetime.min.time(),
+        ).timestamp()
+    )
+    assert params["from"] == expected_start
 
 
 @patch("sync.stryd_sync.requests.get")

--- a/tests/test_sync_backoff.py
+++ b/tests/test_sync_backoff.py
@@ -130,6 +130,19 @@ def test_classify_generic_connection_error_is_transient() -> None:
     assert terminal is False
 
 
+def test_classify_unreadable_credentials_is_terminal() -> None:
+    """Encrypted credentials that cannot be read require reconnection."""
+    from db.connection_credentials import CredentialAccessError
+    from db.sync_scheduler import classify_sync_failure
+
+    status, terminal = classify_sync_failure(
+        CredentialAccessError("stored credentials could not be decrypted")
+    )
+
+    assert status == "auth_required"
+    assert terminal is True
+
+
 # ---------------------------------------------------------------------------
 # _record_sync_failure — DB-level integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a provider-neutral plan-delivery adapter and ledger-backed service
- use encrypted per-user Stryd credentials with a strictly pinned local-development fallback
- preserve manual push/delete compatibility while fencing payload identity, calendar ownership, and provider accounts
- add PostgreSQL/SQLite schema compatibility, operational documentation, and regression coverage

## Validation

- `python -m pytest tests/test_plan_delivery_adapter.py tests/test_plan_ledger.py tests/test_plan_sync_state.py tests/test_plan_endpoints.py tests/test_stryd_push_status_endpoints.py tests/test_stryd_push_status_isolation.py tests/test_stryd_sync.py tests/test_sync_scheduler.py tests/test_sync_backoff.py -q` — 121 passed
- `python -m pytest tests/ --ignore=tests/test_mcp_tools.py` — 1389 passed, 2 skipped
- the unfiltered local suite reached the same 1389 passing tests; 13 `test_mcp_tools.py` cases require a locally cached authenticated MCP user/token and failed only because that local state was absent

Closes #477
