### PR TITLE
Fix Garmin CN managed-plan identity verification

### DIFF
--- a/api/plan_delivery/garmin.py
+++ b/api/plan_delivery/garmin.py
@@ -259,6 +259,7 @@ class GarminPlanDeliveryAdapter:
             and self._profile_account_id is not None
         ):
             return
+        stage = "client_initialization"
         try:
             from garminconnect import Garmin
             from api.routes.sync import (
@@ -271,11 +272,13 @@ class GarminPlanDeliveryAdapter:
                 is_cn=self._is_cn,
             )
             self._client = client
+            stage = "token_load"
             serialized_tokens = (
                 self._token_loader()
                 if self._token_loader is not None
                 else None
             )
+            stage = "login"
             _login_garmin_with_cn_fallback(
                 client,
                 {
@@ -285,12 +288,15 @@ class GarminPlanDeliveryAdapter:
                 },
                 serialized_tokens,
             )
+            stage = "profile_identity"
             profile_id = garmin_user_profile_id(client)
+            stage = "profile_fence"
             profile_account_id = garmin_profile_account_id(
                 user_id=self._user_id,
                 is_cn=self._is_cn,
                 garmin_user_profile_id=profile_id,
             )
+            stage = "provider_identity"
             account_id = garmin_provider_account_id(
                 user_id=self._user_id,
                 display_name=getattr(client, "display_name", ""),
@@ -299,14 +305,21 @@ class GarminPlanDeliveryAdapter:
         except ProviderAuthenticationRequiredError:
             raise
         except _GARMIN_AUTH_ERRORS as exc:
+            logger.warning(
+                "Garmin delivery authentication failed "
+                "(stage=%s, error_type=%s, http_status=%s)",
+                stage,
+                type(exc).__name__,
+                _http_status(exc),
+            )
             try:
                 self._publish_current_tokens_locked()
-            except Exception:
+            except Exception as publish_exc:
                 logger.warning(
                     "Could not persist Garmin OAuth rotation after failed "
-                    "authentication for user %s",
-                    self._user_id,
-                    exc_info=True,
+                    "authentication (stage=%s, error_type=%s)",
+                    stage,
+                    type(publish_exc).__name__,
                 )
             if _is_rate_limited(exc):
                 raise ProviderRateLimitError(
@@ -315,6 +328,14 @@ class GarminPlanDeliveryAdapter:
             if _is_authentication_rejected(exc):
                 raise ProviderAuthenticationRequiredError(
                     "Garmin login failed; reconnect Garmin"
+                ) from exc
+            if stage in {
+                "profile_identity",
+                "profile_fence",
+                "provider_identity",
+            }:
+                raise ProviderAuthenticationError(
+                    "Garmin account identity verification failed"
                 ) from exc
             raise ProviderAuthenticationError("Garmin login failed") from exc
         self._provider_account_id = account_id

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -53,6 +53,19 @@ Expect individual endpoints to 400/404 on `connectapi.garmin.cn` even when the a
 - The recovery loop has per-endpoint consecutive-failure circuit breakers (5 strikes → stop calling that endpoint for the remaining days).
 - `parse_garmin_recovery` uses `isinstance` guards + `or`-coalesce on every nested `.get()` — `dict.get(k, default)` returns `None`, not the default, for a present-but-null key, and the legacy code's crash here used to abort the whole recovery loop.
 
+### Garmin profile identity keys differ by region
+
+The authenticated `/userprofile-service/socialProfile` payload is not identical
+across regions. Legacy/International responses can expose `userProfileId`,
+while Garmin CN exposes `profileId`; the CN value matches the top-level `id`
+from `get_user_profile()`. The social payload's own `id` is a different record
+identifier and must not be used as the account fence.
+
+`garmin_user_profile_id()` therefore prefers `userProfileId` to preserve
+existing delivery-ledger identity, then falls back to `profileId` for CN.
+Profile visibility is unrelated: this is an authenticated self-profile read,
+not a public-profile lookup.
+
 ### Garmin's CAPTCHA gate is time-bound, not sticky
 
 When the headless `garminconnect` flow trips Garmin/Cloudflare's bot detection, the rejection looks **permanent** but isn't. The trap is assuming you need to engineer your way around the gate when you actually just need to stop feeding it.

--- a/sync/garmin_sync.py
+++ b/sync/garmin_sync.py
@@ -63,7 +63,11 @@ def garmin_user_profile_id(client: Any) -> str:
         raise ValueError("Garmin profile payload must be an object")
     normalized = _garmin_calendar_id(profile.get("userProfileId"))
     if normalized is None:
-        raise ValueError("Garmin profile is missing userProfileId")
+        # Garmin CN exposes profileId here; it matches get_user_profile()["id"].
+        # Keep userProfileId first so existing delivery fences remain stable.
+        normalized = _garmin_calendar_id(profile.get("profileId"))
+    if normalized is None:
+        raise ValueError("Garmin profile is missing userProfileId/profileId")
     setattr(client, "_praxys_user_profile_id", normalized)
     return normalized
 

--- a/tests/test_garmin_plan_delivery_adapter.py
+++ b/tests/test_garmin_plan_delivery_adapter.py
@@ -308,8 +308,22 @@ def test_adapter_requires_credential_generation() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("china_account", "region", "profile"),
+    [
+        (
+            False,
+            "international",
+            {"userProfileId": 12345, "profileId": 67890},
+        ),
+        (True, "cn", {"id": 67890, "profileId": 12345}),
+    ],
+)
 def test_authenticate_publishes_in_memory_tokens(
     monkeypatch,
+    china_account: bool,
+    region: str,
+    profile: dict[str, int],
 ) -> None:
     published: list[str] = []
     loaded: list[str] = []
@@ -342,11 +356,11 @@ def test_authenticate_publishes_in_memory_tokens(
         def __init__(self, email, password, is_cn=False):
             assert email == "runner@example.test"
             assert password == "secret"
-            assert is_cn is False
+            assert is_cn is china_account
 
         def connectapi(self, path):
             assert path == "/userprofile-service/socialProfile"
-            return {"userProfileId": 12345}
+            return profile
 
     monkeypatch.setattr("garminconnect.Garmin", AuthenticatedGarmin)
     monkeypatch.setattr(
@@ -367,10 +381,10 @@ def test_authenticate_publishes_in_memory_tokens(
         {
             "email": "runner@example.test",
             "password": "secret",
-            "is_cn": False,
+            "is_cn": china_account,
         },
         user_id="garmin-adapter-user",
-        source_options={"garmin_region": "international"},
+        source_options={"garmin_region": region},
         credential_generation=CREDENTIAL_GENERATION,
         token_loader=load_tokens,
         token_publisher=publish_tokens,
@@ -382,6 +396,53 @@ def test_authenticate_publishes_in_memory_tokens(
     assert login_tokens == ["stored-token-bundle"]
     assert published == ["serialized-token-bundle"]
     assert lease_depth == 0
+
+
+def test_missing_profile_identity_reports_safe_failure_stage(
+    monkeypatch,
+    caplog,
+) -> None:
+    class AuthenticatedGarmin:
+        display_name = "stable-account"
+
+        def __init__(self, email, password, is_cn=False):
+            del email, password, is_cn
+
+        def connectapi(self, path):
+            assert path == "/userprofile-service/socialProfile"
+            return {"id": 12345}
+
+    monkeypatch.setattr("garminconnect.Garmin", AuthenticatedGarmin)
+    monkeypatch.setattr(
+        "api.routes.sync._garmin_tokenstore_lease",
+        lambda user_id: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        "api.routes.sync._login_garmin_with_cn_fallback",
+        lambda client, creds, serialized_tokens: None,
+    )
+    adapter = GarminPlanDeliveryAdapter(
+        {
+            "email": "runner@example.test",
+            "password": "secret",
+            "is_cn": False,
+        },
+        user_id="garmin-adapter-user",
+        source_options={"garmin_region": "international"},
+        credential_generation=CREDENTIAL_GENERATION,
+    )
+
+    with caplog.at_level("WARNING", logger="api.plan_delivery.garmin"):
+        with pytest.raises(
+            ProviderAuthenticationError,
+            match="account identity verification failed",
+        ):
+            adapter.authenticate()
+
+    assert "stage=profile_identity" in caplog.text
+    assert "error_type=ValueError" in caplog.text
+    assert "runner@example.test" not in caplog.text
+    assert "garmin-adapter-user" not in caplog.text
 
 
 def test_token_loader_reconnect_error_is_not_downgraded(monkeypatch) -> None:

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -389,13 +389,32 @@ def test_garmin_user_profile_id_reads_and_caches_social_profile():
         def connectapi(self, path):
             assert path == "/userprofile-service/socialProfile"
             self.calls += 1
-            return {"userProfileId": 12345}
+            return {"userProfileId": 12345, "profileId": 67890}
 
     client = FakeGarmin()
 
     assert garmin_user_profile_id(client) == "12345"
     assert garmin_user_profile_id(client) == "12345"
     assert client.calls == 1
+
+
+def test_garmin_user_profile_id_accepts_cn_profile_id():
+    class FakeGarmin:
+        def connectapi(self, path):
+            assert path == "/userprofile-service/socialProfile"
+            return {"id": 12345, "profileId": 67890}
+
+    assert garmin_user_profile_id(FakeGarmin()) == "67890"
+
+
+def test_garmin_user_profile_id_rejects_social_record_id():
+    class FakeGarmin:
+        def connectapi(self, path):
+            assert path == "/userprofile-service/socialProfile"
+            return {"id": 12345}
+
+    with pytest.raises(ValueError, match="userProfileId/profileId"):
+        garmin_user_profile_id(FakeGarmin())
 
 
 def test_parse_activity_weather_converts_fahrenheit_to_celsius():


### PR DESCRIPTION
## Summary
- accept Garmin CN's authenticated `profileId` when `userProfileId` is absent
- preserve `userProfileId` priority so existing delivery-ledger identity remains stable
- report safe authentication stages without logging credentials, account identifiers, or provider payloads
- document that profile visibility is unrelated to the authenticated identity fence

## Root cause
Garmin CN's `/userprofile-service/socialProfile` response contains `profileId` but not `userProfileId`. Its `profileId` matches the top-level `id` returned by `get_user_profile()`, while the social payload's own `id` is a different record identifier. Delivery therefore failed closed during identity verification and was incorrectly surfaced as `Garmin login failed`.

## Validation
- targeted Garmin tests: 133 passed
- full backend suite: 1874 passed, 2 skipped
- read-only production probe against the dedicated Garmin CN test account authenticated successfully and built both account fences with the fallback; no workout/calendar mutation was performed

## Safety
- the legacy `userProfileId` key remains authoritative when both keys exist
- the unrelated social `id` remains rejected
- managed delivery remains paused until this fix is deployed