### PR TITLE
Recover safely checkpointed Garmin schedules

### DIFF
--- a/api/plan_resolution.py
+++ b/api/plan_resolution.py
@@ -671,6 +671,47 @@ def _merged_delivery_provider_references(
     return normalize_provider_references(merged)
 
 
+def _garmin_restorable_schedule_ids(delivery: PlanDelivery) -> set[str]:
+    """Return Garmin schedule IDs safe to bind from matching observations."""
+    references = delivery.provider_references or {}
+    schedule_ids = {
+        value
+        for raw in (
+            references.get("schedule_id"),
+            delivery.external_id,
+        )
+        if (value := str(raw or "").strip())
+    }
+    returned_schedule_id = str(
+        references.get("returned_schedule_id") or ""
+    ).strip()
+    if (
+        not returned_schedule_id
+        or references.get("schedule_started") is not True
+        or references.get("unexpected_schedule_date")
+    ):
+        return schedule_ids
+    raw_preexisting_schedule_ids = references.get(
+        "preexisting_schedule_ids"
+    )
+    if not isinstance(raw_preexisting_schedule_ids, list):
+        return schedule_ids
+    preexisting_schedule_ids = {
+        value
+        for raw in raw_preexisting_schedule_ids
+        if (value := str(raw or "").strip())
+    }
+    returned_preexisting_id = str(
+        references.get("returned_preexisting_schedule_id") or ""
+    ).strip()
+    if (
+        returned_schedule_id not in preexisting_schedule_ids
+        and returned_schedule_id != returned_preexisting_id
+    ):
+        schedule_ids.add(returned_schedule_id)
+    return schedule_ids
+
+
 def _bind_confirmed_restore(
     db: Session,
     *,
@@ -1399,17 +1440,10 @@ def restore_praxys_version(
             raise PlanResolutionConflict(
                 "Target workout belongs to a different provider account"
             )
-        checkpointed_schedule_id = str(
-            (item.delivery.provider_references or {}).get("schedule_id")
-            or ""
-        ).strip()
         exact_garmin_identity = (
             target != "garmin"
             or observation.external_id
-            in {
-                checkpointed_schedule_id,
-                str(item.delivery.external_id or "").strip(),
-            }
+            in _garmin_restorable_schedule_ids(item.delivery)
         )
         if (
             observation.workout_date == item.delivery.workout_date

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -79,7 +79,9 @@ checkpointed `returned_schedule_id` is promoted to the owned `schedule_id`
 only when the monthly calendar independently shows that exact schedule ID on
 the expected date with the created template, and only when it was absent from
 the pre-mutation schedule set. This recovery fence prevents both duplicate
-retries and adoption of a pre-existing/manual schedule.
+retries and adoption of a pre-existing/manual schedule. Conflict resolution
+uses the same fence to bind a matching observed schedule without another
+provider mutation.
 
 ### Garmin's CAPTCHA gate is time-bound, not sticky
 

--- a/tests/test_plan_sync_state.py
+++ b/tests/test_plan_sync_state.py
@@ -3423,6 +3423,185 @@ def test_restore_matching_garmin_schedule_is_noop_without_checkpoint_id(
         assert delivery.provider_references["template_id"] == "template-7"
 
 
+@pytest.mark.parametrize(
+    ("scenario", "expected_status"),
+    [
+        ("safe", 200),
+        ("preexisting", 409),
+        ("unexpected_date", 409),
+        ("mismatched_observation", 409),
+    ],
+)
+def test_restore_returned_garmin_schedule_requires_new_checkpoint(
+    api_client,
+    monkeypatch,
+    scenario: str,
+    expected_status: int,
+):
+    from api.plan_delivery.base import PreparedWorkoutDelivery
+    from api.plan_delivery.capabilities import plan_delivery_consent_token
+    from db import session as db_session
+    from db.models import (
+        PlanDelivery,
+        UserConfig,
+        UserConnection,
+    )
+
+    client, user_id = api_client
+    target_date = date.today() + timedelta(days=10)
+    fingerprint = "d" * 64
+    external_id = "returned-schedule-42"
+    profile_references = {
+        "template_id": "template-7",
+        "profile_account_id": "international:profile",
+    }
+    _seed_rows(user_id, [{
+        "date": target_date,
+        "source": "praxys",
+        "workout_type": "easy",
+    }])
+    delivery_id = _seed_synced_delivery(
+        user_id,
+        target_date,
+        "easy",
+        external_id,
+        provider_content_version=fingerprint,
+        provider_account_id="garmin-account",
+        target="garmin",
+    )
+    with db_session.SessionLocal() as db:
+        delivery = db.get(PlanDelivery, delivery_id)
+        delivery.state = "conflict"
+        delivery.external_id = None
+        delivery.provider_references = {
+            **profile_references,
+            "preexisting_schedule_ids": (
+                [external_id] if scenario == "preexisting" else []
+            ),
+            "schedule_started": True,
+            "returned_schedule_id": external_id,
+            **(
+                {
+                    "unexpected_schedule_date": (
+                        target_date + timedelta(days=1)
+                    ).isoformat()
+                }
+                if scenario == "unexpected_date"
+                else {}
+            ),
+        }
+        delivery_version = delivery.workout_version
+        db.add(UserConfig(
+            user_id=user_id,
+            source_options={"garmin_region": "international"},
+            plan_management={
+                "mode": "praxys",
+                "execution_target": "garmin",
+                "delivery_enabled": True,
+                "adjustment_policy": "suggest_only",
+            },
+        ))
+        connection = UserConnection(
+            user_id=user_id,
+            platform="garmin",
+            status="connected",
+            encrypted_credentials=b"garmin-credentials",
+            wrapped_dek=b"garmin-dek",
+        )
+        db.add(connection)
+        db.flush()
+        connection.plan_delivery_consent = plan_delivery_consent_token(
+            connection,
+            region="international",
+        )
+        db.commit()
+    _seed_target_snapshot(
+        user_id,
+        [{
+            "date": target_date.isoformat(),
+            "workout_type": "easy",
+            "external_id": (
+                "different-schedule"
+                if scenario == "mismatched_observation"
+                else external_id
+            ),
+            "provider_content_fingerprint": fingerprint,
+            "provider_references": profile_references,
+        }],
+        provider_account_id="garmin-account",
+        target="garmin",
+    )
+    plan_body = client.get("/api/plan").json()
+    owned = next(
+        workout
+        for workout in plan_body["workouts"]
+        if workout["date"] == target_date.isoformat()
+        and workout["source"] in PRAXYS_PLAN_SOURCES
+    )
+    reconciliation_id = owned["reconciliation"]["id"]
+    calls = {"create": 0, "delete": 0}
+
+    class Adapter:
+        target = "garmin"
+        display_name = "Garmin"
+        account_id = "garmin-account"
+
+        def authenticate(self):
+            return None
+
+        def prepare_workout(self, workout, *, threshold_value):
+            return PreparedWorkoutDelivery(
+                version=delivery_version,
+                request={},
+                content_version=fingerprint,
+            )
+
+        def create_workout(self, prepared, *, hooks):
+            calls["create"] += 1
+            raise AssertionError("matching schedule must not be recreated")
+
+        def delete_workout(self, external_id, *, hooks):
+            calls["delete"] += 1
+            raise AssertionError("matching schedule must not be removed")
+
+        def fetch_calendar(self, **kwargs):
+            return []
+
+    from api.routes import plan as plan_mod
+
+    monkeypatch.setattr(
+        plan_mod,
+        "load_plan_delivery_adapter",
+        lambda *args, **kwargs: Adapter(),
+    )
+
+    response = client.post(
+        "/api/plan/reconciliation/resolve",
+        json={
+            "reconciliation_id": reconciliation_id,
+            "action": "restore_praxys",
+        },
+    )
+
+    assert response.status_code == expected_status, response.text
+    assert calls == {"create": 0, "delete": 0}
+    with db_session.SessionLocal() as db:
+        delivery = db.get(PlanDelivery, delivery_id)
+        if scenario != "safe":
+            assert "still present" in response.json()["detail"]
+            assert delivery.state == "conflict"
+            assert delivery.external_id is None
+            assert "schedule_id" not in delivery.provider_references
+        else:
+            assert response.json()["external_id"] == external_id
+            assert delivery.state == "synced"
+            assert delivery.external_id == external_id
+            assert (
+                delivery.provider_references["schedule_id"]
+                == external_id
+            )
+
+
 def test_restore_does_not_claim_unowned_garmin_fingerprint_candidate(
     api_client,
     monkeypatch,


### PR DESCRIPTION
## Summary
- allow Garmin conflict resolution to bind a safely checkpointed `returned_schedule_id` after calendar readback confirms the same account, date, and content
- require scheduling to have started, the returned ID to be absent from the pre-mutation set, and no unexpected-date marker
- keep pre-existing, wrong-date, and mismatched observed schedules fail-closed with no provider mutation
- document that manual conflict recovery uses the same ownership fence as adapter recovery

## Testing
- `python -m pytest tests/ -q` (1882 passed, 2 skipped)