### PR TITLE
Fix local managed-plan MCP startup

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,15 +6,14 @@
       "env": {}
     },
     "praxys-local": {
-      "command": "python",
-      "args": ["-m", "scripts.run_praxys_mcp", "local"],
+      "command": "node",
+      "args": ["scripts/run_praxys_mcp.cjs", "local"],
       "env": {}
     },
     "praxys-dev-test": {
-      "command": "python",
+      "command": "node",
       "args": [
-        "-m",
-        "scripts.run_praxys_mcp",
+        "scripts/run_praxys_mcp.cjs",
         "remote-profile",
         "dev-test"
       ],

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ isolated production test-user token and a self-bootstrapping `praxys-local`
 synthetic SQLite profile. Install the MCP server dependency into the same
 virtualenv with
 `python -m pip install -r plugins/praxys/mcp-server/requirements.txt`. See
-[CLI Skills](docs/skills.md#mcp-development-profiles).
+[CLI Skills](docs/skills.md#mcp-development-profiles). The repository profiles
+use a dependency-free Node launcher to invoke that virtualenv directly, so MCP
+startup does not depend on a machine-specific `python` command name.
 
 ## What's Inside
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -81,8 +81,12 @@ Praxys development deliberately separates three identities:
 | `praxys-local` | `.praxys-local/trainsight.db`, deterministic synthetic user | Offline-safe feature and managed-plan development |
 
 The installed plugin provides `praxys`. The repository `.mcp.json` adds the
-other two through `scripts/run_praxys_mcp.py`; the launcher switches to the
-project `.venv` before loading the submodule server.
+other two through `scripts/run_praxys_mcp.cjs`, a dependency-free Node shim
+that invokes the project `.venv` directly before
+`scripts/run_praxys_mcp.py` loads the submodule server. This avoids relying on
+whether the MCP host exposes Python as `python`, `python3`, or `py`.
+Test harnesses without a project virtualenv can set `PRAXYS_MCP_PYTHON` to an
+absolute interpreter path with the project dependencies installed.
 
 Restart the CLI after changing `.mcp.json` or updating the plugin submodule.
 Use `/mcp` or `/env` to confirm the servers loaded, then call each server's
@@ -120,10 +124,9 @@ Additional production test profiles can reuse the launcher:
 
 ```json
 "praxys-garmin-cn-test": {
-  "command": "python",
+  "command": "node",
   "args": [
-    "-m",
-    "scripts.run_praxys_mcp",
+    "scripts/run_praxys_mcp.cjs",
     "remote-profile",
     "garmin-cn-test"
   ]

--- a/scripts/run_praxys_mcp.cjs
+++ b/scripts/run_praxys_mcp.cjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const configuredPython = process.env.PRAXYS_MCP_PYTHON?.trim();
+const python = configuredPython
+  ? path.resolve(root, configuredPython)
+  : path.join(
+      root,
+      ".venv",
+      process.platform === "win32" ? "Scripts" : "bin",
+      process.platform === "win32" ? "python.exe" : "python",
+    );
+
+if (!fs.existsSync(python)) {
+  console.error(
+    `Praxys project virtualenv not found at ${python}. ` +
+      "Create .venv and install the project requirements first, or set " +
+      "PRAXYS_MCP_PYTHON to an absolute interpreter path.",
+  );
+  process.exit(1);
+}
+
+const child = spawn(
+  python,
+  ["-m", "scripts.run_praxys_mcp", ...process.argv.slice(2)],
+  {
+    cwd: root,
+    env: process.env,
+    stdio: "inherit",
+    windowsHide: true,
+  },
+);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    try {
+      child.kill(signal);
+    } catch {
+      process.exitCode = 1;
+    }
+  });
+}
+
+child.once("error", (error) => {
+  console.error(`Could not start the Praxys MCP launcher: ${error.message}`);
+  process.exitCode = 1;
+});
+
+child.once("exit", (code) => {
+  process.exitCode = code ?? 1;
+});

--- a/scripts/run_praxys_mcp.py
+++ b/scripts/run_praxys_mcp.py
@@ -49,6 +49,16 @@ def _venv_python(root: Path) -> Path:
     )
 
 
+def _runtime_python(root: Path) -> Path:
+    configured = os.environ.get("PRAXYS_MCP_PYTHON", "").strip()
+    if not configured:
+        return _venv_python(root)
+    path = Path(os.path.expandvars(configured)).expanduser()
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
 def _plugin_server(root: Path) -> Path:
     return root / "plugins" / "praxys" / "mcp-server" / "server.py"
 
@@ -60,17 +70,19 @@ def _require_mcp_runtime(root: Path) -> None:
         "requirements.txt"
     )
     raise SystemExit(
-        "The project virtualenv is missing the MCP SDK. Install it with: "
-        f'"{_venv_python(root)}" -m pip install -r "{requirements}"'
+        "The selected Python environment is missing the MCP SDK. "
+        f'Install it with: "{_runtime_python(root)}" -m pip install '
+        f'-r "{requirements}"'
     )
 
 
-def _reexec_in_project_venv(root: Path) -> None:
-    python_path = _venv_python(root)
+def _reexec_in_runtime_python(root: Path) -> None:
+    python_path = _runtime_python(root)
     if not python_path.is_file():
         raise SystemExit(
-            f"Project virtualenv not found at {python_path}. "
-            "Create .venv and install requirements.txt first."
+            f"Praxys MCP Python not found at {python_path}. "
+            "Create .venv and install requirements.txt first, or set "
+            "PRAXYS_MCP_PYTHON to an absolute interpreter path."
         )
     if Path(sys.executable).resolve() == python_path.resolve():
         return
@@ -517,7 +529,7 @@ def main() -> NoReturn:
             "Praxys plugin submodule is missing. Run "
             "'git submodule update --init plugins/praxys'."
         )
-    _reexec_in_project_venv(root)
+    _reexec_in_runtime_python(root)
     _require_mcp_runtime(root)
     args = _parse_args()
     os.chdir(root)
@@ -547,10 +559,8 @@ def main() -> NoReturn:
             raise SystemExit("remote-profile mode requires a profile name")
         configure_remote_profile(args.profile)
 
-    os.execv(
-        str(_venv_python(root)),
-        [str(_venv_python(root)), str(server_path)],
-    )
+    python_path = _runtime_python(root)
+    os.execv(str(python_path), [str(python_path), str(server_path)])
 
 
 if __name__ == "__main__":

--- a/scripts/run_praxys_mcp.py
+++ b/scripts/run_praxys_mcp.py
@@ -530,7 +530,6 @@ def main() -> NoReturn:
             "'git submodule update --init plugins/praxys'."
         )
     _reexec_in_runtime_python(root)
-    _require_mcp_runtime(root)
     args = _parse_args()
     os.chdir(root)
 
@@ -559,6 +558,7 @@ def main() -> NoReturn:
             raise SystemExit("remote-profile mode requires a profile name")
         configure_remote_profile(args.profile)
 
+    _require_mcp_runtime(root)
     python_path = _runtime_python(root)
     os.execv(str(python_path), [str(python_path), str(server_path)])
 

--- a/tests/test_run_praxys_mcp.py
+++ b/tests/test_run_praxys_mcp.py
@@ -171,6 +171,24 @@ def test_remote_profile_forces_isolated_production_auth(
     )
 
 
+def test_runtime_python_override_does_not_require_project_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = run_praxys_mcp.project_root()
+    monkeypatch.setenv("PRAXYS_MCP_PYTHON", sys.executable)
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "_venv_python",
+        lambda _root: tmp_path / "missing-python",
+    )
+
+    assert run_praxys_mcp._runtime_python(root) == Path(
+        sys.executable
+    ).resolve()
+    run_praxys_mcp._reexec_in_runtime_python(root)
+
+
 def test_repository_mcp_config_registers_local_and_dev_test_profiles() -> None:
     root = run_praxys_mcp.project_root()
     config = json.loads((root / ".mcp.json").read_text(encoding="utf-8"))

--- a/tests/test_run_praxys_mcp.py
+++ b/tests/test_run_praxys_mcp.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
+import subprocess
+import sys
 import threading
 import time
 from unittest import mock
@@ -173,19 +176,55 @@ def test_repository_mcp_config_registers_local_and_dev_test_profiles() -> None:
     config = json.loads((root / ".mcp.json").read_text(encoding="utf-8"))
     servers = config["mcpServers"]
 
+    assert servers["praxys-local"]["command"] == "node"
     assert servers["praxys-local"]["args"] == [
-        "-m",
-        "scripts.run_praxys_mcp",
+        "scripts/run_praxys_mcp.cjs",
         "local",
     ]
+    assert servers["praxys-dev-test"]["command"] == "node"
     assert servers["praxys-dev-test"]["args"] == [
-        "-m",
-        "scripts.run_praxys_mcp",
+        "scripts/run_praxys_mcp.cjs",
         "remote-profile",
         "dev-test",
     ]
     assert servers["praxys-local"]["env"] == {}
     assert servers["praxys-dev-test"]["env"] == {}
+
+
+def test_repository_mcp_launcher_honors_python_override(
+    tmp_path: Path,
+) -> None:
+    root = run_praxys_mcp.project_root()
+    node = shutil.which("node")
+    assert node is not None
+    data_dir = tmp_path / "node-launcher-sandbox"
+    env = os.environ.copy()
+    env["PRAXYS_LOCAL_MCP_DATA_DIR"] = str(data_dir)
+    env["PRAXYS_MCP_PYTHON"] = sys.executable
+
+    result = subprocess.run(
+        [
+            node,
+            str(root / "scripts" / "run_praxys_mcp.cjs"),
+            "local",
+            "--prepare-only",
+        ],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    marker = json.loads(
+        (data_dir / ".praxys-mcp-sandbox.json").read_text(
+            encoding="utf-8",
+        )
+    )
+    assert marker["owner"] == "praxys-local-mcp"
+    assert marker["state"] == "ready"
 
 
 @pytest.mark.parametrize("profile", ["..", "dev/test", r"dev\test"])


### PR DESCRIPTION
## Summary
- bump `plugins/praxys` to preload Pandas-backed host modules before local FastMCP startup
- launch repository MCP profiles through a dependency-free Node shim that invokes the project virtualenv directly
- remove machine-specific dependence on `python`, `python3`, or `py` command resolution
- support an explicit `PRAXYS_MCP_PYTHON` path for clean CI/test environments without `.venv`
- document the isolated local and production-test launcher workflow

Plugin change: praxys-run/praxys-coach-plugin#5

## Validation
- full backend suite: 1850 passed, 2 skipped
- plugin MCP tests: 20 passed, 5 subtests
- direct Node-launched `praxys-local` and `praxys-dev-test` MCP stdio calls
- full local managed-plan lifecycle over MCP: create, preview validation, adopt, pause, edit, fail-closed resume, resume, delete, leave, cleanup
- verified the external-provider workout remained unchanged and the sandbox was reset afterward