### PR TITLE
Fix cloud Praxys MCP startup directory

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -64,6 +64,12 @@ jobs:
         # npm v11 strict ci — same reason as .github/workflows/i18n.yml.
         run: npm install --no-audit --no-fund
 
+      - name: Install Praxys cloud MCP launcher
+        run: >-
+          sudo install -m 0755
+          scripts/run_praxys_mcp_cloud.sh
+          /usr/local/bin/praxys-local-mcp
+
       - name: Prepare browser and synthetic Praxys MCP tools
         env:
           PRAXYS_MCP_USE_CURRENT_PYTHON: '1'
@@ -71,4 +77,4 @@ jobs:
           google-chrome --version
           npx -y chrome-devtools-mcp@1.6.0 --version
           python -c "import mcp"
-          python -m scripts.run_praxys_mcp local --prepare-only
+          praxys-local-mcp --prepare-only

--- a/config/copilot-cloud-mcp.json
+++ b/config/copilot-cloud-mcp.json
@@ -44,12 +44,8 @@
     },
     "praxys-local": {
       "type": "stdio",
-      "command": "python",
-      "args": [
-        "-m",
-        "scripts.run_praxys_mcp",
-        "local"
-      ],
+      "command": "praxys-local-mcp",
+      "args": [],
       "env": {
         "PRAXYS_MCP_USE_CURRENT_PYTHON": "1"
       },

--- a/docs/dev/ui-quality-harness.md
+++ b/docs/dev/ui-quality-harness.md
@@ -145,7 +145,11 @@ cloud configuration adds Chrome DevTools plus only read-only tools from the
 synthetic `praxys-local` profile. It deliberately excludes `praxys-dev-test`,
 production authentication, provider connections, sync, and plan mutations.
 `copilot-setup-steps.yml` initializes the plugin submodule, installs its MCP
-runtime, verifies Chrome, and prepares the synthetic sample-data sandbox.
+runtime, verifies Chrome, prepares the synthetic sample-data sandbox, and
+installs a `praxys-local-mcp` launcher that changes to `GITHUB_WORKSPACE`.
+Cloud MCP processes do not reliably inherit the repository root as their
+working directory, so the cloud payload must use that installed launcher
+rather than invoke the repository Python module directly.
 
 Use Chrome/Playwright to judge the rendered experience. Use `praxys-local` only
 to inspect the product's sample-data semantics or expected view payloads.

--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -286,7 +286,8 @@ initialization must not overwrite its Python/Node test environment.
 - **Environment:** `.github/workflows/copilot-setup-steps.yml` initializes the
   plugin submodule, preinstalls Python + backend/Praxys MCP deps and Node/web,
   verifies Chrome DevTools MCP, prepares the synthetic local Praxys sandbox,
-  and bootstraps a throwaway `.env`. The agent can run `pytest`, `npm`, browser
+  installs the workspace-aware `praxys-local-mcp` cloud launcher, and
+  bootstraps a throwaway `.env`. The agent can run `pytest`, `npm`, browser
   review, and read-only product-context tools deterministically instead of
   rediscovering the toolchain. It only takes effect once on the default branch.
 - **UI quality harness:** a user-visible web/miniapp change must invoke

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -89,6 +89,14 @@ and synthetic sandbox preparation. The cloud config's literal
 prepared by `actions/setup-python`; local profiles continue to require the
 project virtualenv unless `PRAXYS_MCP_PYTHON` is explicitly set.
 
+The cloud agent's **Start MCP Servers** step does not guarantee the repository
+root as its working directory. The setup workflow therefore installs
+`scripts/run_praxys_mcp_cloud.sh` as `/usr/local/bin/praxys-local-mcp`. That
+launcher changes to `GITHUB_WORKSPACE` before starting the repository module.
+Keep the cloud payload pointed at the installed command; using
+`python -m scripts.run_praxys_mcp` directly can silently leave every
+`praxys-local` tool unregistered.
+
 Provision after the setup workflow is present on `main`:
 
 1. Copy `config/copilot-cloud-mcp.json` into the repository MCP configuration
@@ -101,8 +109,10 @@ Provision after the setup workflow is present on `main`:
      --jq '.mcp_configuration.mcpServers | keys'
    ```
 
-3. Assign a disposable test issue to Copilot, open **View session**, expand
-   **Start MCP Servers**, and confirm the allowlisted tools are present.
+3. Assign a disposable test issue to Copilot and ask it to call
+   `chrome-devtools/list_pages` and `praxys-local/whoami`. Open **View
+   session**, expand **Start MCP Servers**, and confirm both servers list their
+   allowlisted tools and both calls succeed.
 
 Rollback by removing the affected server from repository MCP settings and
 saving. Built-in Playwright remains available when Chrome DevTools is removed.

--- a/scripts/run_praxys_mcp_cloud.sh
+++ b/scripts/run_praxys_mcp_cloud.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace="${GITHUB_WORKSPACE:-}"
+if [[ -z "$workspace" ]]; then
+  echo "GITHUB_WORKSPACE is required to start praxys-local." >&2
+  exit 1
+fi
+
+launcher="$workspace/scripts/run_praxys_mcp.py"
+if [[ ! -f "$launcher" ]]; then
+  echo "Praxys MCP launcher not found at $launcher." >&2
+  exit 1
+fi
+
+cd "$workspace"
+exec python -m scripts.run_praxys_mcp local "$@"

--- a/tests/test_run_praxys_mcp.py
+++ b/tests/test_run_praxys_mcp.py
@@ -320,6 +320,50 @@ def test_repository_mcp_launcher_honors_python_override(
     assert marker["state"] == "ready"
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="The cloud MCP launcher targets GitHub's Linux runner.",
+)
+def test_cloud_mcp_launcher_uses_github_workspace(
+    tmp_path: Path,
+) -> None:
+    root = run_praxys_mcp.project_root()
+    bash = shutil.which("bash")
+    assert bash is not None
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "python").symlink_to(sys.executable)
+    data_dir = tmp_path / "cloud-launcher-sandbox"
+    env = os.environ.copy()
+    env["GITHUB_WORKSPACE"] = str(root)
+    env["PRAXYS_LOCAL_MCP_DATA_DIR"] = str(data_dir)
+    env["PRAXYS_MCP_USE_CURRENT_PYTHON"] = "1"
+    env["PATH"] = os.pathsep.join((str(bin_dir), env.get("PATH", "")))
+
+    result = subprocess.run(
+        [
+            bash,
+            str(root / "scripts" / "run_praxys_mcp_cloud.sh"),
+            "--prepare-only",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    marker = json.loads(
+        (data_dir / ".praxys-mcp-sandbox.json").read_text(
+            encoding="utf-8",
+        )
+    )
+    assert marker["owner"] == "praxys-local-mcp"
+    assert marker["state"] == "ready"
+
+
 @pytest.mark.parametrize("profile", ["..", "dev/test", r"dev\test"])
 def test_remote_profile_rejects_unsafe_names(profile: str) -> None:
     with pytest.raises(SystemExit, match="Profile names"):

--- a/tests/test_ui_quality_harness.py
+++ b/tests/test_ui_quality_harness.py
@@ -210,15 +210,25 @@ def test_ui_mcp_configs_are_pinned_and_cloud_safe():
         "lighthouse_audit",
         "resize_page",
     }.issubset(servers["chrome-devtools"]["tools"])
-    assert servers["praxys-local"]["env"] == {
+    cloud_praxys = servers["praxys-local"]
+    assert cloud_praxys["command"] == "praxys-local-mcp"
+    assert cloud_praxys["args"] == []
+    assert cloud_praxys["env"] == {
         "PRAXYS_MCP_USE_CURRENT_PYTHON": "1"
     }
     assert all(
         not tool.startswith(
             ("update_", "set_", "connect_", "disconnect_", "trigger_")
         )
-        for tool in servers["praxys-local"]["tools"]
+        for tool in cloud_praxys["tools"]
     )
+
+    wrapper = (
+        ROOT / "scripts" / "run_praxys_mcp_cloud.sh"
+    ).read_text(encoding="utf-8")
+    assert 'workspace="${GITHUB_WORKSPACE:-}"' in wrapper
+    assert 'cd "$workspace"' in wrapper
+    assert 'exec python -m scripts.run_praxys_mcp local "$@"' in wrapper
 
     setup = (
         ROOT / ".github" / "workflows" / "copilot-setup-steps.yml"
@@ -227,3 +237,5 @@ def test_ui_mcp_configs_are_pinned_and_cloud_safe():
     assert "plugins/praxys/mcp-server/requirements.txt" in setup
     assert "chrome-devtools-mcp@1.6.0 --version" in setup
     assert "PRAXYS_MCP_USE_CURRENT_PYTHON: '1'" in setup
+    assert "/usr/local/bin/praxys-local-mcp" in setup
+    assert "praxys-local-mcp --prepare-only" in setup


### PR DESCRIPTION
## Summary

- install a workspace-aware `praxys-local-mcp` launcher during Copilot setup
- point the reviewed cloud MCP payload at the installed launcher
- document the cloud working-directory boundary and cover the launcher/config wiring

## Root cause

Disposable cloud-agent validation in #559 successfully called `chrome-devtools/list_pages`, but `praxys-local` was absent from the registered tools. The cloud **Start MCP Servers** step does not guarantee the repository root as its working directory, while `python -m scripts.run_praxys_mcp local` requires that directory.

## Validation

- `python -m pytest tests/test_ui_quality_harness.py tests/test_run_praxys_mcp.py -q` — 21 passed, 1 platform skip
- shell, JSON, and workflow YAML syntax checks passed

## Operations

After merge, replace the repository MCP setting with the updated `config/copilot-cloud-mcp.json`, then repeat the disposable `list_pages` + `whoami` probe. The current saved setting intentionally remains unchanged until this runner fix is on `main`.