### PR TITLE
Add default-off rolling delivery for managed plans

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -15,6 +15,11 @@ DataCategory = Literal["activities", "recovery", "fitness", "plan"]
 PlanManagementMode = Literal["external", "praxys"]
 PlanAdjustmentPolicy = Literal["suggest_only"]
 
+# The persisted canonical-plan source is still ``ai`` for rolling-deploy
+# compatibility. Issue #504 will migrate ownership to ``praxys`` and split
+# true workout provenance into a separate field.
+PRAXYS_PLAN_SOURCES: tuple[str, ...] = ("ai",)
+
 # Default zone boundaries as fractions of threshold value.
 # 4 boundaries define 5 zones (Z1..Z5).
 DEFAULT_ZONES: dict[str, list[float]] = {
@@ -226,10 +231,15 @@ def is_praxys_managed_plan(config: object) -> bool:
     )
 
 
+def is_praxys_plan_source(value: object) -> bool:
+    """Return whether a stored source belongs to the Praxys canonical lane."""
+    return str(value or "").strip().casefold() in PRAXYS_PLAN_SOURCES
+
+
 def plan_analysis_source(config: object) -> str:
     """Return the source analytical views should treat as canonical."""
     if is_praxys_managed_plan(config):
-        return "ai"
+        return PRAXYS_PLAN_SOURCES[0]
     preferences = getattr(config, "preferences", None)
     if not isinstance(preferences, dict):
         return ""

--- a/api/plan_delivery/__init__.py
+++ b/api/plan_delivery/__init__.py
@@ -9,7 +9,12 @@ from api.plan_delivery.base import (
     PlanDeliveryAdapter,
     PreparedWorkoutDelivery,
     ProviderAuthenticationError,
+    ProviderOutcomeUnknownError,
+    ProviderReadError,
+    ProviderRejectedError,
+    ProviderRemovalError,
     ProviderRequestError,
+    ProviderTransientError,
 )
 from api.plan_delivery.credentials import (
     DeliveryCredentialsInvalid,
@@ -21,6 +26,7 @@ from api.plan_delivery.service import (
     DeliveryAccountVerificationError,
     DeliveryBusyError,
     DeliveryFinalizationError,
+    DeliveryMutationBlockedError,
     DeliveryNotFoundError,
     DeliveryRemovalFailedError,
     DeliveryResult,
@@ -50,6 +56,11 @@ def register_plan_delivery_adapter(
     _ADAPTER_TYPES[target] = adapter_type
 
 
+def is_plan_delivery_target_registered(target: str) -> bool:
+    """Return whether a provider adapter is registered for the target."""
+    return target in _ADAPTER_TYPES
+
+
 def load_plan_delivery_adapter(
     db: Session,
     *,
@@ -77,6 +88,7 @@ __all__ = [
     "DeliveryCredentialsInvalid",
     "DeliveryCredentialsUnavailable",
     "DeliveryFinalizationError",
+    "DeliveryMutationBlockedError",
     "DeliveryNotFoundError",
     "DeliveryRemovalFailedError",
     "DeliveryResult",
@@ -85,9 +97,15 @@ __all__ = [
     "PlanDeliveryService",
     "PreparedWorkoutDelivery",
     "ProviderAuthenticationError",
+    "ProviderOutcomeUnknownError",
+    "ProviderReadError",
+    "ProviderRejectedError",
+    "ProviderRemovalError",
     "ProviderRequestError",
+    "ProviderTransientError",
     "RemovalResult",
     "UnsupportedDeliveryTargetError",
+    "is_plan_delivery_target_registered",
     "load_plan_delivery_adapter",
     "register_plan_delivery_adapter",
 ]

--- a/api/plan_delivery/base.py
+++ b/api/plan_delivery/base.py
@@ -46,6 +46,10 @@ class ProviderRejectedError(PlanDeliveryProviderError):
     """The provider definitely rejected a request."""
 
 
+class ProviderTransientError(PlanDeliveryProviderError):
+    """The provider safely rejected a request that may be retried later."""
+
+
 class ProviderOutcomeUnknownError(PlanDeliveryProviderError):
     """The request may have reached the provider, so retry requires reconciliation."""
 

--- a/api/plan_delivery/credentials.py
+++ b/api/plan_delivery/credentials.py
@@ -17,11 +17,11 @@ from db.connection_credentials import (
 logger = logging.getLogger(__name__)
 
 
-class DeliveryCredentialsUnavailable(RuntimeError):
+class DeliveryCredentialsUnavailable(CredentialAccessError):
     """No credentials are available for the requested delivery target."""
 
 
-class DeliveryCredentialsInvalid(RuntimeError):
+class DeliveryCredentialsInvalid(CredentialAccessError):
     """Stored credentials require the user to reconnect the platform."""
 
 

--- a/api/plan_delivery/rolling.py
+++ b/api/plan_delivery/rolling.py
@@ -1,0 +1,1584 @@
+"""Default-off rolling delivery for Praxys-managed plans."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any, Callable, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from analysis.config import (
+    PLATFORM_CAPABILITIES,
+    PRAXYS_PLAN_SOURCES,
+    normalize_plan_management,
+)
+from analysis.metrics import is_rest_workout
+from api.packs import RequestContext
+from api.plan_delivery import (
+    DeliveryAccountMismatchError,
+    DeliveryAccountVerificationError,
+    DeliveryBusyError,
+    DeliveryCredentialsInvalid,
+    DeliveryCredentialsUnavailable,
+    DeliveryFinalizationError,
+    DeliveryMutationBlockedError,
+    DeliveryNotFoundError,
+    DeliveryRemovalFailedError,
+    DeliveryStartError,
+    PlanDeliveryAdapter,
+    PlanDeliveryService,
+    ProviderAuthenticationError,
+    ProviderReadError,
+    ProviderRequestError,
+    is_plan_delivery_target_registered,
+    load_plan_delivery_adapter,
+)
+from api.plan_reconciliation import (
+    PlanReconciliationItem,
+    build_plan_reconciliation,
+)
+from api.plan_resolution import (
+    PlanResolutionConflict,
+    PlanResolutionProviderError,
+    restore_praxys_version,
+)
+from db.models import (
+    PlanDelivery,
+    PlanDeliveryAttempt,
+    PlanTargetCalendarSync,
+    PlanTargetWorkout,
+    TrainingPlan,
+    UserConfig,
+    UserConnection,
+)
+from db.connection_credentials import connection_credentials_generation
+from db.plan_ledger import (
+    DELIVERY_ATTEMPT_LEASE,
+    canonical_id_from_workout_key,
+    canonical_workout_key,
+    complete_delivery_attempt,
+    lock_plan_writes,
+    plan_snapshot,
+    workout_version,
+)
+from db.plan_reconciliation import record_target_calendar_sync
+
+logger = logging.getLogger(__name__)
+
+ROLLING_DELIVERY_DAYS = 14
+AUTOMATIC_DELIVERY_MAX_ATTEMPTS = 5
+AUTOMATIC_RETRY_BASE = timedelta(minutes=15)
+AUTOMATIC_RETRY_MAX = timedelta(hours=6)
+
+
+@dataclass(frozen=True)
+class ManagedDeliveryItemResult:
+    """Outcome for one canonical workout or owned orphan delivery."""
+
+    canonical_id: str | None
+    workout_date: str
+    action: str
+    status: str
+    reason: str | None = None
+    external_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ManagedDeliveryRunResult:
+    """Summary of one user-scoped rolling delivery pass."""
+
+    user_id: str
+    trigger: str
+    status: str
+    target: str | None
+    window_start: str
+    window_end: str
+    items: tuple[ManagedDeliveryItemResult, ...] = ()
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _DeliveryGate:
+    target: str | None
+    connection: UserConnection | None
+    reason: str | None
+
+    @property
+    def enabled(self) -> bool:
+        return self.reason is None and self.target is not None
+
+
+AdapterLoader = Callable[[Session, str, str], PlanDeliveryAdapter]
+ThresholdLoader = Callable[[Session, str], float | None]
+
+_CONNECTION_FAILURES = (
+    DeliveryCredentialsInvalid,
+    DeliveryCredentialsUnavailable,
+    ProviderAuthenticationError,
+)
+_REMOVAL_FAILURES = (
+    DeliveryAccountMismatchError,
+    DeliveryAccountVerificationError,
+    DeliveryBusyError,
+    DeliveryFinalizationError,
+    DeliveryNotFoundError,
+    DeliveryRemovalFailedError,
+    DeliveryStartError,
+)
+_REPLACEMENT_FAILURES = (
+    PlanResolutionProviderError,
+    ProviderRequestError,
+    *_REMOVAL_FAILURES,
+)
+
+
+def automatic_retry_delay(failure_count: int) -> timedelta:
+    """Return the bounded delay before the next automatic delivery attempt."""
+    exponent = max(failure_count - 1, 0)
+    delay = AUTOMATIC_RETRY_BASE * (2 ** exponent)
+    return min(delay, AUTOMATIC_RETRY_MAX)
+
+
+def _window(today: date) -> tuple[date, date]:
+    return today, today + timedelta(days=ROLLING_DELIVERY_DAYS - 1)
+
+
+def _delivery_gate(
+    db: Session,
+    user_id: str,
+    *,
+    refresh: bool = False,
+) -> _DeliveryGate:
+    config_query = select(UserConfig).where(UserConfig.user_id == user_id)
+    connection_query = select(UserConnection).where(
+        UserConnection.user_id == user_id,
+    )
+    if refresh:
+        config_query = config_query.with_for_update().execution_options(
+            populate_existing=True
+        )
+        connection_query = (
+            connection_query
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+    config_row = db.execute(config_query).scalar_one_or_none()
+    plan_management = normalize_plan_management(
+        config_row.plan_management if config_row is not None else None
+    )
+    target = plan_management["execution_target"]
+    if plan_management["mode"] != "praxys":
+        return _DeliveryGate(target, None, "external_mode")
+    if not plan_management["delivery_enabled"]:
+        return _DeliveryGate(target, None, "delivery_paused")
+    if not target:
+        return _DeliveryGate(None, None, "execution_target_missing")
+    capabilities = PLATFORM_CAPABILITIES.get(target)
+    if not capabilities or not capabilities.get("plan"):
+        return _DeliveryGate(target, None, "execution_target_unsupported")
+    if not is_plan_delivery_target_registered(target):
+        return _DeliveryGate(target, None, "delivery_adapter_unavailable")
+
+    connection = db.execute(
+        connection_query.where(UserConnection.platform == target)
+    ).scalar_one_or_none()
+    if connection is None:
+        return _DeliveryGate(target, None, "connection_missing")
+    if connection.status != "connected":
+        return _DeliveryGate(
+            target,
+            connection,
+            f"connection_{connection.status}",
+        )
+    return _DeliveryGate(target, connection, None)
+
+
+def _default_adapter_loader(
+    db: Session,
+    user_id: str,
+    target: str,
+) -> PlanDeliveryAdapter:
+    return load_plan_delivery_adapter(
+        db,
+        user_id=user_id,
+        target=target,
+    )
+
+
+def _default_threshold_loader(db: Session, user_id: str) -> float | None:
+    return RequestContext(user_id, db).latest_cp_watts
+
+
+def _record_connection_failure(
+    db: Session,
+    connection: UserConnection | None,
+    exc: BaseException,
+    *,
+    trigger: str,
+    connection_generation: str,
+) -> bool:
+    if connection is None:
+        db.rollback()
+        return False
+    from db.sync_scheduler import _record_sync_failure
+
+    return _record_sync_failure(
+        connection,
+        exc,
+        db,
+        trigger=f"managed_delivery:{trigger}",
+        expected_credential_generation=connection_generation,
+    )
+
+
+def _record_connection_success(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    connection_generation: str,
+) -> bool:
+    from db.sync_scheduler import reset_connection_backoff
+
+    connection = db.execute(
+        select(UserConnection)
+        .where(
+            UserConnection.user_id == user_id,
+            UserConnection.platform == target,
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if connection is None:
+        db.rollback()
+        return False
+    if (
+        connection_credentials_generation(connection)
+        != connection_generation
+    ):
+        db.rollback()
+        return False
+    connection.status = "connected"
+    reset_connection_backoff(connection)
+    db.commit()
+    return True
+
+
+def _mutation_guard(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    connection_generation: str,
+) -> None:
+    lock_plan_writes(db, user_id)
+    gate = _delivery_gate(db, user_id, refresh=True)
+    if not gate.enabled or gate.target != target:
+        raise DeliveryMutationBlockedError(
+            gate.reason or "execution_target_changed"
+        )
+    assert gate.connection is not None
+    if (
+        connection_credentials_generation(gate.connection)
+        != connection_generation
+    ):
+        raise DeliveryMutationBlockedError("connection_changed")
+
+
+def _canonical_mutation_guard(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    connection_generation: str,
+    canonical_id: str,
+    expected_version: str,
+) -> None:
+    _mutation_guard(
+        db,
+        user_id=user_id,
+        target=target,
+        connection_generation=connection_generation,
+    )
+    canonical = db.execute(
+        select(TrainingPlan)
+        .where(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.canonical_id == canonical_id,
+            TrainingPlan.source.in_(PRAXYS_PLAN_SOURCES),
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if canonical is None:
+        raise DeliveryMutationBlockedError("canonical_deleted_during_run")
+    if is_rest_workout(str(canonical.workout_type or "")):
+        raise DeliveryMutationBlockedError("canonical_became_rest")
+    if workout_version(plan_snapshot(canonical)) != expected_version:
+        raise DeliveryMutationBlockedError("canonical_changed_during_run")
+
+
+def _rest_mutation_guard(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    connection_generation: str,
+    canonical_id: str,
+    expected_version: str,
+) -> None:
+    _mutation_guard(
+        db,
+        user_id=user_id,
+        target=target,
+        connection_generation=connection_generation,
+    )
+    canonical = db.execute(
+        select(TrainingPlan)
+        .where(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.canonical_id == canonical_id,
+            TrainingPlan.source.in_(PRAXYS_PLAN_SOURCES),
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if canonical is None:
+        return
+    if (
+        not is_rest_workout(str(canonical.workout_type or ""))
+        or workout_version(plan_snapshot(canonical)) != expected_version
+    ):
+        raise DeliveryMutationBlockedError("canonical_changed_during_run")
+
+
+def _refresh_target_calendar(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    adapter: PlanDeliveryAdapter,
+    threshold_value: float | None,
+    window_start: date,
+    window_end: date,
+    observed_at: datetime,
+    mutation_guard: Callable[[], None],
+) -> set[str]:
+    rows = adapter.fetch_calendar(
+        threshold_value=threshold_value,
+        days_ahead=ROLLING_DELIVERY_DAYS + 2,
+        days_back=2,
+    )
+    external_ids = {
+        str(row.get("external_id") or "").strip()
+        for row in rows
+        if str(row.get("external_id") or "").strip()
+    }
+    mutation_guard()
+    record_target_calendar_sync(
+        db,
+        user_id=user_id,
+        target=target,
+        provider_account_id=adapter.account_id,
+        rows=rows,
+        window_start=window_start,
+        window_end=window_end,
+        observed_at=observed_at,
+    )
+    db.commit()
+    return external_ids
+
+
+def _recover_managed_inflight_attempts(
+    db: Session,
+    *,
+    user_id: str,
+    target: str,
+    provider_account_id: str,
+    connection_generation: str,
+    deliveries: list[PlanDelivery],
+) -> None:
+    lock_plan_writes(db, user_id)
+    calendar_sync = db.execute(
+        select(PlanTargetCalendarSync).where(
+            PlanTargetCalendarSync.user_id == user_id,
+            PlanTargetCalendarSync.target == target,
+            PlanTargetCalendarSync.provider_account_id
+            == provider_account_id,
+        )
+    ).scalar_one_or_none()
+    if calendar_sync is None:
+        db.rollback()
+        return
+    observations = db.execute(
+        select(PlanTargetWorkout).where(
+            PlanTargetWorkout.user_id == user_id,
+            PlanTargetWorkout.target == target,
+            PlanTargetWorkout.provider_account_id == provider_account_id,
+        )
+    ).scalars().all()
+    claimed_external_ids = {
+        external_id
+        for external_id in db.execute(
+            select(PlanDelivery.external_id).where(
+                PlanDelivery.user_id == user_id,
+                PlanDelivery.target == target,
+                PlanDelivery.external_id.is_not(None),
+                PlanDelivery.state != "removed",
+            )
+        ).scalars()
+        if external_id
+    }
+    changed = False
+
+    for delivery in deliveries:
+        if delivery.state != "delivering":
+            continue
+        attempt = db.execute(
+            select(PlanDeliveryAttempt)
+            .where(PlanDeliveryAttempt.delivery_id == delivery.id)
+            .order_by(
+                PlanDeliveryAttempt.attempt_number.desc(),
+                PlanDeliveryAttempt.id.desc(),
+            )
+        ).scalars().first()
+        if (
+            attempt is None
+            or attempt.state != "delivering"
+            or not isinstance(attempt.response, dict)
+            or attempt.response.get("managed_delivery") is not True
+            or calendar_sync.synced_at < attempt.started_at
+            or attempt.started_at
+            > datetime.utcnow() - DELIVERY_ATTEMPT_LEASE
+            or not (
+                calendar_sync.window_start
+                <= delivery.workout_date
+                <= calendar_sync.window_end
+            )
+        ):
+            continue
+
+        response = {
+            **attempt.response,
+            "recovered_from_calendar": True,
+        }
+        if (
+            attempt.response.get("provider_account_id")
+            != provider_account_id
+            or attempt.response.get("connection_generation")
+            != connection_generation
+        ):
+            complete_delivery_attempt(
+                db,
+                user_id=user_id,
+                delivery_id=delivery.id,
+                attempt_id=attempt.id,
+                attempt_state="conflict",
+                error="Provider account changed during recovery",
+                response={
+                    **response,
+                    "error_category": "provider_account_changed",
+                    "retryable": False,
+                },
+            )
+            changed = True
+            continue
+        if attempt.operation == "deliver":
+            preexisting_external_ids = {
+                str(external_id)
+                for external_id in attempt.response.get(
+                    "preexisting_external_ids",
+                    [],
+                )
+                if external_id
+            }
+            matches = [
+                observation
+                for observation in observations
+                if (
+                    observation.present
+                    and observation.workout_date == delivery.workout_date
+                    and delivery.provider_content_version
+                    and observation.content_fingerprint
+                    == delivery.provider_content_version
+                    and observation.external_id
+                    not in preexisting_external_ids
+                )
+            ]
+            if len(matches) == 1:
+                if matches[0].external_id in claimed_external_ids:
+                    matches = []
+            if len(matches) == 1:
+                observation = matches[0]
+                complete_delivery_attempt(
+                    db,
+                    user_id=user_id,
+                    delivery_id=delivery.id,
+                    attempt_id=attempt.id,
+                    attempt_state="synced",
+                    external_id=observation.external_id,
+                    response=response,
+                    provider_account_id=provider_account_id,
+                )
+                claimed_external_ids.add(observation.external_id)
+            else:
+                complete_delivery_attempt(
+                    db,
+                    user_id=user_id,
+                    delivery_id=delivery.id,
+                    attempt_id=attempt.id,
+                    attempt_state="conflict",
+                    error="Delivery outcome requires reconciliation",
+                    response={
+                        **response,
+                        "error_category": "provider_outcome_unknown",
+                        "retryable": False,
+                    },
+                )
+            changed = True
+            continue
+
+        if attempt.operation != "remove" or not delivery.external_id:
+            continue
+        exact = next(
+            (
+                observation
+                for observation in observations
+                if observation.external_id == delivery.external_id
+            ),
+            None,
+        )
+        if exact is not None and exact.present:
+            unchanged = (
+                exact.workout_date == delivery.workout_date
+                and delivery.provider_content_version is not None
+                and exact.content_fingerprint
+                == delivery.provider_content_version
+            )
+            complete_delivery_attempt(
+                db,
+                user_id=user_id,
+                delivery_id=delivery.id,
+                attempt_id=attempt.id,
+                attempt_state="failed",
+                delivery_state="synced",
+                error="Removal was not confirmed by the target calendar",
+                response={
+                    **response,
+                    "error_category": "provider_removal",
+                    "retryable": unchanged,
+                },
+            )
+        else:
+            complete_delivery_attempt(
+                db,
+                user_id=user_id,
+                delivery_id=delivery.id,
+                attempt_id=attempt.id,
+                attempt_state="conflict",
+                error="Removal outcome requires reconciliation",
+                response={
+                    **response,
+                    "error_category": "provider_outcome_unknown",
+                    "retryable": False,
+                },
+            )
+        changed = True
+
+    if changed:
+        from db.cache_revision import bump_revisions
+
+        bump_revisions(db, user_id, ["plans"])
+        db.commit()
+    else:
+        db.rollback()
+
+
+def _retry_eligibility(
+    db: Session,
+    delivery: PlanDelivery,
+    *,
+    operation: str,
+    now: datetime,
+    allow_initial: bool = False,
+    expected_canonical_version: str | None = None,
+) -> tuple[bool, str | None]:
+    attempts = db.execute(
+        select(PlanDeliveryAttempt)
+        .where(
+            PlanDeliveryAttempt.delivery_id == delivery.id,
+            PlanDeliveryAttempt.operation == operation,
+        )
+        .order_by(
+            PlanDeliveryAttempt.attempt_number,
+            PlanDeliveryAttempt.id,
+        )
+    ).scalars().all()
+    if not attempts:
+        return (
+            (True, None)
+            if allow_initial
+            else (False, "failure_not_recorded")
+        )
+    latest = attempts[-1]
+    if latest.state != "failed":
+        return True, None
+    if (
+        expected_canonical_version is not None
+        and isinstance(latest.response, dict)
+        and latest.response.get("canonical_version") is not None
+        and latest.response.get("canonical_version")
+        != expected_canonical_version
+    ):
+        return True, None
+    if not (
+        isinstance(latest.response, dict)
+        and latest.response.get("managed_delivery") is True
+    ):
+        return False, "failure_not_automatic"
+    last_success_index = max(
+        (
+            index
+            for index, attempt in enumerate(attempts)
+            if attempt.state in {"synced", "removed"}
+        ),
+        default=-1,
+    )
+    automatic_attempts = [
+        attempt
+        for attempt in attempts[last_success_index + 1:]
+        if attempt.state == "failed"
+        and isinstance(attempt.response, dict)
+        and attempt.response.get("managed_delivery") is True
+    ]
+    if not bool((latest.response or {}).get("retryable")):
+        return False, "failure_not_retryable"
+    if (latest.response or {}).get("error_category") == "delivery_gate_changed":
+        return True, None
+    failure_count = sum(
+        (attempt.response or {}).get(
+            "counts_toward_retry_limit",
+            True,
+        )
+        is not False
+        for attempt in automatic_attempts
+    )
+    if failure_count >= AUTOMATIC_DELIVERY_MAX_ATTEMPTS:
+        return False, "retry_limit_reached"
+    completed_at = latest.completed_at or latest.started_at
+    if now < completed_at + automatic_retry_delay(failure_count):
+        return False, "retry_backoff"
+    return True, None
+
+
+def _current_canonical(
+    db: Session,
+    *,
+    user_id: str,
+    canonical_id: str,
+) -> TrainingPlan | None:
+    return db.execute(
+        select(TrainingPlan).where(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.canonical_id == canonical_id,
+            TrainingPlan.source.in_(PRAXYS_PLAN_SOURCES),
+        ).execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+
+
+def _retry_wait_status(reason: str | None) -> str:
+    return "skipped" if reason == "retry_backoff" else "blocked"
+
+
+def _owned_removal_safe(
+    db: Session,
+    *,
+    delivery: PlanDelivery,
+    provider_account_id: str,
+) -> tuple[bool, str | None]:
+    if delivery.provider_account_id != provider_account_id:
+        return False, "provider_account_mismatch"
+    if delivery.state != "synced" or not delivery.external_id:
+        return False, f"delivery_{delivery.state}"
+
+    exact = db.execute(
+        select(PlanTargetWorkout).where(
+            PlanTargetWorkout.user_id == delivery.user_id,
+            PlanTargetWorkout.target == delivery.target,
+            PlanTargetWorkout.provider_account_id == provider_account_id,
+            PlanTargetWorkout.external_id == delivery.external_id,
+        )
+    ).scalar_one_or_none()
+    if exact is None or not exact.present:
+        return False, "target_workout_absent"
+    if exact.workout_date != delivery.workout_date:
+        return False, "target_workout_moved"
+    if (
+        not delivery.provider_content_version
+        or exact.content_fingerprint != delivery.provider_content_version
+    ):
+        return False, "target_workout_edited"
+    return True, None
+
+
+def _result(
+    canonical_id: str | None,
+    workout_date: date,
+    action: str,
+    status: str,
+    *,
+    reason: str | None = None,
+    external_id: str | None = None,
+) -> ManagedDeliveryItemResult:
+    return ManagedDeliveryItemResult(
+        canonical_id=canonical_id,
+        workout_date=workout_date.isoformat(),
+        action=action,
+        status=status,
+        reason=reason,
+        external_id=external_id,
+    )
+
+
+def _remove_owned_delivery(
+    db: Session,
+    *,
+    service: PlanDeliveryService,
+    delivery: PlanDelivery,
+    canonical_id: str | None,
+    provider_account_id: str,
+    connection: UserConnection | None,
+    connection_generation: str,
+    trigger: str,
+    timestamp: datetime,
+    attempt_context: Mapping[str, Any],
+    mutation_guard: Callable[[], None],
+) -> tuple[ManagedDeliveryItemResult, bool]:
+    safe, reason = _owned_removal_safe(
+        db,
+        delivery=delivery,
+        provider_account_id=provider_account_id,
+    )
+    if not safe:
+        return (
+            _result(
+                canonical_id,
+                delivery.workout_date,
+                "remove",
+                "blocked",
+                reason=reason,
+                external_id=delivery.external_id,
+            ),
+            False,
+        )
+    retryable, reason = _retry_eligibility(
+        db,
+        delivery,
+        operation="remove",
+        now=timestamp,
+        allow_initial=True,
+    )
+    if not retryable:
+        return (
+            _result(
+                canonical_id,
+                delivery.workout_date,
+                "remove",
+                _retry_wait_status(reason),
+                reason=reason,
+                external_id=delivery.external_id,
+            ),
+            False,
+        )
+    try:
+        removal = service.remove(
+            str(delivery.external_id),
+            attempt_context=attempt_context,
+            mutation_guard=mutation_guard,
+        )
+    except DeliveryMutationBlockedError as exc:
+        return (
+            _result(
+                canonical_id,
+                delivery.workout_date,
+                "remove",
+                "skipped",
+                reason=str(exc),
+                external_id=delivery.external_id,
+            ),
+            True,
+        )
+    except _CONNECTION_FAILURES as exc:
+        recorded = _record_connection_failure(
+            db,
+            connection,
+            exc,
+            trigger=trigger,
+            connection_generation=connection_generation,
+        )
+        category = (
+            type(exc).__name__ if recorded else "connection_changed"
+        )
+        logger.warning(
+            "Managed removal blocked user=%s target=%s canonical=%s "
+            "category=%s",
+            delivery.user_id,
+            delivery.target,
+            canonical_id,
+            category,
+        )
+        return (
+            _result(
+                canonical_id,
+                delivery.workout_date,
+                "remove",
+                "failed",
+                reason=category,
+                external_id=delivery.external_id,
+            ),
+            True,
+        )
+    except _REMOVAL_FAILURES as exc:
+        category = type(exc).__name__
+        logger.warning(
+            "Managed removal failed user=%s target=%s canonical=%s category=%s",
+            delivery.user_id,
+            delivery.target,
+            canonical_id,
+            category,
+        )
+        return (
+            _result(
+                canonical_id,
+                delivery.workout_date,
+                "remove",
+                "failed",
+                reason=category,
+                external_id=delivery.external_id,
+            ),
+            False,
+        )
+    return (
+        _result(
+            canonical_id,
+            delivery.workout_date,
+            "remove",
+            "removed",
+            external_id=removal.external_id,
+        ),
+        False,
+    )
+
+
+def run_rolling_delivery_for_user(
+    db: Session,
+    *,
+    user_id: str,
+    trigger: str,
+    now: datetime | None = None,
+    adapter_loader: AdapterLoader = _default_adapter_loader,
+    threshold_loader: ThresholdLoader = _default_threshold_loader,
+) -> ManagedDeliveryRunResult:
+    """Reconcile and deliver one user's managed plan for 14 calendar days."""
+    timestamp = now or datetime.utcnow()
+    window_start, window_end = _window(timestamp.date())
+    gate = _delivery_gate(db, user_id)
+    if not gate.enabled:
+        return ManagedDeliveryRunResult(
+            user_id=user_id,
+            trigger=trigger,
+            status="skipped",
+            target=gate.target,
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            reason=gate.reason,
+        )
+    assert gate.target is not None
+    assert gate.connection is not None
+    target = gate.target
+    connection_generation = connection_credentials_generation(
+        gate.connection
+    )
+    mutation_guard = lambda: _mutation_guard(
+        db,
+        user_id=user_id,
+        target=target,
+        connection_generation=connection_generation,
+    )
+
+    canonicals = db.execute(
+        select(TrainingPlan)
+        .where(
+            TrainingPlan.user_id == user_id,
+            TrainingPlan.source.in_(PRAXYS_PLAN_SOURCES),
+            TrainingPlan.date >= window_start,
+            TrainingPlan.date <= window_end,
+        )
+        .order_by(TrainingPlan.date, TrainingPlan.id)
+    ).scalars().all()
+    canonical_keys = {
+        canonical_workout_key(plan_snapshot(canonical))
+        for canonical in canonicals
+    }
+    owned_deliveries = db.execute(
+        select(PlanDelivery).where(
+            PlanDelivery.user_id == user_id,
+            PlanDelivery.target == target,
+            PlanDelivery.workout_date >= window_start,
+            PlanDelivery.workout_date <= window_end,
+            PlanDelivery.state != "removed",
+        )
+    ).scalars().all()
+    if not canonicals and not owned_deliveries:
+        return ManagedDeliveryRunResult(
+            user_id=user_id,
+            trigger=trigger,
+            status="complete",
+            target=target,
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+        )
+
+    threshold_value = threshold_loader(db, user_id)
+    try:
+        adapter = adapter_loader(db, user_id, target)
+        adapter.authenticate()
+        observed_external_ids = _refresh_target_calendar(
+            db,
+            user_id=user_id,
+            target=target,
+            adapter=adapter,
+            threshold_value=threshold_value,
+            window_start=window_start,
+            window_end=window_end,
+            observed_at=timestamp,
+            mutation_guard=mutation_guard,
+        )
+    except DeliveryMutationBlockedError as exc:
+        db.rollback()
+        return ManagedDeliveryRunResult(
+            user_id=user_id,
+            trigger=trigger,
+            status="skipped",
+            target=target,
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            reason=str(exc),
+        )
+    except (
+        DeliveryCredentialsInvalid,
+        DeliveryCredentialsUnavailable,
+        ProviderAuthenticationError,
+        ProviderReadError,
+    ) as exc:
+        recorded = _record_connection_failure(
+            db,
+            gate.connection,
+            exc,
+            trigger=trigger,
+            connection_generation=connection_generation,
+        )
+        category = (
+            type(exc).__name__ if recorded else "connection_changed"
+        )
+        logger.warning(
+            "Managed delivery blocked user=%s target=%s trigger=%s category=%s",
+            user_id,
+            target,
+            trigger,
+            category,
+        )
+        return ManagedDeliveryRunResult(
+            user_id=user_id,
+            trigger=trigger,
+            status="blocked",
+            target=target,
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            reason=category,
+        )
+
+    if not _record_connection_success(
+        db,
+        user_id=user_id,
+        target=target,
+        connection_generation=connection_generation,
+    ):
+        return ManagedDeliveryRunResult(
+            user_id=user_id,
+            trigger=trigger,
+            status="skipped",
+            target=target,
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            reason="connection_changed",
+        )
+    _recover_managed_inflight_attempts(
+        db,
+        user_id=user_id,
+        target=target,
+        provider_account_id=adapter.account_id,
+        connection_generation=connection_generation,
+        deliveries=owned_deliveries,
+    )
+    reconciliation = build_plan_reconciliation(
+        db,
+        user_id=user_id,
+        target=target,
+        start=window_start,
+        end=window_end,
+    )
+    if reconciliation is None:
+        return ManagedDeliveryRunResult(
+            user_id=user_id,
+            trigger=trigger,
+            status="blocked",
+            target=target,
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            reason="calendar_reconciliation_unavailable",
+        )
+
+    service = PlanDeliveryService(
+        db=db,
+        user_id=user_id,
+        target=target,
+        adapter_loader=lambda: adapter,
+    )
+    base_attempt_context: dict[str, Any] = {
+        "managed_delivery": True,
+        "trigger": trigger,
+        "provider_account_id": adapter.account_id,
+        "connection_generation": connection_generation,
+        "calendar_synced_at": (
+            reconciliation.calendar_sync.synced_at.isoformat()
+        ),
+    }
+
+    def attempt_context() -> Mapping[str, Any]:
+        return {
+            **base_attempt_context,
+            "preexisting_external_ids": sorted(observed_external_ids),
+        }
+
+    items: list[ManagedDeliveryItemResult] = []
+
+    for delivery in owned_deliveries:
+        canonical_id = canonical_id_from_workout_key(delivery.canonical_key)
+        if canonical_id is None or delivery.canonical_key in canonical_keys:
+            continue
+        gate = _delivery_gate(db, user_id)
+        if not gate.enabled or gate.target != target:
+            items.append(_result(
+                canonical_id,
+                delivery.workout_date,
+                "remove",
+                "skipped",
+                reason=gate.reason or "execution_target_changed",
+            ))
+            break
+        removal_result, stop_batch = _remove_owned_delivery(
+            db,
+            service=service,
+            delivery=delivery,
+            provider_account_id=adapter.account_id,
+            canonical_id=canonical_id,
+            connection=gate.connection,
+            connection_generation=connection_generation,
+            trigger=trigger,
+            timestamp=timestamp,
+            attempt_context=attempt_context(),
+            mutation_guard=mutation_guard,
+        )
+        items.append(removal_result)
+        if stop_batch:
+            break
+
+    for canonical in canonicals:
+        canonical_id = str(canonical.canonical_id)
+        workout_type = str(canonical.workout_type or "")
+        item: PlanReconciliationItem | None = (
+            reconciliation.canonical_items.get(canonical_id)
+        )
+        if item is None:
+            items.append(_result(
+                canonical_id,
+                canonical.date,
+                "deliver",
+                "blocked",
+                reason="reconciliation_item_missing",
+            ))
+            continue
+        if is_rest_workout(workout_type):
+            if item.state == "not_delivered" or (
+                item.state == "delivery_failed"
+                and item.delivery is not None
+                and not item.delivery.external_id
+            ):
+                items.append(_result(
+                    canonical_id,
+                    canonical.date,
+                    "deliver",
+                    "skipped",
+                    reason="rest_day",
+                ))
+                continue
+            if (
+                item.state
+                not in {"matching", "pending_observation", "canonical_changed"}
+                or item.delivery is None
+            ):
+                items.append(_result(
+                    canonical_id,
+                    canonical.date,
+                    "remove",
+                    "blocked",
+                    reason=item.state,
+                    external_id=(
+                        item.delivery.external_id
+                        if item.delivery is not None
+                        else None
+                    ),
+                ))
+                continue
+            current_rest = _current_canonical(
+                db,
+                user_id=user_id,
+                canonical_id=canonical_id,
+            )
+            if (
+                current_rest is not None
+                and not is_rest_workout(
+                    str(current_rest.workout_type or "")
+                )
+            ):
+                items.append(_result(
+                    canonical_id,
+                    canonical.date,
+                    "remove",
+                    "skipped",
+                    reason="canonical_changed_during_run",
+                    external_id=item.delivery.external_id,
+                ))
+                continue
+            gate = _delivery_gate(db, user_id)
+            if not gate.enabled or gate.target != target:
+                items.append(_result(
+                    canonical_id,
+                    canonical.date,
+                    "remove",
+                    "skipped",
+                    reason=gate.reason or "execution_target_changed",
+                    external_id=item.delivery.external_id,
+                ))
+                break
+            rest_mutation_guard = mutation_guard
+            if current_rest is not None:
+                expected_rest_version = workout_version(
+                    plan_snapshot(current_rest)
+                )
+                rest_mutation_guard = lambda: _rest_mutation_guard(
+                    db,
+                    user_id=user_id,
+                    target=target,
+                    connection_generation=connection_generation,
+                    canonical_id=canonical_id,
+                    expected_version=expected_rest_version,
+                )
+            removal_result, stop_batch = _remove_owned_delivery(
+                db,
+                service=service,
+                delivery=item.delivery,
+                canonical_id=canonical_id,
+                provider_account_id=adapter.account_id,
+                connection=gate.connection,
+                connection_generation=connection_generation,
+                trigger=trigger,
+                timestamp=timestamp,
+                attempt_context=attempt_context(),
+                mutation_guard=rest_mutation_guard,
+            )
+            items.append(removal_result)
+            if stop_batch:
+                break
+            continue
+
+        action = "deliver"
+        if item.state in {"matching", "pending_observation"}:
+            items.append(_result(
+                canonical_id,
+                canonical.date,
+                action,
+                "skipped",
+                reason=item.state,
+                external_id=(
+                    item.delivery.external_id
+                    if item.delivery is not None
+                    else None
+                ),
+            ))
+            continue
+        if item.state == "canonical_changed":
+            action = "replace"
+        elif item.state == "delivery_failed":
+            if item.delivery is None or item.delivery.state != "failed":
+                items.append(_result(
+                    canonical_id,
+                    canonical.date,
+                    action,
+                    "blocked",
+                    reason="reconciliation_required",
+                ))
+                continue
+            current_version = workout_version(plan_snapshot(canonical))
+            failed_version = (
+                item.delivery.plan_version
+                or item.delivery.workout_version
+            )
+            corrected_version = (
+                current_version != failed_version
+                and not item.delivery.external_id
+            )
+            if not corrected_version:
+                retryable, reason = _retry_eligibility(
+                    db,
+                    item.delivery,
+                    operation="deliver",
+                    now=timestamp,
+                )
+                if not retryable:
+                    items.append(_result(
+                        canonical_id,
+                        canonical.date,
+                        action,
+                        _retry_wait_status(reason),
+                        reason=reason,
+                    ))
+                    continue
+        elif item.state != "not_delivered":
+            items.append(_result(
+                canonical_id,
+                canonical.date,
+                action,
+                "blocked",
+                reason=item.state,
+                external_id=(
+                    item.delivery.external_id
+                    if item.delivery is not None
+                    else None
+                ),
+            ))
+            continue
+
+        gate = _delivery_gate(db, user_id)
+        if not gate.enabled or gate.target != target:
+            items.append(_result(
+                canonical_id,
+                canonical.date,
+                action,
+                "skipped",
+                reason=gate.reason or "execution_target_changed",
+            ))
+            break
+        current = _current_canonical(
+            db,
+            user_id=user_id,
+            canonical_id=canonical_id,
+        )
+        if current is None or not (
+            window_start <= current.date <= window_end
+        ):
+            items.append(_result(
+                canonical_id,
+                canonical.date,
+                action,
+                "skipped",
+                reason="canonical_changed_during_run",
+            ))
+            continue
+        if not threshold_value:
+            items.append(_result(
+                canonical_id,
+                current.date,
+                action,
+                "blocked",
+                reason="threshold_unavailable",
+            ))
+            continue
+
+        if action == "replace":
+            assert item.delivery is not None
+            expected_version = workout_version(plan_snapshot(current))
+            retryable, reason = _retry_eligibility(
+                db,
+                item.delivery,
+                operation="deliver",
+                now=timestamp,
+                allow_initial=True,
+                expected_canonical_version=expected_version,
+            )
+            if not retryable:
+                items.append(_result(
+                    canonical_id,
+                    current.date,
+                    action,
+                    _retry_wait_status(reason),
+                    reason=reason,
+                    external_id=item.delivery.external_id,
+                ))
+                continue
+            retryable, reason = _retry_eligibility(
+                db,
+                item.delivery,
+                operation="remove",
+                now=timestamp,
+                allow_initial=True,
+            )
+            if not retryable:
+                items.append(_result(
+                    canonical_id,
+                    current.date,
+                    action,
+                    _retry_wait_status(reason),
+                    reason=reason,
+                    external_id=item.delivery.external_id,
+                ))
+                continue
+            try:
+                canonical_mutation_guard = lambda: _canonical_mutation_guard(
+                    db,
+                    user_id=user_id,
+                    target=target,
+                    connection_generation=connection_generation,
+                    canonical_id=canonical_id,
+                    expected_version=expected_version,
+                )
+                restored = restore_praxys_version(
+                    db,
+                    user_id=user_id,
+                    target=target,
+                    item=item,
+                    threshold_value=threshold_value,
+                    adapter_loader=lambda: adapter,
+                    actor_type="system",
+                    actor_id=None,
+                    origin="managed_plan.rolling_delivery",
+                    trigger=trigger,
+                    attempt_context=attempt_context(),
+                    mutation_guard=canonical_mutation_guard,
+                )
+            except DeliveryMutationBlockedError as exc:
+                items.append(_result(
+                    canonical_id,
+                    current.date,
+                    action,
+                    "skipped",
+                    reason=str(exc),
+                ))
+                break
+            except _CONNECTION_FAILURES as exc:
+                recorded = _record_connection_failure(
+                    db,
+                    gate.connection,
+                    exc,
+                    trigger=trigger,
+                    connection_generation=connection_generation,
+                )
+                category = (
+                    type(exc).__name__
+                    if recorded
+                    else "connection_changed"
+                )
+                items.append(_result(
+                    canonical_id,
+                    current.date,
+                    action,
+                    "failed",
+                    reason=category,
+                ))
+                break
+            except PlanResolutionConflict as exc:
+                logger.info(
+                    "Managed replacement blocked user=%s target=%s "
+                    "canonical=%s category=PlanResolutionConflict reason=%s",
+                    user_id,
+                    target,
+                    canonical_id,
+                    str(exc),
+                )
+                items.append(_result(
+                    canonical_id,
+                    current.date,
+                    action,
+                    "blocked",
+                    reason="plan_resolution_conflict",
+                ))
+                continue
+            except _REPLACEMENT_FAILURES as exc:
+                items.append(_result(
+                    canonical_id,
+                    current.date,
+                    action,
+                    "failed",
+                    reason=type(exc).__name__,
+                ))
+                continue
+            items.append(_result(
+                canonical_id,
+                current.date,
+                action,
+                "replaced",
+                external_id=restored.external_id,
+            ))
+            if restored.external_id:
+                observed_external_ids.add(restored.external_id)
+            continue
+
+        try:
+            expected_version = workout_version(plan_snapshot(current))
+            canonical_mutation_guard = lambda: _canonical_mutation_guard(
+                db,
+                user_id=user_id,
+                target=target,
+                connection_generation=connection_generation,
+                canonical_id=canonical_id,
+                expected_version=expected_version,
+            )
+            outcome = service.deliver(
+                plan_snapshot(current),
+                threshold_value=threshold_value,
+                observed_external_ids=None,
+                attempt_context=attempt_context(),
+                mutation_guard=canonical_mutation_guard,
+            )
+        except DeliveryMutationBlockedError as exc:
+            items.append(_result(
+                canonical_id,
+                current.date,
+                action,
+                "skipped",
+                reason=str(exc),
+            ))
+            break
+        except _CONNECTION_FAILURES as exc:
+            recorded = _record_connection_failure(
+                db,
+                gate.connection,
+                exc,
+                trigger=trigger,
+                connection_generation=connection_generation,
+            )
+            category = (
+                type(exc).__name__
+                if recorded
+                else "connection_changed"
+            )
+            items.append(_result(
+                canonical_id,
+                current.date,
+                action,
+                "failed",
+                reason=category,
+            ))
+            break
+        if outcome.error_category == "delivery_gate_changed":
+            items.append(_result(
+                canonical_id,
+                current.date,
+                action,
+                "skipped",
+                reason=outcome.error or "delivery_gate_changed",
+            ))
+            break
+        items.append(_result(
+            canonical_id,
+            current.date,
+            action,
+            "delivered" if outcome.status == "success" else "failed",
+            reason=outcome.error_category or "delivery_failed",
+            external_id=outcome.external_id,
+        ))
+        if outcome.external_id:
+            observed_external_ids.add(outcome.external_id)
+
+    failed = sum(item.status == "failed" for item in items)
+    blocked = sum(item.status == "blocked" for item in items)
+    logger.info(
+        "Managed delivery complete user=%s target=%s trigger=%s items=%d "
+        "failed=%d blocked=%d",
+        user_id,
+        target,
+        trigger,
+        len(items),
+        failed,
+        blocked,
+    )
+    return ManagedDeliveryRunResult(
+        user_id=user_id,
+        trigger=trigger,
+        status="partial" if failed or blocked else "complete",
+        target=target,
+        window_start=window_start.isoformat(),
+        window_end=window_end.isoformat(),
+        items=tuple(items),
+    )
+
+
+def trigger_managed_plan_delivery(
+    user_id: str,
+    *,
+    trigger: str,
+) -> ManagedDeliveryRunResult | None:
+    """Run one post-commit delivery pass without changing mutation success."""
+    from db.session import SessionLocal, init_db
+
+    init_db()
+    db = SessionLocal()
+    try:
+        return run_rolling_delivery_for_user(
+            db,
+            user_id=user_id,
+            trigger=trigger,
+        )
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "Managed delivery trigger failed user=%s trigger=%s",
+            user_id,
+            trigger,
+        )
+        return None
+    finally:
+        db.close()
+
+
+def run_scheduled_managed_deliveries() -> None:
+    """Run one isolated rolling-delivery pass for every explicitly enabled user."""
+    from db.session import SessionLocal, init_db
+
+    init_db()
+    db = SessionLocal()
+    try:
+        rows = db.execute(
+            select(UserConfig.user_id, UserConfig.plan_management)
+        ).all()
+        user_ids = []
+        for user_id, raw_plan_management in rows:
+            plan_management = normalize_plan_management(
+                raw_plan_management
+            )
+            if (
+                plan_management["mode"] == "praxys"
+                and plan_management["delivery_enabled"]
+            ):
+                user_ids.append(user_id)
+    finally:
+        db.close()
+
+    for user_id in user_ids:
+        trigger_managed_plan_delivery(
+            user_id,
+            trigger="scheduled_retry",
+        )

--- a/api/plan_delivery/service.py
+++ b/api/plan_delivery/service.py
@@ -17,6 +17,7 @@ from api.plan_delivery.base import (
     ProviderRejectedError,
     ProviderRemovalError,
     ProviderRequestError,
+    ProviderTransientError,
 )
 from api.plan_delivery.credentials import (
     DeliveryCredentialsInvalid,
@@ -31,6 +32,7 @@ from db.plan_ledger import (
     find_delivery_by_external_id,
     find_unverified_delivery_for_date,
     get_or_create_delivery,
+    workout_version,
 )
 
 logger = logging.getLogger(__name__)
@@ -38,12 +40,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class DeliveryResult:
-    """One manual delivery outcome."""
+    """One delivery outcome."""
 
     status: str
     external_id: str | None = None
     error: str | None = None
     delivered_at: datetime | None = None
+    error_category: str | None = None
+    retryable: bool = False
 
 
 @dataclass(frozen=True)
@@ -80,6 +84,10 @@ class DeliveryRemovalFailedError(RuntimeError):
 
 class DeliveryFinalizationError(RuntimeError):
     """The provider changed but the durable ledger could not be finalized."""
+
+
+class DeliveryMutationBlockedError(RuntimeError):
+    """A fresh managed-delivery gate blocked provider mutation."""
 
 
 class PlanDeliveryService:
@@ -145,12 +153,76 @@ class PlanDeliveryService:
             self.db.commit()
         return updated
 
+    def _record_preflight_delivery_failure(
+        self,
+        snapshot: Mapping[str, Any],
+        *,
+        error: ProviderRequestError,
+        attempt_context: Mapping[str, Any] | None,
+    ) -> DeliveryResult:
+        """Persist a definite no-write preparation failure."""
+        canonical_version = workout_version(snapshot)
+        try:
+            delivery, _ = get_or_create_delivery(
+                self.db,
+                user_id=self.user_id,
+                target=self.target,
+                snapshot=snapshot,
+                workout_version_override=canonical_version,
+                provider_content_version_override=canonical_version,
+            )
+            delivery, attempt, disposition = begin_delivery_attempt(
+                self.db,
+                delivery,
+                operation="deliver",
+            )
+            if disposition != "started" or attempt is None:
+                self.db.rollback()
+                return DeliveryResult(
+                    status="error",
+                    error=str(error),
+                    error_category="invalid_workout",
+                )
+            attempt.response = dict(attempt_context or {})
+            delivery_id = delivery.id
+            attempt_id = attempt.id
+            bump_revisions(self.db, self.user_id, ["plans"])
+            self.db.commit()
+            self._record_terminal_attempt(
+                delivery_id=delivery_id,
+                attempt_id=attempt_id,
+                state="failed",
+                error=str(error),
+                response={
+                    **dict(attempt_context or {}),
+                    "canonical_version": canonical_version,
+                    "error_category": "invalid_workout",
+                    "retryable": False,
+                },
+            )
+        except (SQLAlchemyError, ValueError):
+            self.db.rollback()
+            logger.exception(
+                "Failed to persist delivery preflight failure "
+                "user=%s target=%s date=%s",
+                self.user_id,
+                self.target,
+                snapshot.get("date"),
+            )
+        return DeliveryResult(
+            status="error",
+            error=str(error),
+            error_category="invalid_workout",
+        )
+
     def deliver(
         self,
         snapshot: Mapping[str, Any],
         *,
         threshold_value: float,
         observed_external_ids: object = None,
+        attempt_context: Mapping[str, Any] | None = None,
+        mutation_guard: Callable[[], None] | None = None,
     ) -> DeliveryResult:
         """Deliver one canonical workout version to the configured target."""
         workout_date = str(snapshot["date"])
@@ -163,8 +235,14 @@ class PlanDeliveryService:
             )
             adapter.authenticate()
             provider_account_id = adapter.account_id
+            if mutation_guard is not None:
+                mutation_guard()
         except ProviderRequestError as exc:
-            return DeliveryResult(status="error", error=str(exc))
+            return self._record_preflight_delivery_failure(
+                snapshot,
+                error=exc,
+                attempt_context=attempt_context,
+            )
 
         try:
             delivery, delivery_created = get_or_create_delivery(
@@ -188,6 +266,7 @@ class PlanDeliveryService:
                         f"This {provider_name} delivery belongs to a "
                         f"different {provider_name} account"
                     ),
+                    error_category="provider_account_mismatch",
                 )
             unverified = find_unverified_delivery_for_date(
                 self.db,
@@ -202,6 +281,7 @@ class PlanDeliveryService:
                     error=(
                         f"Delivery outcome is uncertain; sync {provider_name} before retrying"
                     ),
+                    error_category="reconciliation_required",
                 )
 
             delivery, attempt, disposition = begin_delivery_attempt(
@@ -225,6 +305,7 @@ class PlanDeliveryService:
                     error=(
                         f"Delivery outcome is uncertain; sync {provider_name} before retrying"
                     ),
+                    error_category="reconciliation_required",
                 )
             if disposition == "replacement_required":
                 self._cleanup_new_delivery(delivery, delivery_created)
@@ -234,8 +315,11 @@ class PlanDeliveryService:
                         f"The existing Praxys-managed {provider_name} workout "
                         "must be removed before replacement"
                     ),
+                    error_category="replacement_required",
                 )
             assert attempt is not None
+            if attempt_context is not None:
+                attempt.response = dict(attempt_context)
             delivery_id = delivery.id
             attempt_id = attempt.id
             bump_revisions(self.db, self.user_id, ["plans"])
@@ -251,21 +335,61 @@ class PlanDeliveryService:
             return DeliveryResult(
                 status="error",
                 error=f"Could not start delivery: {exc}",
+                error_category="ledger_start_failed",
+                retryable=True,
             )
 
         try:
+            if mutation_guard is not None:
+                mutation_guard()
             provider_result = adapter.create_workout(prepared)
             if provider_result.provider_account_id != provider_account_id:
                 raise ProviderOutcomeUnknownError(
                     f"{provider_name} account changed during delivery"
                 )
-        except (ProviderRequestError, ProviderRejectedError) as exc:
+        except DeliveryMutationBlockedError as exc:
+            response = {
+                **dict(attempt_context or {}),
+                "error_category": "delivery_gate_changed",
+                "retryable": True,
+                "counts_toward_retry_limit": False,
+            }
             try:
                 self._record_terminal_attempt(
                     delivery_id=delivery_id,
                     attempt_id=attempt_id,
                     state="failed",
                     error=str(exc),
+                    response=response,
+                )
+            except SQLAlchemyError:
+                self.db.rollback()
+                logger.exception(
+                    "Failed to persist delivery gate change for "
+                    "user=%s target=%s date=%s",
+                    self.user_id,
+                    self.target,
+                    workout_date,
+                )
+            return DeliveryResult(
+                status="error",
+                error=str(exc),
+                error_category="delivery_gate_changed",
+                retryable=True,
+            )
+        except ProviderTransientError as exc:
+            response = {
+                **dict(attempt_context or {}),
+                "error_category": "provider_transient",
+                "retryable": True,
+            }
+            try:
+                self._record_terminal_attempt(
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    state="failed",
+                    error=str(exc),
+                    response=response,
                 )
             except SQLAlchemyError:
                 self.db.rollback()
@@ -275,18 +399,56 @@ class PlanDeliveryService:
                     self.user_id,
                     workout_date,
                 )
-            return DeliveryResult(status="error", error=str(exc))
+            return DeliveryResult(
+                status="error",
+                error=str(exc),
+                error_category="provider_transient",
+                retryable=True,
+            )
+        except (ProviderRequestError, ProviderRejectedError) as exc:
+            response = {
+                **dict(attempt_context or {}),
+                "error_category": "provider_rejected",
+                "retryable": False,
+            }
+            try:
+                self._record_terminal_attempt(
+                    delivery_id=delivery_id,
+                    attempt_id=attempt_id,
+                    state="failed",
+                    error=str(exc),
+                    response=response,
+                )
+            except SQLAlchemyError:
+                self.db.rollback()
+                logger.exception(
+                    "Failed to persist %s delivery failure for user=%s date=%s",
+                    self.target,
+                    self.user_id,
+                    workout_date,
+                )
+            return DeliveryResult(
+                status="error",
+                error=str(exc),
+                error_category="provider_rejected",
+            )
         except ProviderOutcomeUnknownError as exc:
             message = (
                 f"{provider_name} delivery outcome is uncertain; "
                 f"sync {provider_name} before retrying"
             )
+            response = {
+                **dict(attempt_context or {}),
+                "error_category": "provider_outcome_unknown",
+                "retryable": False,
+            }
             try:
                 self._record_terminal_attempt(
                     delivery_id=delivery_id,
                     attempt_id=attempt_id,
                     state="conflict",
                     error=f"{message}: {exc}",
+                    response=response,
                 )
             except SQLAlchemyError:
                 self.db.rollback()
@@ -296,15 +458,23 @@ class PlanDeliveryService:
                     self.user_id,
                     workout_date,
                 )
-            return DeliveryResult(status="error", error=message)
+            return DeliveryResult(
+                status="error",
+                error=message,
+                error_category="provider_outcome_unknown",
+            )
 
         try:
+            response = {
+                **dict(provider_result.response),
+                **dict(attempt_context or {}),
+            }
             self._record_terminal_attempt(
                 delivery_id=delivery_id,
                 attempt_id=attempt_id,
                 state="synced",
                 external_id=provider_result.external_id,
-                response=provider_result.response,
+                response=response,
                 provider_account_id=provider_result.provider_account_id,
             )
         except SQLAlchemyError:
@@ -322,6 +492,7 @@ class PlanDeliveryService:
                     f"{provider_name} accepted the workout, but delivery state could not "
                     "be finalized"
                 ),
+                error_category="ledger_finalization_failed",
             )
         return DeliveryResult(
             status="success",
@@ -329,7 +500,13 @@ class PlanDeliveryService:
             delivered_at=datetime.utcnow(),
         )
 
-    def remove(self, external_id: str) -> RemovalResult:
+    def remove(
+        self,
+        external_id: str,
+        *,
+        attempt_context: Mapping[str, Any] | None = None,
+        mutation_guard: Callable[[], None] | None = None,
+    ) -> RemovalResult:
         """Remove one caller-owned provider workout and finalize its ledger."""
         provider_name = self.target.capitalize()
         delivery = find_delivery_by_external_id(
@@ -386,6 +563,8 @@ class PlanDeliveryService:
                 f"This {provider_name} delivery belongs to a different "
                 f"{provider_name} account"
             )
+        if mutation_guard is not None:
+            mutation_guard()
 
         previous_state = delivery.state
         if previous_state == "delivering" and delivery.external_id:
@@ -405,6 +584,8 @@ class PlanDeliveryService:
                     f"{provider_name} workout delivery is already being updated"
                 )
             assert attempt is not None
+            if attempt_context is not None:
+                attempt.response = dict(attempt_context)
             delivery_id = delivery.id
             attempt_id = attempt.id
             bump_revisions(self.db, self.user_id, ["plans"])
@@ -423,7 +604,13 @@ class PlanDeliveryService:
                 f"Could not start {provider_name} workout removal"
             ) from exc
 
-        def record_failure(message: str) -> bool:
+        def record_failure(
+            message: str,
+            *,
+            error_category: str,
+            retryable: bool,
+            counts_toward_retry_limit: bool = True,
+        ) -> bool:
             try:
                 updated = self._record_terminal_attempt(
                     delivery_id=delivery_id,
@@ -431,6 +618,14 @@ class PlanDeliveryService:
                     state="failed",
                     delivery_state=previous_state,
                     error=message,
+                    response={
+                        **dict(attempt_context or {}),
+                        "error_category": error_category,
+                        "retryable": retryable,
+                        "counts_toward_retry_limit": (
+                            counts_toward_retry_limit
+                        ),
+                    },
                 )
                 current = find_delivery_by_external_id(
                     self.db,
@@ -454,27 +649,49 @@ class PlanDeliveryService:
                 return False
 
         try:
+            if mutation_guard is not None:
+                mutation_guard()
             provider_result = adapter.delete_workout(external_id)
+        except DeliveryMutationBlockedError as exc:
+            record_failure(
+                str(exc),
+                error_category="delivery_gate_changed",
+                retryable=True,
+                counts_toward_retry_limit=False,
+            )
+            raise
         except (
             DeliveryCredentialsUnavailable,
             DeliveryCredentialsInvalid,
             ProviderAuthenticationError,
         ) as exc:
-            if record_failure(str(exc)):
+            if record_failure(
+                str(exc),
+                error_category="provider_authentication",
+                retryable=True,
+            ):
                 return RemovalResult(external_id=external_id)
             raise
         except ProviderRemovalError as exc:
-            if record_failure(str(exc)):
+            if record_failure(
+                str(exc),
+                error_category="provider_removal",
+                retryable=True,
+            ):
                 return RemovalResult(external_id=external_id)
             raise DeliveryRemovalFailedError(str(exc)) from exc
 
         try:
+            response = {
+                "already_absent": provider_result.already_absent,
+                **dict(attempt_context or {}),
+            }
             self._record_terminal_attempt(
                 delivery_id=delivery_id,
                 attempt_id=attempt_id,
                 state="removed",
                 external_id=external_id,
-                response={"already_absent": provider_result.already_absent},
+                response=response,
                 commit=False,
             )
             self.db.query(TrainingPlan).filter(

--- a/api/plan_delivery/stryd.py
+++ b/api/plan_delivery/stryd.py
@@ -17,6 +17,7 @@ from api.plan_delivery.base import (
     ProviderRemoveResult,
     ProviderRemovalError,
     ProviderRequestError,
+    ProviderTransientError,
 )
 from db.plan_ledger import normalize_stryd_workout_id
 from sync import stryd_sync
@@ -228,6 +229,10 @@ class StrydPlanDeliveryAdapter:
             detail = self._http_detail(exc)
             if status_code is None or status_code == 408 or status_code >= 500:
                 raise ProviderOutcomeUnknownError(detail) from exc
+            if status_code == 429:
+                raise ProviderTransientError(
+                    f"Stryd API rate limit: {detail}"
+                ) from exc
             raise ProviderRejectedError(f"Stryd API error: {detail}") from exc
         except requests.RequestException as exc:
             raise ProviderOutcomeUnknownError(str(exc)) from exc

--- a/api/plan_resolution.py
+++ b/api/plan_resolution.py
@@ -10,8 +10,19 @@ from typing import Any, Callable, Mapping
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from api.plan_delivery.base import PlanDeliveryAdapter
-from api.plan_delivery.service import PlanDeliveryService
+from api.plan_delivery.base import (
+    PlanDeliveryAdapter,
+    ProviderAuthenticationError,
+    ProviderRequestError,
+)
+from api.plan_delivery.credentials import (
+    DeliveryCredentialsInvalid,
+    DeliveryCredentialsUnavailable,
+)
+from api.plan_delivery.service import (
+    DeliveryMutationBlockedError,
+    PlanDeliveryService,
+)
 from api.plan_reconciliation import PlanReconciliationItem
 from db.cache_revision import bump_revisions
 from db.models import (
@@ -475,6 +486,10 @@ def _record_restore_revision(
     target: str,
     item: PlanReconciliationItem,
     canonical: TrainingPlan,
+    actor_type: str,
+    actor_id: str | None,
+    origin: str,
+    trigger: str | None,
 ) -> tuple[PlanRevision, dict[str, Any], str]:
     snapshot = plan_snapshot(canonical)
     current_version = workout_version(snapshot)
@@ -486,9 +501,9 @@ def _record_restore_revision(
         db,
         user_id=user_id,
         operation="restore_target",
-        actor_type="user",
-        actor_id=user_id,
-        origin="api.plan.reconciliation.restore",
+        actor_type=actor_type,
+        actor_id=actor_id,
+        origin=origin,
         before=[snapshot],
         after=[snapshot],
         details={
@@ -502,6 +517,7 @@ def _record_restore_revision(
                 if item.delivery is not None
                 else None
             ),
+            **({"trigger": trigger} if trigger else {}),
         },
         idempotency_key=idempotency_key,
     )
@@ -816,6 +832,8 @@ def _record_restore_preflight_failure(
     delivery_id: str,
     revision_id: str,
     error: Exception,
+    canonical_version: str,
+    attempt_context: Mapping[str, Any] | None,
 ) -> None:
     """Best-effort delivery event for a restore that failed before provider I/O."""
     try:
@@ -835,9 +853,33 @@ def _record_restore_preflight_failure(
             external_id=delivery.external_id,
             error=str(error),
             response={
+                **dict(attempt_context or {}),
                 "resolution": "restore_praxys",
                 "revision_id": revision_id,
                 "preflight": True,
+                "canonical_version": canonical_version,
+                "error_category": (
+                    "invalid_workout"
+                    if isinstance(error, ProviderRequestError)
+                    else "provider_authentication"
+                    if isinstance(
+                        error,
+                        (
+                            DeliveryCredentialsInvalid,
+                            DeliveryCredentialsUnavailable,
+                            ProviderAuthenticationError,
+                        ),
+                    )
+                    else "reconciliation_required"
+                ),
+                "retryable": isinstance(
+                    error,
+                    (
+                        DeliveryCredentialsInvalid,
+                        DeliveryCredentialsUnavailable,
+                        ProviderAuthenticationError,
+                    ),
+                ),
             },
         )
         bump_revisions(db, user_id, ["plans"])
@@ -859,6 +901,12 @@ def restore_praxys_version(
     item: PlanReconciliationItem,
     threshold_value: float,
     adapter_loader: Callable[[], PlanDeliveryAdapter],
+    actor_type: str = "user",
+    actor_id: str | None = None,
+    origin: str = "api.plan.reconciliation.restore",
+    trigger: str | None = None,
+    attempt_context: Mapping[str, Any] | None = None,
+    mutation_guard: Callable[[], None] | None = None,
 ) -> PlanResolutionResult:
     """Restore the current canonical version with retry-safe provider writes."""
     if item.canonical is None or item.delivery is None:
@@ -920,6 +968,14 @@ def restore_praxys_version(
         target=target,
         item=item,
         canonical=canonical,
+        actor_type=actor_type,
+        actor_id=(
+            user_id
+            if actor_type == "user" and actor_id is None
+            else actor_id
+        ),
+        origin=origin,
+        trigger=trigger,
     )
 
     try:
@@ -937,13 +993,21 @@ def restore_praxys_version(
             raise PlanResolutionConflict(
                 "Delivery belongs to a different provider account"
             )
-    except Exception as exc:
+    except (
+        DeliveryCredentialsInvalid,
+        DeliveryCredentialsUnavailable,
+        PlanResolutionConflict,
+        ProviderAuthenticationError,
+        ProviderRequestError,
+    ) as exc:
         _record_restore_preflight_failure(
             db,
             user_id=user_id,
             delivery_id=prior_delivery_id,
             revision_id=revision.id,
             error=exc,
+            canonical_version=expected_plan_version,
+            attempt_context=attempt_context,
         )
         raise
 
@@ -1003,7 +1067,15 @@ def restore_praxys_version(
             target=target,
             item=item,
         )
-        service.remove(item.delivery.external_id)
+        service.remove(
+            item.delivery.external_id,
+            attempt_context={
+                **dict(attempt_context or {}),
+                "resolution": "restore_praxys",
+                "revision_id": revision.id,
+            },
+            mutation_guard=mutation_guard,
+        )
     _assert_resolution_generation(
         db,
         user_id=user_id,
@@ -1014,7 +1086,17 @@ def restore_praxys_version(
         snapshot,
         threshold_value=threshold_value,
         observed_external_ids=None,
+        attempt_context={
+            **dict(attempt_context or {}),
+            "resolution": "restore_praxys",
+            "revision_id": revision.id,
+        },
+        mutation_guard=mutation_guard,
     )
+    if outcome.error_category == "delivery_gate_changed":
+        raise DeliveryMutationBlockedError(
+            outcome.error or "Managed delivery gate changed"
+        )
     if outcome.status != "success" or not outcome.external_id:
         raise PlanResolutionProviderError(
             outcome.error or "Provider restore did not complete"

--- a/api/routes/ai.py
+++ b/api/routes/ai.py
@@ -1,6 +1,7 @@
 """AI-related endpoints: training context, plan upload, per-day upsert/delete."""
 import csv
 import io
+import logging
 from collections import defaultdict
 from datetime import date, datetime
 from typing import Optional
@@ -23,6 +24,7 @@ from db.plan_ledger import (
 from db.session import get_db
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("/ai/context")
@@ -107,6 +109,20 @@ def _assign_missing_canonical_ids(plans: list[TrainingPlan]) -> None:
     for plan in plans:
         if not plan.canonical_id:
             plan.canonical_id = str(uuid4())
+
+
+def _trigger_managed_delivery(user_id: str, *, trigger: str) -> None:
+    """Run the post-commit delivery hook without changing mutation success."""
+    try:
+        from api.plan_delivery.rolling import trigger_managed_plan_delivery
+
+        trigger_managed_plan_delivery(user_id, trigger=trigger)
+    except Exception:
+        logger.exception(
+            "Post-commit managed delivery hook failed user=%s trigger=%s",
+            user_id,
+            trigger,
+        )
 
 
 def _parse_csv_row(row: dict, row_index: int) -> dict:
@@ -208,6 +224,7 @@ def upload_plan(
         db.rollback()
         raise
 
+    _trigger_managed_delivery(user_id, trigger="plan_upload")
     return {"status": "saved", "rows": len(parsed_rows), "mode": mode}
 
 
@@ -275,6 +292,7 @@ def upsert_plan_day(
         db.rollback()
         raise
     db.refresh(plan)
+    _trigger_managed_delivery(user_id, trigger="plan_upsert")
     return _row_to_response(plan)
 
 
@@ -320,4 +338,6 @@ def delete_plan_day(
     except Exception:
         db.rollback()
         raise
+    if deleted:
+        _trigger_managed_delivery(user_id, trigger="plan_delete")
     return {"status": "deleted", "rows": deleted, "date": plan_date}

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -34,7 +34,9 @@ from analysis.thresholds import detect_thresholds
 from analysis.training_base import get_display_config
 from api.auth import get_data_user_id, require_write_access
 from api.env_compat import getenv_compat
+from api.plan_delivery import is_plan_delivery_target_registered
 from api.views import utc_isoformat
+from db.models import UserConnection
 from db.session import get_db
 from db.sync_scheduler import (
     ALLOWED_SYNC_INTERVAL_HOURS,
@@ -90,6 +92,9 @@ def _legacy_execution_target(plan_source: object) -> str | None:
 def _apply_plan_management_update(
     config: UserConfig,
     update: PlanManagementUpdate,
+    *,
+    user_id: str,
+    db: Session,
 ) -> None:
     """Validate and merge an explicit managed-plan settings update."""
     changes = update.model_dump(exclude_unset=True)
@@ -101,17 +106,28 @@ def _apply_plan_management_update(
             )
 
     candidate = {**config.plan_management, **changes}
+    if (
+        changes.get("mode") == "external"
+        and "delivery_enabled" not in changes
+    ):
+        candidate["delivery_enabled"] = False
     if candidate.get("delivery_enabled"):
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                "Managed-plan delivery is not available yet. "
-                "Plan ownership can be selected without enabling platform writes."
-            ),
-        )
+        if candidate.get("mode") != "praxys":
+            raise HTTPException(
+                status_code=400,
+                detail="Managed-plan delivery requires Praxys mode",
+            )
+        if not candidate.get("execution_target"):
+            raise HTTPException(
+                status_code=400,
+                detail="Managed-plan delivery requires an execution target",
+            )
 
     target = candidate.get("execution_target")
-    if target is not None:
+    if target is not None and (
+        "execution_target" in changes
+        or candidate.get("delivery_enabled")
+    ):
         if target not in config.connections:
             raise HTTPException(
                 status_code=400,
@@ -122,6 +138,20 @@ def _apply_plan_management_update(
             raise HTTPException(
                 status_code=400,
                 detail=f"{target} does not support plan delivery",
+            )
+        if not is_plan_delivery_target_registered(target):
+            raise HTTPException(
+                status_code=409,
+                detail=f"{target} plan delivery is not available",
+            )
+        connection = db.query(UserConnection).filter(
+            UserConnection.user_id == user_id,
+            UserConnection.platform == target,
+        ).first()
+        if connection is None or connection.status != "connected":
+            raise HTTPException(
+                status_code=409,
+                detail="Plan execution target must be actively connected",
             )
 
     config.plan_management = normalize_plan_management(candidate)
@@ -335,6 +365,7 @@ def update_settings(
 ) -> dict:
     """Update user settings and persist to database."""
     config = load_config_from_db(user_id, db)
+    prior_plan_management = dict(config.plan_management)
 
     if body.display_name is not None:
         config.display_name = body.display_name
@@ -359,7 +390,12 @@ def update_settings(
                 "execution_target": legacy_target,
             })
     if body.plan_management is not None:
-        _apply_plan_management_update(config, body.plan_management)
+        _apply_plan_management_update(
+            config,
+            body.plan_management,
+            user_id=user_id,
+            db=db,
+        )
     # `thresholds` updates are accepted-and-dropped: manual numeric overrides
     # are no longer supported; source selection lives in
     # ``preferences.threshold_sources``. Kept in the schema for API compat
@@ -401,6 +437,25 @@ def update_settings(
     from db.cache_revision import bump_revisions
     bump_revisions(db, user_id, ["config"])
     save_config_to_db(user_id, config, db)
+
+    if (
+        config.plan_management["mode"] == "praxys"
+        and config.plan_management["delivery_enabled"]
+        and config.plan_management != prior_plan_management
+    ):
+        try:
+            from api.plan_delivery.rolling import trigger_managed_plan_delivery
+
+            trigger_managed_plan_delivery(
+                user_id,
+                trigger="plan_management_enabled",
+            )
+        except Exception:
+            logger.exception(
+                "Post-commit managed delivery hook failed user=%s "
+                "trigger=plan_management_enabled",
+                user_id,
+            )
 
     return {
         "status": "ok",

--- a/db/connection_credentials.py
+++ b/db/connection_credentials.py
@@ -1,6 +1,7 @@
 """Shared access to encrypted per-user platform credentials."""
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any
 
@@ -14,6 +15,15 @@ from db.models import UserConnection
 
 class CredentialAccessError(RuntimeError):
     """Stored platform credentials exist but cannot be decoded safely."""
+
+
+def connection_credentials_generation(connection: UserConnection) -> str:
+    """Fingerprint one connection's encrypted credential generation."""
+    digest = hashlib.sha256()
+    digest.update(bytes(connection.encrypted_credentials or b""))
+    digest.update(b"\0")
+    digest.update(bytes(connection.wrapped_dek or b""))
+    return f"{connection.id}:{digest.hexdigest()}"
 
 
 def load_connection_credentials(

--- a/db/plan_ledger.py
+++ b/db/plan_ledger.py
@@ -13,6 +13,7 @@ import time
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Iterator, Mapping, Sequence
+from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -209,6 +210,17 @@ def canonical_workout_key(snapshot: Mapping[str, Any]) -> str:
         raise ValueError("plan snapshot must include a date")
     workout_type = str(snapshot.get("workout_type") or "unknown").strip().casefold()
     return f"{source}:{workout_date}:{workout_type or 'unknown'}"
+
+
+def canonical_id_from_workout_key(canonical_key: str) -> str | None:
+    """Return the UUID from a modern canonical key, excluding legacy slots."""
+    _, separator, candidate = str(canonical_key or "").partition(":")
+    if not separator:
+        return None
+    try:
+        return str(UUID(candidate))
+    except (ValueError, AttributeError):
+        return None
 
 
 def legacy_unknown_version(snapshot: Mapping[str, Any]) -> str:

--- a/db/sync_scheduler.py
+++ b/db/sync_scheduler.py
@@ -109,7 +109,13 @@ def _short_error(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {msg}" if msg else type(exc).__name__
 
 
-def _record_sync_failure(conn, exc: BaseException, db, trigger: str = "unknown") -> None:
+def _record_sync_failure(
+    conn,
+    exc: BaseException,
+    db,
+    trigger: str = "unknown",
+    expected_credential_generation: str | None = None,
+) -> bool:
     """Update a connection row after a sync failure with classification + backoff.
 
     Rolls back any pending state from the failed sync, then writes the
@@ -123,7 +129,40 @@ def _record_sync_failure(conn, exc: BaseException, db, trigger: str = "unknown")
         pass
 
     if str(exc) == "SYNC_USER_DELETED":
-        return
+        return False
+
+    fresh = None
+    if expected_credential_generation is not None:
+        try:
+            from db.connection_credentials import (
+                connection_credentials_generation,
+            )
+            from db.models import UserConnection
+
+            fresh = db.query(UserConnection).filter(
+                UserConnection.id == conn.id,
+            ).with_for_update().first()
+            if (
+                fresh is None
+                or connection_credentials_generation(fresh)
+                != expected_credential_generation
+            ):
+                db.rollback()
+                logger.info(
+                    "Ignoring stale sync failure after credential change: "
+                    "user=%s platform=%s",
+                    getattr(conn, "user_id", "?"),
+                    getattr(conn, "platform", "?"),
+                )
+                return False
+        except Exception:
+            db.rollback()
+            logger.exception(
+                "Failed to fence stale sync failure for user=%s platform=%s",
+                getattr(conn, "user_id", "?"),
+                getattr(conn, "platform", "?"),
+            )
+            return False
 
     # Fleet-level telemetry: emit before the DB bookkeeping so a spike in a
     # systemic failure_class across many distinct users stays visible even if
@@ -144,11 +183,12 @@ def _record_sync_failure(conn, exc: BaseException, db, trigger: str = "unknown")
         # Re-fetch in case rollback detached state from the prior session.
         from db.models import UserConnection
 
-        fresh = db.query(UserConnection).filter(
-            UserConnection.id == conn.id,
-        ).first()
         if fresh is None:
-            return
+            fresh = db.query(UserConnection).filter(
+                UserConnection.id == conn.id,
+            ).with_for_update().first()
+        if fresh is None:
+            return False
 
         new_failures = (fresh.consecutive_failures or 0) + 1
         status, terminal = classify_sync_failure(exc)
@@ -171,6 +211,7 @@ def _record_sync_failure(conn, exc: BaseException, db, trigger: str = "unknown")
             fresh.user_id, fresh.platform, status, new_failures,
             fresh.next_retry_at,
         )
+        return True
     except Exception:
         logger.exception(
             "Failed to record sync failure metadata for user=%s platform=%s",
@@ -180,6 +221,7 @@ def _record_sync_failure(conn, exc: BaseException, db, trigger: str = "unknown")
             db.rollback()
         except Exception:
             pass
+        return False
 
 
 def reset_connection_backoff(conn) -> None:
@@ -276,7 +318,18 @@ def _scheduler_loop():
             _check_and_sync()
         except Exception:
             logger.exception("Scheduler tick failed")
+        _run_managed_delivery_tick()
         _stop_event.wait(CHECK_INTERVAL_SEC)
+
+
+def _run_managed_delivery_tick() -> None:
+    """Run managed-plan retries without disrupting regular platform sync."""
+    try:
+        from api.plan_delivery.rolling import run_scheduled_managed_deliveries
+
+        run_scheduled_managed_deliveries()
+    except Exception:
+        logger.exception("Managed-plan delivery scheduler tick failed")
 
 
 def _check_and_sync():

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -903,6 +903,11 @@ deleting a missing date returns `{ "status": "deleted", "rows": 0 }`.
 Every request appends a `delete` revision event with its before snapshot and an
 empty after snapshot; a real deletion and its event commit atomically.
 
+After a successful upload, upsert, or real deletion commits, Praxys starts a
+best-effort rolling-delivery pass. The plan mutation remains successful if the
+provider is unavailable. External writes occur only when managed mode and
+delivery consent are already enabled.
+
 ## Settings
 
 ### GET /api/settings
@@ -952,17 +957,22 @@ Update settings (partial update).
   "plan_management": {
     "mode": "praxys",
     "execution_target": "stryd",
-    "delivery_enabled": false,
+    "delivery_enabled": true,
     "adjustment_policy": "suggest_only"
   }
 }
 ```
 
 `plan_management.mode` is `external` or `praxys`. Praxys mode makes
-Praxys-authored rows canonical but does not itself write to a platform.
-`execution_target` must be a connected plan-capable platform. During the
-foundation rollout, `delivery_enabled=true` returns 409 because automatic
-delivery has not shipped yet. `suggest_only` is the only adjustment policy.
+Praxys-owned rows canonical. `execution_target` must be an actively connected
+plan-capable platform with a registered delivery adapter. Setting
+`delivery_enabled=true` commits explicit consent and then starts a best-effort
+delivery pass for today through day 13. The same rolling pass runs after
+committed plan mutations and on scheduler ticks. Repeated runs are idempotent;
+target edits/deletions and uncertain provider outcomes block only the affected
+workout. Setting `delivery_enabled=false` pauses new writes and retries
+immediately. Switching to `external` also pauses delivery but keeps workouts
+already delivered to the target. `suggest_only` is the only adjustment policy.
 Legacy `preferences.plan` remains supported as the external-mode analytical
 source selector and may seed the execution target, but it never activates
 managed mode or delivery.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -137,6 +137,22 @@ partial failure is explicit and recoverable rather than success-shaped.
 Unowned provider workouts are never deleted and do not block Praxys from adding
 a separate workout on the same date.
 
+`api/plan_delivery/rolling.py` applies that boundary to the next 14 calendar
+days. Every provider mutation rechecks Praxys ownership mode, explicit delivery
+consent, adapter capability, and the current connection status. A fresh target
+calendar snapshot then gates each workout through reconciliation: matching or
+pending observations are no-ops, target edits/deletions remain explicit
+conflicts, and accepted canonical edits replace only the exact UUID-owned
+delivery. Deleting a canonical workout while managed removes that owned target
+workout; leaving managed mode or pausing delivery never performs cleanup.
+
+Plan commits and delivery commits remain separate. Settings adoption and
+committed plan upload/upsert/delete operations start a best-effort post-commit
+pass, while the existing background scheduler advances the rolling horizon and
+retries safe failures. Automatic retries are durable, exponential, capped, and
+limited to definite retry-safe outcomes; ambiguous create outcomes remain
+conflicts to prevent duplicate workouts.
+
 ### Admin System
 
 Admin endpoints (`api/routes/admin.py`) are gated by `is_superuser=True` on the authenticated user. Capabilities:
@@ -206,10 +222,11 @@ Plan ownership is separate from provider preference. `config.plan_management`
 contains `mode`, `execution_target`, `delivery_enabled`, and
 `adjustment_policy`. External mode preserves the legacy
 `config.preferences.plan` preferred-source fallback. Praxys mode treats only
-Praxys-authored (`source='ai'`) rows as canonical; platform rows remain loaded
-for management and later reconciliation but never silently become the plan.
-The additive contract defaults to external mode with delivery disabled, so
-existing users are not enrolled in platform writes.
+the Praxys-owned compatibility lane (`source='ai'`) as canonical; platform rows
+remain loaded for management and reconciliation but never silently become the
+plan. The additive contract defaults to external mode with delivery disabled,
+so existing users are not enrolled in platform writes. Enabling delivery
+requires an actively connected target with a registered plan adapter.
 
 Plan mutations write immutable `PlanRevision` events in the same transaction as
 their `TrainingPlan` changes. Each plan row has a durable UUID that survives

--- a/docs/ops/cost-and-scaling.md
+++ b/docs/ops/cost-and-scaling.md
@@ -32,9 +32,11 @@ az appservice plan update -n plan-trainsight -g rg-trainsight --number-of-worker
 
 **Scale-out caveat (important):** each worker runs its own background **sync
 scheduler** (`db/sync_scheduler.py`, started per-worker in `api/main.py`).
-Per-row `last_sync` checks make duplicate ticks idempotent, but to run exactly
-one scheduler set `PRAXYS_SYNC_SCHEDULER=false` on N-1 workers, or keep a
-single-worker deployment. Verify behaviour before relying on multi-worker.
+Per-row `last_sync` checks and the plan-delivery ledger make duplicate writes
+idempotent, but duplicate workers still repeat provider calendar reads and
+compete for the same retry work. To run exactly one scheduler set
+`PRAXYS_SYNC_SCHEDULER=false` on N-1 workers, or keep a single-worker
+deployment. Verify behaviour before relying on multi-worker.
 
 **Database and scale-out (#360):** true scale-out (multiple instances) is only
 safe once the DB is **PostgreSQL** - the legacy SQLite file on `/home` needs a

--- a/docs/ops/sync-troubleshooting.md
+++ b/docs/ops/sync-troubleshooting.md
@@ -1,8 +1,8 @@
 # Sync troubleshooting
 
 > **Summary:** Diagnose and recover stuck platform syncs (Garmin / Stryd / Oura).
-> **Use when:** A user's dashboard data stops updating, or a connection card shows
-> `auth_required`.
+> **Use when:** A user's dashboard data or managed workouts stop updating, or a
+> connection card shows `auth_required`.
 
 Domain detail lives in [`docs/dev/gotchas.md`](../dev/gotchas.md) → "Garmin sync";
 this is the operational quick-path.
@@ -56,10 +56,36 @@ All per-source failures log at `warning`+ (debug once hid CN failures for months
 Aggregate warnings fire at ≥ max(3, total/2) failures; HRV/sleep circuit-break
 after 5 consecutive. Check `az webapp log tail -n trainsight-app -g rg-trainsight`.
 
+## Managed-plan delivery is paused or stuck
+
+Rolling delivery shares the background scheduler and the target's
+`UserConnection`, but it remains default-off. Confirm these conditions before
+investigating the provider:
+
+1. `user_config.plan_management` has `mode=praxys`,
+   `delivery_enabled=true`, and the expected `execution_target`.
+2. The target connection is `connected`. Credential decode failures move it to
+   `auth_required`; reconnecting is the recovery path.
+3. Search logs for `Managed delivery blocked`, `Managed removal failed`, or
+   `Managed replacement blocked`. The logged category is safe to use for
+   triage; provider credentials and payloads are never logged.
+4. Inspect `plan_delivery_attempts.response` for `managed_delivery=true`,
+   `error_category`, and `retryable`.
+
+HTTP 429 creates and idempotent removals use durable exponential retry (15
+minutes initially, capped at 6 hours and 5 failed automatic attempts).
+Timeouts, HTTP 408/5xx creates, target edits/deletions, and account mismatches do
+not auto-retry because the provider outcome or ownership is unresolved. Resolve
+the affected workout through plan reconciliation instead of deleting unrelated
+target workouts. Pausing delivery or switching to external mode takes effect
+before the next write and intentionally keeps already-delivered workouts.
+
 ## Verify
 
 After recovery: trigger a sync (Settings → Sync, or `POST /api/sync`), confirm the
 connection card leaves `auth_required` and new activities/recovery rows appear.
+For managed plans, confirm the next scheduler tick creates only missing
+Praxys-owned workouts inside the 14-day horizon.
 
 ## Related
 

--- a/miniapp/types/api.ts
+++ b/miniapp/types/api.ts
@@ -80,11 +80,19 @@ export interface SettingsPreferences extends Partial<Record<DataCategory, Platfo
   threshold_sources?: Partial<Record<string, string>>;
 }
 
+export interface PlanManagementConfig {
+  mode: 'external' | 'praxys';
+  execution_target: PlatformName | null;
+  delivery_enabled: boolean;
+  adjustment_policy: 'suggest_only';
+}
+
 export interface SettingsConfig {
   display_name: string;
   unit_system: UnitSystem;
   connections: PlatformName[];
   preferences: SettingsPreferences;
+  plan_management: PlanManagementConfig;
   training_base: TrainingBase;
   thresholds: Record<string, number | string | null>;
   zones: Record<string, number[]>;
@@ -92,6 +100,10 @@ export interface SettingsConfig {
   source_options: Record<string, unknown>;
   /** UI language preference ("en" | "zh"). `null` means auto-detect from browser. */
   language: UiLanguage | null;
+}
+
+export interface SettingsUpdate extends Omit<Partial<SettingsConfig>, 'plan_management'> {
+  plan_management?: Partial<PlanManagementConfig>;
 }
 
 export interface ThresholdValue {

--- a/tests/test_managed_plan_delivery.py
+++ b/tests/test_managed_plan_delivery.py
@@ -1,0 +1,1124 @@
+"""Provider-neutral rolling managed-plan delivery tests."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime, timedelta
+from typing import Any, Callable, Mapping
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+
+from api.plan_delivery.base import (
+    PreparedWorkoutDelivery,
+    ProviderCreateResult,
+    ProviderRejectedError,
+    ProviderRemoveResult,
+    ProviderRemovalError,
+    ProviderRequestError,
+    ProviderTransientError,
+)
+from api.plan_delivery.credentials import DeliveryCredentialsInvalid
+from api.plan_delivery.rolling import run_rolling_delivery_for_user
+from db.models import (
+    Base,
+    PlanDelivery,
+    PlanDeliveryAttempt,
+    PlanRevision,
+    TrainingPlan,
+    User,
+    UserConfig,
+    UserConnection,
+)
+from db.plan_ledger import DELIVERY_ATTEMPT_LEASE, plan_snapshot
+
+
+USER_ID = "managed-delivery-user"
+TARGET = "stryd"
+ACCOUNT_ID = "provider-account"
+CP_WATTS = 280.0
+
+
+class FakeDeliveryAdapter:
+    """In-memory provider adapter with deterministic fingerprints."""
+
+    target = TARGET
+    display_name = "Fake target"
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.provider_account_id = ACCOUNT_ID
+        self.calendar: list[dict[str, Any]] = []
+        self.create_attempts = 0
+        self.prepare_attempts = 0
+        self.delete_attempts = 0
+        self.fetch_attempts = 0
+        self.authenticate_attempts = 0
+        self.create_failures: list[Exception] = []
+        self.prepare_failures: list[Exception] = []
+        self.delete_failures: list[Exception] = []
+        self.on_create: Callable[[], None] | None = None
+        self.on_delete: Callable[[], None] | None = None
+        self.on_authenticate: Callable[[int], None] | None = None
+        self.hidden_external_ids: set[str] = set()
+
+    @property
+    def account_id(self) -> str:
+        return self.provider_account_id
+
+    def authenticate(self) -> None:
+        """Authenticate the fake provider."""
+        self.authenticate_attempts += 1
+        if self.on_authenticate is not None:
+            self.on_authenticate(self.authenticate_attempts)
+
+    def prepare_workout(
+        self,
+        workout: Mapping[str, Any],
+        *,
+        threshold_value: float,
+    ) -> PreparedWorkoutDelivery:
+        """Prepare one deterministic fake provider request."""
+        self.prepare_attempts += 1
+        if self.prepare_failures:
+            raise self.prepare_failures.pop(0)
+        snapshot = dict(workout)
+        encoded = json.dumps(
+            {
+                "snapshot": snapshot,
+                "threshold_value": threshold_value,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        version = hashlib.sha256(encoded).hexdigest()
+        content_version = hashlib.sha256(
+            b"content:" + encoded
+        ).hexdigest()
+        return PreparedWorkoutDelivery(
+            version=version,
+            content_version=content_version,
+            request={
+                "snapshot": snapshot,
+                "content_version": content_version,
+            },
+        )
+
+    def create_workout(
+        self,
+        prepared: PreparedWorkoutDelivery,
+    ) -> ProviderCreateResult:
+        """Create one fake calendar workout."""
+        self.create_attempts += 1
+        if self.create_failures:
+            raise self.create_failures.pop(0)
+        external_id = f"managed-{self.create_attempts}"
+        snapshot = dict(prepared.request["snapshot"])
+        self.calendar.append({
+            **snapshot,
+            "external_id": external_id,
+            "provider_content_fingerprint": prepared.content_version,
+            "provider_payload_fingerprint": prepared.version,
+        })
+        if self.on_create is not None:
+            self.on_create()
+        return ProviderCreateResult(
+            external_id=external_id,
+            provider_account_id=self.provider_account_id,
+            response={"id": external_id},
+        )
+
+    def delete_workout(self, external_id: str) -> ProviderRemoveResult:
+        """Delete one fake calendar workout."""
+        self.delete_attempts += 1
+        if self.delete_failures:
+            raise self.delete_failures.pop(0)
+        for index, row in enumerate(self.calendar):
+            if row["external_id"] == external_id:
+                self.calendar.pop(index)
+                if self.on_delete is not None:
+                    self.on_delete()
+                return ProviderRemoveResult()
+        if self.on_delete is not None:
+            self.on_delete()
+        return ProviderRemoveResult(already_absent=True)
+
+    def fetch_calendar(
+        self,
+        *,
+        threshold_value: float | None = None,
+        days_ahead: int = 14,
+        days_back: int = 0,
+        timezone_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return a copy of the fake calendar."""
+        self.fetch_attempts += 1
+        return [
+            dict(row)
+            for row in self.calendar
+            if row["external_id"] not in self.hidden_external_ids
+        ]
+
+
+@pytest.fixture
+def managed_db(tmp_path):
+    """Yield an enabled managed-plan database and fake provider."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'managed-delivery.db'}")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    db = session_factory()
+    db.add(User(
+        id=USER_ID,
+        email="managed-delivery@example.test",
+        hashed_password="test",
+    ))
+    db.add(UserConfig(
+        user_id=USER_ID,
+        plan_management={
+            "mode": "praxys",
+            "execution_target": TARGET,
+            "delivery_enabled": True,
+            "adjustment_policy": "suggest_only",
+        },
+    ))
+    db.add(UserConnection(
+        user_id=USER_ID,
+        platform=TARGET,
+        status="connected",
+        preferences={"plan": True},
+    ))
+    db.commit()
+    adapter = FakeDeliveryAdapter(db)
+    try:
+        yield db, adapter
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def _add_plan(
+    db: Session,
+    workout_date: date,
+    *,
+    workout_type: str = "easy",
+    description: str = "Easy run",
+) -> TrainingPlan:
+    plan = TrainingPlan(
+        user_id=USER_ID,
+        canonical_id=str(uuid4()),
+        date=workout_date,
+        workout_type=workout_type,
+        planned_duration_min=45,
+        workout_description=description,
+        source="ai",
+    )
+    db.add(plan)
+    db.commit()
+    return plan
+
+
+def _run(
+    db: Session,
+    adapter: FakeDeliveryAdapter,
+    *,
+    now: datetime,
+    trigger: str = "test",
+):
+    return run_rolling_delivery_for_user(
+        db,
+        user_id=USER_ID,
+        trigger=trigger,
+        now=now,
+        adapter_loader=lambda session, user_id, target: adapter,
+        threshold_loader=lambda session, user_id: CP_WATTS,
+    )
+
+
+@pytest.mark.parametrize(
+    "plan_management,expected_reason",
+    [
+        (
+            {
+                "mode": "external",
+                "execution_target": TARGET,
+                "delivery_enabled": False,
+                "adjustment_policy": "suggest_only",
+            },
+            "external_mode",
+        ),
+        (
+            {
+                "mode": "praxys",
+                "execution_target": TARGET,
+                "delivery_enabled": False,
+                "adjustment_policy": "suggest_only",
+            },
+            "delivery_paused",
+        ),
+    ],
+)
+def test_default_off_modes_make_zero_provider_calls(
+    managed_db,
+    plan_management,
+    expected_reason,
+):
+    db, adapter = managed_db
+    db.get(UserConfig, USER_ID).plan_management = plan_management
+    _add_plan(db, date(2026, 8, 2))
+
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+
+    assert result.status == "skipped"
+    assert result.reason == expected_reason
+    assert adapter.fetch_attempts == 0
+    assert adapter.create_attempts == 0
+    assert adapter.delete_attempts == 0
+
+
+def test_delivery_uses_exact_fourteen_day_horizon(managed_db):
+    db, adapter = managed_db
+    today = date(2026, 8, 1)
+    _add_plan(db, today - timedelta(days=1), description="Past")
+    _add_plan(db, today, description="First")
+    _add_plan(db, today + timedelta(days=13), description="Last")
+    _add_plan(db, today + timedelta(days=14), description="Outside")
+    _add_plan(
+        db,
+        today + timedelta(days=5),
+        workout_type="rest",
+        description="Rest",
+    )
+
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+
+    assert result.window_start == "2026-08-01"
+    assert result.window_end == "2026-08-14"
+    assert {
+        row["date"] for row in adapter.calendar
+    } == {"2026-08-01", "2026-08-14"}
+    assert adapter.create_attempts == 2
+
+
+def test_repeated_run_is_idempotent_and_preserves_target_only_workouts(
+    managed_db,
+):
+    db, adapter = managed_db
+    workout_date = date(2026, 8, 3)
+    _add_plan(db, workout_date)
+    adapter.calendar.append({
+        "date": workout_date.isoformat(),
+        "workout_type": "manual",
+        "workout_description": "External coach workout",
+        "external_id": "external-manual",
+        "provider_content_fingerprint": "manual-content",
+        "provider_payload_fingerprint": "manual-payload",
+    })
+
+    first = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    second = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+
+    assert first.status == "complete"
+    assert second.status == "complete"
+    assert adapter.create_attempts == 1
+    assert {row["external_id"] for row in adapter.calendar} == {
+        "external-manual",
+        "managed-1",
+    }
+    assert second.items[0].reason == "matching"
+
+
+def test_target_edit_blocks_only_affected_workout(managed_db):
+    db, adapter = managed_db
+    first_plan = _add_plan(db, date(2026, 8, 3), description="First")
+    _add_plan(db, date(2026, 8, 4), description="Second")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    changed = next(
+        row for row in adapter.calendar
+        if row["canonical_id"] == first_plan.canonical_id
+    )
+    changed["workout_description"] = "Edited outside Praxys"
+    changed["provider_content_fingerprint"] = "external-edit"
+
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+
+    affected = next(
+        item for item in result.items
+        if item.canonical_id == first_plan.canonical_id
+    )
+    unaffected = next(
+        item for item in result.items
+        if item.canonical_id != first_plan.canonical_id
+    )
+    assert affected.status == "blocked"
+    assert affected.reason == "target_edited"
+    assert unaffected.status == "skipped"
+    assert unaffected.reason == "matching"
+    assert adapter.create_attempts == 2
+    assert adapter.delete_attempts == 0
+
+
+def test_accepted_canonical_edit_replaces_owned_workout(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    original_external_id = adapter.calendar[0]["external_id"]
+    plan.workout_description = "After"
+    db.commit()
+
+    result = _run(
+        db,
+        adapter,
+        now=datetime(2026, 8, 1, 10),
+        trigger="plan_upsert",
+    )
+
+    assert result.status == "complete"
+    assert result.items[0].status == "replaced"
+    assert adapter.create_attempts == 2
+    assert adapter.delete_attempts == 1
+    assert len(adapter.calendar) == 1
+    assert adapter.calendar[0]["external_id"] != original_external_id
+    revision = db.execute(
+        select(PlanRevision)
+        .where(
+            PlanRevision.user_id == USER_ID,
+            PlanRevision.operation == "restore_target",
+        )
+    ).scalar_one()
+    assert revision.actor_type == "system"
+    assert revision.actor_id is None
+    assert revision.origin == "managed_plan.rolling_delivery"
+    assert revision.details["trigger"] == "plan_upsert"
+
+
+def test_replacement_rechecks_pause_between_delete_and_create(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    plan.workout_description = "After"
+    db.commit()
+
+    def pause_delivery() -> None:
+        config = db.get(UserConfig, USER_ID)
+        config.plan_management = {
+            **config.plan_management,
+            "delivery_enabled": False,
+        }
+
+    adapter.on_delete = pause_delivery
+    result = _run(
+        db,
+        adapter,
+        now=datetime(2026, 8, 1, 10),
+        trigger="plan_upsert",
+    )
+
+    assert result.items[0].status == "skipped"
+    assert result.items[0].reason == "delivery_paused"
+    assert adapter.delete_attempts == 1
+    assert adapter.create_attempts == 1
+    assert adapter.calendar == []
+
+
+def test_replacement_blocks_when_connection_credentials_change(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    plan.workout_description = "After"
+    db.commit()
+
+    def reconnect() -> None:
+        connection = db.execute(
+            select(UserConnection).where(
+                UserConnection.user_id == USER_ID,
+                UserConnection.platform == TARGET,
+            )
+        ).scalar_one()
+        connection.encrypted_credentials = b"new-credentials"
+        connection.wrapped_dek = b"new-wrapped-key"
+
+    adapter.on_delete = reconnect
+    result = _run(
+        db,
+        adapter,
+        now=datetime(2026, 8, 1, 10),
+        trigger="plan_upsert",
+    )
+
+    assert result.items[0].status == "skipped"
+    assert result.items[0].reason == "connection_changed"
+    assert adapter.delete_attempts == 1
+    assert adapter.create_attempts == 1
+    assert adapter.calendar == []
+
+
+def test_changing_owned_workout_to_rest_removes_target_copy(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    plan.workout_type = "rest"
+    plan.workout_description = "Rest"
+    db.commit()
+
+    result = _run(
+        db,
+        adapter,
+        now=datetime(2026, 8, 1, 10),
+        trigger="plan_upsert",
+    )
+
+    assert result.status == "complete"
+    assert result.items[0].action == "remove"
+    assert result.items[0].status == "removed"
+    assert adapter.delete_attempts == 1
+    assert adapter.create_attempts == 1
+    assert adapter.calendar == []
+
+
+def test_rest_cleanup_rechecks_canonical_before_delete(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    plan.workout_type = "rest"
+    plan.workout_description = "Rest"
+    db.commit()
+
+    def reactivate(attempt_number: int) -> None:
+        if attempt_number == 4:
+            plan.workout_type = "easy"
+            plan.workout_description = "Reactivated"
+            db.commit()
+
+    adapter.on_authenticate = reactivate
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+
+    assert result.items[0].status == "skipped"
+    assert result.items[0].reason == "canonical_changed_during_run"
+    assert adapter.delete_attempts == 0
+    assert len(adapter.calendar) == 1
+
+
+def test_concurrent_rest_transition_blocks_create(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+
+    def change_to_rest(attempt_number: int) -> None:
+        if attempt_number == 2:
+            plan.workout_type = "rest"
+            plan.workout_description = "Rest"
+            db.commit()
+
+    adapter.on_authenticate = change_to_rest
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+
+    assert result.items[0].status == "skipped"
+    assert result.items[0].reason == "canonical_became_rest"
+    assert adapter.create_attempts == 0
+    assert adapter.calendar == []
+
+
+def test_corrected_version_does_not_inherit_definite_old_failure(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Rejected")
+    adapter.create_failures.append(
+        ProviderRejectedError("definite provider rejection")
+    )
+    failed = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    blocked = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+    plan.workout_description = "Corrected"
+    db.commit()
+
+    corrected = _run(db, adapter, now=datetime(2026, 8, 1, 11))
+    repeated = _run(db, adapter, now=datetime(2026, 8, 1, 12))
+
+    assert failed.items[0].status == "failed"
+    assert blocked.items[0].status == "blocked"
+    assert blocked.items[0].reason == "failure_not_retryable"
+    assert corrected.items[0].status == "delivered"
+    assert repeated.items[0].status == "skipped"
+    assert repeated.items[0].reason == "matching"
+    assert adapter.create_attempts == 2
+    assert len(adapter.calendar) == 1
+
+
+def test_invalid_initial_workout_is_durable_and_not_retried(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Invalid")
+    adapter.prepare_failures.append(
+        ProviderRequestError("invalid workout structure")
+    )
+
+    failed = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    blocked = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+    plan.workout_description = "Corrected"
+    db.commit()
+    corrected = _run(db, adapter, now=datetime(2026, 8, 1, 11))
+
+    assert failed.items[0].status == "failed"
+    assert failed.items[0].reason == "invalid_workout"
+    assert blocked.items[0].status == "blocked"
+    assert blocked.items[0].reason == "failure_not_retryable"
+    assert corrected.items[0].status == "delivered"
+    assert adapter.prepare_attempts == 2
+
+
+def test_invalid_replacement_preflight_is_not_retried(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3), description="Before")
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    plan.workout_description = "Invalid edit"
+    db.commit()
+    adapter.prepare_failures.append(
+        ProviderRequestError("invalid replacement")
+    )
+
+    failed = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+    attempts_after_failure = adapter.prepare_attempts
+    blocked = _run(db, adapter, now=datetime(2026, 8, 1, 11))
+    attempts_after_block = adapter.prepare_attempts
+    plan.workout_description = "Corrected edit"
+    db.commit()
+    corrected = _run(db, adapter, now=datetime(2026, 8, 1, 12))
+
+    assert failed.items[0].status == "failed"
+    assert blocked.items[0].status == "blocked"
+    assert blocked.items[0].reason == "failure_not_retryable"
+    assert corrected.items[0].status == "replaced"
+    assert attempts_after_block == attempts_after_failure
+    assert adapter.prepare_attempts == 4
+    assert adapter.delete_attempts == 1
+
+
+def test_inferred_absence_does_not_delete_hidden_moved_workout(managed_db):
+    db, adapter = managed_db
+    plan = _add_plan(db, date(2026, 8, 3))
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    external_id = adapter.calendar[0]["external_id"]
+    adapter.calendar[0]["date"] = "2026-09-15"
+    adapter.hidden_external_ids.add(external_id)
+    db.delete(plan)
+    db.commit()
+
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+
+    assert result.status == "partial"
+    assert result.items[0].status == "blocked"
+    assert result.items[0].reason == "target_workout_absent"
+    assert adapter.delete_attempts == 0
+    assert adapter.calendar[0]["external_id"] == external_id
+
+
+def test_inflight_create_is_recovered_from_calendar(
+    managed_db,
+    monkeypatch,
+):
+    from api.plan_delivery.service import PlanDeliveryService
+
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    _add_plan(db, started_at.date() + timedelta(days=2))
+    original = PlanDeliveryService._record_terminal_attempt
+    failed_once = False
+
+    def fail_create_finalization(self, **kwargs):
+        nonlocal failed_once
+        if kwargs["state"] == "synced" and not failed_once:
+            failed_once = True
+            raise SQLAlchemyError("forced create finalization failure")
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(
+        PlanDeliveryService,
+        "_record_terminal_attempt",
+        fail_create_finalization,
+    )
+    failed = _run(db, adapter, now=started_at)
+    monkeypatch.setattr(
+        PlanDeliveryService,
+        "_record_terminal_attempt",
+        original,
+    )
+    pending = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(minutes=5),
+    )
+    attempt = db.execute(
+        select(PlanDeliveryAttempt).where(
+            PlanDeliveryAttempt.state == "delivering",
+        )
+    ).scalar_one()
+    attempt.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    db.commit()
+
+    recovered = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=1),
+    )
+
+    assert failed.items[0].status == "failed"
+    assert failed.items[0].reason == "ledger_finalization_failed"
+    assert pending.items[0].reason == "pending_observation"
+    assert recovered.items[0].status == "skipped"
+    assert recovered.items[0].reason == "matching"
+    assert adapter.create_attempts == 1
+    delivery = db.execute(select(PlanDelivery)).scalar_one()
+    assert delivery.state == "synced"
+    assert delivery.external_id == adapter.calendar[0]["external_id"]
+
+
+def test_inflight_removal_becomes_visible_conflict(
+    managed_db,
+    monkeypatch,
+):
+    from api.plan_delivery.service import PlanDeliveryService
+
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    plan = _add_plan(db, started_at.date() + timedelta(days=2))
+    _run(db, adapter, now=started_at)
+    db.delete(plan)
+    db.commit()
+    original = PlanDeliveryService._record_terminal_attempt
+    failed_once = False
+
+    def fail_remove_finalization(self, **kwargs):
+        nonlocal failed_once
+        if kwargs["state"] == "removed" and not failed_once:
+            failed_once = True
+            raise SQLAlchemyError("forced remove finalization failure")
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(
+        PlanDeliveryService,
+        "_record_terminal_attempt",
+        fail_remove_finalization,
+    )
+    failed = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        PlanDeliveryService,
+        "_record_terminal_attempt",
+        original,
+    )
+    attempt = db.execute(
+        select(PlanDeliveryAttempt).where(
+            PlanDeliveryAttempt.state == "delivering",
+            PlanDeliveryAttempt.operation == "remove",
+        )
+    ).scalar_one()
+    attempt.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    db.commit()
+
+    recovered = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=2),
+    )
+
+    assert failed.items[0].status == "failed"
+    assert recovered.status == "partial"
+    assert recovered.items[0].status == "blocked"
+    assert recovered.items[0].reason == "delivery_conflict"
+    delivery = db.execute(select(PlanDelivery)).scalar_one()
+    assert delivery.state == "conflict"
+    assert adapter.delete_attempts == 1
+
+
+def test_crash_before_create_does_not_claim_identical_manual_workout(
+    managed_db,
+):
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    plan = _add_plan(db, started_at.date() + timedelta(days=2))
+    snapshot = plan_snapshot(plan)
+    prepared = adapter.prepare_workout(
+        snapshot,
+        threshold_value=CP_WATTS,
+    )
+    adapter.calendar.append({
+        **snapshot,
+        "external_id": "manual-existing",
+        "provider_content_fingerprint": prepared.content_version,
+        "provider_payload_fingerprint": prepared.version,
+    })
+    adapter.create_failures.append(RuntimeError("crash before provider send"))
+
+    with pytest.raises(RuntimeError, match="crash before provider send"):
+        _run(db, adapter, now=started_at)
+
+    attempt = db.execute(
+        select(PlanDeliveryAttempt).where(
+            PlanDeliveryAttempt.state == "delivering",
+        )
+    ).scalar_one()
+    attempt.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    db.commit()
+    recovered = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=1),
+    )
+
+    assert recovered.status == "partial"
+    assert recovered.items[0].status == "blocked"
+    delivery = db.execute(select(PlanDelivery)).scalar_one()
+    assert delivery.state == "conflict"
+    assert delivery.external_id is None
+    assert adapter.calendar[0]["external_id"] == "manual-existing"
+    assert adapter.delete_attempts == 0
+
+
+def test_recovery_snapshot_includes_ids_outside_delivery_horizon(
+    managed_db,
+):
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    plan = _add_plan(db, started_at.date() + timedelta(days=2))
+    snapshot = plan_snapshot(plan)
+    prepared = adapter.prepare_workout(
+        snapshot,
+        threshold_value=CP_WATTS,
+    )
+    adapter.calendar.append({
+        "date": (started_at.date() + timedelta(days=14)).isoformat(),
+        "workout_type": "manual",
+        "workout_description": "Outside delivery horizon",
+        "external_id": "outside-existing",
+        "provider_content_fingerprint": "outside-content",
+        "provider_payload_fingerprint": "outside-payload",
+    })
+    adapter.create_failures.append(RuntimeError("crash before provider send"))
+
+    with pytest.raises(RuntimeError):
+        _run(db, adapter, now=started_at)
+
+    adapter.calendar[0] = {
+        **snapshot,
+        "external_id": "outside-existing",
+        "provider_content_fingerprint": prepared.content_version,
+        "provider_payload_fingerprint": prepared.version,
+    }
+    attempt = db.execute(
+        select(PlanDeliveryAttempt).where(
+            PlanDeliveryAttempt.state == "delivering",
+        )
+    ).scalar_one()
+    attempt.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    db.commit()
+
+    recovered = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=1),
+    )
+
+    assert recovered.status == "partial"
+    delivery = db.execute(select(PlanDelivery)).scalar_one()
+    assert delivery.state == "conflict"
+    assert delivery.external_id is None
+    assert adapter.calendar[0]["external_id"] == "outside-existing"
+
+
+def test_inflight_create_does_not_cross_reconnected_accounts(
+    managed_db,
+    monkeypatch,
+):
+    from api.plan_delivery.service import PlanDeliveryService
+
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    plan = _add_plan(db, started_at.date() + timedelta(days=2))
+    snapshot = plan_snapshot(plan)
+    prepared = adapter.prepare_workout(
+        snapshot,
+        threshold_value=CP_WATTS,
+    )
+    original = PlanDeliveryService._record_terminal_attempt
+    failed_once = False
+
+    def fail_create_finalization(self, **kwargs):
+        nonlocal failed_once
+        if kwargs["state"] == "synced" and not failed_once:
+            failed_once = True
+            raise SQLAlchemyError("forced create finalization failure")
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(
+        PlanDeliveryService,
+        "_record_terminal_attempt",
+        fail_create_finalization,
+    )
+    _run(db, adapter, now=started_at)
+    monkeypatch.setattr(
+        PlanDeliveryService,
+        "_record_terminal_attempt",
+        original,
+    )
+    attempt = db.execute(
+        select(PlanDeliveryAttempt).where(
+            PlanDeliveryAttempt.state == "delivering",
+        )
+    ).scalar_one()
+    attempt.started_at = (
+        datetime.utcnow() - DELIVERY_ATTEMPT_LEASE - timedelta(seconds=1)
+    )
+    connection = db.execute(
+        select(UserConnection).where(
+            UserConnection.user_id == USER_ID,
+            UserConnection.platform == TARGET,
+        )
+    ).scalar_one()
+    connection.encrypted_credentials = b"account-b"
+    connection.wrapped_dek = b"account-b-key"
+    adapter.provider_account_id = "provider-account-b"
+    adapter.calendar = [{
+        **snapshot,
+        "external_id": "manual-account-b",
+        "provider_content_fingerprint": prepared.content_version,
+        "provider_payload_fingerprint": prepared.version,
+    }]
+    db.commit()
+
+    recovered = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=1),
+    )
+
+    assert recovered.status == "partial"
+    assert recovered.items[0].status == "blocked"
+    delivery = db.execute(select(PlanDelivery)).scalar_one()
+    assert delivery.state == "conflict"
+    assert delivery.external_id is None
+    assert adapter.calendar[0]["external_id"] == "manual-account-b"
+    assert adapter.delete_attempts == 0
+
+
+def test_deleted_canonical_removal_retries_with_backoff(managed_db):
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    plan = _add_plan(db, started_at.date() + timedelta(days=2))
+    _run(db, adapter, now=started_at)
+    external_id = adapter.calendar[0]["external_id"]
+    db.delete(plan)
+    db.commit()
+    adapter.delete_failures.append(ProviderRemovalError("temporary delete failure"))
+
+    failed = _run(db, adapter, now=started_at + timedelta(minutes=1))
+    backed_off = _run(db, adapter, now=started_at + timedelta(minutes=5))
+    retried = _run(db, adapter, now=started_at + timedelta(minutes=20))
+
+    assert failed.items[0].status == "failed"
+    assert backed_off.items[0].status == "skipped"
+    assert backed_off.items[0].reason == "retry_backoff"
+    assert retried.items[0].status == "removed"
+    assert adapter.delete_attempts == 2
+    assert all(
+        row["external_id"] != external_id for row in adapter.calendar
+    )
+
+
+def test_transient_create_failure_retries_after_backoff(managed_db):
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    _add_plan(db, started_at.date() + timedelta(days=2))
+    adapter.create_failures.append(
+        ProviderTransientError("provider rate limit")
+    )
+
+    failed = _run(db, adapter, now=started_at)
+    backed_off = _run(db, adapter, now=started_at + timedelta(minutes=5))
+    retried = _run(db, adapter, now=started_at + timedelta(minutes=20))
+
+    assert failed.items[0].status == "failed"
+    assert failed.items[0].reason == "provider_transient"
+    assert backed_off.items[0].status == "skipped"
+    assert backed_off.items[0].reason == "retry_backoff"
+    assert retried.items[0].status == "delivered"
+    assert adapter.create_attempts == 2
+    attempts = db.execute(
+        select(PlanDeliveryAttempt)
+        .where(PlanDeliveryAttempt.operation == "deliver")
+        .order_by(PlanDeliveryAttempt.attempt_number)
+    ).scalars().all()
+    assert attempts[0].response["managed_delivery"] is True
+    assert attempts[0].response["retryable"] is True
+    assert attempts[1].response["managed_delivery"] is True
+
+
+def test_transient_create_retry_stops_at_durable_cap(managed_db):
+    db, adapter = managed_db
+    started_at = datetime.utcnow()
+    _add_plan(db, started_at.date() + timedelta(days=2))
+    adapter.create_failures.extend(
+        ProviderTransientError("provider rate limit")
+        for _ in range(5)
+    )
+
+    for attempt_number in range(5):
+        result = _run(
+            db,
+            adapter,
+            now=started_at + timedelta(hours=7 * attempt_number),
+        )
+        assert result.items[0].status == "failed"
+
+    capped = _run(
+        db,
+        adapter,
+        now=started_at + timedelta(hours=42),
+    )
+
+    assert capped.status == "partial"
+    assert capped.items[0].status == "blocked"
+    assert capped.items[0].reason == "retry_limit_reached"
+    assert adapter.create_attempts == 5
+
+
+def test_pause_is_rechecked_before_each_mutation(managed_db):
+    db, adapter = managed_db
+    _add_plan(db, date(2026, 8, 3), description="First")
+    _add_plan(db, date(2026, 8, 4), description="Second")
+
+    def pause_delivery() -> None:
+        config = db.get(UserConfig, USER_ID)
+        config.plan_management = {
+            **config.plan_management,
+            "delivery_enabled": False,
+        }
+
+    adapter.on_create = pause_delivery
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+
+    assert adapter.create_attempts == 1
+    assert len(adapter.calendar) == 1
+    assert any(
+        item.status == "skipped" and item.reason == "delivery_paused"
+        for item in result.items
+    )
+
+
+def test_disconnect_blocks_delivery_before_provider_access(managed_db):
+    db, adapter = managed_db
+    _add_plan(db, date(2026, 8, 3))
+    connection = db.execute(
+        select(UserConnection).where(
+            UserConnection.user_id == USER_ID,
+            UserConnection.platform == TARGET,
+        )
+    ).scalar_one()
+    connection.status = "disconnected"
+    db.commit()
+
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 9))
+
+    assert result.status == "skipped"
+    assert result.reason == "connection_disconnected"
+    assert adapter.fetch_attempts == 0
+    assert adapter.create_attempts == 0
+
+
+def test_invalid_credentials_require_reconnect(managed_db):
+    db, adapter = managed_db
+    _add_plan(db, date(2026, 8, 3))
+
+    result = run_rolling_delivery_for_user(
+        db,
+        user_id=USER_ID,
+        trigger="test",
+        now=datetime(2026, 8, 1, 9),
+        adapter_loader=lambda session, user_id, target: (
+            _ for _ in ()
+        ).throw(DeliveryCredentialsInvalid("cannot decrypt")),
+        threshold_loader=lambda session, user_id: CP_WATTS,
+    )
+
+    connection = db.execute(
+        select(UserConnection).where(
+            UserConnection.user_id == USER_ID,
+            UserConnection.platform == TARGET,
+        )
+    ).scalar_one()
+    assert result.status == "blocked"
+    assert result.reason == "DeliveryCredentialsInvalid"
+    assert connection.status == "auth_required"
+    assert connection.next_retry_at is None
+    assert adapter.create_attempts == 0
+
+
+def test_stale_credential_failure_does_not_overwrite_reconnect(managed_db):
+    db, adapter = managed_db
+    _add_plan(db, date(2026, 8, 3))
+
+    def stale_loader(session, user_id, target):
+        connection = session.execute(
+            select(UserConnection).where(
+                UserConnection.user_id == USER_ID,
+                UserConnection.platform == TARGET,
+            )
+        ).scalar_one()
+        connection.encrypted_credentials = b"replacement"
+        connection.wrapped_dek = b"replacement-key"
+        connection.status = "connected"
+        session.commit()
+        raise DeliveryCredentialsInvalid("old credentials failed")
+
+    result = run_rolling_delivery_for_user(
+        db,
+        user_id=USER_ID,
+        trigger="test",
+        now=datetime(2026, 8, 1, 9),
+        adapter_loader=stale_loader,
+        threshold_loader=lambda session, user_id: CP_WATTS,
+    )
+
+    connection = db.execute(
+        select(UserConnection).where(
+            UserConnection.user_id == USER_ID,
+            UserConnection.platform == TARGET,
+        )
+    ).scalar_one()
+    assert result.status == "blocked"
+    assert result.reason == "connection_changed"
+    assert connection.status == "connected"
+    assert connection.consecutive_failures == 0
+    assert connection.next_retry_at is None
+    assert adapter.create_attempts == 0
+
+
+def test_leaving_managed_mode_keeps_delivered_workouts(managed_db):
+    db, adapter = managed_db
+    _add_plan(db, date(2026, 8, 3))
+    _run(db, adapter, now=datetime(2026, 8, 1, 9))
+    config = db.get(UserConfig, USER_ID)
+    config.plan_management = {
+        **config.plan_management,
+        "mode": "external",
+        "delivery_enabled": False,
+    }
+    db.commit()
+
+    result = _run(db, adapter, now=datetime(2026, 8, 1, 10))
+
+    assert result.status == "skipped"
+    assert result.reason == "external_mode"
+    assert adapter.delete_attempts == 0
+    assert len(adapter.calendar) == 1
+    delivery = db.execute(select(PlanDelivery)).scalar_one()
+    assert delivery.state == "synced"

--- a/tests/test_plan_delivery_adapter.py
+++ b/tests/test_plan_delivery_adapter.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from api.plan_delivery.base import (
     PlanDeliveryAdapter,
     ProviderAuthenticationError,
+    ProviderTransientError,
 )
 from api.plan_delivery.service import PlanDeliveryService
 from api.plan_delivery.stryd import StrydPlanDeliveryAdapter
@@ -123,6 +124,35 @@ def test_stryd_adapter_sends_the_prepared_payload_unchanged(monkeypatch):
         for key, value in captured.items()
         if key not in {"user_id", "token"}
     } == prepared.request
+
+
+def test_stryd_adapter_marks_rate_limit_as_safely_retryable(monkeypatch):
+    monkeypatch.setattr(
+        "sync.stryd_sync._login_api",
+        lambda email, password: ("provider-user", "provider-token"),
+    )
+
+    def _rate_limited(**kwargs):
+        response = requests.Response()
+        response.status_code = 429
+        raise requests.HTTPError("rate limited", response=response)
+
+    monkeypatch.setattr("sync.stryd_sync.create_workout_api", _rate_limited)
+    adapter = StrydPlanDeliveryAdapter({
+        "email": "runner@example.test",
+        "password": "secret",
+    })
+    prepared = adapter.prepare_workout(
+        {
+            "date": "2026-08-02",
+            "workout_type": "easy",
+            "planned_duration_min": 45,
+        },
+        threshold_value=280.0,
+    )
+
+    with pytest.raises(ProviderTransientError):
+        adapter.create_workout(prepared)
 
 
 def test_stryd_prepared_payload_is_stable_and_tracks_threshold():

--- a/tests/test_plan_endpoints.py
+++ b/tests/test_plan_endpoints.py
@@ -436,6 +436,57 @@ def test_upload_rejects_invalid_mode(api_client):
     assert res.status_code == 422
 
 
+def test_plan_mutation_hooks_run_after_commit(api_client, monkeypatch):
+    client, user_id = api_client
+    target = (date.today() + timedelta(days=8)).isoformat()
+    observed: list[tuple[str, int, str | None]] = []
+
+    def capture_hook(called_user_id: str, *, trigger: str) -> None:
+        from db import session as db_session
+        from db.models import PlanRevision, TrainingPlan
+
+        db = db_session.SessionLocal()
+        try:
+            revisions = db.query(PlanRevision).filter(
+                PlanRevision.user_id == called_user_id,
+            ).count()
+            row = db.query(TrainingPlan).filter(
+                TrainingPlan.user_id == called_user_id,
+                TrainingPlan.date == date.fromisoformat(target),
+            ).first()
+            observed.append((
+                trigger,
+                revisions,
+                row.workout_description if row is not None else None,
+            ))
+        finally:
+            db.close()
+
+    monkeypatch.setattr(
+        "api.plan_delivery.rolling.trigger_managed_plan_delivery",
+        capture_hook,
+    )
+
+    upload = client.post("/api/plan/upload?mode=merge", json={
+        "csv": "date,workout_type,workout_description\n"
+               f"{target},easy,Uploaded\n",
+    })
+    upsert = client.put(f"/api/plan/{target}", json={
+        "workout_type": "threshold",
+        "workout_description": "Updated",
+    })
+    deleted = client.delete(f"/api/plan/{target}")
+
+    assert upload.status_code == 200, upload.text
+    assert upsert.status_code == 200, upsert.text
+    assert deleted.status_code == 200, deleted.text
+    assert observed == [
+        ("plan_upload", 1, "Uploaded"),
+        ("plan_upsert", 2, "Updated"),
+        ("plan_delete", 3, None),
+    ]
+
+
 def test_plan_mutations_append_before_and_after_revisions(api_client):
     client, user_id = api_client
     target = (date.today() + timedelta(days=8)).isoformat()

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -198,9 +198,20 @@ def test_settings_rejects_unconnected_plan_target(api_client):
     assert "connected platform" in res.json()["detail"]
 
 
-def test_settings_rejects_delivery_enablement_before_delivery_exists(api_client):
+def test_settings_enables_delivery_and_runs_post_commit_hook(
+    api_client,
+    monkeypatch,
+):
     client, user_id = api_client
     _seed_connection(user_id, "stryd")
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "api.plan_delivery.rolling.trigger_managed_plan_delivery",
+        lambda called_user_id, *, trigger: calls.append(
+            (called_user_id, trigger)
+        ),
+    )
+
     res = client.put("/api/settings", json={
         "plan_management": {
             "mode": "praxys",
@@ -208,8 +219,47 @@ def test_settings_rejects_delivery_enablement_before_delivery_exists(api_client)
             "delivery_enabled": True,
         },
     })
-    assert res.status_code == 409, res.text
-    assert "not available yet" in res.json()["detail"]
+
+    assert res.status_code == 200, res.text
+    assert res.json()["config"]["plan_management"]["delivery_enabled"] is True
+    assert calls == [(user_id, "plan_management_enabled")]
+
+
+def test_leaving_managed_mode_pauses_without_cleanup_hook(
+    api_client,
+    monkeypatch,
+):
+    client, user_id = api_client
+    _seed_connection(user_id, "stryd")
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "api.plan_delivery.rolling.trigger_managed_plan_delivery",
+        lambda called_user_id, *, trigger: calls.append(
+            (called_user_id, trigger)
+        ),
+    )
+    enabled = client.put("/api/settings", json={
+        "plan_management": {
+            "mode": "praxys",
+            "execution_target": "stryd",
+            "delivery_enabled": True,
+        },
+    })
+    assert enabled.status_code == 200, enabled.text
+    calls.clear()
+
+    disabled = client.put("/api/settings", json={
+        "plan_management": {"mode": "external"},
+    })
+
+    assert disabled.status_code == 200, disabled.text
+    assert disabled.json()["config"]["plan_management"] == {
+        "mode": "external",
+        "execution_target": "stryd",
+        "delivery_enabled": False,
+        "adjustment_policy": "suggest_only",
+    }
+    assert calls == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sync_scheduler.py
+++ b/tests/test_sync_scheduler.py
@@ -5,6 +5,7 @@ import pytest
 from db.sync_scheduler import (
     ALLOWED_SYNC_INTERVAL_HOURS,
     DEFAULT_SYNC_INTERVAL_HOURS,
+    _run_managed_delivery_tick,
     get_user_sync_interval_hours,
     normalize_sync_interval_hours,
 )
@@ -37,3 +38,31 @@ def test_normalize_sync_interval_hours_rejects_invalid_values(hours: object) -> 
 def test_get_user_sync_interval_hours_fallbacks(source_options: dict | None, expected: int) -> None:
     """Scheduler should safely fall back to default on missing/invalid config."""
     assert get_user_sync_interval_hours(source_options) == expected
+
+
+def test_scheduler_tick_runs_managed_delivery(monkeypatch) -> None:
+    """Each scheduler cycle should run the isolated managed-plan retry pass."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "api.plan_delivery.rolling.run_scheduled_managed_deliveries",
+        lambda: calls.append("managed"),
+    )
+
+    _run_managed_delivery_tick()
+
+    assert calls == ["managed"]
+
+
+def test_scheduler_tick_isolates_managed_delivery_failure(
+    monkeypatch,
+) -> None:
+    """Managed delivery failures must not escape into the sync scheduler."""
+    def fail() -> None:
+        raise RuntimeError("managed delivery failed")
+
+    monkeypatch.setattr(
+        "api.plan_delivery.rolling.run_scheduled_managed_deliveries",
+        fail,
+    )
+
+    _run_managed_delivery_tick()

--- a/web/src/contexts/SettingsContext.tsx
+++ b/web/src/contexts/SettingsContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import type { DisplayConfig, SettingsConfig, SettingsResponse, TrainingBase, ThresholdValue, DetectedThreshold } from '../types/api';
+import type { DisplayConfig, SettingsConfig, SettingsResponse, SettingsUpdate, TrainingBase, ThresholdValue, DetectedThreshold } from '../types/api';
 import { API_BASE, getAuthHeaders } from '../hooks/useApi';
 
 interface SettingsContextValue {
@@ -13,7 +13,7 @@ interface SettingsContextValue {
   detectedThresholds: Record<string, DetectedThreshold>;
   loading: boolean;
   error: string | null;
-  updateSettings: (update: Partial<SettingsConfig>) => Promise<void>;
+  updateSettings: (update: SettingsUpdate) => Promise<void>;
   refetch: () => void;
 }
 
@@ -87,7 +87,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return () => { cancelled = true; };
   }, [fetchKey]);
 
-  const updateSettings = async (update: Partial<SettingsConfig>) => {
+  const updateSettings = async (update: SettingsUpdate) => {
     const res = await fetch(`${API_BASE}/api/settings`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -77,11 +77,19 @@ export interface SettingsPreferences extends Partial<Record<DataCategory, Platfo
   threshold_sources?: Partial<Record<string, string>>;
 }
 
+export interface PlanManagementConfig {
+  mode: 'external' | 'praxys';
+  execution_target: PlatformName | null;
+  delivery_enabled: boolean;
+  adjustment_policy: 'suggest_only';
+}
+
 export interface SettingsConfig {
   display_name: string;
   unit_system: UnitSystem;
   connections: PlatformName[];
   preferences: SettingsPreferences;
+  plan_management: PlanManagementConfig;
   training_base: TrainingBase;
   thresholds: Record<string, number | string | null>;
   zones: Record<string, number[]>;
@@ -89,6 +97,10 @@ export interface SettingsConfig {
   source_options: Record<string, unknown>;
   /** UI language preference ("en" | "zh"). `null` means auto-detect from browser. */
   language: UiLanguage | null;
+}
+
+export interface SettingsUpdate extends Omit<Partial<SettingsConfig>, 'plan_management'> {
+  plan_management?: Partial<PlanManagementConfig>;
 }
 
 export interface ThresholdValue {


### PR DESCRIPTION
## Summary

- add a provider-neutral rolling delivery service for Praxys-managed plans
- keep delivery default-off and require managed mode, explicit consent, a supported target, and an active connection
- maintain an exact 14-calendar-day delivery horizon after committed plan/settings changes and from the existing scheduler
- reconcile the target calendar before writes and mutate only exact workouts previously delivered by Praxys
- add durable bounded retry/backoff, provider-account and credential-generation fencing, and conservative crash recovery
- update API client types plus architecture, API, scaling, and troubleshooting documentation

## Ownership model

Praxys is the canonical planner; Stryd is the first execution adapter and is not treated as the plan owner. Manual workouts and workouts from other coaching platforms are never adopted, changed, or deleted automatically.

Existing users remain in external mode with delivery disabled. The adoption UI remains scoped to #480. The temporary persisted `source="ai"` compatibility lane is centralized through `PRAXYS_PLAN_SOURCES`; the ownership/provenance migration remains scoped to #504.

## Validation

- 208 focused managed-delivery, reconciliation, scheduler, settings, and endpoint tests
- full backend run: 1,462 non-optional tests passed
- web production build
- miniapp typecheck and generated-contract checks
- selective-review policy validation
- high-confidence ownership, locking, and crash-recovery review

Closes #479
