### PR TITLE
Use setup Python for cloud Praxys MCP

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -71,8 +71,6 @@ jobs:
           /usr/local/bin/praxys-local-mcp
 
       - name: Prepare browser and synthetic Praxys MCP tools
-        env:
-          PRAXYS_MCP_USE_CURRENT_PYTHON: '1'
         run: |
           google-chrome --version
           npx -y chrome-devtools-mcp@1.6.0 --version

--- a/config/copilot-cloud-mcp.json
+++ b/config/copilot-cloud-mcp.json
@@ -46,9 +46,6 @@
       "type": "stdio",
       "command": "praxys-local-mcp",
       "args": [],
-      "env": {
-        "PRAXYS_MCP_USE_CURRENT_PYTHON": "1"
-      },
       "tools": [
         "get_daily_brief",
         "get_training_review",

--- a/docs/dev/ui-quality-harness.md
+++ b/docs/dev/ui-quality-harness.md
@@ -148,8 +148,10 @@ production authentication, provider connections, sync, and plan mutations.
 runtime, verifies Chrome, prepares the synthetic sample-data sandbox, and
 installs a `praxys-local-mcp` launcher that changes to `GITHUB_WORKSPACE`.
 Cloud MCP processes do not reliably inherit the repository root as their
-working directory, so the cloud payload must use that installed launcher
-rather than invoke the repository Python module directly.
+working directory or pass the configured Python-selection environment, so the
+launcher also selects the interpreter prepared by `actions/setup-python`. The
+cloud payload must use that installed launcher rather than invoke the
+repository Python module directly.
 
 Use Chrome/Playwright to judge the rendered experience. Use `praxys-local` only
 to inspect the product's sample-data semantics or expected view payloads.

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -85,15 +85,17 @@ production tokens, provider credentials, sync tools, or plan-mutation tools to
 the cloud allowlist. `.github/workflows/copilot-setup-steps.yml` must remain the
 owner of the submodule checkout, MCP Python dependency, Chrome verification,
 and synthetic sandbox preparation. The cloud config's literal
-`PRAXYS_MCP_USE_CURRENT_PYTHON=1` tells the launcher to use the interpreter
-prepared by `actions/setup-python`; local profiles continue to require the
-project virtualenv unless `PRAXYS_MCP_PYTHON` is explicitly set.
+`praxys-local-mcp` command uses the interpreter prepared by
+`actions/setup-python`; local profiles continue to require the project
+virtualenv unless `PRAXYS_MCP_PYTHON` is explicitly set.
 
 The cloud agent's **Start MCP Servers** step does not guarantee the repository
 root as its working directory. The setup workflow therefore installs
 `scripts/run_praxys_mcp_cloud.sh` as `/usr/local/bin/praxys-local-mcp`. That
-launcher changes to `GITHUB_WORKSPACE` before starting the repository module.
-Keep the cloud payload pointed at the installed command; using
+launcher changes to `GITHUB_WORKSPACE` and exports
+`PRAXYS_MCP_USE_CURRENT_PYTHON=1` before starting the repository module. Keep
+the cloud payload pointed at the installed command; relying on an MCP `env`
+entry for the interpreter flag, or using
 `python -m scripts.run_praxys_mcp` directly can silently leave every
 `praxys-local` tool unregistered.
 

--- a/scripts/run_praxys_mcp_cloud.sh
+++ b/scripts/run_praxys_mcp_cloud.sh
@@ -14,4 +14,5 @@ if [[ ! -f "$launcher" ]]; then
 fi
 
 cd "$workspace"
+export PRAXYS_MCP_USE_CURRENT_PYTHON=1
 exec python -m scripts.run_praxys_mcp local "$@"

--- a/tests/test_run_praxys_mcp.py
+++ b/tests/test_run_praxys_mcp.py
@@ -337,7 +337,7 @@ def test_cloud_mcp_launcher_uses_github_workspace(
     env = os.environ.copy()
     env["GITHUB_WORKSPACE"] = str(root)
     env["PRAXYS_LOCAL_MCP_DATA_DIR"] = str(data_dir)
-    env["PRAXYS_MCP_USE_CURRENT_PYTHON"] = "1"
+    env.pop("PRAXYS_MCP_USE_CURRENT_PYTHON", None)
     env["PATH"] = os.pathsep.join((str(bin_dir), env.get("PATH", "")))
 
     result = subprocess.run(

--- a/tests/test_ui_quality_harness.py
+++ b/tests/test_ui_quality_harness.py
@@ -213,9 +213,7 @@ def test_ui_mcp_configs_are_pinned_and_cloud_safe():
     cloud_praxys = servers["praxys-local"]
     assert cloud_praxys["command"] == "praxys-local-mcp"
     assert cloud_praxys["args"] == []
-    assert cloud_praxys["env"] == {
-        "PRAXYS_MCP_USE_CURRENT_PYTHON": "1"
-    }
+    assert "env" not in cloud_praxys
     assert all(
         not tool.startswith(
             ("update_", "set_", "connect_", "disconnect_", "trigger_")
@@ -228,6 +226,7 @@ def test_ui_mcp_configs_are_pinned_and_cloud_safe():
     ).read_text(encoding="utf-8")
     assert 'workspace="${GITHUB_WORKSPACE:-}"' in wrapper
     assert 'cd "$workspace"' in wrapper
+    assert "export PRAXYS_MCP_USE_CURRENT_PYTHON=1" in wrapper
     assert 'exec python -m scripts.run_praxys_mcp local "$@"' in wrapper
 
     setup = (
@@ -236,6 +235,5 @@ def test_ui_mcp_configs_are_pinned_and_cloud_safe():
     assert "submodules: true" in setup
     assert "plugins/praxys/mcp-server/requirements.txt" in setup
     assert "chrome-devtools-mcp@1.6.0 --version" in setup
-    assert "PRAXYS_MCP_USE_CURRENT_PYTHON: '1'" in setup
     assert "/usr/local/bin/praxys-local-mcp" in setup
     assert "praxys-local-mcp --prepare-only" in setup


### PR DESCRIPTION
## Summary

- make the installed cloud launcher export `PRAXYS_MCP_USE_CURRENT_PYTHON=1`
- remove reliance on repository MCP `env` propagation
- exercise the Linux launcher test without that ambient variable

## Root cause

The post-#560 cloud diagnostic found `/usr/local/bin/praxys-local-mcp` and the correct `GITHUB_WORKSPACE`, but the process exited because `PRAXYS_MCP_USE_CURRENT_PYTHON` was absent and the launcher fell back to a nonexistent `.venv/bin/python`.

## Validation

- `python -m pytest tests/test_ui_quality_harness.py tests/test_run_praxys_mcp.py -q` — 21 passed, 1 platform skip
- shell, JSON, and workflow YAML syntax checks passed

## Operations

No secret is required. After merge, the existing saved MCP command remains valid; repasting the payload only removes the now-unnecessary `env` entry. A final disposable `list_pages` + `whoami` probe will verify registration.