### PR TITLE
Persist explicit Praxys plan ownership

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -32,12 +32,10 @@ PlanAdjustmentPolicy = Literal["suggest_only"]
 
 PRAXYS_PLAN_SOURCE = "praxys"
 LEGACY_PRAXYS_PLAN_SOURCE = "ai"
-# Expand release: retain the legacy storage value until every deployed reader
-# understands both aliases. The contract release flips this constant to the
-# explicit source without changing call sites.
-PRAXYS_PLAN_WRITE_SOURCE = LEGACY_PRAXYS_PLAN_SOURCE
-# New workers read both aliases while older deployed workers still read/write
-# ``ai``. Ownership exposed to clients is always the explicit Praxys source.
+# The expand release centralized this write value on ``ai`` until every
+# deployed reader understood both aliases. Contract writes now use the explicit
+# ownership source while reads retain the legacy alias for compatibility.
+PRAXYS_PLAN_WRITE_SOURCE = PRAXYS_PLAN_SOURCE
 PRAXYS_PLAN_SOURCES: tuple[str, ...] = (
     PRAXYS_PLAN_SOURCE,
     LEGACY_PRAXYS_PLAN_SOURCE,

--- a/db/session.py
+++ b/db/session.py
@@ -577,8 +577,36 @@ def _ensure_schema(engine_obj, backend: str) -> None:
         Base.metadata.create_all(bind=engine_obj)
         _ensure_sqlite_compat_columns(engine_obj)
         _ensure_sqlite_training_plan_identity(engine_obj)
+        _normalize_praxys_plan_sources(engine_obj)
         return
     _run_alembic_upgrade(engine_obj)
+    _normalize_praxys_plan_sources(engine_obj)
+
+
+def _normalize_praxys_plan_sources(engine_obj) -> None:
+    """Contract legacy Praxys ownership aliases without changing identity."""
+    from analysis.config import (
+        LEGACY_PRAXYS_PLAN_SOURCE,
+        PRAXYS_PLAN_SOURCE,
+    )
+
+    with engine_obj.begin() as conn:
+        result = conn.execute(
+            text(
+                "UPDATE training_plans "
+                "SET source = :canonical_source "
+                "WHERE source = :legacy_source"
+            ),
+            {
+                "canonical_source": PRAXYS_PLAN_SOURCE,
+                "legacy_source": LEGACY_PRAXYS_PLAN_SOURCE,
+            },
+        )
+    if result.rowcount and result.rowcount > 0:
+        logger.info(
+            "Normalized %d legacy Praxys plan source rows",
+            result.rowcount,
+        )
 
 
 def _run_alembic_upgrade(engine_obj) -> None:

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -224,16 +224,16 @@ contains `mode`, `execution_target`, `delivery_enabled`, and
 `config.preferences.plan` preferred-source fallback. Praxys mode treats only
 the explicit Praxys-owned lane (`source='praxys'`) as canonical; historical
 `source='ai'` rows remain a read-compatible storage alias during the
-expand/contract rollout. The expand release keeps writes on `ai` while
-centralizing the storage alias behind `PRAXYS_PLAN_WRITE_SOURCE`; the additive
-migration backfills provenance without rewriting ownership values, so an older
-binary can still read the plan during deployment or rollback. The contract
-release flips that one write constant and normalizes rows only after every
-deployed reader accepts both aliases. Platform rows remain loaded for
-management and reconciliation but never silently become the plan. The additive
-contract defaults to external mode with delivery disabled, so existing users
-are not enrolled in platform writes. Enabling delivery requires an actively
-connected target with a registered plan adapter.
+expand/contract rollout. The expand release centralized writes behind
+`PRAXYS_PLAN_WRITE_SOURCE` while retaining `ai`; after that release deployed,
+the contract release flipped the constant to `praxys` and added an idempotent
+startup normalization for legacy rows. Reads continue accepting both aliases,
+so a late expand worker or rollback to the expand release remains safe.
+Platform rows remain loaded for management and reconciliation but never
+silently become the plan. The additive contract defaults to external mode with
+delivery disabled, so existing users are not enrolled in platform writes.
+Enabling delivery requires an actively connected target with a registered plan
+adapter.
 
 Ownership and authorship are separate. `TrainingPlan.source` identifies the
 owner lane, while `TrainingPlan.workout_origin` records whether content was

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -167,11 +167,10 @@ render read-only with a source badge.
   target, imported, or retained as legacy history. Treat historical
   `source="ai"` as a read-compatible ownership alias only, and make API clients
   use `owner` / `origin` rather than derive semantics from the deprecated
-  `source` response field. During the expand phase, both existing rows and new
-  writes retain `ai` through the centralized `PRAXYS_PLAN_WRITE_SOURCE`;
-  otherwise an older binary can miss or duplicate a newly written `praxys`
-  row. Flip the write constant and normalize storage only in a later contract
-  release after every deployed reader accepts both aliases.
+  `source` response field. The expand release retained `ai` through the
+  centralized `PRAXYS_PLAN_WRITE_SOURCE`; the contract release now writes
+  `praxys` and normalizes legacy rows at startup. Keep both aliases in every
+  read path until the compatibility window is deliberately closed.
 - Praxys may create, replace, or remove only workouts represented by the
   authenticated user's delivery ledger. A manual workout or another coach's
   workout on the same date is not a conflict by itself and must remain

--- a/tests/test_ai_plan.py
+++ b/tests/test_ai_plan.py
@@ -321,7 +321,7 @@ class TestAiPlanProvider:
             df = provider.load_plan(tmpdir)
             assert len(df) == 2
             assert df.iloc[0]["workout_type"] == "easy"
-            assert set(df["source"]) == {"ai"}
+            assert set(df["source"]) == {"praxys"}
             assert set(df["workout_origin"]) == {"generated"}
 
     def test_load_plan_handles_unquoted_commas(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,8 +42,8 @@ class TestUserConfigDefaults:
         })
         assert plan_analysis_source(config) == PRAXYS_PLAN_SOURCE
 
-    def test_expand_release_keeps_legacy_write_alias(self):
-        assert PRAXYS_PLAN_WRITE_SOURCE == "ai"
+    def test_contract_release_uses_explicit_write_source(self):
+        assert PRAXYS_PLAN_WRITE_SOURCE == PRAXYS_PLAN_SOURCE
 
     def test_legacy_plan_source_normalizes_to_praxys(self):
         assert normalize_plan_source("ai") == PRAXYS_PLAN_SOURCE

--- a/tests/test_plan_ledger.py
+++ b/tests/test_plan_ledger.py
@@ -458,9 +458,9 @@ def test_sqlite_init_migrates_training_plan_identity_constraint(
             """
             INSERT INTO training_plans (
                 user_id, date, workout_type, source
-            ) VALUES (
-                'legacy-user', '2026-08-04', 'easy', 'ai'
-            )
+            ) VALUES
+                ('legacy-user', '2026-08-04', 'easy', 'ai'),
+                ('legacy-user', '2026-08-05', 'long_run', 'stryd')
             """
         )
     legacy.dispose()
@@ -494,8 +494,17 @@ def test_sqlite_init_migrates_training_plan_identity_constraint(
                 """
             ).one()
             assert canonical_id
-            assert source == "ai"
+            assert source == "praxys"
             assert origin == "legacy"
+            external_source, external_origin = conn.exec_driver_sql(
+                """
+                SELECT source, workout_origin
+                FROM training_plans
+                WHERE id = 2
+                """
+            ).one()
+            assert external_source == "stryd"
+            assert external_origin == "imported"
             conn.exec_driver_sql(
                 """
                 INSERT INTO training_plans (
@@ -509,6 +518,17 @@ def test_sqlite_init_migrates_training_plan_identity_constraint(
                 )
                 """
             )
+        db_session._normalize_praxys_plan_sources(db_session.engine)
+        db_session._normalize_praxys_plan_sources(db_session.engine)
+        with db_session.engine.connect() as conn:
+            assert conn.exec_driver_sql(
+                """
+                SELECT source
+                FROM training_plans
+                WHERE canonical_id =
+                    '22222222-2222-2222-2222-222222222222'
+                """
+            ).scalar_one() == "praxys"
     finally:
         if db_session.engine is not None:
             db_session.engine.dispose()


### PR DESCRIPTION
## Summary
- flip the centralized plan write source from the legacy `ai` alias to explicit `praxys`
- normalize existing `ai` ownership rows idempotently at startup on SQLite and PostgreSQL
- preserve dual-read compatibility, frozen delivery keys, and pre-flip workout hashes
- keep the Alembic head unchanged so rollback to the deployed expand release remains boot-safe

## Rollout safety
The expand phase in #508 is already deployed successfully to the frontend and backend. That release reads both aliases, so it is the safe rollback target for this contract phase. A late expand worker can still write `ai`; contract readers accept it and the next startup reconverges it.

## Validation
- `python -m pytest tests/ --ignore=tests/test_mcp_tools.py -q` (1474 passed, 2 skipped)
- targeted ownership/normalization suite (127 passed)
- repeated startup normalization and late legacy-write convergence coverage

Closes #504.