### PR TITLE
Support Garmin CN schedule verification

### DIFF
--- a/api/plan_delivery/garmin.py
+++ b/api/plan_delivery/garmin.py
@@ -663,13 +663,39 @@ class GarminPlanDeliveryAdapter:
             raise ProviderOutcomeUnknownError(
                 "Garmin schedule response did not include workoutScheduleId"
             )
-        response_date = str(response.get("date") or schedule_date)
+        response_date = str(
+            response.get("date")
+            or response.get("calendarDate")
+            or schedule_date
+        )
         if response_date[:10] != schedule_date:
             raise ProviderOutcomeUnknownError(
                 "Garmin scheduled the workout on an unexpected date",
                 external_id=external_id,
             )
         return external_id
+
+    @staticmethod
+    def _scheduled_workout_template_id(response: object) -> str | None:
+        """Read a template ID from flat or Garmin CN schedule details."""
+        if not isinstance(response, Mapping):
+            return None
+        template_id = _positive_id(response.get("workoutId"))
+        if template_id is not None:
+            return template_id
+        workout = response.get("workout")
+        if not isinstance(workout, Mapping):
+            return None
+        return _positive_id(workout.get("workoutId"))
+
+    @staticmethod
+    def _scheduled_workout_date(response: object) -> str:
+        """Read a schedule date from flat or Garmin CN schedule details."""
+        if not isinstance(response, Mapping):
+            return ""
+        return str(
+            response.get("date") or response.get("calendarDate") or ""
+        )[:10]
 
     def create_workout(
         self,
@@ -912,6 +938,40 @@ class GarminPlanDeliveryAdapter:
         checkpointed_schedule_id = _positive_id(
             references.get("schedule_id")
         )
+        returned_schedule_id = _positive_id(
+            references.get("returned_schedule_id")
+        )
+        if (
+            checkpointed_schedule_id is None
+            and returned_schedule_id is not None
+            and references.get("schedule_started") is True
+            and not references.get("unexpected_schedule_date")
+        ):
+            returned_preexisting_id = _positive_id(
+                references.get("returned_preexisting_schedule_id")
+            )
+            if (
+                returned_schedule_id in preexisting_schedule_ids
+                or returned_preexisting_id == returned_schedule_id
+            ):
+                raise ProviderOutcomeUnknownError(
+                    "Returned Garmin schedule identity was pre-existing",
+                    provider_references=references,
+                )
+            exact_returned = [
+                row for row in scheduled
+                if str(row["external_id"]) == returned_schedule_id
+            ]
+            if len(exact_returned) != 1:
+                raise ProviderOutcomeUnknownError(
+                    "Returned Garmin schedule is not uniquely visible for "
+                    "its template and date",
+                    provider_references=references,
+                )
+            references.pop("candidate_schedule_ids", None)
+            references["schedule_id"] = returned_schedule_id
+            hooks.checkpoint(references, returned_schedule_id)
+            checkpointed_schedule_id = returned_schedule_id
         if checkpointed_schedule_id is not None:
             exact_checkpoint = [
                 row for row in scheduled
@@ -1012,9 +1072,8 @@ class GarminPlanDeliveryAdapter:
                                 provider_references=references,
                             ) from read_exc
                         if (
-                            not isinstance(returned_schedule, Mapping)
-                            or _positive_id(
-                                returned_schedule.get("workoutId")
+                            self._scheduled_workout_template_id(
+                                returned_schedule
                             )
                             != template_id
                         ):
@@ -1024,8 +1083,8 @@ class GarminPlanDeliveryAdapter:
                                 "created template",
                                 provider_references=references,
                             ) from exc
-                        references["unexpected_schedule_date"] = str(
-                            returned_schedule.get("date") or ""
+                        references["unexpected_schedule_date"] = (
+                            self._scheduled_workout_date(returned_schedule)
                         )
                         hooks.checkpoint(references, None)
                         raise ProviderOutcomeUnknownError(
@@ -1065,14 +1124,12 @@ class GarminPlanDeliveryAdapter:
                             provider_references=references,
                         ) from read_exc
                     returned_template_id = (
-                        _positive_id(returned_schedule.get("workoutId"))
-                        if isinstance(returned_schedule, Mapping)
-                        else None
+                        self._scheduled_workout_template_id(
+                            returned_schedule
+                        )
                     )
-                    returned_date = (
-                        str(returned_schedule.get("date") or "")[:10]
-                        if isinstance(returned_schedule, Mapping)
-                        else ""
+                    returned_date = self._scheduled_workout_date(
+                        returned_schedule
                     )
                     if returned_template_id != template_id:
                         hooks.checkpoint(references, None)
@@ -1262,7 +1319,9 @@ class GarminPlanDeliveryAdapter:
                 provider_references=hooks.provider_references,
             )
         if scheduled is not None:
-            observed_template_id = _positive_id(scheduled.get("workoutId"))
+            observed_template_id = self._scheduled_workout_template_id(
+                scheduled
+            )
             if observed_template_id != template_id:
                 raise ProviderRemovalOutcomeUnknownError(
                     "Garmin schedule no longer references the owned template",

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -66,6 +66,21 @@ existing delivery-ledger identity, then falls back to `profileId` for CN.
 Profile visibility is unrelated: this is an authenticated self-profile read,
 not a public-profile lookup.
 
+### Garmin CN schedule details are nested
+
+`get_scheduled_workout_by_id()` returns a flat International-style shape in
+some accounts (`workoutId`, `date`), but Garmin CN returns the template under
+`workout.workoutId` and the date as `calendarDate`. The monthly calendar still
+uses `calendarItems[].workoutId`, `calendarItems[].id`, and
+`calendarItems[].date`.
+
+Creation and deletion verification must accept both detail shapes. A
+checkpointed `returned_schedule_id` is promoted to the owned `schedule_id`
+only when the monthly calendar independently shows that exact schedule ID on
+the expected date with the created template, and only when it was absent from
+the pre-mutation schedule set. This recovery fence prevents both duplicate
+retries and adoption of a pre-existing/manual schedule.
+
 ### Garmin's CAPTCHA gate is time-bound, not sticky
 
 When the headless `garminconnect` flow trips Garmin/Cloudflare's bot detection, the rejection looks **permanent** but isn't. The trap is assuming you need to engineer your way around the gate when you actually just need to stop feeding it.

--- a/tests/test_garmin_plan_delivery_adapter.py
+++ b/tests/test_garmin_plan_delivery_adapter.py
@@ -610,6 +610,31 @@ def test_create_checkpoints_both_garmin_identities() -> None:
     assert client.schedule_calls == 1
 
 
+def test_create_accepts_nested_cn_schedule_details() -> None:
+    client = FakeGarmin()
+    adapter = _adapter(client)
+    prepared = adapter.prepare_workout(_workout(), threshold_value=250)
+    original_read = client.get_scheduled_workout_by_id
+
+    def read_nested(external_id: object) -> dict[str, Any]:
+        flat = original_read(external_id)
+        return {
+            "workoutScheduleId": flat["workoutScheduleId"],
+            "workout": {"workoutId": flat["workoutId"]},
+            "calendarDate": flat["date"],
+        }
+
+    client.get_scheduled_workout_by_id = read_nested
+
+    result = adapter.create_workout(prepared)
+
+    assert result.external_id == "201"
+    assert result.provider_references["template_id"] == "101"
+    assert result.provider_references["schedule_id"] == "201"
+    assert client.upload_calls == 1
+    assert client.schedule_calls == 1
+
+
 def test_mutation_checkpoint_precedes_final_guard_and_provider_io() -> None:
     client = FakeGarmin()
     adapter = _adapter(client)
@@ -1134,6 +1159,65 @@ def test_manual_reuse_of_retained_template_is_never_adopted() -> None:
     assert client.schedule_calls == 0
 
 
+def test_returned_schedule_checkpoint_recovers_without_duplicate() -> None:
+    client = FakeGarmin()
+    adapter = _adapter(client)
+    prepared = adapter.prepare_workout(_workout(), threshold_value=250)
+    client.templates["101"] = deepcopy(dict(prepared.request["workout"]))
+    client.schedules["201"] = {
+        "template_id": "101",
+        "date": "2026-08-05",
+    }
+    references, checkpoints, mutations, hooks = _recording_hooks({
+        "template_marker": prepared.request["marker"],
+        "payload_fingerprint": prepared.content_version,
+        "preexisting_template_ids": [],
+        "template_id": "101",
+        "preexisting_schedule_ids": [],
+        "schedule_started": True,
+        "returned_schedule_id": "201",
+    })
+
+    result = adapter.create_workout(prepared, hooks=hooks)
+
+    assert result.external_id == "201"
+    assert references["schedule_id"] == "201"
+    assert checkpoints[-1][1] == "201"
+    assert mutations == []
+    assert client.schedule_calls == 0
+    assert list(client.schedules) == ["201"]
+
+
+def test_returned_preexisting_checkpoint_is_never_recovered() -> None:
+    client = FakeGarmin()
+    adapter = _adapter(client)
+    prepared = adapter.prepare_workout(_workout(), threshold_value=250)
+    client.templates["101"] = deepcopy(dict(prepared.request["workout"]))
+    client.schedules["201"] = {
+        "template_id": "101",
+        "date": "2026-08-05",
+    }
+    references, _, mutations, hooks = _recording_hooks({
+        "template_marker": prepared.request["marker"],
+        "payload_fingerprint": prepared.content_version,
+        "preexisting_template_ids": [],
+        "template_id": "101",
+        "preexisting_schedule_ids": ["201"],
+        "schedule_started": True,
+        "returned_schedule_id": "201",
+    })
+
+    with pytest.raises(
+        ProviderOutcomeUnknownError,
+        match="pre-existing",
+    ):
+        adapter.create_workout(prepared, hooks=hooks)
+
+    assert "schedule_id" not in references
+    assert mutations == []
+    assert client.schedule_calls == 0
+
+
 def test_checkpointed_schedule_absence_fails_closed() -> None:
     client = FakeGarmin()
     adapter = _adapter(client)
@@ -1185,6 +1269,37 @@ def test_delete_unschedules_only_owned_instance_and_retains_template() -> None:
     assert set(client.templates) == {"101"}
     assert mutations == ["before"]
     assert result.response["template_retained"] is True
+
+
+def test_delete_accepts_nested_cn_schedule_details() -> None:
+    client = FakeGarmin()
+    adapter = _adapter(client)
+    client.schedules["201"] = {
+        "template_id": "101",
+        "date": "2026-08-05",
+    }
+    original_read = client.get_scheduled_workout_by_id
+
+    def read_nested(external_id: object) -> dict[str, Any]:
+        flat = original_read(external_id)
+        return {
+            "workoutScheduleId": flat["workoutScheduleId"],
+            "workout": {"workoutId": flat["workoutId"]},
+            "calendarDate": flat["date"],
+        }
+
+    client.get_scheduled_workout_by_id = read_nested
+    _, _, mutations, hooks = _recording_hooks({
+        "template_id": "101",
+        "profile_account_id": PROFILE_ACCOUNT_ID,
+    })
+
+    result = adapter.delete_workout("201", hooks=hooks)
+
+    assert result.already_absent is False
+    assert client.unschedule_calls == ["201"]
+    assert client.schedules == {}
+    assert mutations == ["before"]
 
 
 def test_delete_holds_shared_tokenstore_lease(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- accept both flat and Garmin CN nested scheduled-workout detail shapes
- verify CN template identity from `workout.workoutId` and date from `calendarDate`
- recover a checkpointed returned schedule without issuing a duplicate write
- apply the same dual-shape ownership check before deletion

## Root cause
Garmin CN successfully created both test schedules, but `get_scheduled_workout_by_id()` returned the template under `workout.workoutId` and the date as `calendarDate`. The adapter expected top-level `workoutId` / `date`, so it correctly failed closed with an uncertain outcome even though the monthly calendar showed the exact schedules.

## Recovery safety
A persisted `returned_schedule_id` is promoted to owned `schedule_id` only when the monthly calendar independently confirms all of the following:
- exact returned schedule ID
- exact created template ID
- expected date
- schedule ID was absent from the pre-mutation set

Unexpected-date and pre-existing/manual schedules remain blocked. This lets the two current CN pilot schedules recover without another provider mutation.

## Validation
- Garmin delivery regression set: 262 passed
- full backend suite: 1878 passed, 2 skipped
- live CN schema inspected using field names and equality relationships only; no provider IDs, credentials, tokens, or raw values were logged

Managed delivery remains paused until deployment and explicit conflict recovery.