### PR TITLE
Remove stale timeAgo issue comment

### DIFF
--- a/web/src/components/AiInsightsCard.tsx
+++ b/web/src/components/AiInsightsCard.tsx
@@ -50,8 +50,6 @@ interface Props {
 
 const PLUGIN_URL = 'https://github.com/praxys-run/praxys-coach-plugin#install';
 
-// Mirrors Today.tsx's helper. Should be extracted to web/src/lib/format.ts
-// when a third caller appears — see issue #236.
 function timeAgo(isoDate: string, locale: string): string {
   const diff = Date.now() - new Date(isoDate).getTime();
   const rtf = new Intl.RelativeTimeFormat(locale === 'zh' ? 'zh-CN' : 'en-US', { style: 'short' });


### PR DESCRIPTION
Issue #236 is already resolved in the web architecture: Today, Training, and Goal now use the shared `AiInsightsCard` surface, leaving one web `timeAgo` implementation. Remove the obsolete comment that incorrectly described the helper as duplicated and awaiting extraction.

No behavior changes.

Closes #236