### PR TITLE
Fix MCP prepare-only deployment regression

### DIFF
--- a/scripts/run_praxys_mcp.py
+++ b/scripts/run_praxys_mcp.py
@@ -523,12 +523,6 @@ def _parse_args() -> argparse.Namespace:
 def main() -> NoReturn:
     """Replace this bootstrap process with the selected MCP server."""
     root = project_root()
-    server_path = _plugin_server(root)
-    if not server_path.is_file():
-        raise SystemExit(
-            "Praxys plugin submodule is missing. Run "
-            "'git submodule update --init plugins/praxys'."
-        )
     _reexec_in_runtime_python(root)
     args = _parse_args()
     os.chdir(root)
@@ -558,6 +552,12 @@ def main() -> NoReturn:
             raise SystemExit("remote-profile mode requires a profile name")
         configure_remote_profile(args.profile)
 
+    server_path = _plugin_server(root)
+    if not server_path.is_file():
+        raise SystemExit(
+            "Praxys plugin submodule is missing. Run "
+            "'git submodule update --init plugins/praxys'."
+        )
     _require_mcp_runtime(root)
     python_path = _runtime_python(root)
     os.execv(str(python_path), [str(python_path), str(server_path)])

--- a/tests/test_run_praxys_mcp.py
+++ b/tests/test_run_praxys_mcp.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import threading
 import time
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -187,6 +188,59 @@ def test_runtime_python_override_does_not_require_project_venv(
         sys.executable
     ).resolve()
     run_praxys_mcp._reexec_in_runtime_python(root)
+
+
+def test_prepare_only_does_not_require_plugin_submodule(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = run_praxys_mcp.project_root()
+    data_dir = tmp_path / "prepared-sandbox"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "_reexec_in_runtime_python",
+        lambda _root: None,
+    )
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "_parse_args",
+        lambda: SimpleNamespace(
+            mode="local",
+            profile=None,
+            reset=False,
+            prepare_only=True,
+        ),
+    )
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "_resolve_local_data_dir",
+        lambda _root: data_dir,
+    )
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "ensure_local_sandbox",
+        lambda _root, _data_dir, *, reset: run_praxys_mcp.BootstrapResult(
+            data_dir=data_dir,
+            reset=reset,
+            fingerprint="test",
+        ),
+    )
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "_plugin_server",
+        lambda _root: tmp_path / "missing-server.py",
+    )
+    monkeypatch.setattr(
+        run_praxys_mcp,
+        "_require_mcp_runtime",
+        lambda _root: pytest.fail("prepare-only loaded the MCP runtime"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_praxys_mcp.main()
+
+    assert exc_info.value.code == 0
 
 
 def test_repository_mcp_config_registers_local_and_dev_test_profiles() -> None:


### PR DESCRIPTION
## Summary
- defer the plugin submodule requirement until MCP server startup
- keep `local --prepare-only` usable in backend/deployment jobs without a submodule checkout
- add regression coverage that preparation skips both the plugin server and MCP runtime

## Validation
- full backend suite: 1870 passed, 2 skipped
- targeted MCP launcher/integration tests: 14 passed