### PR TITLE
Make selective review safely default-off

### DIFF
--- a/.github/scripts/revoke-selective-review.sh
+++ b/.github/scripts/revoke-selective-review.sh
@@ -7,27 +7,90 @@ set -euo pipefail
 : "${POLICY_APP_LOGIN:?POLICY_APP_LOGIN is required}"
 
 pull_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
-[[ "$(jq -r '.state' <<< "$pull_json")" == "open" ]] || exit 0
+pull_state="$(jq -r '.state' <<< "$pull_json")"
+pull_merged="$(jq -r '.merged' <<< "$pull_json")"
+if [[ "$pull_state" != "open" ]]; then
+  if [[ "${REQUIRE_POLICY_STATE:-false}" == "true" &&
+    "$pull_merged" == "true" ]]; then
+    echo "::error::Pull request #${PR_NUMBER} merged during selective-review cleanup."
+    exit 1
+  fi
+  exit 0
+fi
 
 reviews_json="$(
   gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" \
     --paginate --slurp
 )"
-policy_review_count="$(
-  jq --arg login "${POLICY_APP_LOGIN,,}" \
-    '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("\\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\\)$"))] | length' \
+auto_merge_enabled="$(jq -r '.auto_merge != null' <<< "$pull_json")"
+latest_policy_reviews="$(
+  jq '
+    [.[][] |
+      select(
+        (((.user.type // "") | ascii_downcase) == "bot") or
+        (((.user.login // "") | ascii_downcase) | endswith("[bot]"))
+      ) |
+      select(
+        (.body // "") |
+        test("\\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\\)$|\\(selective-review-(revoked|emergency-stop)\\)")
+      ) |
+      {
+        login: ((.user.login // "") | ascii_downcase),
+        submitted_at: (.submitted_at // ""),
+        id: (.id // 0),
+        state: (.state // ""),
+        body: (.body // "")
+      }
+    ] |
+    sort_by([.login, .submitted_at, .id]) |
+    group_by(.login) |
+    map(last)
+  ' \
     <<< "$reviews_json"
 )"
-(( policy_review_count > 0 )) || exit 0
+active_policy_reviews="$(
+  jq --argjson auto_merge "$auto_merge_enabled" '
+    [.[] |
+      select(
+        (
+          .state == "APPROVED" and
+          ((.body // "") | test("\\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\\)$"))
+        ) or
+        $auto_merge
+      )
+    ]
+  ' <<< "$latest_policy_reviews"
+)"
+foreign_owners="$(
+  jq -r --arg login "${POLICY_APP_LOGIN,,}" \
+    '[.[] | select(.login != $login) | .login] | unique | join(",")' \
+    <<< "$active_policy_reviews"
+)"
+if [[ -n "$foreign_owners" ]]; then
+  echo "::error::Active selective-review state is owned by an unexpected bot: ${foreign_owners}."
+  exit 1
+fi
+configured_state_active="$(
+  jq -r --arg login "${POLICY_APP_LOGIN,,}" \
+    'any(.[]; .login == $login)' <<< "$active_policy_reviews"
+)"
+if [[ "$configured_state_active" != "true" ]]; then
+  if [[ "${REQUIRE_POLICY_STATE:-false}" == "true" &&
+    "$auto_merge_enabled" == "true" ]]; then
+    echo "::error::Detected policy auto-merge has no verifiable owner."
+    exit 1
+  fi
+  exit 0
+fi
 
-if [[ "$(jq -r '.auto_merge != null' <<< "$pull_json")" == "true" ]]; then
+if [[ "$auto_merge_enabled" == "true" ]]; then
   gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --disable-auto
 fi
 
 current_head="$(jq -r '.head.sha' <<< "$pull_json")"
 latest_policy_review_is_blocking="$(
   jq --arg login "${POLICY_APP_LOGIN,,}" --arg head "$current_head" \
-    '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("selective-review"))] | sort_by(.submitted_at) | last | (.commit_id == $head and .state == "CHANGES_REQUESTED")' \
+    '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("selective-review"))] | sort_by([.submitted_at, (.id // 0)]) | last | (.commit_id == $head and .state == "CHANGES_REQUESTED")' \
     <<< "$reviews_json"
 )"
 if [[ "$latest_policy_review_is_blocking" != "true" ]]; then
@@ -39,6 +102,16 @@ if [[ "$latest_policy_review_is_blocking" != "true" ]]; then
 fi
 
 final_pull_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+final_state="$(jq -r '.state' <<< "$final_pull_json")"
+final_merged="$(jq -r '.merged' <<< "$final_pull_json")"
+if [[ "$final_state" != "open" ]]; then
+  if [[ "${REQUIRE_POLICY_STATE:-false}" == "true" &&
+    "$final_merged" == "true" ]]; then
+    echo "::error::Pull request #${PR_NUMBER} merged during selective-review cleanup."
+    exit 1
+  fi
+  exit 0
+fi
 final_reviews_json="$(
   gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" \
     --paginate --slurp
@@ -46,7 +119,7 @@ final_reviews_json="$(
 final_auto_merge="$(jq -r '.auto_merge != null' <<< "$final_pull_json")"
 latest_policy_review_is_blocking="$(
   jq --arg login "${POLICY_APP_LOGIN,,}" --arg head "$current_head" \
-    '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("selective-review"))] | sort_by(.submitted_at) | last | (.commit_id == $head and .state == "CHANGES_REQUESTED")' \
+    '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("selective-review"))] | sort_by([.submitted_at, (.id // 0)]) | last | (.commit_id == $head and .state == "CHANGES_REQUESTED")' \
     <<< "$final_reviews_json"
 )"
 if [[ "$final_auto_merge" == "true" ||

--- a/.github/workflows/selective-review-emergency-stop.yml
+++ b/.github/workflows/selective-review-emergency-stop.yml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
+  statuses: write
 
 concurrency:
   group: selective-review-emergency-stop
@@ -25,7 +27,174 @@ jobs:
             exit 1
           fi
 
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Block active policy state before privileged cleanup
+        id: barrier
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          affected_file="$RUNNER_TEMP/selective-review-prs.txt"
+          : > "$affected_file"
+          pulls_json="$(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+              --paginate --slurp
+          )"
+          pull_rows="$(
+            jq -r \
+              '.[][] | [.number, .head.sha, (.auto_merge != null)] | @tsv' \
+              <<< "$pulls_json"
+          )"
+          affected=0
+          while IFS=$'\t' read -r pr_number head_sha auto_merge_enabled; do
+            [[ -n "$pr_number" ]] || continue
+            reviews_json="$(
+              gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews?per_page=100" \
+                --paginate --slurp
+            )"
+            active_policy_count="$(
+              jq --argjson auto_merge "$auto_merge_enabled" '
+                [.[][] |
+                  select(
+                    (((.user.type // "") | ascii_downcase) == "bot") or
+                    (((.user.login // "") | ascii_downcase) | endswith("[bot]"))
+                  ) |
+                  select(
+                    (.body // "") |
+                    test("\\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\\)$|\\(selective-review-(revoked|emergency-stop)\\)")
+                  ) |
+                  {
+                    login: ((.user.login // "") | ascii_downcase),
+                    submitted_at: (.submitted_at // ""),
+                    id: (.id // 0),
+                    state: (.state // ""),
+                    body: (.body // "")
+                  }
+                ] |
+                sort_by([.login, .submitted_at, .id]) |
+                group_by(.login) |
+                map(last) |
+                [.[] |
+                  select(
+                    (
+                      .state == "APPROVED" and
+                      ((.body // "") | test("\\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\\)$"))
+                    ) or
+                    $auto_merge
+                  )
+                ] |
+                length
+              ' <<< "$reviews_json"
+            )"
+            if (( active_policy_count == 0 )); then
+              continue
+            fi
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
+              -f state=failure \
+              -f context=selective-review-policy \
+              -f description="Emergency stop requires policy-state cleanup." \
+              --silent
+            echo "$pr_number" >> "$affected_file"
+            affected=$((affected + 1))
+          done <<< "$pull_rows"
+          echo "affected=$affected" >> "$GITHUB_OUTPUT"
+          echo "Blocked ${affected} active selective-review pull request(s)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Quiesce in-flight selective-review runs
+        id: quiesce
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          active_statuses='["queued","in_progress","waiting","requested","pending"]'
+          runs_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/selective-review.yml/runs?per_page=100" \
+              --paginate --slurp
+          )"
+          run_ids="$(
+            jq -r --argjson statuses "$active_statuses" \
+              '.[] | .workflow_runs[]? | select(.status as $status | $statuses | index($status)) | .id' \
+              <<< "$runs_json"
+          )"
+          while IFS= read -r run_id; do
+            [[ -n "$run_id" ]] || continue
+            gh api -X POST \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" \
+              --silent || true
+          done <<< "$run_ids"
+
+          active_count=1
+          for _ in {1..60}; do
+            runs_json="$(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/selective-review.yml/runs?per_page=100" \
+                --paginate --slurp
+            )"
+            active_count="$(
+              jq -r --argjson statuses "$active_statuses" \
+                '[.[] | .workflow_runs[]? | select(.status as $status | $statuses | index($status))] | length' \
+                <<< "$runs_json"
+            )"
+            (( active_count == 0 )) && break
+            sleep 2
+          done
+          if (( active_count != 0 )); then
+            echo "::error::Selective-review runs did not quiesce before emergency cleanup."
+            exit 1
+          fi
+
+      - name: Reassert emergency barriers after quiescence
+        id: final-barrier
+        if: always() && steps.barrier.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          affected_file="$RUNNER_TEMP/selective-review-prs.txt"
+          if [[ ! -f "$affected_file" ]]; then
+            echo "::error::Emergency cleanup target list is missing."
+            exit 1
+          fi
+          merge_races=()
+          while IFS= read -r pr_number; do
+            [[ -n "$pr_number" ]] || continue
+            pull_json="$(
+              gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}"
+            )"
+            if [[ "$(jq -r '.merged' <<< "$pull_json")" == "true" ]]; then
+              merge_races+=("#${pr_number}")
+              continue
+            fi
+            [[ "$(jq -r '.state' <<< "$pull_json")" == "open" ]] || continue
+            current_head="$(jq -r '.head.sha' <<< "$pull_json")"
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${current_head}" \
+              -f state=failure \
+              -f context=selective-review-policy \
+              -f description="Emergency stop requires policy-state cleanup." \
+              --silent
+          done < "$affected_file"
+          if (( ${#merge_races[@]} > 0 )); then
+            printf '%s\n' \
+              "Merge races detected during emergency quiescence: ${merge_races[*]}" \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Mint independent policy App token
+        if: >-
+          steps.quiesce.outcome == 'success' &&
+          steps.final-barrier.outcome == 'success' &&
+          steps.barrier.outputs.affected != '0' &&
+          vars.PRAXYS_REVIEW_POLICY_APP_ID != '' &&
+          vars.PRAXYS_REVIEW_POLICY_APP_SLUG != ''
         id: policy-token
         uses: actions/create-github-app-token@v2
         with:
@@ -36,138 +205,59 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - name: Require the exact policy App identity
+        id: policy-app
+        if: >-
+          always() &&
+          steps.barrier.outcome == 'success' &&
+          steps.quiesce.outcome == 'success' &&
+          steps.final-barrier.outcome == 'success' &&
+          steps.barrier.outputs.affected != '0'
+        env:
+          POLICY_APP_TOKEN: ${{ steps.policy-token.outputs.token }}
+          POLICY_APP_SLUG: ${{ steps.policy-token.outputs.app-slug }}
+          EXPECTED_POLICY_APP_SLUG: ${{ vars.PRAXYS_REVIEW_POLICY_APP_SLUG }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$EXPECTED_POLICY_APP_SLUG" ]]; then
+            echo "::error::PRAXYS_REVIEW_POLICY_APP_SLUG is required for emergency cleanup."
+            exit 1
+          fi
+          if [[ -z "$POLICY_APP_TOKEN" || -z "$POLICY_APP_SLUG" ]]; then
+            echo "::error::Could not resolve the selective-review App identity."
+            exit 1
+          fi
+          if [[ "$POLICY_APP_SLUG" != "$EXPECTED_POLICY_APP_SLUG" ]]; then
+            echo "::error::The minted policy App identity does not match the configured slug."
+            exit 1
+          fi
+
       - name: Neutralize policy-enabled auto-merge
+        if: steps.policy-app.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.policy-token.outputs.token }}
           POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
         shell: bash
         run: |
           set -uo pipefail
-          if [[ "$POLICY_APP_LOGIN" == "[bot]" ]]; then
-            echo "::error::Could not resolve the selective-review App identity."
+          affected_file="$RUNNER_TEMP/selective-review-prs.txt"
+          if [[ ! -f "$affected_file" ]]; then
+            echo "::error::Emergency cleanup target list is missing."
             exit 1
           fi
-          affected=0
+          neutralized=0
           failures=()
-          if ! pr_numbers="$(
-            gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
-              --paginate --slurp | jq -r '.[][] | .number'
-          )"; then
-            echo "::error::Could not enumerate open pull requests."
-            exit 1
-          fi
           while IFS= read -r pr_number; do
             [[ -n "$pr_number" ]] || continue
-            if ! pull_json="$(
-              gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}"
-            )"; then
-              failures+=("#${pr_number}:read-pull-request")
-              continue
+            if PR_NUMBER="$pr_number" REQUIRE_POLICY_STATE=true \
+              bash .github/scripts/revoke-selective-review.sh; then
+              neutralized=$((neutralized + 1))
+            else
+              failures+=("#${pr_number}:cleanup")
             fi
-            if ! state="$(jq -er '.state' <<< "$pull_json")"; then
-              failures+=("#${pr_number}:parse-pull-request")
-              continue
-            fi
-            [[ "$state" == "open" ]] || continue
-            if ! current_head="$(jq -er '.head.sha' <<< "$pull_json")"; then
-              failures+=("#${pr_number}:parse-head")
-              continue
-            fi
-            if ! reviews_json="$(
-              gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews?per_page=100" \
-                --paginate --slurp
-            )"; then
-              failures+=("#${pr_number}:read-reviews")
-              continue
-            fi
-            if ! policy_review_count="$(
-              jq --arg login "${POLICY_APP_LOGIN,,}" \
-                '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("\\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\\)$"))] | length' \
-                <<< "$reviews_json"
-            )"; then
-              failures+=("#${pr_number}:parse-reviews")
-              continue
-            fi
-            if (( policy_review_count == 0 )); then
-              continue
-            fi
-            affected=$((affected + 1))
-            if ! auto_merge_enabled="$(
-              jq -r '.auto_merge != null' <<< "$pull_json"
-            )"; then
-              failures+=("#${pr_number}:parse-auto-merge")
-              continue
-            fi
-            if [[ "$auto_merge_enabled" != "true" &&
-              "$auto_merge_enabled" != "false" ]]; then
-              failures+=("#${pr_number}:invalid-auto-merge-state")
-              continue
-            fi
-            if [[ "$auto_merge_enabled" == "true" ]]; then
-              if ! gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --disable-auto; then
-                failures+=("#${pr_number}:disable-auto-merge")
-              fi
-            fi
-            if ! gh api -X POST "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews" \
-              -f event=REQUEST_CHANGES \
-              -f commit_id="$current_head" \
-              -f body="Selective-review kill switch activated; human review is required. (selective-review-emergency-stop)" \
-              >/dev/null; then
-              failures+=("#${pr_number}:request-changes")
-            fi
-            if ! final_pull_json="$(
-              gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}"
-            )"; then
-              failures+=("#${pr_number}:verify-pull-request")
-              continue
-            fi
-            if ! final_state="$(jq -er '.state' <<< "$final_pull_json")" ||
-              ! final_merged="$(jq -r '.merged' <<< "$final_pull_json")"; then
-              failures+=("#${pr_number}:parse-final-pull-request")
-              continue
-            fi
-            if [[ "$final_merged" != "true" && "$final_merged" != "false" ]]; then
-              failures+=("#${pr_number}:invalid-final-merged-state")
-              continue
-            fi
-            if [[ "$final_state" != "open" ]]; then
-              if [[ "$final_merged" == "true" ]]; then
-                failures+=("#${pr_number}:merged-during-emergency-stop")
-              fi
-              continue
-            fi
-            if ! final_auto_merge="$(
-              jq -r '.auto_merge != null' <<< "$final_pull_json"
-            )"; then
-              failures+=("#${pr_number}:parse-final-auto-merge")
-              continue
-            fi
-            if [[ "$final_auto_merge" != "true" &&
-              "$final_auto_merge" != "false" ]]; then
-              failures+=("#${pr_number}:invalid-final-auto-merge-state")
-              continue
-            fi
-            if ! final_reviews_json="$(
-              gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/reviews?per_page=100" \
-                --paginate --slurp
-            )"; then
-              failures+=("#${pr_number}:verify-reviews")
-              continue
-            fi
-            if ! latest_policy_review_is_emergency="$(
-              jq --arg login "${POLICY_APP_LOGIN,,}" \
-                '[.[][] | select(((.user.login // "") | ascii_downcase) == $login) | select((.body // "") | test("selective-review"))] | sort_by(.submitted_at) | last | (.state == "CHANGES_REQUESTED" and ((.body // "") | contains("selective-review-emergency-stop")))' \
-                <<< "$final_reviews_json"
-            )"; then
-              failures+=("#${pr_number}:parse-final-reviews")
-              continue
-            fi
-            if [[ "$final_auto_merge" == "true" ||
-              "$latest_policy_review_is_emergency" != "true" ]]; then
-              failures+=("#${pr_number}:final-state-not-neutralized")
-            fi
-          done <<< "$pr_numbers"
-          echo "Neutralized selective-review state on ${affected} open pull request(s)." \
+          done < "$affected_file"
+          echo "Neutralized selective-review state on ${neutralized} open pull request(s)." \
             >> "$GITHUB_STEP_SUMMARY"
           if (( ${#failures[@]} > 0 )); then
             printf '%s\n' "Cleanup failures: ${failures[*]}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/selective-review.yml
+++ b/.github/workflows/selective-review.yml
@@ -72,41 +72,6 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      - name: Mint independent policy App token
-        if: >-
-          always() &&
-          steps.target.outputs.pr_number != '' &&
-          vars.PRAXYS_REVIEW_POLICY_APP_ID != ''
-        id: policy-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.PRAXYS_REVIEW_POLICY_APP_ID }}
-          private-key: ${{ secrets.PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Require the policy App for targeted pull requests
-        if: always() && steps.target.outputs.pr_number != ''
-        env:
-          POLICY_APP_TOKEN: ${{ steps.policy-token.outputs.token }}
-          POLICY_APP_SLUG: ${{ steps.policy-token.outputs.app-slug }}
-        shell: bash
-        run: |
-          if [[ -z "$POLICY_APP_TOKEN" || -z "$POLICY_APP_SLUG" ]]; then
-            echo "::error::The selective-review policy App is not configured."
-            exit 1
-          fi
-
-      - name: Revoke prior policy state before evaluation
-        if: always() && steps.policy-token.outputs.token != ''
-        env:
-          GH_TOKEN: ${{ steps.policy-token.outputs.token }}
-          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
-          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
-        run: bash .github/scripts/revoke-selective-review.sh
-
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -118,33 +83,92 @@ jobs:
           INPUT_PR_NUMBER: ${{ steps.target.outputs.pr_number }}
           SELECTIVE_REVIEW_ENABLED: ${{ vars.PRAXYS_SELECTIVE_REVIEW_ENABLED }}
           SELECTIVE_REVIEW_KILL_SWITCH: ${{ vars.PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH }}
-          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
+          POLICY_APP_SLUG: ${{ vars.PRAXYS_REVIEW_POLICY_APP_SLUG }}
         run: python scripts/selective_review_gate.py
 
+      - name: Mint independent policy App token
+        if: >-
+          steps.policy.outputs.needs_policy_app == 'true' &&
+          vars.PRAXYS_REVIEW_POLICY_APP_ID != '' &&
+          vars.PRAXYS_REVIEW_POLICY_APP_SLUG != ''
+        id: policy-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PRAXYS_REVIEW_POLICY_APP_ID }}
+          private-key: ${{ secrets.PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Require the policy App for autonomous action or cleanup
+        id: policy-app
+        if: always() && steps.policy.outputs.needs_policy_app == 'true'
+        env:
+          POLICY_APP_TOKEN: ${{ steps.policy-token.outputs.token }}
+          POLICY_APP_SLUG: ${{ steps.policy-token.outputs.app-slug }}
+          EXPECTED_POLICY_APP_SLUG: ${{ vars.PRAXYS_REVIEW_POLICY_APP_SLUG }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$EXPECTED_POLICY_APP_SLUG" ]]; then
+            echo "::error::PRAXYS_REVIEW_POLICY_APP_SLUG is required for autonomous action or cleanup."
+            exit 1
+          fi
+          if [[ -z "$POLICY_APP_TOKEN" || -z "$POLICY_APP_SLUG" ]]; then
+            echo "::error::The selective-review policy App is required for this candidate or stale-state cleanup."
+            exit 1
+          fi
+          if [[ "$POLICY_APP_SLUG" != "$EXPECTED_POLICY_APP_SLUG" ]]; then
+            echo "::error::The minted policy App identity does not match the configured slug."
+            exit 1
+          fi
+
+      - name: Neutralize prior policy state before privileged action
+        if: always() && steps.policy-app.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.policy-token.outputs.token }}
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
+          REQUIRE_POLICY_STATE: ${{ steps.policy.outputs.policy_state_present }}
+        run: bash .github/scripts/revoke-selective-review.sh
+
       - name: Re-evaluate current policy state
-        if: steps.policy.outputs.decision == 'auto-merge-candidate'
+        if: >-
+          steps.policy.outputs.decision == 'auto-merge-candidate' &&
+          steps.policy-app.outcome == 'success'
         id: final-policy
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR_NUMBER: ${{ steps.policy.outputs.pr_number }}
           SELECTIVE_REVIEW_ENABLED: ${{ vars.PRAXYS_SELECTIVE_REVIEW_ENABLED }}
           SELECTIVE_REVIEW_KILL_SWITCH: ${{ vars.PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH }}
-          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
+          POLICY_APP_SLUG: ${{ steps.policy-token.outputs.app-slug }}
         run: python scripts/selective_review_gate.py
 
-      - name: Revoke policy state after non-candidate or evaluation failure
-        if: >-
-          always() &&
-          steps.policy-token.outputs.token != '' &&
-          steps.final-policy.outputs.decision != 'auto-merge-candidate'
+      - name: Require the same exact refs after privileged setup
+        if: steps.final-policy.outputs.decision == 'auto-merge-candidate'
         env:
-          GH_TOKEN: ${{ steps.policy-token.outputs.token }}
-          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
-          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
-        run: bash .github/scripts/revoke-selective-review.sh
+          INITIAL_HEAD_SHA: ${{ steps.policy.outputs.head_sha }}
+          INITIAL_BASE_REF: ${{ steps.policy.outputs.base_ref }}
+          INITIAL_BASE_SHA: ${{ steps.policy.outputs.base_sha }}
+          FINAL_HEAD_SHA: ${{ steps.final-policy.outputs.head_sha }}
+          FINAL_BASE_REF: ${{ steps.final-policy.outputs.base_ref }}
+          FINAL_BASE_SHA: ${{ steps.final-policy.outputs.base_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$FINAL_HEAD_SHA" != "$INITIAL_HEAD_SHA" ||
+            "$FINAL_BASE_REF" != "$INITIAL_BASE_REF" ||
+            "$FINAL_BASE_SHA" != "$INITIAL_BASE_SHA" ]]; then
+            echo "::error::Pull request refs changed during privileged policy setup."
+            exit 1
+          fi
 
       - name: Recheck runtime controls before approval
-        if: steps.final-policy.outputs.decision == 'auto-merge-candidate'
+        if: >-
+          steps.policy-app.outcome == 'success' &&
+          steps.final-policy.outputs.decision == 'auto-merge-candidate'
         env:
           GH_TOKEN: ${{ github.token }}
           POLICY_APP_TOKEN: ${{ steps.policy-token.outputs.token }}
@@ -170,7 +194,9 @@ jobs:
           fi
 
       - name: Approve through the independent policy App
-        if: steps.final-policy.outputs.decision == 'auto-merge-candidate'
+        if: >-
+          steps.policy-app.outcome == 'success' &&
+          steps.final-policy.outputs.decision == 'auto-merge-candidate'
         env:
           GH_TOKEN: ${{ steps.policy-token.outputs.token }}
           PR_NUMBER: ${{ steps.final-policy.outputs.pr_number }}
@@ -220,7 +246,9 @@ jobs:
           fi
 
       - name: Enable normal squash auto-merge
-        if: steps.final-policy.outputs.decision == 'auto-merge-candidate'
+        if: >-
+          steps.policy-app.outcome == 'success' &&
+          steps.final-policy.outputs.decision == 'auto-merge-candidate'
         env:
           GH_TOKEN: ${{ steps.policy-token.outputs.token }}
           PR_NUMBER: ${{ steps.final-policy.outputs.pr_number }}
@@ -246,25 +274,45 @@ jobs:
           gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
             --auto --squash --delete-branch --match-head-commit "$HEAD_SHA"
 
-      - name: Revoke policy state after action failure
-        if: failure() && steps.policy-token.outputs.token != ''
-        env:
-          GH_TOKEN: ${{ steps.policy-token.outputs.token }}
-          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
-          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
-        run: bash .github/scripts/revoke-selective-review.sh
-
       - name: Mark policy gate safe
         if: success() && steps.gate-status.outputs.head_sha != ''
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.gate-status.outputs.head_sha }}
+        shell: bash
         run: |
+          set -euo pipefail
+          variables_json="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/variables?per_page=100" \
+              --paginate --slurp
+          )"
+          kill_switch="$(
+            jq -r '
+              [.[] | .variables[]? |
+                select(.name == "PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH") |
+                .value
+              ] |
+              last // "false" |
+              ascii_downcase
+            ' <<< "$variables_json"
+          )"
+          if [[ "$kill_switch" == "true" ]]; then
+            echo "::error::Selective review was emergency-stopped before policy completion."
+            exit 1
+          fi
           gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state=success \
             -f context=selective-review-policy \
             -f description="Selective-review policy completed safely." \
             --silent
+
+      - name: Revoke policy state after action failure
+        if: failure() && steps.policy-app.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.policy-token.outputs.token }}
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          POLICY_APP_LOGIN: ${{ steps.policy-token.outputs.app-slug }}[bot]
+        run: bash .github/scripts/revoke-selective-review.sh
 
       - name: Mark policy gate failed
         if: failure() && steps.gate-status.outputs.head_sha != ''

--- a/analysis/review_policy.py
+++ b/analysis/review_policy.py
@@ -93,6 +93,7 @@ def class_policy_fingerprint(policy: dict[str, Any], class_name: str) -> str:
         "candidate_class": candidate_classes[class_name],
         "classifier_semantics": policy.get("classifier_semantics"),
         "default_decision": policy.get("default_decision"),
+        "enforcement_model": policy.get("enforcement_model"),
         "policy_version": policy.get("version"),
         "promotion_requirements": policy.get("promotion_requirements", {}),
         "required_checks": policy.get("required_checks", []),
@@ -222,6 +223,32 @@ def evaluate_selective_review(
             "auto-merge-candidate" if not unique_reasons else "review-required"
         ),
         change_class=change_class,
+        reasons=unique_reasons,
+    )
+
+
+def apply_runtime_controls(
+    decision: ReviewDecision,
+    *,
+    enabled: bool,
+    kill_switch: bool,
+) -> ReviewDecision:
+    """Apply default-off runtime controls to a deterministic policy decision."""
+    reasons = list(decision.reasons)
+    if not enabled:
+        reasons.append("selective_review_disabled")
+    if kill_switch:
+        reasons.append("kill_switch_enabled")
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    return ReviewDecision(
+        disposition=(
+            "auto-merge-candidate"
+            if decision.disposition == "auto-merge-candidate"
+            and enabled
+            and not kill_switch
+            else "review-required"
+        ),
+        change_class=decision.change_class,
         reasons=unique_reasons,
     )
 
@@ -456,6 +483,11 @@ def validate_promoted_classes(
         errors.append("classifier_semantics_missing")
     if selective.get("default_decision") != "review-required":
         errors.append("default_decision_must_require_review")
+    if (
+        selective.get("enforcement_model")
+        != "independent-github-app-approval"
+    ):
+        errors.append("enforcement_model_must_use_independent_app_approval")
     if set(selective.get("allowed_base_branches") or []) != {"main"}:
         errors.append("allowed_base_branches_must_be_main")
     if "Copilot" not in set(selective.get("allowed_authors") or []):

--- a/config/agent-loop-policies.json
+++ b/config/agent-loop-policies.json
@@ -9,6 +9,7 @@
       "version": "selective-review-v1",
       "classifier_semantics": "review-policy-v1",
       "default_decision": "review-required",
+      "enforcement_model": "independent-github-app-approval",
       "allowed_authors": [
         "Copilot"
       ],
@@ -34,6 +35,7 @@
         "enabled_variable": "PRAXYS_SELECTIVE_REVIEW_ENABLED",
         "kill_switch_variable": "PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH",
         "policy_app_id_variable": "PRAXYS_REVIEW_POLICY_APP_ID",
+        "policy_app_slug_variable": "PRAXYS_REVIEW_POLICY_APP_SLUG",
         "policy_app_private_key_secret": "PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY"
       },
       "sensitive_paths": [

--- a/data/agent_evals/change/review_promotion.json
+++ b/data/agent_evals/change/review_promotion.json
@@ -3,11 +3,11 @@
   "as_of": "2026-07-25",
   "classes": {
     "documentation-only": {
-      "policy_fingerprint": "462b4205749abb10d7efec94aa284b72c7d3b3c5251c6d45c4c3ee2ef1b34457",
+      "policy_fingerprint": "2aa059daeacdfd3c8466e93a958c8ec6dba9e6dac9a74ff4e40d74caaeb50c03",
       "observations": []
     },
     "translation-catalog-only": {
-      "policy_fingerprint": "c6eabbfe5ac5046ac130973b0572a647ebe526dab0c4eb11475d6d8880ff7428",
+      "policy_fingerprint": "d3e8c30ea951b43108b9b1907e7eee7a0859bc66b10b49b332520ed0f3633137",
       "observations": []
     },
     "full-stack": {

--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -277,6 +277,9 @@ Those outcomes train both triage precision and draft quality. They also feed the
 default-off `review-required | auto-merge-candidate` policy:
 
 - `analysis/review_policy.py` is the pure classifier and promotion evaluator.
+- The committed enforcement model is
+  `independent-github-app-approval`: AI reviews are evidence, while only the
+  deterministic policy and dedicated App identity authorize autonomous merge.
 - `data/agent_evals/change/review_promotion.json` stores text-free completed-PR
   evidence. Each bucket is bound to the exact class/sensitive-path/check policy
   fingerprint, and duplicate PR numbers cannot inflate the sample.
@@ -288,6 +291,10 @@ default-off `review-required | auto-merge-candidate` policy:
   PR. It denies non-`main` bases, incomplete/truncated file inventories,
   sensitive paths, missing checks, draft PRs, post-ready commits, requested
   changes, unpromoted classes, and missing tests where applicable.
+- Evaluation happens before App-token creation. Disabled, unpromoted, sensitive,
+  and otherwise review-required PRs finish successfully without App
+  configuration. A token is required only for an exact enabled candidate or for
+  cleanup of bot-authored stale policy state.
 - A qualifying PR is approved by the independent review-policy App, then normal
   squash auto-merge is enabled. The App never bypasses the ruleset or checks.
 - Every reevaluation first marks the PR head's `selective-review-policy` status
@@ -302,12 +309,17 @@ default-off `review-required | auto-merge-candidate` policy:
 The initial `promoted_classes` list is empty. Runtime is independently default
 off through `PRAXYS_SELECTIVE_REVIEW_ENABLED`. For rollback, set
 `PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH=true`, then dispatch the workflow with
-`selective-review-emergency-stop.yml`; it replaces policy approval with a
-blocking review and disables pending auto-merge. Per-PR evaluation uses
-per-PR concurrency, so unrelated events cannot discard a revocation. The gate
-also refuses autonomy unless the effective main-branch rules require an
-independent approval and invalidate it after a later push, and unless required
-checks are strict against the latest `main`.
+`selective-review-emergency-stop.yml`; it first fails the required policy status
+on every affected head, cancels and waits for in-flight gate runs, and
+reasserts the barrier on current heads before replacing policy approval with a
+blocking review and disabling pending auto-merge through the verified App
+identity. The ordinary gate rechecks the kill switch before publishing success.
+Foreign bot ownership, a merge race, or incomplete cleanup remains failed
+rather than reporting success.
+Per-PR evaluation uses per-PR concurrency, so unrelated events cannot discard a
+revocation. The gate also refuses autonomy unless the effective main-branch
+rules require an independent approval and invalidate it after a later push, and
+unless required checks are strict against the latest `main`.
 Provisioning and promotion steps:
 [setup-review-policy-app.md](./setup-review-policy-app.md).
 

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -642,10 +642,36 @@ frequency change that saves money; slowing one past 15 min saves nothing. To cut
 noise, tune the window/threshold rather than deleting. Update the inventory table
 after any change.
 
+## GitHub automation health
+
+Selective review is repository governance rather than an Azure Monitor signal,
+so it has no alert-rule charge and is not included in the Azure inventory
+subtotal above. Its required commit status and Actions run are the operational
+health surface.
+
+| Workflow | Healthy default-off result | Privileged result | Failure response |
+|---|---|---|---|
+| `Selective review gate` | Run succeeds as `review-required`; summary says `Policy App required: false`; token step is skipped | An exact promoted candidate or detected stale policy state mints the dedicated App token, rechecks exact refs, and approves or revokes | Keep/restore `PRAXYS_SELECTIVE_REVIEW_ENABLED=false`; inspect the run; restore App credentials before stale-state cleanup |
+| `Selective review issue guard` | Linked issue changes dispatch a fresh evaluation and leave the current head pending until it completes | A no-longer-valid candidate is revoked by the policy App | Set the kill switch and dispatch the emergency stop if reevaluation cannot complete |
+| `Selective review emergency stop` | No active policy state means no App token is needed | With the kill switch set, immediately fails affected heads, quiesces in-flight gates, reasserts current-head barriers, then disables policy-owned auto-merge and replaces policy approval through the exact App identity | Treat the failed status as the merge barrier; any merge race fails the run; restore/rotate the App identity, rerun, and verify every affected PR is neutralized |
+
+Inspect recent runs and the status on a PR head:
+
+```bash
+gh run list --workflow=selective-review.yml \
+  --repo praxys-run/praxys --limit 10
+gh pr checks <PR_NUMBER> --repo praxys-run/praxys
+```
+
+An absent policy App is healthy only when no privileged action is needed. A
+candidate or stale-state cleanup that cannot mint the App token must remain
+failed because the required `selective-review-policy` status is the fail-closed
+merge barrier.
+
 ## Related
 
 - `api/telemetry.py` (signal emitters) · [cost-and-scaling.md](./cost-and-scaling.md) (budget + LLM spend) · [admin-tasks.md](./admin-tasks.md) (feedback triage)
 - In-app: Admin → User Feedback (badge + Approve/Retry/Reject).
 
 ---
-_Last reviewed: 2026-07-18 · Owner: @dddtc2005 · Alert inventory + cost model current as of this review._
+_Last reviewed: 2026-07-29 · Owner: @dddtc2005 · Alert inventory + cost model current as of this review._

--- a/docs/ops/setup-review-policy-app.md
+++ b/docs/ops/setup-review-policy-app.md
@@ -2,7 +2,8 @@
 
 > **Summary:** Provision the independent GitHub App that approves qualifying
 > low-risk Copilot PRs and enables normal auto-merge without bypassing checks.
-> **Use when:** Enabling or rotating Loop A selective review.
+> **Use when:** Preparing to enable, smoke-test, or rotate Loop A selective
+> review. Ordinary review-required operation does not need this App.
 
 ## Prerequisites
 
@@ -11,6 +12,20 @@
 - `gh auth status` succeeds for the repository.
 - A class is not promoted until `python scripts/validate_review_policy.py`
   succeeds with at least five clean, seven-day observations.
+
+## Selected trust model
+
+Praxys uses the **approval model**: a dedicated GitHub App is the independent
+identity that submits `APPROVE` and enables normal squash auto-merge only after
+deterministic policy checks. Copilot Code Review, Rubber Duck, and the Praxys
+invariant reviewer remain useful evidence, but none is an approval identity or
+the merge trust boundary.
+
+The policy is intentionally safe before this App exists. When selective review
+is disabled, no class is promoted, or a PR is otherwise review-required, the
+workflow succeeds without minting or requiring App credentials. The App becomes
+mandatory only for an exact autonomous candidate or cleanup of previously
+created policy-App state.
 
 ## Steps
 
@@ -33,17 +48,22 @@ independent merge-gate identity and is not a ruleset bypass actor.
 
 ### 2. Store the App identity
 
-Generate a private key from the App settings page, note the App ID, then set:
+Generate a private key from the App settings page, note the App ID and URL slug,
+then set:
 
 ```bash
 gh variable set PRAXYS_REVIEW_POLICY_APP_ID \
   --repo praxys-run/praxys --body "<APP_ID>"
 
+gh variable set PRAXYS_REVIEW_POLICY_APP_SLUG \
+  --repo praxys-run/praxys --body "<APP_SLUG>"
+
 gh secret set PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY \
   --repo praxys-run/praxys < path/to/praxys-review-policy.pem
 ```
 
-Delete the downloaded key after the Actions secret is confirmed.
+The slug is the App URL component without the `[bot]` suffix. Delete the
+downloaded key after the Actions secret is confirmed.
 
 ### 3. Provision runtime controls default-off
 
@@ -77,6 +97,14 @@ Before enabling the runtime, edit **Settings → Rules → Rulesets → default*
 Provisioning the App does not approve anything: the committed
 `promoted_classes` list starts empty and the runtime enable variable starts
 `false`.
+
+Default-off behavior:
+
+| Policy result | App credentials |
+|---|---|
+| Disabled, unpromoted, sensitive, or otherwise review-required | Not read or required |
+| Enabled exact promoted candidate | Required; absence fails closed |
+| Prior bot-authored policy approval/auto-merge needs cleanup | Required; absence leaves the required policy status failed |
 
 ### 4. Promote one proven class
 
@@ -126,10 +154,12 @@ gh workflow run selective-review.yml \
 ```
 
 For an unpromoted or sensitive PR, the Actions summary must say
-`review-required` and no App review appears. For an enabled, promoted, same-repo
-Copilot PR that closes an `agent-ready` issue, has a stable ready handoff, and
-passes `backend-tests`, the App submits one approval and
-`gh pr merge --auto --squash` schedules the normal merge.
+`review-required`, `Policy App required: false`, and no App-token step or review
+appears. This remains true when the App variables and secret are completely
+absent. For an enabled, promoted, same-repo Copilot PR that closes an
+`agent-ready` issue, has a stable ready handoff, and passes `backend-tests`, the
+App submits one approval and `gh pr merge --auto --squash` schedules the normal
+merge.
 
 ## Rollback / Recovery
 
@@ -143,13 +173,27 @@ gh workflow run selective-review-emergency-stop.yml \
   --repo praxys-run/praxys
 ```
 
-The emergency job refuses to run until the kill-switch variable is true. On
-every affected open PR it replaces the policy App's approval with a blocking
-`REQUEST_CHANGES` review and disables auto-merge. Confirm the workflow succeeds
-before treating the stop as complete. Then open a policy PR removing the
-affected class from `promoted_classes` and record the correction, failure,
-revert, or reopen in the evidence corpus. Never add the policy App as a ruleset
-bypass actor.
+The emergency job refuses to run until the kill-switch variable is true. It
+immediately marks every head with active selective-review state as failed under
+the required `selective-review-policy` context, cancels and waits for in-flight
+gate runs, then reasserts the barrier on each current head before minting App
+credentials. Initially affected PRs remain in the cleanup set, so a merge during
+quiescence fails the run instead of disappearing from the open-PR scan. The job
+then verifies the exact App identity, rejects state owned by any other bot,
+replaces the policy App's approval with a blocking `REQUEST_CHANGES` review, and
+disables auto-merge. The ordinary gate also rechecks the kill switch before it
+may post success. If credentials or cleanup fail, the failed status remains the
+merge barrier. Confirm the workflow succeeds before treating the stop as
+complete.
+Then open a policy PR removing the affected class from `promoted_classes` and
+record the correction, failure, revert, or reopen in the evidence corpus. Never
+add the policy App as a ruleset bypass actor.
+
+If stale autonomous state exists but App credentials cannot be minted, the
+workflow leaves `selective-review-policy` failed. Once that status is required,
+the stale approval or auto-merge display cannot produce a merge. Restore the App
+identity, rerun the gate, and then run the emergency stop if broad cleanup is
+needed.
 
 If the App key is exposed, generate a replacement key, update
 `PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY`, verify one manual workflow dispatch, then

--- a/scripts/selective_review_gate.py
+++ b/scripts/selective_review_gate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -18,7 +19,17 @@ if str(ROOT) not in sys.path:
 
 from analysis.review_policy import (  # noqa: E402
     PullRequestFacts,
+    apply_runtime_controls,
     evaluate_selective_review,
+)
+
+
+_POLICY_APPROVAL_MARKER = re.compile(
+    r"\(selective-review:[A-Za-z0-9._-]+:[0-9a-f]{40}\)$"
+)
+_POLICY_REVOCATION_MARKERS = (
+    "selective-review-revoked",
+    "selective-review-emergency-stop",
 )
 
 
@@ -27,6 +38,20 @@ def _parse_time(value: str | None) -> datetime | None:
         return None
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     return parsed.astimezone(timezone.utc)
+
+
+def _review_order(
+    row: dict[str, Any],
+    submitted: datetime,
+    position: int,
+) -> tuple[datetime, int]:
+    """Return a stable chronological key for reviews submitted together."""
+    raw_id = row.get("id")
+    try:
+        review_id = int(raw_id)
+    except (TypeError, ValueError):
+        review_id = position
+    return submitted, review_id
 
 
 def _request_json(path: str) -> tuple[Any, dict[str, str]]:
@@ -113,8 +138,8 @@ def _changes_requested(
     reviews: list[dict[str, Any]],
     policy_app_login: str = "",
 ) -> bool:
-    latest_by_reviewer: dict[str, tuple[datetime, str]] = {}
-    for row in reviews:
+    latest_by_reviewer: dict[str, tuple[tuple[datetime, int], str]] = {}
+    for position, row in enumerate(reviews):
         login = str((row.get("user") or {}).get("login") or "")
         submitted = _parse_time(row.get("submitted_at"))
         if not login or submitted is None:
@@ -126,16 +151,64 @@ def _changes_requested(
         if (
             login.lower() == policy_app_login.lower()
             and state == "CHANGES_REQUESTED"
-            and (
-                "selective-review-revoked" in body
-                or "selective-review-emergency-stop" in body
-            )
+            and any(marker in body for marker in _POLICY_REVOCATION_MARKERS)
         ):
             continue
+        order = _review_order(row, submitted, position)
         current = latest_by_reviewer.get(login)
-        if current is None or submitted > current[0]:
-            latest_by_reviewer[login] = (submitted, state)
+        if current is None or order > current[0]:
+            latest_by_reviewer[login] = (order, state)
     return any(state == "CHANGES_REQUESTED" for _, state in latest_by_reviewer.values())
+
+
+def _policy_app_login(slug: str) -> str:
+    normalized = slug.strip()
+    if not normalized:
+        return ""
+    return normalized if normalized.lower().endswith("[bot]") else f"{normalized}[bot]"
+
+
+def _policy_state_present(
+    reviews: list[dict[str, Any]],
+    *,
+    auto_merge_enabled: bool,
+) -> bool:
+    """Return whether a bot-authored selective-review state still needs cleanup."""
+    latest_by_bot: dict[str, tuple[tuple[datetime, int], str, str]] = {}
+    for position, row in enumerate(reviews):
+        user = row.get("user") or {}
+        login = str(user.get("login") or "")
+        user_type = str(user.get("type") or "")
+        submitted = _parse_time(row.get("submitted_at"))
+        state = str(row.get("state") or "")
+        body = str(row.get("body") or "").strip()
+        is_bot = user_type.lower() == "bot" or login.lower().endswith("[bot]")
+        is_approval = bool(_POLICY_APPROVAL_MARKER.search(body))
+        is_revocation = any(
+            marker in body for marker in _POLICY_REVOCATION_MARKERS
+        )
+        if (
+            not login
+            or not is_bot
+            or submitted is None
+            or state not in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED")
+            or not (is_approval or is_revocation)
+        ):
+            continue
+        order = _review_order(row, submitted, position)
+        current = latest_by_bot.get(login.lower())
+        if current is None or order > current[0]:
+            latest_by_bot[login.lower()] = (
+                order,
+                state,
+                "approval" if is_approval else "revocation",
+            )
+
+    active_approval = any(
+        state == "APPROVED" and marker_type == "approval"
+        for _, state, marker_type in latest_by_bot.values()
+    )
+    return active_approval or (auto_merge_enabled and bool(latest_by_bot))
 
 
 def _check_states(
@@ -429,6 +502,8 @@ def main() -> int:
     if pr_number is None:
         _write_output("skip", "true")
         _write_output("decision", "review-required")
+        _write_output("policy_state_present", "false")
+        _write_output("needs_policy_app", "false")
         _write_summary(["## Selective review", "", "No pull request was associated with this run."])
         return 0
 
@@ -495,7 +570,7 @@ def main() -> int:
         ready_head_sha=_ready_head_sha(timeline),
         changes_requested=_changes_requested(
             reviews,
-            os.environ.get("POLICY_APP_LOGIN", ""),
+            _policy_app_login(os.environ.get("POLICY_APP_SLUG", "")),
         ),
         agent_ready_issue_linked=_has_agent_ready_closing_issue(
             repository,
@@ -511,17 +586,18 @@ def main() -> int:
     policy_result = evaluate_selective_review(facts, policy)
     enabled = os.environ.get("SELECTIVE_REVIEW_ENABLED", "").lower() == "true"
     kill_switch = os.environ.get("SELECTIVE_REVIEW_KILL_SWITCH", "").lower() == "true"
-    runtime_reasons = list(policy_result.reasons)
-    if not enabled:
-        runtime_reasons.append("selective_review_disabled")
-    if kill_switch:
-        runtime_reasons.append("kill_switch_enabled")
-    decision = (
-        "auto-merge-candidate"
-        if policy_result.disposition == "auto-merge-candidate"
-        and enabled
-        and not kill_switch
-        else "review-required"
+    runtime_result = apply_runtime_controls(
+        policy_result,
+        enabled=enabled,
+        kill_switch=kill_switch,
+    )
+    policy_state_present = _policy_state_present(
+        reviews,
+        auto_merge_enabled=pull.get("auto_merge") is not None,
+    )
+    needs_policy_app = (
+        runtime_result.disposition == "auto-merge-candidate"
+        or policy_state_present
     )
 
     _write_output("skip", "false")
@@ -532,10 +608,12 @@ def main() -> int:
     _write_output("policy_version", str(policy["version"]))
     _write_output("change_class", policy_result.change_class or "unclassified")
     _write_output("policy_decision", policy_result.disposition)
-    _write_output("decision", decision)
+    _write_output("decision", runtime_result.disposition)
     _write_output("enabled", str(enabled).lower())
     _write_output("kill_switch", str(kill_switch).lower())
-    _write_output("reasons", ",".join(dict.fromkeys(runtime_reasons)))
+    _write_output("policy_state_present", str(policy_state_present).lower())
+    _write_output("needs_policy_app", str(needs_policy_app).lower())
+    _write_output("reasons", ",".join(runtime_result.reasons))
     _write_summary(
         [
             "## Selective review",
@@ -544,8 +622,10 @@ def main() -> int:
             f"- Policy: `{policy['version']}`",
             f"- Class: `{policy_result.change_class or 'unclassified'}`",
             f"- Policy disposition: `{policy_result.disposition}`",
-            f"- Runtime disposition: `{decision}`",
-            f"- Reasons: `{','.join(dict.fromkeys(runtime_reasons)) or 'none'}`",
+            f"- Runtime disposition: `{runtime_result.disposition}`",
+            f"- Prior autonomous state: `{str(policy_state_present).lower()}`",
+            f"- Policy App required: `{str(needs_policy_app).lower()}`",
+            f"- Reasons: `{','.join(runtime_result.reasons) or 'none'}`",
             "",
             "The workflow never bypasses branch protection; qualifying PRs receive an "
             "independent App approval and normal squash auto-merge.",

--- a/tests/test_review_policy.py
+++ b/tests/test_review_policy.py
@@ -9,6 +9,8 @@ import pytest
 from analysis.review_policy import (
     PromotionObservation,
     PullRequestFacts,
+    ReviewDecision,
+    apply_runtime_controls,
     class_policy_fingerprint,
     classify_change,
     evaluate_promotion,
@@ -21,6 +23,7 @@ POLICY = {
     "version": "selective-review-test-v1",
     "classifier_semantics": "review-policy-test-v1",
     "default_decision": "review-required",
+    "enforcement_model": "independent-github-app-approval",
     "allowed_authors": ["Copilot"],
     "allowed_base_branches": ["main"],
     "trusted_assignment_actors": ["maintainer"],
@@ -110,6 +113,36 @@ def test_unpromoted_class_remains_review_required():
     assert decision.disposition == "review-required"
     assert decision.change_class == "documentation-only"
     assert decision.reasons == ("class_not_promoted:documentation-only",)
+
+
+def test_runtime_controls_are_default_off_and_kill_switch_closed():
+    candidate = ReviewDecision(
+        disposition="auto-merge-candidate",
+        change_class="documentation-only",
+        reasons=(),
+    )
+    disabled = apply_runtime_controls(
+        candidate,
+        enabled=False,
+        kill_switch=False,
+    )
+    assert disabled.disposition == "review-required"
+    assert disabled.reasons == ("selective_review_disabled",)
+
+    killed = apply_runtime_controls(
+        candidate,
+        enabled=True,
+        kill_switch=True,
+    )
+    assert killed.disposition == "review-required"
+    assert killed.reasons == ("kill_switch_enabled",)
+
+    enabled = apply_runtime_controls(
+        candidate,
+        enabled=True,
+        kill_switch=False,
+    )
+    assert enabled == candidate
 
 
 def test_promoted_class_passes_only_after_stable_handoff():
@@ -270,6 +303,27 @@ def test_promotion_thresholds_cannot_be_weakened():
     }
     with pytest.raises(ValueError, match="minimum_completed_prs_below_floor"):
         validate_promoted_classes(policy, {"classes": {}})
+
+
+def test_promotion_requires_the_independent_app_approval_model():
+    selective = deepcopy(POLICY)
+    selective["enforcement_model"] = "status-check"
+    selective["promotion_requirements"] = {
+        "minimum_completed_prs": 5,
+        "minimum_observation_days": 7,
+        "maximum_correction_rate": 0.0,
+        "maximum_pr_caused_failure_rate": 0.0,
+        "maximum_revert_or_reopen_rate": 0.0,
+        "minimum_test_policy_rate": 1.0,
+    }
+    with pytest.raises(
+        ValueError,
+        match="enforcement_model_must_use_independent_app_approval",
+    ):
+        validate_promoted_classes(
+            {"change": {"selective_review": selective}},
+            {"classes": {}},
+        )
 
 
 def test_promotion_evidence_is_bound_to_the_exact_class_policy():

--- a/tests/test_selective_review_workflow.py
+++ b/tests/test_selective_review_workflow.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from scripts.selective_review_gate import (
     _changes_requested,
     _parse_time,
+    _policy_state_present,
     _ready_head_sha,
     _trusted_assignment_matches,
 )
@@ -32,7 +33,27 @@ def test_selective_review_workflow_is_default_off_and_never_bypasses():
     ) == 2
     assert "set -euo pipefail" in workflow
     assert "steps.policy-token.outputs.app-slug" in workflow
-    assert "Require the policy App for targeted pull requests" in workflow
+    assert "Require the policy App for targeted pull requests" not in workflow
+    assert "Require the policy App for autonomous action or cleanup" in workflow
+    assert "steps.policy.outputs.needs_policy_app == 'true'" in workflow
+    assert "vars.PRAXYS_REVIEW_POLICY_APP_SLUG" in workflow
+    assert "id: policy-app" in workflow
+    assert 'if [[ -z "$EXPECTED_POLICY_APP_SLUG" ]]' in workflow
+    assert '"$POLICY_APP_SLUG" != "$EXPECTED_POLICY_APP_SLUG"' in workflow
+    assert workflow.count("steps.policy-app.outcome == 'success'") == 6
+    assert "REQUIRE_POLICY_STATE: ${{ steps.policy.outputs.policy_state_present }}" in workflow
+    assert "Selective review was emergency-stopped before policy completion." in workflow
+    assert 'actions/variables?per_page=100' in workflow
+    assert "2>/dev/null || printf 'false'" not in workflow
+    assert workflow.index("Mark policy gate safe") < workflow.index(
+        "Revoke policy state after action failure"
+    )
+    assert workflow.index("Evaluate deterministic review policy") < workflow.index(
+        "Mint independent policy App token"
+    )
+    assert "Require the same exact refs after privileged setup" in workflow
+    assert 'FINAL_HEAD_SHA" != "$INITIAL_HEAD_SHA' in workflow
+    assert 'FINAL_BASE_SHA" != "$INITIAL_BASE_SHA' in workflow
     assert workflow.count("context=selective-review-policy") == 3
     assert "-f state=pending" in workflow
     assert "-f state=success" in workflow
@@ -43,6 +64,12 @@ def test_selective_review_workflow_is_default_off_and_never_bypasses():
     assert "(.user.login // \"\") | ascii_downcase" in revoke_script
     assert "--disable-auto" in revoke_script
     assert "REQUEST_CHANGES" in revoke_script
+    assert "REQUIRE_POLICY_STATE" in revoke_script
+    assert "selective-review-(revoked|emergency-stop)" in revoke_script
+    assert "foreign_owners" in revoke_script
+    assert "unexpected bot" in revoke_script
+    assert "sort_by([.submitted_at, (.id // 0)])" in revoke_script
+    assert "merged during selective-review cleanup" in revoke_script
     assert "always()" in workflow
     assert "previous_filename" in (
         ROOT / "scripts" / "selective_review_gate.py"
@@ -62,10 +89,33 @@ def test_selective_review_workflow_is_default_off_and_never_bypasses():
         / "selective-review-emergency-stop.yml"
     ).read_text(encoding="utf-8")
     assert "steps.policy-token.outputs.app-slug" in emergency
-    assert "(.user.login // \"\") | ascii_downcase" in emergency
-    assert "--disable-auto" in emergency
-    assert "REQUEST_CHANGES" in emergency
-    assert "sort_by(.submitted_at) | last" in emergency
+    assert "vars.PRAXYS_REVIEW_POLICY_APP_SLUG" in emergency
+    assert "id: policy-app" in emergency
+    assert 'if [[ -z "$EXPECTED_POLICY_APP_SLUG" ]]' in emergency
+    assert '"$POLICY_APP_SLUG" != "$EXPECTED_POLICY_APP_SLUG"' in emergency
+    assert "if: steps.policy-app.outcome == 'success'" in emergency
+    assert "statuses: write" in emergency
+    assert "actions: write" in emergency
+    assert "Quiesce in-flight selective-review runs" in emergency
+    assert "/actions/runs/${run_id}/cancel" in emergency
+    assert "did not quiesce before emergency cleanup" in emergency
+    assert "Block active policy state before privileged cleanup" in emergency
+    assert "Reassert emergency barriers after quiescence" in emergency
+    assert "Merge races detected during emergency quiescence" in emergency
+    assert "context=selective-review-policy" in emergency
+    assert "-f state=failure" in emergency
+    assert "steps.barrier.outputs.affected != '0'" in emergency
+    assert "bash .github/scripts/revoke-selective-review.sh" in emergency
+    assert "REQUIRE_POLICY_STATE=true" in emergency
+    assert emergency.index(
+        "Block active policy state before privileged cleanup"
+    ) < emergency.index("Quiesce in-flight selective-review runs")
+    assert emergency.index(
+        "Quiesce in-flight selective-review runs"
+    ) < emergency.index("Reassert emergency barriers after quiescence")
+    assert emergency.index(
+        "Reassert emergency barriers after quiescence"
+    ) < emergency.index("Mint independent policy App token")
     assert "--admin" not in emergency
 
     issue_guard = (
@@ -131,7 +181,7 @@ def test_comment_review_does_not_clear_requested_changes():
 
     policy_reviews = [
         {
-            "user": {"login": "policy-app[bot]"},
+            "user": {"login": "policy-app[bot]", "type": "Bot"},
             "submitted_at": "2026-07-25T10:15:00Z",
             "state": "CHANGES_REQUESTED",
             "body": "Human review required. (selective-review-revoked)",
@@ -140,6 +190,79 @@ def test_comment_review_does_not_clear_requested_changes():
     assert not _changes_requested(
         policy_reviews,
         policy_app_login="policy-app[bot]",
+    )
+
+    assert _changes_requested(policy_reviews) is True
+
+
+def test_only_bot_authored_policy_markers_trigger_stale_state_cleanup():
+    marker = (
+        "Approved by the independent selective-review policy App. "
+        "(selective-review:selective-review-v1:"
+        "0123456789abcdef0123456789abcdef01234567)"
+    )
+    human_review = {
+        "user": {"login": "reviewer", "type": "User"},
+        "submitted_at": "2026-07-25T10:00:00Z",
+        "state": "APPROVED",
+        "body": marker,
+    }
+    assert not _policy_state_present(
+        [human_review],
+        auto_merge_enabled=False,
+    )
+
+    app_approval = {
+        **human_review,
+        "user": {"login": "policy-app[bot]", "type": "Bot"},
+    }
+    assert _policy_state_present(
+        [app_approval],
+        auto_merge_enabled=False,
+    )
+
+    app_revocation = {
+        "user": {"login": "policy-app[bot]", "type": "Bot"},
+        "submitted_at": "2026-07-25T10:05:00Z",
+        "state": "CHANGES_REQUESTED",
+        "body": "Human review required. (selective-review-revoked)",
+    }
+    assert not _policy_state_present(
+        [app_approval, app_revocation],
+        auto_merge_enabled=False,
+    )
+    assert _policy_state_present(
+        [app_approval, app_revocation],
+        auto_merge_enabled=True,
+    )
+
+    dismissed_approval = {
+        **app_approval,
+        "state": "DISMISSED",
+        "submitted_at": "2026-07-25T10:10:00Z",
+    }
+    assert not _policy_state_present(
+        [dismissed_approval],
+        auto_merge_enabled=False,
+    )
+    assert _policy_state_present(
+        [dismissed_approval],
+        auto_merge_enabled=True,
+    )
+
+    same_second_revocation = {
+        **app_revocation,
+        "id": 101,
+        "submitted_at": "2026-07-25T10:15:00Z",
+    }
+    same_second_approval = {
+        **app_approval,
+        "id": 102,
+        "submitted_at": "2026-07-25T10:15:00Z",
+    }
+    assert _policy_state_present(
+        [same_second_revocation, same_second_approval],
+        auto_merge_enabled=False,
     )
 
 


### PR DESCRIPTION
Closes #500

## Summary
- evaluate deterministic policy before creating the independent GitHub App token, so disabled and review-required PRs stay healthy without App credentials
- bind promotion evidence to the `independent-github-app-approval` trust model and exact head/base refs
- make stale-state and emergency cleanup fail closed with exact App identity, ownership checks, required-status barriers, run quiescence, and merge-race detection
- document default-off operation, provisioning, rollback, and monitoring

## Bootstrap order
The current default-branch `pull_request_target` workflow still requires the policy App before it evaluates a PR, so this PR cannot validate that gate without the App. Provision and install the dedicated App first, set its ID/slug/private-key Actions values, rerun the failed selective-review workflow, then merge this PR. After merge, ordinary default-off/review-required runs no longer need those credentials.

No review class is promoted and runtime remains default-off throughout this bootstrap.

## Validation
- `24 passed` in the focused policy/workflow suite
- policy validator, Python compilation, shell syntax, and diff checks passed
- GitHub Backend CI and review-policy validation passed on this head
- full local backend run: `1390 passed, 2 skipped`; 13 existing `test_mcp_tools.py` failures require a local user/auth token and do not touch this change
- final independent enforcement audit reported no high-confidence findings