### PR TITLE
Fix default-off selective review completion

### DIFF
--- a/.github/workflows/selective-review.yml
+++ b/.github/workflows/selective-review.yml
@@ -279,24 +279,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ steps.gate-status.outputs.head_sha }}
+          RUNTIME_KILL_SWITCH: ${{ vars.PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH }}
         shell: bash
         run: |
           set -euo pipefail
-          variables_json="$(
-            gh api "repos/${GITHUB_REPOSITORY}/actions/variables?per_page=100" \
-              --paginate --slurp
-          )"
-          kill_switch="$(
-            jq -r '
-              [.[] | .variables[]? |
-                select(.name == "PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH") |
-                .value
-              ] |
-              last // "false" |
-              ascii_downcase
-            ' <<< "$variables_json"
-          )"
-          if [[ "$kill_switch" == "true" ]]; then
+          if [[ "${RUNTIME_KILL_SWITCH,,}" == "true" ]]; then
             echo "::error::Selective review was emergency-stopped before policy completion."
             exit 1
           fi

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -666,7 +666,10 @@ gh pr checks <PR_NUMBER> --repo praxys-run/praxys
 An absent policy App is healthy only when no privileged action is needed. A
 candidate or stale-state cleanup that cannot mint the App token must remain
 failed because the required `selective-review-policy` status is the fail-closed
-merge barrier.
+merge barrier. Default-off completion uses the workflow's injected
+`PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH` value; `GITHUB_TOKEN` cannot call the
+repository Actions-variables REST endpoint, so ordinary review-required runs
+must not depend on that API.
 
 ## Related
 

--- a/tests/test_selective_review_workflow.py
+++ b/tests/test_selective_review_workflow.py
@@ -43,7 +43,12 @@ def test_selective_review_workflow_is_default_off_and_never_bypasses():
     assert workflow.count("steps.policy-app.outcome == 'success'") == 6
     assert "REQUIRE_POLICY_STATE: ${{ steps.policy.outputs.policy_state_present }}" in workflow
     assert "Selective review was emergency-stopped before policy completion." in workflow
-    assert 'actions/variables?per_page=100' in workflow
+    assert 'actions/variables?per_page=100' not in workflow
+    safe_step = workflow.split("Mark policy gate safe", 1)[1].split(
+        "Revoke policy state after action failure", 1
+    )[0]
+    assert "RUNTIME_KILL_SWITCH: ${{ vars.PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH }}" in safe_step
+    assert "actions/variables/" not in safe_step
     assert "2>/dev/null || printf 'false'" not in workflow
     assert workflow.index("Mark policy gate safe") < workflow.index(
         "Revoke policy state after action failure"


### PR DESCRIPTION
## Summary
- stop calling the Actions variables REST API from the default-off completion step
- use the workflow-injected kill-switch value already evaluated by the policy
- add a regression assertion and document the `GITHUB_TOKEN` limitation

## Production evidence
Merged PR #502 correctly skipped App-token creation on a review-required PR, then failed at `Mark policy gate safe` with `Resource not accessible by integration (HTTP 403)` while listing repository variables.

## Validation
- `24 passed` in the focused policy/workflow suite
- review-policy validator and diff checks passed