### PR TITLE
Add miniapp managed-plan controls

### DIFF
--- a/miniapp/components/managed-plan/index.json
+++ b/miniapp/components/managed-plan/index.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/miniapp/components/managed-plan/index.scss
+++ b/miniapp/components/managed-plan/index.scss
@@ -1,0 +1,330 @@
+.managed-plan {
+  margin-bottom: 36rpx;
+}
+
+.managed-plan__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24rpx;
+  margin-bottom: 20rpx;
+}
+
+.managed-plan__title {
+  display: block;
+  color: var(--text);
+  font-size: 30rpx;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.managed-plan__conflicts {
+  display: block;
+  margin-top: 6rpx;
+  font-size: 22rpx;
+  line-height: 1.35;
+}
+
+.managed-plan__count {
+  display: flex;
+  flex: none;
+  align-items: baseline;
+  gap: 8rpx;
+  color: var(--text-muted);
+}
+
+.managed-plan__count-value {
+  color: var(--text);
+  font-size: 28rpx;
+  font-weight: 650;
+}
+
+.managed-plan__count-label {
+  max-width: 180rpx;
+  font-size: 20rpx;
+  line-height: 1.2;
+  text-align: right;
+}
+
+.managed-plan__management {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20rpx;
+  padding: 20rpx 0;
+  border-top: 1rpx solid var(--border-subtle);
+  border-bottom: 1rpx solid var(--border-subtle);
+}
+
+.managed-plan__management-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.managed-plan__management-heading {
+  display: flex;
+  align-items: center;
+  gap: 10rpx;
+  color: var(--text);
+  font-size: 25rpx;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.managed-plan__state-dot {
+  width: 14rpx;
+  height: 14rpx;
+  flex: none;
+  border-radius: 50%;
+  background-color: var(--text-muted);
+}
+
+.managed-plan__management--positive .managed-plan__state-dot {
+  background-color: var(--primary);
+}
+
+.managed-plan__management--warning .managed-plan__state-dot {
+  background-color: var(--warning);
+}
+
+.managed-plan__management-detail {
+  display: block;
+  margin-top: 6rpx;
+  color: var(--text-muted);
+  font-size: 21rpx;
+  line-height: 1.45;
+}
+
+.managed-plan__manage,
+.managed-plan__retry {
+  min-height: 88rpx;
+  margin: 0;
+  padding: 0 8rpx 0 24rpx;
+  border: 0;
+  background: transparent;
+  color: var(--primary);
+  font-size: 22rpx;
+  font-weight: 650;
+  line-height: 88rpx;
+}
+
+.managed-plan__manage::after,
+.managed-plan__retry::after,
+.managed-plan__status::after {
+  border: 0;
+}
+
+.managed-plan__loading {
+  padding: 28rpx 0 8rpx;
+}
+
+.managed-plan__skeleton {
+  height: 72rpx;
+  margin-bottom: 12rpx;
+}
+
+.managed-plan__skeleton--short {
+  width: 72%;
+}
+
+.managed-plan__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20rpx;
+  padding: 24rpx 0;
+}
+
+.managed-plan__error-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.managed-plan__error-title,
+.managed-plan__error-detail {
+  display: block;
+}
+
+.managed-plan__error-title {
+  color: var(--destructive);
+  font-size: 24rpx;
+  font-weight: 650;
+}
+
+.managed-plan__error-detail {
+  margin-top: 4rpx;
+  color: var(--text-muted);
+  font-size: 21rpx;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.managed-plan__empty {
+  display: block;
+  padding: 28rpx 0;
+  color: var(--text-muted);
+  font-size: 24rpx;
+  line-height: 1.5;
+}
+
+.managed-plan__workouts {
+  border-bottom: 1rpx solid var(--border-subtle);
+}
+
+.managed-plan__workout {
+  display: flex;
+  min-height: 112rpx;
+  box-sizing: border-box;
+  align-items: center;
+  gap: 18rpx;
+  padding: 16rpx 0;
+  border-bottom: 1rpx solid var(--border-subtle);
+}
+
+.managed-plan__workout:last-child {
+  border-bottom: 0;
+}
+
+.managed-plan__date {
+  display: flex;
+  width: 64rpx;
+  flex: none;
+  flex-direction: column;
+  align-items: center;
+}
+
+.managed-plan__weekday {
+  color: var(--text-muted);
+  font-size: 18rpx;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.managed-plan__day {
+  color: var(--text);
+  font-size: 30rpx;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.managed-plan__workout-copy {
+  min-width: 0;
+  flex: 1;
+}
+
+.managed-plan__workout-type,
+.managed-plan__details,
+.managed-plan__description {
+  display: block;
+}
+
+.managed-plan__workout-type {
+  color: var(--text);
+  font-size: 25rpx;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.managed-plan__details,
+.managed-plan__description {
+  margin-top: 4rpx;
+  color: var(--text-muted);
+  font-size: 20rpx;
+  line-height: 1.4;
+}
+
+.managed-plan__description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.managed-plan__status {
+  display: inline-flex;
+  min-height: 72rpx;
+  max-width: 210rpx;
+  box-sizing: border-box;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 10rpx 18rpx;
+  border: 0;
+  border-radius: 999rpx;
+  font-size: 20rpx;
+  font-weight: 650;
+  line-height: 1.25;
+  text-align: center;
+}
+
+button.managed-plan__status {
+  min-height: 88rpx;
+}
+
+.managed-plan__status--static {
+  min-height: 56rpx;
+}
+
+.managed-plan__status--neutral {
+  background-color: var(--surface-subtle);
+  color: var(--text-muted);
+}
+
+.managed-plan__status--positive {
+  background-color: rgba(30, 142, 91, 0.12);
+  color: var(--primary);
+}
+
+.managed-plan__status--warning {
+  background-color: rgba(217, 119, 6, 0.12);
+  color: var(--warning);
+}
+
+.managed-plan__status--danger {
+  background-color: rgba(217, 58, 44, 0.12);
+  color: var(--destructive);
+}
+
+.managed-plan__status--reasoning {
+  background-color: rgba(46, 113, 198, 0.12);
+  color: var(--accent-cobalt);
+}
+
+.managed-plan__status:disabled {
+  opacity: 0.5;
+}
+
+.managed-plan__boundary {
+  display: block;
+  padding: 18rpx 0 0;
+  color: var(--text-muted);
+  font-size: 21rpx;
+  line-height: 1.5;
+}
+
+.managed-plan__action-error {
+  display: block;
+  margin-top: 16rpx;
+  color: var(--destructive);
+  font-size: 22rpx;
+  line-height: 1.45;
+}
+
+.managed-plan--today {
+  margin-top: -8rpx;
+  margin-bottom: 24rpx;
+}
+
+.managed-plan--today .managed-plan__management {
+  padding-top: 16rpx;
+  padding-bottom: 16rpx;
+}
+
+.managed-plan--today .managed-plan__workouts {
+  border-bottom: 0;
+}
+
+.managed-plan--today .managed-plan__workout {
+  min-height: 96rpx;
+  padding: 12rpx 0;
+}

--- a/miniapp/components/managed-plan/index.ts
+++ b/miniapp/components/managed-plan/index.ts
@@ -1,0 +1,697 @@
+import { apiGet, apiPost } from '../../utils/api-client';
+import type { ApiError } from '../../utils/api-client';
+import { detectLocale, t, tFmt, tNamed } from '../../utils/i18n';
+import {
+  beginManagedPlanRequest,
+  formatWorkoutType,
+  invalidateManagedPlanRequests,
+  isPraxysOwned,
+  isLatestManagedPlanRequest,
+  managedPlanState,
+  planWindowUrl,
+  workoutKey,
+} from '../../utils/managed-plan';
+import type {
+  PlanReconciliation,
+  PlanResolutionAction,
+  PlanResolutionResponse,
+  PlanResponse,
+  PlannedWorkout,
+  PlanTargetWorkoutSnapshot,
+  SettingsResponse,
+  StrydPushResult,
+} from '../../types/api';
+import type { ManagedPlanState } from '../../utils/managed-plan';
+
+type StatusTone = 'neutral' | 'positive' | 'warning' | 'danger' | 'reasoning';
+type WorkoutAction = '' | 'deliver' | 'review';
+const REFRESH_WORKING_KEY = '__managed_plan_refresh__';
+
+interface WorkoutStatus {
+  label: string;
+  tone: StatusTone;
+  action: WorkoutAction;
+  disabled: boolean;
+}
+
+interface WorkoutView {
+  key: string;
+  day: string;
+  weekday: string;
+  workoutType: string;
+  details: string;
+  description: string;
+  statusLabel: string;
+  statusTone: StatusTone;
+  action: WorkoutAction;
+  actionDisabled: boolean;
+}
+
+function translations() {
+  return {
+    upcomingPlan: t('Upcoming Plan'),
+    upcomingWorkouts: t('Upcoming workouts'),
+    planManagement: t('Plan management'),
+    managedByPraxys: t('Managed by Praxys'),
+    managedDeliveryPaused: t('Managed delivery paused'),
+    externalPlanMode: t('External plan mode'),
+    manageInSettings: t('Manage in Settings'),
+    adoptInSettings: t('Adopt in Settings'),
+    externalWorkoutsUntouched: t(
+      'Praxys only changes workouts it created or you explicitly adopt. Manual workouts and workouts from another coach stay untouched. To avoid overlapping sessions, use one planner at a time.',
+    ),
+    noWorkouts: t('No workouts scheduled in this window.'),
+    retry: t('Retry'),
+    failedToLoad: t('Failed to load training plan'),
+    working: t('Working…'),
+    external: t('External'),
+    useInPraxys: t('Use in Praxys'),
+    conflictRetained: t('Conflict retained'),
+    praxysOnly: t('Praxys only'),
+    paused: t('Paused'),
+    inSync: t('In sync'),
+    verifying: t('Verifying'),
+    reviewConflict: t('Review conflict'),
+    retryDelivery: t('Retry delivery'),
+    syncTargetToReview: t('Sync target to review'),
+    deliverNow: t('Deliver now'),
+    queued: t('Queued'),
+    done: t('Done'),
+    cancel: t('Cancel'),
+    confirm: t('Confirm'),
+    resolveConflict: t('Resolve workout conflict'),
+    praxysVersion: t('Praxys version'),
+    targetUnavailable: t('The target version is unavailable.'),
+    couldNotResolve: t('Could not resolve this workout'),
+    deliveryFailed: t('Delivery failed'),
+    missingDeliveryResult: t('No delivery result was returned for this workout'),
+  };
+}
+
+function platformLabel(value: string | null): string {
+  if (!value) return '';
+  if (value === 'stryd') return 'Stryd';
+  if (value === 'garmin') return 'Garmin';
+  if (value === 'coros') return 'COROS';
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function managementCopy(
+  state: ManagedPlanState,
+  target: string | null,
+  targetConnected: boolean,
+): { title: string; detail: string; tone: StatusTone; action: string } {
+  const targetName = platformLabel(target);
+  if (state === 'active') {
+    if (targetConnected) {
+      return {
+        title: t('Managed by Praxys'),
+        detail: tFmt('The rolling 14-day window is delivered to {0}.', targetName),
+        tone: 'positive',
+        action: t('Manage in Settings'),
+      };
+    }
+    return {
+      title: t('Managed by Praxys'),
+      detail: targetName
+        ? tNamed(
+          'Reconnect {target} to continue delivery. The Praxys plan remains canonical.',
+          { target: targetName },
+        )
+        : t('Select an execution target in Settings to continue delivery.'),
+      tone: 'warning',
+      action: t('Manage in Settings'),
+    };
+  }
+  if (state === 'paused') {
+    return {
+      title: t('Managed delivery paused'),
+      detail: t('The Praxys plan is preserved; no target workouts will change.'),
+      tone: 'warning',
+      action: t('Manage in Settings'),
+    };
+  }
+  return {
+    title: t('External plan mode'),
+    detail: t('Praxys is read-only and leaves every target workout untouched.'),
+    tone: 'neutral',
+    action: t('Adopt in Settings'),
+  };
+}
+
+function workoutDateParts(workout: PlannedWorkout): { day: string; weekday: string } {
+  const parsed = workout.start_time
+    ? new Date(workout.start_time)
+    : new Date(`${workout.date}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) {
+    return { day: workout.date.slice(-2), weekday: '' };
+  }
+  const locale = detectLocale() === 'zh' ? 'zh-CN' : 'en-US';
+  const weekday = parsed.toLocaleDateString(locale, { weekday: 'short' });
+  return {
+    day: String(parsed.getDate()).padStart(2, '0'),
+    weekday: detectLocale() === 'zh' ? weekday : weekday.toUpperCase(),
+  };
+}
+
+function workoutDetails(workout: PlannedWorkout): string {
+  const details: string[] = [];
+  if (workout.duration_min != null) {
+    details.push(`${Math.round(workout.duration_min)} min`);
+  }
+  if (workout.distance_km != null) {
+    details.push(`${workout.distance_km} km`);
+  }
+  if (workout.power_min != null && workout.power_max != null) {
+    details.push(`${workout.power_min}–${workout.power_max} W`);
+  }
+  return details.join(' · ');
+}
+
+function targetWorkoutDetails(workout: PlanTargetWorkoutSnapshot): string {
+  const details: string[] = [t(formatWorkoutType(workout.workout_type))];
+  if (workout.planned_duration_min != null) {
+    details.push(`${Math.round(workout.planned_duration_min)} min`);
+  }
+  if (workout.planned_distance_km != null) {
+    details.push(`${workout.planned_distance_km} km`);
+  }
+  return details.join(' · ');
+}
+
+function statusForWorkout(
+  workout: PlannedWorkout,
+  state: ManagedPlanState,
+  target: string | null,
+  targetConnected: boolean,
+  working: boolean,
+  anyActionWorking: boolean,
+): WorkoutStatus {
+  if (working) {
+    return {
+      label: t('Working…'),
+      tone: 'reasoning',
+      action: '',
+      disabled: true,
+    };
+  }
+
+  const reconciliation = workout.reconciliation;
+  const owned = isPraxysOwned(workout);
+  const canAccept = reconciliation?.resolutions.includes('accept_target') ?? false;
+  const hasConflict = reconciliation?.conflict === true
+    || workout.sync_state === 'mismatch';
+  const localResolutionAvailable = canAccept;
+
+  if (!owned) {
+    return canAccept
+      ? {
+        label: t('Use in Praxys'),
+        tone: 'positive',
+        action: 'review',
+        disabled: anyActionWorking,
+      }
+      : {
+        label: t('External'),
+        tone: 'neutral',
+        action: '',
+        disabled: true,
+      };
+  }
+
+  if (workout.workout_type.toLowerCase() === 'rest') {
+    return {
+      label: state === 'external' ? t('Praxys only') : t('Rest'),
+      tone: 'neutral',
+      action: '',
+      disabled: true,
+    };
+  }
+  if (state !== 'active' && hasConflict) {
+    return {
+      label: t('Conflict retained'),
+      tone: 'warning',
+      action: '',
+      disabled: true,
+    };
+  }
+  if (state === 'external') {
+    return {
+      label: t('Praxys only'),
+      tone: 'neutral',
+      action: '',
+      disabled: true,
+    };
+  }
+  if (state === 'paused') {
+    return {
+      label: t('Paused'),
+      tone: 'warning',
+      action: '',
+      disabled: true,
+    };
+  }
+
+  const disabled = anyActionWorking
+    || (!targetConnected && !localResolutionAvailable);
+  const reconciliationState = reconciliation?.state;
+  if (reconciliationState === 'matching' || workout.sync_state === 'synced') {
+    return {
+      label: t('In sync'),
+      tone: 'positive',
+      action: '',
+      disabled: true,
+    };
+  }
+  if (reconciliationState === 'pending_observation') {
+    return {
+      label: t('Verifying'),
+      tone: 'reasoning',
+      action: '',
+      disabled: true,
+    };
+  }
+  if (
+    reconciliationState === 'target_edited'
+    || reconciliationState === 'canonical_changed'
+    || reconciliationState === 'target_deleted'
+  ) {
+    return {
+      label: t('Review conflict'),
+      tone: 'warning',
+      action: 'review',
+      disabled,
+    };
+  }
+  if (reconciliationState === 'delivery_failed') {
+    return {
+      label: t('Retry delivery'),
+      tone: 'danger',
+      action: 'review',
+      disabled,
+    };
+  }
+  if (workout.sync_state === 'mismatch' && reconciliation) {
+    return {
+      label: t('Review conflict'),
+      tone: 'warning',
+      action: 'review',
+      disabled,
+    };
+  }
+  if (workout.sync_state === 'mismatch') {
+    return {
+      label: t('Sync target to review'),
+      tone: 'warning',
+      action: '',
+      disabled: true,
+    };
+  }
+  if (target === 'stryd') {
+    if (!workout.canonical_id) {
+      return {
+        label: t('Unavailable'),
+        tone: 'warning',
+        action: '',
+        disabled: true,
+      };
+    }
+    return {
+      label: t('Deliver now'),
+      tone: 'positive',
+      action: 'deliver',
+      disabled,
+    };
+  }
+  return {
+    label: t('Queued'),
+    tone: 'reasoning',
+    action: '',
+    disabled: true,
+  };
+}
+
+function buildWorkoutViews(
+  workouts: PlannedWorkout[],
+  state: ManagedPlanState,
+  target: string | null,
+  targetConnected: boolean,
+  workingKey: string,
+): WorkoutView[] {
+  return workouts.map((workout) => {
+    const key = workoutKey(workout);
+    const status = statusForWorkout(
+      workout,
+      state,
+      target,
+      targetConnected,
+      key === workingKey,
+      Boolean(workingKey),
+    );
+    const date = workoutDateParts(workout);
+    return {
+      key,
+      day: date.day,
+      weekday: date.weekday,
+      workoutType: t(formatWorkoutType(workout.workout_type)),
+      details: workoutDetails(workout),
+      description: workout.description ?? '',
+      statusLabel: status.label,
+      statusTone: status.tone,
+      action: status.action,
+      actionDisabled: status.disabled,
+    };
+  });
+}
+
+function resolutionLabel(
+  action: PlanResolutionAction,
+  reconciliation: PlanReconciliation,
+): string {
+  if (action === 'accept_target') {
+    return tNamed(
+      'Use {target} version',
+      { target: platformLabel(reconciliation.target) },
+    );
+  }
+  return reconciliation.state === 'delivery_failed'
+    ? t('Retry delivery')
+    : t('Restore Praxys');
+}
+
+function resolutionDescription(
+  workout: PlannedWorkout,
+  reconciliation: PlanReconciliation,
+  action: PlanResolutionAction,
+): string {
+  const target = platformLabel(reconciliation.target);
+  const lines: string[] = [];
+  if (reconciliation.state !== 'target_only') {
+    lines.push(
+      `${t('Praxys version')}: ${t(formatWorkoutType(workout.workout_type))}`
+      + (workoutDetails(workout) ? ` · ${workoutDetails(workout)}` : ''),
+    );
+  }
+  lines.push(
+    `${tNamed('{target} version', { target })}: ${
+      reconciliation.target_workout
+        ? targetWorkoutDetails(reconciliation.target_workout)
+        : t('The target version is unavailable.')
+    }`,
+  );
+
+  if (action === 'accept_target') {
+    lines.push(
+      t('copy the target workout into Praxys; future management follows that version.'),
+    );
+  } else {
+    lines.push(
+      t('keep the Praxys workout canonical and replace or recreate the target version.'),
+    );
+  }
+  return lines.join('\n\n');
+}
+
+Component({
+  options: { addGlobalClass: true },
+
+  properties: {
+    scope: {
+      type: String as StringConstructor,
+      value: 'window',
+    },
+  },
+
+  data: {
+    loading: true,
+    errorMessage: '',
+    actionError: '',
+    hasResponse: false,
+    refreshing: false,
+    hasWorkouts: false,
+    rawWorkouts: [] as PlannedWorkout[],
+    workouts: [] as WorkoutView[],
+    workoutCount: 0,
+    conflictCount: 0,
+    managementState: 'external' as ManagedPlanState,
+    managementTitle: '',
+    managementDetail: '',
+    managementTone: 'neutral' as StatusTone,
+    managementAction: '',
+    target: '' as string,
+    targetConnected: false,
+    workingKey: '',
+    tr: translations(),
+  },
+
+  lifetimes: {
+    attached() {
+      this.setData({ tr: translations() });
+      void this.refresh();
+    },
+    detached() {
+      invalidateManagedPlanRequests(this);
+    },
+  },
+
+  pageLifetimes: {
+    show() {
+      if (this.data.hasResponse) void this.refresh();
+    },
+  },
+
+  methods: {
+    async refresh() {
+      const requestGeneration = beginManagedPlanRequest(this);
+      const isBackground = this.data.hasResponse;
+      if (isBackground) {
+        this.setData({
+          errorMessage: '',
+          refreshing: true,
+          workouts: buildWorkoutViews(
+            this.data.rawWorkouts,
+            this.data.managementState,
+            this.data.target || null,
+            this.data.targetConnected,
+            this.data.workingKey || REFRESH_WORKING_KEY,
+          ),
+        });
+      } else {
+        this.setData({
+          loading: true,
+          refreshing: true,
+          errorMessage: '',
+        });
+      }
+      const days = this.data.scope === 'today' ? 1 : 14;
+      try {
+        const [settings, plan] = await Promise.all([
+          apiGet<SettingsResponse>('/api/settings'),
+          apiGet<PlanResponse>(planWindowUrl(days)),
+        ]);
+        if (!isLatestManagedPlanRequest(this, requestGeneration)) return;
+        const state = managedPlanState(settings.config.plan_management);
+        const target = settings.config.plan_management.execution_target
+          ?? plan.sync_target
+          ?? null;
+        const targetConnected = target != null
+          && settings.connection_statuses[target] === 'connected';
+        const management = managementCopy(state, target, targetConnected);
+        const rawWorkouts = plan.workouts;
+        const workingKey = this.data.workingKey;
+        this.setData({
+          loading: false,
+          refreshing: false,
+          errorMessage: '',
+          actionError: '',
+          hasResponse: true,
+          hasWorkouts: rawWorkouts.length > 0,
+          rawWorkouts,
+          workouts: buildWorkoutViews(
+            rawWorkouts,
+            state,
+            target,
+            targetConnected,
+            workingKey,
+          ),
+          workoutCount: rawWorkouts.length,
+          conflictCount: rawWorkouts.filter(
+            (workout) => workout.reconciliation?.conflict,
+          ).length,
+          managementState: state,
+          managementTitle: management.title,
+          managementDetail: management.detail,
+          managementTone: management.tone,
+          managementAction: management.action,
+          target: target ?? '',
+          targetConnected,
+          workingKey,
+        });
+      } catch (error) {
+        if (!isLatestManagedPlanRequest(this, requestGeneration)) return;
+        const apiError = error as Partial<ApiError>;
+        if (apiError.code === 'UNAUTHENTICATED') {
+          this.setData({ loading: false, refreshing: false });
+          return;
+        }
+        this.setData({
+          loading: false,
+          refreshing: false,
+          errorMessage: apiError.detail ?? String(error),
+        });
+      }
+    },
+
+    onRetry() {
+      void this.refresh();
+    },
+
+    onManagePlan() {
+      wx.switchTab({ url: '/pages/settings/index' });
+    },
+
+    onWorkoutAction(event: WechatMiniprogram.TouchEvent) {
+      if (this.data.workingKey || this.data.refreshing) return;
+      const key = String(event.currentTarget.dataset.key ?? '');
+      const action = String(event.currentTarget.dataset.action ?? '') as WorkoutAction;
+      const workout = this.data.rawWorkouts.find(
+        (candidate) => workoutKey(candidate) === key,
+      );
+      if (!workout) return;
+      if (action === 'deliver') {
+        void this.deliverWorkout(workout);
+      } else if (action === 'review') {
+        this.reviewWorkout(workout);
+      }
+    },
+
+    reviewWorkout(workout: PlannedWorkout) {
+      const reconciliation = workout.reconciliation;
+      if (!reconciliation || reconciliation.resolutions.length === 0) return;
+      const actions = reconciliation.resolutions.filter(
+        (action) => (
+          action === 'accept_target'
+          || (action === 'restore_praxys' && this.data.targetConnected)
+        ),
+      );
+      if (actions.length === 0) return;
+      const choices = actions.map(
+        (action) => resolutionLabel(action, reconciliation),
+      );
+      const choose = (index: number) => {
+        const action = actions[index];
+        if (action) this.confirmResolution(workout, reconciliation, action);
+      };
+      if (choices.length === 1) {
+        choose(0);
+        return;
+      }
+      wx.showActionSheet({
+        itemList: choices,
+        success: (result) => choose(result.tapIndex),
+      });
+    },
+
+    confirmResolution(
+      workout: PlannedWorkout,
+      reconciliation: PlanReconciliation,
+      action: PlanResolutionAction,
+    ) {
+      wx.showModal({
+        title: resolutionLabel(action, reconciliation),
+        content: resolutionDescription(workout, reconciliation, action),
+        confirmText: this.data.tr.confirm,
+        cancelText: this.data.tr.cancel,
+        success: (result) => {
+          if (result.confirm) void this.resolveWorkout(workout, action);
+        },
+      });
+    },
+
+    async deliverWorkout(workout: PlannedWorkout) {
+      if (!workout.canonical_id) {
+        this.setData({ actionError: this.data.tr.deliveryFailed });
+        return;
+      }
+      const key = workoutKey(workout);
+      this.setWorking(key);
+      try {
+        const body = {
+          workout_dates: [workout.date],
+          canonical_ids: [workout.canonical_id],
+        };
+        const response = await apiPost<{ results: StrydPushResult[] }>(
+          '/api/plan/push-stryd',
+          body,
+        );
+        const result = response.results.find(
+          (candidate) => candidate.canonical_id === workout.canonical_id
+            || (
+              candidate.canonical_id == null
+              && candidate.date === workout.date
+            ),
+        );
+        if (!result) throw new Error(this.data.tr.missingDeliveryResult);
+        if (result.status === 'error') throw new Error(result.error);
+        await this.refresh();
+      } catch (error) {
+        const apiError = error as Partial<ApiError>;
+        if (apiError.code === 'UNAUTHENTICATED') return;
+        this.setData({
+          actionError: apiError.detail
+            ?? (error instanceof Error ? error.message : this.data.tr.deliveryFailed),
+        });
+      } finally {
+        this.setWorking('');
+      }
+    },
+
+    async resolveWorkout(
+      workout: PlannedWorkout,
+      action: PlanResolutionAction,
+    ) {
+      const reconciliationId = workout.reconciliation?.id;
+      if (!reconciliationId) return;
+      const key = workoutKey(workout);
+      this.setWorking(key);
+      try {
+        await apiPost<PlanResolutionResponse>(
+          '/api/plan/reconciliation/resolve',
+          {
+            reconciliation_id: reconciliationId,
+            action,
+          },
+        );
+        wx.showToast({
+          title: this.data.tr.done,
+          icon: 'success',
+          duration: 1200,
+        });
+        await this.refresh();
+      } catch (error) {
+        const apiError = error as Partial<ApiError>;
+        if (apiError.code === 'UNAUTHENTICATED') return;
+        this.setData({
+          actionError: apiError.detail
+            ?? (error instanceof Error ? error.message : this.data.tr.couldNotResolve),
+        });
+      } finally {
+        this.setWorking('');
+      }
+    },
+
+    setWorking(key: string) {
+      if (key) this.setData({ actionError: '' });
+      this.setData({
+        workingKey: key,
+        workouts: buildWorkoutViews(
+          this.data.rawWorkouts,
+          this.data.managementState,
+          this.data.target || null,
+          this.data.targetConnected,
+          key || (this.data.refreshing ? REFRESH_WORKING_KEY : ''),
+        ),
+      });
+    },
+  },
+});

--- a/miniapp/components/managed-plan/index.wxml
+++ b/miniapp/components/managed-plan/index.wxml
@@ -1,0 +1,90 @@
+<view class="managed-plan managed-plan--{{scope}}">
+  <view wx:if="{{scope === 'window'}}" class="managed-plan__header">
+    <view>
+      <text class="managed-plan__title">{{tr.upcomingPlan}}</text>
+      <text wx:if="{{conflictCount}}" class="managed-plan__conflicts ts-warning">
+        {{conflictCount}} · {{tr.reviewConflict}}
+      </text>
+    </view>
+    <view wx:if="{{hasResponse}}" class="managed-plan__count">
+      <text class="managed-plan__count-value ts-value">{{workoutCount}}</text>
+      <text class="managed-plan__count-label">{{tr.upcomingWorkouts}}</text>
+    </view>
+  </view>
+
+  <view
+    wx:if="{{hasResponse}}"
+    class="managed-plan__management managed-plan__management--{{managementTone}}"
+  >
+    <view class="managed-plan__management-copy">
+      <view class="managed-plan__management-heading">
+        <view class="managed-plan__state-dot"></view>
+        <text>{{managementTitle}}</text>
+      </view>
+      <text class="managed-plan__management-detail">{{managementDetail}}</text>
+    </view>
+    <button
+      class="managed-plan__manage"
+      bindtap="onManagePlan"
+    >{{managementAction}}</button>
+  </view>
+
+  <view wx:if="{{loading && !hasResponse}}" class="managed-plan__loading">
+    <view class="ts-skeleton managed-plan__skeleton"></view>
+    <view class="ts-skeleton managed-plan__skeleton managed-plan__skeleton--short"></view>
+  </view>
+
+  <view wx:elif="{{errorMessage}}" class="managed-plan__error" role="alert">
+    <view class="managed-plan__error-copy">
+      <text class="managed-plan__error-title">{{tr.failedToLoad}}</text>
+      <text class="managed-plan__error-detail">{{errorMessage}}</text>
+    </view>
+    <button class="managed-plan__retry" bindtap="onRetry">{{tr.retry}}</button>
+  </view>
+
+  <block wx:elif="{{hasResponse}}">
+    <text
+      wx:if="{{scope === 'window' && !hasWorkouts}}"
+      class="managed-plan__empty"
+    >{{tr.noWorkouts}}</text>
+
+    <view wx:if="{{hasWorkouts}}" class="managed-plan__workouts">
+      <view
+        wx:for="{{workouts}}"
+        wx:key="key"
+        class="managed-plan__workout"
+      >
+        <view wx:if="{{scope === 'window'}}" class="managed-plan__date">
+          <text class="managed-plan__weekday">{{item.weekday}}</text>
+          <text class="managed-plan__day ts-value">{{item.day}}</text>
+        </view>
+        <view class="managed-plan__workout-copy">
+          <text class="managed-plan__workout-type">{{item.workoutType}}</text>
+          <text wx:if="{{item.details}}" class="managed-plan__details ts-value">{{item.details}}</text>
+          <text wx:if="{{item.description && scope === 'window'}}" class="managed-plan__description">{{item.description}}</text>
+        </view>
+        <button
+          wx:if="{{item.action}}"
+          class="managed-plan__status managed-plan__status--{{item.statusTone}}"
+          data-key="{{item.key}}"
+          data-action="{{item.action}}"
+          disabled="{{item.actionDisabled}}"
+          bindtap="onWorkoutAction"
+        >{{item.statusLabel}}</button>
+        <view
+          wx:else
+          class="managed-plan__status managed-plan__status--static managed-plan__status--{{item.statusTone}}"
+        >{{item.statusLabel}}</view>
+      </view>
+    </view>
+
+    <text
+      wx:if="{{scope === 'window'}}"
+      class="managed-plan__boundary"
+    >{{tr.externalWorkoutsUntouched}}</text>
+  </block>
+
+  <text wx:if="{{actionError}}" class="managed-plan__action-error" role="alert">
+    {{actionError}}
+  </text>
+</view>

--- a/miniapp/pages/settings/index.scss
+++ b/miniapp/pages/settings/index.scss
@@ -229,6 +229,309 @@
   color: var(--text-muted);
 }
 
+.settings-plan {
+  padding-top: 24rpx;
+  padding-bottom: 32rpx;
+}
+
+.settings-plan-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20rpx;
+  margin-bottom: 12rpx;
+}
+
+.settings-plan-label {
+  margin-bottom: 0;
+}
+
+.settings-plan-state {
+  flex: none;
+  padding: 7rpx 16rpx;
+  border-radius: 999rpx;
+  background-color: var(--surface-subtle);
+  color: var(--text-muted);
+  font-size: 20rpx;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.settings-plan-state--active {
+  background-color: rgba(30, 142, 91, 0.12);
+  color: var(--primary);
+}
+
+.settings-plan-state--paused {
+  background-color: rgba(217, 119, 6, 0.12);
+  color: var(--warning);
+}
+
+.settings-plan-title,
+.settings-plan-detail {
+  display: block;
+}
+
+.settings-plan-title {
+  color: var(--text);
+  font-size: 28rpx;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.settings-plan-detail {
+  margin-top: 6rpx;
+  color: var(--text-muted);
+  font-size: 23rpx;
+  line-height: 1.5;
+}
+
+.settings-plan-boundary {
+  display: flex;
+  align-items: flex-start;
+  gap: 14rpx;
+  margin-top: 20rpx;
+  padding: 20rpx;
+  border-radius: 12rpx;
+  background-color: rgba(46, 113, 198, 0.09);
+  color: var(--text);
+  font-size: 22rpx;
+  line-height: 1.5;
+}
+
+.settings-plan-boundary-mark {
+  width: 16rpx;
+  height: 16rpx;
+  flex: none;
+  margin-top: 8rpx;
+  border-radius: 50%;
+  background-color: var(--accent-cobalt);
+}
+
+.settings-plan-preview {
+  margin-top: 24rpx;
+  padding: 22rpx 0;
+  border-top: 1rpx solid var(--border-subtle);
+  border-bottom: 1rpx solid var(--border-subtle);
+}
+
+.settings-plan-preview-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24rpx;
+}
+
+.settings-plan-preview-title,
+.settings-plan-preview-window {
+  display: block;
+}
+
+.settings-plan-preview-title {
+  color: var(--text);
+  font-size: 24rpx;
+  font-weight: 650;
+}
+
+.settings-plan-preview-window {
+  margin-top: 4rpx;
+  color: var(--text-muted);
+  font-size: 20rpx;
+}
+
+.settings-plan-preview-stats {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4rpx;
+  color: var(--text-muted);
+  font-size: 20rpx;
+  line-height: 1.3;
+}
+
+.settings-plan-preview-loading {
+  padding-top: 20rpx;
+}
+
+.settings-plan-skeleton {
+  height: 56rpx;
+  margin-bottom: 10rpx;
+}
+
+.settings-plan-skeleton--short {
+  width: 68%;
+}
+
+.settings-plan-preview-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20rpx;
+  padding-top: 20rpx;
+}
+
+.settings-plan-preview-error-title,
+.settings-plan-preview-error-detail {
+  display: block;
+}
+
+.settings-plan-preview-error-title {
+  color: var(--destructive);
+  font-size: 22rpx;
+  font-weight: 650;
+}
+
+.settings-plan-preview-error-detail {
+  margin-top: 4rpx;
+  color: var(--text-muted);
+  font-size: 20rpx;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.settings-plan-link {
+  min-height: 88rpx;
+  margin: 0;
+  padding: 0 8rpx 0 24rpx;
+  border: 0;
+  background-color: transparent;
+  color: var(--primary);
+  font-size: 22rpx;
+  font-weight: 650;
+  line-height: 88rpx;
+}
+
+.settings-plan-link::after {
+  border: 0;
+}
+
+.settings-plan-preview-list {
+  margin-top: 16rpx;
+}
+
+.settings-plan-preview-row {
+  display: flex;
+  align-items: center;
+  gap: 18rpx;
+  min-height: 72rpx;
+  border-top: 1rpx solid var(--border-subtle);
+}
+
+.settings-plan-preview-date {
+  width: 108rpx;
+  flex: none;
+  color: var(--text-muted);
+  font-size: 20rpx;
+}
+
+.settings-plan-preview-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16rpx;
+}
+
+.settings-plan-preview-workout {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 23rpx;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-plan-preview-details {
+  flex: none;
+  color: var(--text-muted);
+  font-size: 20rpx;
+}
+
+.settings-plan-preview-more,
+.settings-plan-preview-empty {
+  display: block;
+  padding-top: 14rpx;
+  color: var(--text-muted);
+  font-size: 21rpx;
+  line-height: 1.5;
+}
+
+.settings-plan-target {
+  margin-top: 8rpx;
+}
+
+.settings-plan-target--static {
+  pointer-events: none;
+}
+
+.settings-plan-target-hint {
+  display: block;
+  margin-top: 8rpx;
+  color: var(--text-muted);
+  font-size: 21rpx;
+  line-height: 1.45;
+}
+
+.settings-plan-target-hint--warning {
+  color: var(--warning);
+}
+
+.settings-plan-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12rpx;
+  margin-top: 20rpx;
+}
+
+.settings-plan-action {
+  width: 100%;
+  min-height: 88rpx;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.settings-plan-action:disabled {
+  opacity: 0.5;
+}
+
+.settings-plan-cleanup {
+  margin-top: 20rpx;
+  padding: 20rpx;
+  border: 1rpx solid rgba(217, 119, 6, 0.35);
+  border-radius: 12rpx;
+  background-color: rgba(217, 119, 6, 0.08);
+}
+
+.settings-plan-cleanup-title {
+  display: block;
+  color: var(--warning);
+  font-size: 23rpx;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
+.settings-plan-cleanup-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10rpx 24rpx;
+  margin-top: 10rpx;
+  color: var(--text-muted);
+  font-size: 21rpx;
+}
+
+.settings-plan-cleanup-action {
+  margin-top: 16rpx;
+}
+
+.settings-plan-error {
+  display: block;
+  margin-top: 16rpx;
+  color: var(--destructive);
+  font-size: 22rpx;
+  line-height: 1.45;
+}
+
 .settings-version {
   display: block;
   text-align: center;

--- a/miniapp/pages/settings/index.ts
+++ b/miniapp/pages/settings/index.ts
@@ -12,7 +12,24 @@ import type { ThemePref } from '../../utils/theme';
 import type { IAppOption } from '../../app';
 import { getLanguagePreference, setLanguagePreference } from '../../utils/share';
 import { t, tFmt } from '../../utils/i18n';
-import type { SettingsResponse } from '../../types/api';
+import {
+  beginManagedPlanRequest,
+  formatWorkoutType,
+  invalidateManagedPlanRequests,
+  isPraxysOwned,
+  isLatestManagedPlanRequest,
+  managedPlanState,
+  managedPlanWindow,
+  planWindowUrl,
+} from '../../utils/managed-plan';
+import type {
+  PlanCleanupResponse,
+  PlanResponse,
+  PlatformName,
+  SettingsResponse,
+  SettingsUpdate,
+} from '../../types/api';
+import type { ManagedPlanState } from '../../utils/managed-plan';
 import { MINIAPP_BUILD_VERSION } from '../../utils/version';
 
 function buildSettingsTr() {
@@ -83,6 +100,82 @@ function buildSettingsTr() {
     trainingBasePower: t('Power'),
     trainingBaseHr: t('Heart rate'),
     trainingBasePace: t('Pace'),
+    planManagement: t('Plan management'),
+    active: t('Active'),
+    paused: t('Paused'),
+    external: t('External'),
+    activePlanner: t('Praxys is your active planner.'),
+    pausedPlanner: t('Praxys owns the plan; delivery is paused.'),
+    externalPlanner: t('Your external planner remains in control.'),
+    activePlannerDetail: t(
+      'Praxys automatically keeps its workouts in the next 14 days aligned with {targetLabel}.',
+    ),
+    pausedPlannerDetail: t(
+      'The canonical Praxys plan is preserved. Existing target workouts stay in place until you resume or leave.',
+    ),
+    externalPlannerDetail: t(
+      'Praxys can analyze this schedule, but it will not create, replace, or remove target workouts.',
+    ),
+    ownershipBoundary: t(
+      'Praxys only changes workouts it created or you explicitly adopt. Manual workouts and workouts from another coach stay untouched. To avoid overlapping sessions, use one planner at a time.',
+    ),
+    managedWindow: t('14-day managed window'),
+    noPraxysWorkouts: t(
+      'No Praxys workouts are scheduled in this window. Future Praxys-created workouts will enter the rolling window automatically.',
+    ),
+    previewFailed: t('Could not load the managed-window preview.'),
+    executionTarget: t('Execution target'),
+    connectTarget: t('Connect a supported platform first'),
+    targetSelectionHint: t(
+      'Selecting a target does not enable delivery. You will confirm the managed window next.',
+    ),
+    connectTargetHint: t(
+      'Connect a supported execution platform above before adopting managed delivery.',
+    ),
+    reviewAndActivate: t('Review and activate'),
+    reviewAndResume: t('Review and resume'),
+    pauseDelivery: t('Pause delivery'),
+    leaveManagedMode: t('Leave managed mode'),
+    removeFutureDeliveries: t('Remove future Praxys deliveries'),
+    retryCleanup: t('Retry cleanup'),
+    cleanupIncomplete: t('Managed mode is off, but cleanup did not finish.'),
+    removed: t('Removed'),
+    remaining: t('Remaining'),
+    retryPreview: t('Retry'),
+    enabling: t('Enabling…'),
+    pausing: t('Pausing…'),
+    leaving: t('Leaving…'),
+    removing: t('Removing…'),
+    confirm: t('Confirm'),
+    cancel: t('Cancel'),
+    adoptTitle: t('Let Praxys manage this plan?'),
+    resumeTitle: t('Resume managed delivery?'),
+    confirmBoundary: t('Confirm the boundary before Praxys writes to {targetLabel}.'),
+    canonicalBoundary: t(
+      'Praxys becomes canonical for its own and explicitly adopted workouts.',
+    ),
+    manualBoundary: t(
+      'Manual and other-coach workouts remain external and will not be edited or deleted.',
+    ),
+    plannerWarning: t(
+      'Disable delivery from any other planner first. Two planners can create overlapping sessions.',
+    ),
+    stalePreview: t(
+      'The managed window changed. Review the refreshed preview before enabling delivery.',
+    ),
+    enableFailed: t('Could not enable managed delivery'),
+    pauseFailed: t('Could not pause delivery'),
+    leaveTitle: t('Leave managed mode?'),
+    keepFuture: t('Keep future workouts'),
+    keepFutureDetail: t(
+      'Recommended. Delivered workouts stay on the calendar; Praxys simply stops managing them.',
+    ),
+    removeFutureDetail: t(
+      "Only workouts recorded in Praxys's delivery ledger are removed. Manual and other-coach workouts stay untouched.",
+    ),
+    leaveFailed: t('Could not leave managed mode'),
+    cleanupFailed: t('Could not remove future delivered workouts'),
+    done: t('Done'),
   };
 }
 
@@ -190,6 +283,18 @@ interface ThresholdRow {
   origin: string;
 }
 
+interface PlanPreviewRow {
+  key: string;
+  date: string;
+  workoutType: string;
+  details: string;
+}
+
+interface PlanTargetOption {
+  key: PlatformName;
+  label: string;
+}
+
 interface ThemeOption {
   key: ThemePref;
   label: string;
@@ -224,6 +329,31 @@ interface SettingsState {
   trainingBase: 'power' | 'hr' | 'pace';
   /** Human-readable label for the active training base, e.g. "Power". */
   trainingBaseLabel: string;
+
+  planManagementState: ManagedPlanState;
+  planStateLabel: string;
+  planStateTitle: string;
+  planStateDetail: string;
+  planTargetOptions: PlanTargetOption[];
+  configuredPlanTarget: PlatformName | '';
+  configuredPlanTargetLabel: string;
+  selectedPlanTarget: PlatformName | '';
+  selectedPlanTargetLabel: string;
+  configuredPlanTargetConnected: boolean;
+  planLoading: boolean;
+  planPreviewError: string;
+  hasPlanPreview: boolean;
+  planWindowLabel: string;
+  planPraxysCount: number;
+  planExternalCount: number;
+  planPreviewRows: PlanPreviewRow[];
+  planPreviewMoreCount: number;
+  planAction: string;
+  planActionError: string;
+  planCleanupPartial: boolean;
+  planCleanupRemoved: number;
+  planCleanupRemaining: number;
+  planCleanupTarget: string;
 
   webUrl: string;
 
@@ -276,6 +406,53 @@ function trainingBaseLabelFor(base: string): string {
   return t('Pace');
 }
 
+function planStateCopy(
+  state: ManagedPlanState,
+  targetLabel: string,
+): { label: string; title: string; detail: string } {
+  const tr = buildSettingsTr();
+  if (state === 'active') {
+    return {
+      label: tr.active,
+      title: tr.activePlanner,
+      detail: tr.activePlannerDetail.replace('{targetLabel}', targetLabel),
+    };
+  }
+  if (state === 'paused') {
+    return {
+      label: tr.paused,
+      title: tr.pausedPlanner,
+      detail: tr.pausedPlannerDetail,
+    };
+  }
+  return {
+    label: tr.external,
+    title: tr.externalPlanner,
+    detail: tr.externalPlannerDetail,
+  };
+}
+
+function formatPlanDate(value: string): string {
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(
+    getApp<IAppOption>().globalData.locale === 'zh' ? 'zh-CN' : 'en-US',
+    { month: 'short', day: 'numeric' },
+  );
+}
+
+function planTargetOptions(response: SettingsResponse): PlanTargetOption[] {
+  return response.config.connections
+    .filter((target) => (
+      response.connection_statuses[target] === 'connected'
+      && response.platform_capabilities[target]?.plan === true
+    ))
+    .map((target) => ({
+      key: target,
+      label: formatPlatform(target),
+    }));
+}
+
 const initialData: SettingsState = {
   themeClass: getApp<IAppOption>().globalData.themeClass,
   loading: true,
@@ -292,6 +469,30 @@ const initialData: SettingsState = {
   thresholdRows: [],
   trainingBase: 'pace',
   trainingBaseLabel: t('Pace'),
+  planManagementState: 'external',
+  planStateLabel: t('External'),
+  planStateTitle: '',
+  planStateDetail: '',
+  planTargetOptions: [],
+  configuredPlanTarget: '',
+  configuredPlanTargetLabel: t('Connect a supported platform first'),
+  selectedPlanTarget: '',
+  selectedPlanTargetLabel: t('Connect a supported platform first'),
+  configuredPlanTargetConnected: false,
+  planLoading: true,
+  planPreviewError: '',
+  hasPlanPreview: false,
+  planWindowLabel: '',
+  planPraxysCount: 0,
+  planExternalCount: 0,
+  planPreviewRows: [],
+  planPreviewMoreCount: 0,
+  planAction: '',
+  planActionError: '',
+  planCleanupPartial: false,
+  planCleanupRemoved: 0,
+  planCleanupRemaining: 0,
+  planCleanupTarget: '',
   webUrl: WEB_URL,
   syncing: false,
   syncMessage: '',
@@ -397,6 +598,21 @@ function buildSettingsState(response: SettingsResponse): Partial<SettingsState> 
   const hasThresholds = thresholdRows.some((r) => r.display !== '—');
 
   const trainingBase = (config.training_base as 'power' | 'hr' | 'pace') ?? 'pace';
+  const targets = planTargetOptions(response);
+  const configuredTarget = config.plan_management.execution_target;
+  const configuredTargetConnected = configuredTarget != null
+    && targets.some((target) => target.key === configuredTarget);
+  const selectedTarget = configuredTargetConnected
+    ? configuredTarget
+    : targets[0]?.key ?? '';
+  const selectedTargetLabel = selectedTarget
+    ? formatPlatform(selectedTarget)
+    : t('Connect a supported platform first');
+  const managementState = managedPlanState(config.plan_management);
+  const stateCopy = planStateCopy(
+    managementState,
+    configuredTarget ? formatPlatform(configuredTarget) : selectedTargetLabel,
+  );
   return {
     loading: false,
     errorMessage: '',
@@ -408,6 +624,52 @@ function buildSettingsState(response: SettingsResponse): Partial<SettingsState> 
     thresholdRows,
     trainingBase,
     trainingBaseLabel: trainingBaseLabelFor(trainingBase),
+    planManagementState: managementState,
+    planStateLabel: stateCopy.label,
+    planStateTitle: stateCopy.title,
+    planStateDetail: stateCopy.detail,
+    planTargetOptions: targets,
+    configuredPlanTarget: configuredTarget ?? '',
+    configuredPlanTargetLabel: configuredTarget
+      ? formatPlatform(configuredTarget)
+      : t('Connect a supported platform first'),
+    selectedPlanTarget: selectedTarget,
+    selectedPlanTargetLabel: selectedTargetLabel,
+    configuredPlanTargetConnected: configuredTargetConnected,
+  };
+}
+
+function buildPlanPreviewState(response: PlanResponse): Partial<SettingsState> {
+  const praxysWorkouts = response.workouts.filter(isPraxysOwned);
+  const externalWorkouts = response.workouts.filter(
+    (workout) => !isPraxysOwned(workout),
+  );
+  const previewRows: PlanPreviewRow[] = praxysWorkouts.slice(0, 4).map((workout) => {
+    const details: string[] = [];
+    if (workout.duration_min != null) {
+      details.push(`${Math.round(workout.duration_min)} min`);
+    }
+    if (workout.distance_km != null) {
+      details.push(`${workout.distance_km} km`);
+    }
+    return {
+      key: workout.canonical_id
+        ?? workout.reconciliation?.id
+        ?? `${workout.date}-${workout.workout_type}`,
+      date: formatPlanDate(workout.date),
+      workoutType: t(formatWorkoutType(workout.workout_type)),
+      details: details.join(' · '),
+    };
+  });
+  return {
+    planLoading: false,
+    planPreviewError: '',
+    hasPlanPreview: true,
+    planWindowLabel: `${formatPlanDate(response.window.start)} – ${formatPlanDate(response.window.end)}`,
+    planPraxysCount: praxysWorkouts.length,
+    planExternalCount: externalWorkouts.length,
+    planPreviewRows: previewRows,
+    planPreviewMoreCount: Math.max(praxysWorkouts.length - previewRows.length, 0),
   };
 }
 
@@ -432,6 +694,15 @@ Page({
   onShow() {
     applyThemeChrome();
     setTabBarSelected(this, 4);
+    const pageState = this as unknown as Record<string, unknown>;
+    if (pageState._hasShownOnce === true) {
+      void this.refetch();
+    }
+    pageState._hasShownOnce = true;
+  },
+
+  onUnload() {
+    invalidateManagedPlanRequests(this);
   },
 
   onRetry() {
@@ -439,18 +710,319 @@ Page({
   },
 
   async refetch() {
-    this.setData({ loading: true, errorMessage: '' });
+    const requestGeneration = beginManagedPlanRequest(this);
+    this.setData(this.data.hasResponse
+      ? { errorMessage: '', planLoading: true }
+      : { loading: true, errorMessage: '', planLoading: true });
     try {
       const response = await apiGet<SettingsResponse>('/api/settings');
+      if (!isLatestManagedPlanRequest(this, requestGeneration)) return;
       this.setData(buildSettingsState(response) as Record<string, unknown>);
+      await this.refetchPlan(requestGeneration);
     } catch (e) {
+      if (!isLatestManagedPlanRequest(this, requestGeneration)) return;
       const err = e as Partial<ApiError>;
       if (err?.code === 'UNAUTHENTICATED') {
-        this.setData({ loading: false });
+        this.setData({ loading: false, planLoading: false });
         return;
       }
       const detail = err?.detail ?? String(e);
-      this.setData({ loading: false, errorMessage: detail, hasResponse: false });
+      this.setData({
+        loading: false,
+        planLoading: false,
+        errorMessage: detail,
+        hasResponse: false,
+      });
+    }
+  },
+
+  async refetchPlan(existingGeneration?: number) {
+    const requestGeneration = existingGeneration
+      ?? beginManagedPlanRequest(this);
+    const pageState = this as unknown as Record<string, unknown>;
+    this.setData({ planLoading: true, planPreviewError: '' });
+    try {
+      const response = await apiGet<PlanResponse>(planWindowUrl());
+      if (!isLatestManagedPlanRequest(this, requestGeneration)) return;
+      pageState._managedPlanPreview = response;
+      this.setData(buildPlanPreviewState(response) as Record<string, unknown>);
+    } catch (e) {
+      if (!isLatestManagedPlanRequest(this, requestGeneration)) return;
+      const err = e as Partial<ApiError>;
+      if (err?.code === 'UNAUTHENTICATED') {
+        this.setData({ planLoading: false });
+        return;
+      }
+      pageState._managedPlanPreview = undefined;
+      this.setData({
+        planLoading: false,
+        planPreviewError: err?.detail ?? String(e),
+        hasPlanPreview: false,
+      });
+    }
+  },
+
+  onPickPlanTarget() {
+    if (
+      this.data.planManagementState !== 'external'
+      || this.data.planAction
+      || this.data.planLoading
+      || this.data.planTargetOptions.length === 0
+    ) {
+      return;
+    }
+    wx.showActionSheet({
+      itemList: this.data.planTargetOptions.map((target) => target.label),
+      success: (result) => {
+        const target = this.data.planTargetOptions[result.tapIndex];
+        if (!target) return;
+        this.setData({
+          selectedPlanTarget: target.key,
+          selectedPlanTargetLabel: target.label,
+          planActionError: '',
+        });
+      },
+    });
+  },
+
+  onReviewManagedPlan() {
+    if (this.data.planAction || this.data.planLoading) return;
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    if (this.data.planCleanupPartial) {
+      this.setData({ planActionError: tr.cleanupIncomplete });
+      return;
+    }
+    const mode = this.data.planManagementState === 'paused' ? 'resume' : 'adopt';
+    const target = mode === 'resume'
+      ? this.data.configuredPlanTarget
+      : this.data.selectedPlanTarget;
+    if (
+      !target
+      || (mode === 'resume' && !this.data.configuredPlanTargetConnected)
+    ) {
+      wx.showToast({ title: tr.connectTarget, icon: 'none', duration: 1800 });
+      return;
+    }
+
+    const pageState = this as unknown as Record<string, unknown>;
+    const preview = pageState._managedPlanPreview as PlanResponse | undefined;
+    const expectedWindow = managedPlanWindow();
+    if (
+      preview == null
+      || preview.window.start !== expectedWindow.start
+      || preview.window.end !== expectedWindow.end
+    ) {
+      this.setData({ planActionError: tr.stalePreview });
+      void this.refetchPlan();
+      return;
+    }
+
+    const targetLabel = formatPlatform(target);
+    const content = [
+      tr.confirmBoundary.replace('{targetLabel}', targetLabel),
+      tr.canonicalBoundary,
+      `${tr.managedWindow}: ${this.data.planWindowLabel}`,
+      tFmt(
+        '{0} Praxys · {1} external',
+        this.data.planPraxysCount,
+        this.data.planExternalCount,
+      ),
+      tr.manualBoundary,
+      tr.plannerWarning,
+    ].join('\n\n');
+    wx.showModal({
+      title: mode === 'resume' ? tr.resumeTitle : tr.adoptTitle,
+      content,
+      confirmText: tr.confirm,
+      cancelText: tr.cancel,
+      success: (result) => {
+        if (result.confirm) {
+          void this.enableManagedPlan(mode, target, expectedWindow.start);
+        }
+      },
+    });
+  },
+
+  async enableManagedPlan(
+    mode: 'adopt' | 'resume',
+    target: PlatformName,
+    previewStart: string,
+  ) {
+    if (
+      this.data.planAction
+      || this.data.planLoading
+      || this.data.planCleanupPartial
+    ) {
+      return;
+    }
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    this.setData({ planAction: mode, planActionError: '' });
+    const update: SettingsUpdate = {
+      managed_plan_preview_start: previewStart,
+      plan_management: {
+        mode: 'praxys',
+        execution_target: target,
+        delivery_enabled: true,
+        adjustment_policy: 'suggest_only',
+      },
+    };
+    try {
+      await apiPut('/api/settings', update);
+      await this.refetch();
+    } catch (e) {
+      const err = e as Partial<ApiError>;
+      if (err?.code === 'UNAUTHENTICATED') return;
+      this.setData({
+        planActionError: err?.detail ?? tr.enableFailed,
+      });
+    } finally {
+      this.setData({ planAction: '' });
+    }
+  },
+
+  async onPauseManagedPlan() {
+    if (this.data.planAction || this.data.planLoading) return;
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    this.setData({ planAction: 'pause', planActionError: '' });
+    try {
+      await apiPut('/api/settings', {
+        plan_management: { delivery_enabled: false },
+      } satisfies SettingsUpdate);
+      await this.refetch();
+    } catch (e) {
+      const err = e as Partial<ApiError>;
+      if (err?.code === 'UNAUTHENTICATED') return;
+      this.setData({ planActionError: err?.detail ?? tr.pauseFailed });
+    } finally {
+      this.setData({ planAction: '' });
+    }
+  },
+
+  onLeaveManagedPlan() {
+    if (this.data.planAction || this.data.planLoading) return;
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    wx.showActionSheet({
+      itemList: [tr.keepFuture, tr.removeFutureDeliveries],
+      success: (result) => {
+        const removeFuture = result.tapIndex === 1;
+        wx.showModal({
+          title: tr.leaveTitle,
+          content: removeFuture ? tr.removeFutureDetail : tr.keepFutureDetail,
+          confirmText: tr.confirm,
+          cancelText: tr.cancel,
+          success: (confirmation) => {
+            if (confirmation.confirm) {
+              void this.runLeaveManagedPlan(removeFuture);
+            }
+          },
+        });
+      },
+    });
+  },
+
+  async runLeaveManagedPlan(removeFuture: boolean) {
+    if (this.data.planAction) return;
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    let managedModeDisabled = false;
+    let cleanupIncomplete = false;
+    this.setData({
+      planAction: 'leave',
+      planActionError: '',
+      planCleanupPartial: false,
+    });
+    try {
+      await apiPut('/api/settings', {
+        plan_management: {
+          mode: 'external',
+          delivery_enabled: false,
+        },
+      } satisfies SettingsUpdate);
+      managedModeDisabled = true;
+      if (removeFuture) {
+        this.setData({ planAction: 'cleanup' });
+        const cleanup = await this.cleanupFuturePlanDeliveries();
+        cleanupIncomplete = cleanup.status === 'partial';
+        this.setData({
+          planCleanupPartial: cleanupIncomplete,
+          planCleanupRemoved: cleanup.removed_count,
+          planCleanupRemaining: cleanup.remaining_count,
+          planCleanupTarget: cleanup.target
+            ? formatPlatform(cleanup.target)
+            : '',
+        });
+      }
+      await this.refetch();
+      if (!cleanupIncomplete) {
+        wx.showToast({ title: tr.done, icon: 'success', duration: 1400 });
+      }
+    } catch (e) {
+      const err = e as Partial<ApiError>;
+      if (err?.code === 'UNAUTHENTICATED') return;
+      if (managedModeDisabled) await this.refetch();
+      const detail = err?.detail ?? tr.leaveFailed;
+      this.setData({
+        planActionError: managedModeDisabled
+          ? `${tr.cleanupIncomplete} ${detail}`
+          : detail,
+      });
+    } finally {
+      this.setData({ planAction: '' });
+    }
+  },
+
+  cleanupFuturePlanDeliveries(): Promise<PlanCleanupResponse> {
+    return apiPost<PlanCleanupResponse>(
+      '/api/plan/deliveries/cleanup',
+      { scope: 'future' },
+    );
+  },
+
+  onRemoveFuturePlanDeliveries() {
+    if (this.data.planAction || this.data.planLoading) return;
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    wx.showModal({
+      title: tr.removeFutureDeliveries,
+      content: tr.removeFutureDetail,
+      confirmText: tr.confirm,
+      cancelText: tr.cancel,
+      success: (result) => {
+        if (result.confirm) void this.onRetryPlanCleanup();
+      },
+    });
+  },
+
+  async onRetryPlanCleanup() {
+    if (
+      this.data.planAction
+      || this.data.planLoading
+      || this.data.planManagementState !== 'external'
+    ) {
+      return;
+    }
+    const tr = this.data.tr as ReturnType<typeof buildSettingsTr>;
+    this.setData({ planAction: 'cleanup', planActionError: '' });
+    try {
+      const cleanup = await this.cleanupFuturePlanDeliveries();
+      this.setData({
+        planCleanupPartial: cleanup.status === 'partial',
+        planCleanupRemoved: cleanup.removed_count,
+        planCleanupRemaining: cleanup.remaining_count,
+        planCleanupTarget: cleanup.target
+          ? formatPlatform(cleanup.target)
+          : '',
+      });
+      await this.refetchPlan();
+      if (cleanup.status === 'complete') {
+        wx.showToast({ title: tr.done, icon: 'success', duration: 1400 });
+      }
+    } catch (e) {
+      const err = e as Partial<ApiError>;
+      if (err?.code === 'UNAUTHENTICATED') return;
+      this.setData({
+        planActionError: `${tr.cleanupIncomplete} ${err?.detail ?? tr.cleanupFailed}`,
+      });
+    } finally {
+      this.setData({ planAction: '' });
     }
   },
 

--- a/miniapp/pages/settings/index.wxml
+++ b/miniapp/pages/settings/index.wxml
@@ -52,6 +52,161 @@
         <text wx:else class="settings-empty ts-muted">{{tr.noPlatformsHint}}</text>
       </view>
 
+      <view class="ts-section settings-plan">
+        <view class="settings-plan-head">
+          <text class="ts-section-label settings-plan-label">{{tr.planManagement}}</text>
+          <text class="settings-plan-state settings-plan-state--{{planManagementState}}">
+            {{planStateLabel}}
+          </text>
+        </view>
+        <text class="settings-plan-title">{{planStateTitle}}</text>
+        <text class="settings-plan-detail">{{planStateDetail}}</text>
+
+        <view class="settings-plan-boundary">
+          <view class="settings-plan-boundary-mark"></view>
+          <text>{{tr.ownershipBoundary}}</text>
+        </view>
+
+        <view class="settings-plan-preview">
+          <view class="settings-plan-preview-head">
+            <view>
+              <text class="settings-plan-preview-title">{{tr.managedWindow}}</text>
+              <text wx:if="{{planWindowLabel}}" class="settings-plan-preview-window ts-value">
+                {{planWindowLabel}}
+              </text>
+            </view>
+            <view wx:if="{{hasPlanPreview}}" class="settings-plan-preview-stats">
+              <text>
+                <text class="ts-value">{{planPraxysCount}}</text> Praxys
+              </text>
+              <text wx:if="{{planExternalCount}}">
+                <text class="ts-value">{{planExternalCount}}</text> {{tr.external}}
+              </text>
+            </view>
+          </view>
+
+          <view wx:if="{{planLoading}}" class="settings-plan-preview-loading">
+            <view class="ts-skeleton settings-plan-skeleton"></view>
+            <view class="ts-skeleton settings-plan-skeleton settings-plan-skeleton--short"></view>
+          </view>
+          <view wx:elif="{{planPreviewError}}" class="settings-plan-preview-error">
+            <view>
+              <text class="settings-plan-preview-error-title">{{tr.previewFailed}}</text>
+              <text class="settings-plan-preview-error-detail">{{planPreviewError}}</text>
+            </view>
+            <button class="settings-plan-link" bindtap="refetchPlan">{{tr.retryPreview}}</button>
+          </view>
+          <block wx:elif="{{hasPlanPreview}}">
+            <view wx:if="{{planPreviewRows.length}}" class="settings-plan-preview-list">
+              <view
+                wx:for="{{planPreviewRows}}"
+                wx:key="key"
+                class="settings-plan-preview-row"
+              >
+                <text class="settings-plan-preview-date ts-value">{{item.date}}</text>
+                <view class="settings-plan-preview-copy">
+                  <text class="settings-plan-preview-workout">{{item.workoutType}}</text>
+                  <text wx:if="{{item.details}}" class="settings-plan-preview-details ts-value">{{item.details}}</text>
+                </view>
+              </view>
+              <text wx:if="{{planPreviewMoreCount}}" class="settings-plan-preview-more">
+                +{{planPreviewMoreCount}}
+              </text>
+            </view>
+            <text wx:else class="settings-plan-preview-empty">{{tr.noPraxysWorkouts}}</text>
+          </block>
+        </view>
+
+        <view
+          class="settings-pick-row settings-plan-target {{planManagementState !== 'external' || !planTargetOptions.length ? 'settings-plan-target--static' : ''}}"
+          bindtap="onPickPlanTarget"
+        >
+          <text class="settings-pick-label">{{tr.executionTarget}}</text>
+          <view class="settings-pick-right">
+            <text class="settings-pick-value ts-value">
+              {{planManagementState === 'external' ? selectedPlanTargetLabel : configuredPlanTargetLabel}}
+            </text>
+            <text
+              wx:if="{{planManagementState === 'external' && planTargetOptions.length}}"
+              class="settings-pick-chev ts-muted"
+            >›</text>
+          </view>
+        </view>
+        <text
+          wx:if="{{planManagementState === 'external'}}"
+          class="settings-plan-target-hint"
+        >
+          {{planTargetOptions.length ? tr.targetSelectionHint : tr.connectTargetHint}}
+        </text>
+        <text
+          wx:elif="{{!configuredPlanTargetConnected}}"
+          class="settings-plan-target-hint settings-plan-target-hint--warning"
+        >{{tr.connectTargetHint}}</text>
+
+        <view class="settings-plan-actions">
+          <block wx:if="{{planManagementState === 'external'}}">
+            <button
+              class="ts-button settings-plan-action"
+              disabled="{{planAction || planLoading || planCleanupPartial || !hasPlanPreview || !selectedPlanTarget}}"
+              bindtap="onReviewManagedPlan"
+            >
+              {{planAction === 'adopt' ? tr.enabling : tr.reviewAndActivate}}
+            </button>
+            <button
+              wx:if="{{!planCleanupPartial}}"
+              class="ts-button ts-button--secondary settings-plan-action"
+              disabled="{{planAction || planLoading}}"
+              bindtap="onRemoveFuturePlanDeliveries"
+            >{{tr.removeFutureDeliveries}}</button>
+          </block>
+          <block wx:elif="{{planManagementState === 'active'}}">
+            <button
+              class="ts-button ts-button--secondary settings-plan-action"
+              disabled="{{planAction || planLoading}}"
+              bindtap="onPauseManagedPlan"
+            >{{planAction === 'pause' ? tr.pausing : tr.pauseDelivery}}</button>
+            <button
+              class="ts-button ts-button--ghost settings-plan-action"
+              disabled="{{planAction || planLoading}}"
+              bindtap="onLeaveManagedPlan"
+            >{{planAction === 'leave' || planAction === 'cleanup' ? tr.leaving : tr.leaveManagedMode}}</button>
+          </block>
+          <block wx:else>
+            <button
+              class="ts-button settings-plan-action"
+              disabled="{{planAction || planLoading || planCleanupPartial || !hasPlanPreview || !configuredPlanTargetConnected}}"
+              bindtap="onReviewManagedPlan"
+            >{{planAction === 'resume' ? tr.enabling : tr.reviewAndResume}}</button>
+            <button
+              class="ts-button ts-button--ghost settings-plan-action"
+              disabled="{{planAction || planLoading}}"
+              bindtap="onLeaveManagedPlan"
+            >{{planAction === 'leave' || planAction === 'cleanup' ? tr.leaving : tr.leaveManagedMode}}</button>
+          </block>
+        </view>
+
+        <view
+          wx:if="{{planCleanupPartial && planManagementState === 'external'}}"
+          class="settings-plan-cleanup"
+          role="alert"
+        >
+          <text class="settings-plan-cleanup-title">{{tr.cleanupIncomplete}}</text>
+          <view class="settings-plan-cleanup-counts">
+            <text>{{tr.removed}} <text class="ts-value">{{planCleanupRemoved}}</text></text>
+            <text>{{tr.remaining}} <text class="ts-value">{{planCleanupRemaining}}</text></text>
+            <text wx:if="{{planCleanupTarget}}" class="ts-value">{{planCleanupTarget}}</text>
+          </view>
+          <button
+            class="ts-button ts-button--secondary settings-plan-action settings-plan-cleanup-action"
+            disabled="{{planAction || planLoading}}"
+            bindtap="onRetryPlanCleanup"
+          >{{planAction === 'cleanup' ? tr.removing : tr.retryCleanup}}</button>
+        </view>
+        <text wx:if="{{planActionError}}" class="settings-plan-error" role="alert">
+          {{planActionError}}
+        </text>
+      </view>
+
       <view class="ts-section">
         <view class="settings-pick-row" bindtap="onPickTrainingBase">
           <text class="settings-pick-label ts-muted">{{tr.trainingBase}}</text>

--- a/miniapp/pages/today/index.json
+++ b/miniapp/pages/today/index.json
@@ -4,7 +4,8 @@
     "nav-bar": "/components/nav-bar/index",
     "line-chart": "/components/line-chart/index",
     "state-card": "../../components/state-card/index",
-    "decision-check": "/components/decision-check/index"
+    "decision-check": "/components/decision-check/index",
+    "managed-plan": "/components/managed-plan/index"
   },
   "backgroundColor": "@bgColor",
   "backgroundColorBottom": "@bgColor",

--- a/miniapp/pages/today/index.ts
+++ b/miniapp/pages/today/index.ts
@@ -892,6 +892,10 @@ Page({
     // We mirror Webview's onPullDownRefresh semantics: refetch and let
     // the refresher unwind once the data settles.
     this.setData({ refreshing: true });
+    const managedPlan = this.selectComponent(
+      '#today-managed-plan',
+    ) as unknown as { refresh?: () => Promise<void> } | null;
+    void managedPlan?.refresh?.();
     void this.refetch().finally(() => this.setData({ refreshing: false }));
   },
 

--- a/miniapp/pages/today/index.wxml
+++ b/miniapp/pages/today/index.wxml
@@ -198,6 +198,7 @@
         <text class="today-plan-eyebrow">{{planEyebrow}}</text>
         <text class="today-plan-text">{{planText}}</text>
       </view>
+      <managed-plan id="today-managed-plan" scope="today" />
 
       <view class="today-methodology">
         <view class="today-methodology-toggle" bindtap="toggleMethodology">

--- a/miniapp/pages/training/index.json
+++ b/miniapp/pages/training/index.json
@@ -6,7 +6,8 @@
     "scatter-chart": "/components/scatter-chart/index",
     "bar-chart": "/components/bar-chart/index",
     "state-card": "../../components/state-card/index",
-    "insight-feedback": "/components/insight-feedback/index"
+    "insight-feedback": "/components/insight-feedback/index",
+    "managed-plan": "/components/managed-plan/index"
   },
   "backgroundColor": "@bgColor",
   "backgroundColorBottom": "@bgColor",

--- a/miniapp/pages/training/index.ts
+++ b/miniapp/pages/training/index.ts
@@ -877,6 +877,10 @@ Page<TrainingState & { tr: ReturnType<typeof buildTrainingTr> }, PageMethods>({
 
   onScrollRefresh() {
     this.setData({ refreshing: true });
+    const managedPlan = this.selectComponent(
+      '#training-managed-plan',
+    ) as unknown as { refresh?: () => Promise<void> } | null;
+    void managedPlan?.refresh?.();
     void this.refetch().finally(() => this.setData({ refreshing: false }));
   },
 

--- a/miniapp/pages/training/index.wxml
+++ b/miniapp/pages/training/index.wxml
@@ -11,6 +11,7 @@
     aria-hidden="{{activeMetric !== ''}}"
   >
     <view class="train-content">
+    <managed-plan id="training-managed-plan" scope="window" />
 
     <block wx:if="{{loading && !hasResponse}}">
       <state-card type="loading" />

--- a/miniapp/utils/i18n-extra.ts
+++ b/miniapp/utils/i18n-extra.ts
@@ -377,6 +377,12 @@ const EN_SETTINGS = {
   'Add photo': 'Add photo',
   'Send without': 'Send without',
   'Image must be under 5 MB.': 'Image must be under 5 MB.',
+  'Managed mode is off, but cleanup did not finish.':
+    'Managed mode is off, but cleanup did not finish.',
+  Removed: 'Removed',
+  Confirm: 'Confirm',
+  'Keep future workouts': 'Keep future workouts',
+  '{0} Praxys · {1} external': '{0} Praxys · {1} external',
 };
 
 const EN_NAV_CHARTS = {
@@ -753,6 +759,12 @@ const ZH_SETTINGS = {
   'Add photo': '添加图片',
   'Send without': '直接发送',
   'Image must be under 5 MB.': '图片不得超过 5 MB。',
+  'Managed mode is off, but cleanup did not finish.':
+    '托管模式已关闭，但清理未完成。',
+  Removed: '已移除',
+  Confirm: '确认',
+  'Keep future workouts': '保留未来训练',
+  '{0} Praxys · {1} external': 'Praxys 训练 {0} 个 · 外部训练 {1} 个',
 };
 
 const ZH_NAV_CHARTS = {

--- a/miniapp/utils/managed-plan.ts
+++ b/miniapp/utils/managed-plan.ts
@@ -1,0 +1,80 @@
+import type {
+  PlanManagementConfig,
+  PlannedWorkout,
+} from '../types/api';
+
+export const MANAGED_PLAN_WINDOW_DAYS = 14;
+
+const requestGenerations = new WeakMap<object, number>();
+
+export function beginManagedPlanRequest(owner: object): number {
+  const generation = (requestGenerations.get(owner) ?? 0) + 1;
+  requestGenerations.set(owner, generation);
+  return generation;
+}
+
+export function isLatestManagedPlanRequest(
+  owner: object,
+  generation: number,
+): boolean {
+  return requestGenerations.get(owner) === generation;
+}
+
+export function invalidateManagedPlanRequests(owner: object): void {
+  beginManagedPlanRequest(owner);
+}
+
+function utcIsoDate(value: Date): string {
+  const year = value.getUTCFullYear();
+  const month = String(value.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(value.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function managedPlanWindow(
+  days = MANAGED_PLAN_WINDOW_DAYS,
+  now = new Date(),
+): { start: string; end: string } {
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() + Math.max(days - 1, 0));
+  return {
+    start: utcIsoDate(now),
+    end: utcIsoDate(end),
+  };
+}
+
+export function planWindowUrl(
+  days = MANAGED_PLAN_WINDOW_DAYS,
+  now = new Date(),
+): string {
+  const { start, end } = managedPlanWindow(days, now);
+  return `/api/plan?start=${start}&end=${end}`;
+}
+
+export function isPraxysOwned(workout: PlannedWorkout): boolean {
+  return workout.owner === 'praxys'
+    || (workout.owner === undefined && workout.source === 'ai');
+}
+
+export type ManagedPlanState = 'external' | 'active' | 'paused';
+
+export function managedPlanState(
+  config: PlanManagementConfig,
+): ManagedPlanState {
+  if (config.mode === 'external') return 'external';
+  return config.delivery_enabled ? 'active' : 'paused';
+}
+
+export function workoutKey(workout: PlannedWorkout): string {
+  return workout.canonical_id
+    ?? workout.reconciliation?.id
+    ?? `${workout.source}-${workout.date}-${workout.workout_type}`;
+}
+
+export function formatWorkoutType(value: string): string {
+  return value
+    .split(/[\s_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/tests/test_managed_plan_miniapp_parity.py
+++ b/tests/test_managed_plan_miniapp_parity.py
@@ -1,0 +1,87 @@
+"""Regression contracts for miniapp managed-plan parity."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SETTINGS_TS = ROOT / "miniapp" / "pages" / "settings" / "index.ts"
+SETTINGS_WXML = ROOT / "miniapp" / "pages" / "settings" / "index.wxml"
+TRAINING_WXML = ROOT / "miniapp" / "pages" / "training" / "index.wxml"
+TRAINING_JSON = ROOT / "miniapp" / "pages" / "training" / "index.json"
+TODAY_WXML = ROOT / "miniapp" / "pages" / "today" / "index.wxml"
+TODAY_JSON = ROOT / "miniapp" / "pages" / "today" / "index.json"
+MANAGED_PLAN_TS = ROOT / "miniapp" / "components" / "managed-plan" / "index.ts"
+MANAGED_PLAN_WXML = ROOT / "miniapp" / "components" / "managed-plan" / "index.wxml"
+MANAGED_PLAN_UTIL = ROOT / "miniapp" / "utils" / "managed-plan.ts"
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+def test_settings_owns_explicit_managed_plan_lifecycle() -> None:
+    """Settings must expose consent, pause/resume, and safe leave choices."""
+    source = _source(SETTINGS_TS)
+    markup = _source(SETTINGS_WXML)
+
+    assert "managed_plan_preview_start" in source
+    assert "mode: 'praxys'" in source
+    assert "delivery_enabled: true" in source
+    assert "delivery_enabled: false" in source
+    assert "mode: 'external'" in source
+    assert "'/api/plan/deliveries/cleanup'" in source
+    assert "scope: 'future'" in source
+    assert "onReviewManagedPlan" in source
+    assert "onPauseManagedPlan" in source
+    assert "onLeaveManagedPlan" in source
+    assert "onRetryPlanCleanup" in source
+    assert "beginManagedPlanRequest(this)" in source
+    assert "await this.refetchPlan(requestGeneration)" in source
+
+    assert "{{tr.planManagement}}" in markup
+    assert 'bindtap="onPickPlanTarget"' in markup
+    assert 'bindtap="onReviewManagedPlan"' in markup
+    assert 'bindtap="onPauseManagedPlan"' in markup
+    assert 'bindtap="onLeaveManagedPlan"' in markup
+    assert 'bindtap="onRetryPlanCleanup"' in markup
+    assert "planCleanupPartial && planManagementState === 'external'" in markup
+
+
+def test_training_and_today_share_native_managed_plan_surface() -> None:
+    """Both daily-use pages must surface the same ownership semantics."""
+    training_markup = _source(TRAINING_WXML)
+    today_markup = _source(TODAY_WXML)
+    training_components = json.loads(_source(TRAINING_JSON))["usingComponents"]
+    today_components = json.loads(_source(TODAY_JSON))["usingComponents"]
+
+    assert training_components["managed-plan"] == "/components/managed-plan/index"
+    assert today_components["managed-plan"] == "/components/managed-plan/index"
+    assert '<managed-plan id="training-managed-plan" scope="window"' in training_markup
+    assert '<managed-plan id="today-managed-plan" scope="today"' in today_markup
+
+
+def test_managed_plan_actions_use_opaque_identity_and_ownership() -> None:
+    """Miniapp actions must preserve the server's ownership-safe contracts."""
+    source = _source(MANAGED_PLAN_TS)
+    markup = _source(MANAGED_PLAN_WXML)
+    helper = _source(MANAGED_PLAN_UTIL)
+
+    assert "'/api/settings'" in source
+    assert "'/api/plan/reconciliation/resolve'" in source
+    assert "'/api/plan/push-stryd'" in source
+    assert "if (!workout.canonical_id)" in source
+    assert "canonical_ids: [workout.canonical_id]" in source
+    assert "isLatestManagedPlanRequest(this, requestGeneration)" in source
+    assert "reconciliation_id" in source
+    assert "'restore_praxys'" in source
+    assert "'accept_target'" in source
+    assert "workout.reconciliation?.id" in source
+
+    assert "workout.owner === 'praxys'" in helper
+    assert "workout.owner === undefined && workout.source === 'ai'" in helper
+    assert "MANAGED_PLAN_WINDOW_DAYS = 14" in helper
+
+    assert 'bindtap="onWorkoutAction"' in markup
+    assert "{{managementAction}}" in markup
+    assert "{{tr.externalWorkoutsUntouched}}" in markup


### PR DESCRIPTION
## Summary

- add native miniapp adoption, execution-target selection, pause, resume, and keep-or-remove leave controls
- surface the managed 14-day window on Training and current-day delivery/conflict actions on Today
- preserve Praxys ownership boundaries with canonical delivery IDs, opaque reconciliation IDs, and external workouts left untouched
- guard lifecycle refreshes against stale responses and keep partial cleanup recoverable before reactivation

## Validation

- `cd miniapp && npm run typecheck`
- `python -m pytest tests/ -q` (`1506 passed, 3 skipped` in the CI-equivalent dependency set)

Closes #481
