### PR TITLE
Tune insight-generation time windows per insight type

### DIFF
--- a/api/ai.py
+++ b/api/ai.py
@@ -28,7 +28,13 @@ from analysis.metrics import is_hard_workout, is_rest_workout
 # ---------------------------------------------------------------------------
 
 
-def _build_context_from_data(data: dict, *, user_id: str | None = None, db=None) -> dict:
+def _build_context_from_data(
+    data: dict,
+    *,
+    user_id: str | None = None,
+    db=None,
+    recent_training_weeks: int = 8,
+) -> dict:
     """Reshape pre-computed dashboard data into AI training context.
 
     Accepts the dict returned by ``get_dashboard_data()`` and produces the
@@ -36,11 +42,15 @@ def _build_context_from_data(data: dict, *, user_id: str | None = None, db=None)
     ``get_dashboard_data()`` a second time when the caller already has the data
     (e.g. the ``/api/ai/context`` route).
 
-    Pass ``user_id`` + ``db`` for multi-user mode (the post-sync insight
-    runner) so that ``athlete_profile`` reflects the per-user config (zones,
-    training base, goal). Without them the legacy single-user
-    ``load_config()`` is used.
+    Pass ``user_id`` + ``db`` for multi-user mode so that
+    ``athlete_profile`` reflects the per-user config (zones, training base,
+    goal). ``recent_training_weeks`` defaults to the shared 8-week context;
+    insight generation may request a wider review window. Without database
+    arguments the legacy single-user ``load_config()`` is used.
     """
+    if recent_training_weeks < 1:
+        raise ValueError("recent_training_weeks must be at least 1")
+
     if user_id is not None and db is not None:
         config = load_config_from_db(user_id, db)
     else:
@@ -101,8 +111,8 @@ def _build_context_from_data(data: dict, *, user_id: str | None = None, db=None)
         "race_countdown": data.get("race_countdown", {}),
     }
 
-    # -- Recent training (up to 12 weeks for full build-cycle reviews) --
-    cutoff = (today - timedelta(weeks=12)).isoformat()
+    # -- Recent training --
+    cutoff = (today - timedelta(weeks=recent_training_weeks)).isoformat()
     all_activities = data.get("activities", [])
     recent_sessions = [
         a for a in all_activities
@@ -208,19 +218,31 @@ def _build_context_from_data(data: dict, *, user_id: str | None = None, db=None)
     }
 
 
-def build_training_context(user_id: str | None = None, db=None) -> dict:
+def build_training_context(
+    user_id: str | None = None,
+    db=None,
+    *,
+    recent_training_weeks: int = 8,
+) -> dict:
     """Build a structured training context dict for LLM plan generation.
 
     Calls ``get_dashboard_data()`` and reshapes the result into sections:
     athlete_profile, current_fitness, recent_training (with individual
     sessions + splits), recovery_state, and current_plan.
 
-    Pass ``user_id`` + ``db`` for multi-user mode (post-sync insight runner).
+    Pass ``user_id`` + ``db`` for multi-user mode. The default 8-week history
+    remains appropriate for plan generation and general consumers; callers
+    producing longer-range reviews can explicitly request a wider window.
     """
     from api.deps import get_dashboard_data
 
     data = get_dashboard_data(user_id=user_id, db=db)
-    return _build_context_from_data(data, user_id=user_id, db=db)
+    return _build_context_from_data(
+        data,
+        user_id=user_id,
+        db=db,
+        recent_training_weeks=recent_training_weeks,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/api/ai.py
+++ b/api/ai.py
@@ -101,8 +101,8 @@ def _build_context_from_data(data: dict, *, user_id: str | None = None, db=None)
         "race_countdown": data.get("race_countdown", {}),
     }
 
-    # -- Recent training (last 8 weeks of individual sessions + splits) --
-    cutoff = (today - timedelta(weeks=8)).isoformat()
+    # -- Recent training (up to 12 weeks for full build-cycle reviews) --
+    cutoff = (today - timedelta(weeks=12)).isoformat()
     all_activities = data.get("activities", [])
     recent_sessions = [
         a for a in all_activities

--- a/api/insights_generator.py
+++ b/api/insights_generator.py
@@ -203,7 +203,8 @@ def _frame_intro(context: dict) -> str:
 def _training_review_system(context: dict) -> str:
     return (
         _frame_intro(context)
-        + "\n\nYou will receive up to 12 weeks of training sessions (date, distance, "
+        + "\n\nYou will receive a rolling review window capped at 12 weeks of "
+        "training sessions (date, distance, "
         "RSS, duration), weekly aggregates, and a deterministic diagnosis whose "
         "intensity fields come only from timestamped samples or activity splits. "
         "Produce a diagnosis: headline names the dominant pattern, summary explains "

--- a/api/insights_generator.py
+++ b/api/insights_generator.py
@@ -203,7 +203,7 @@ def _frame_intro(context: dict) -> str:
 def _training_review_system(context: dict) -> str:
     return (
         _frame_intro(context)
-        + "\n\nYou will receive 6-8 weeks of training sessions (date, distance, "
+        + "\n\nYou will receive up to 12 weeks of training sessions (date, distance, "
         "RSS, duration), weekly aggregates, and a deterministic diagnosis whose "
         "intensity fields come only from timestamped samples or activity splits. "
         "Produce a diagnosis: headline names the dominant pattern, summary explains "

--- a/api/insights_runner.py
+++ b/api/insights_runner.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 GENERATORS_ORDER = ("training_review", "race_forecast")
+INSIGHT_CONTEXT_LOOKBACK_WEEKS = 12
 _RUN_LOCKS = tuple(threading.Lock() for _ in range(64))
 
 
@@ -145,7 +146,11 @@ def _run(db: Session, user_id: str) -> dict:
             revisions_before = get_revisions(db, user_id, SCOPES)
             cfg = load_config_from_db(user_id, db)
             pillars = dict(getattr(cfg, "science", {}) or {})
-            context = build_training_context(user_id=user_id, db=db)
+            context = build_training_context(
+                user_id=user_id,
+                db=db,
+                recent_training_weeks=INSIGHT_CONTEXT_LOOKBACK_WEEKS,
+            )
             source_revisions = get_revisions(db, user_id, SCOPES)
             if run_date == date.today() and revisions_before == source_revisions:
                 break

--- a/tests/test_ai_plan.py
+++ b/tests/test_ai_plan.py
@@ -275,7 +275,32 @@ class TestPlannedTodayContext:
             "alternatives": ["Walk only"],
         }
 
-    def test_recent_training_keeps_at_most_twelve_weeks(self, monkeypatch):
+    def test_recent_training_defaults_to_eight_weeks(self, monkeypatch):
+        from api.ai import _build_context_from_data
+        from analysis.config import UserConfig
+
+        monkeypatch.setattr("api.ai.load_config", lambda: UserConfig())
+        today = date.today()
+        data = self._empty_data([])
+        data["activities"] = [
+            {
+                "date": (today - timedelta(weeks=7)).isoformat(),
+                "distance_km": 10.0,
+                "rss": 50.0,
+            },
+            {
+                "date": (today - timedelta(weeks=9)).isoformat(),
+                "distance_km": 20.0,
+                "rss": 100.0,
+            },
+        ]
+
+        recent = _build_context_from_data(data)["recent_training"]
+
+        assert [session["distance_km"] for session in recent["sessions"]] == [10.0]
+        assert sum(week["sessions"] for week in recent["weekly_summary"]) == 1
+
+    def test_recent_training_can_expand_to_twelve_weeks(self, monkeypatch):
         from api.ai import _build_context_from_data
         from analysis.config import UserConfig
 
@@ -295,10 +320,25 @@ class TestPlannedTodayContext:
             },
         ]
 
-        recent = _build_context_from_data(data)["recent_training"]
+        recent = _build_context_from_data(
+            data,
+            recent_training_weeks=12,
+        )["recent_training"]
 
         assert [session["distance_km"] for session in recent["sessions"]] == [10.0]
         assert sum(week["sessions"] for week in recent["weekly_summary"]) == 1
+
+    def test_recent_training_rejects_invalid_window(self, monkeypatch):
+        from api.ai import _build_context_from_data
+        from analysis.config import UserConfig
+
+        monkeypatch.setattr("api.ai.load_config", lambda: UserConfig())
+
+        with pytest.raises(ValueError, match="must be at least 1"):
+            _build_context_from_data(
+                self._empty_data([]),
+                recent_training_weeks=0,
+            )
 
     def test_readiness_comes_from_recovery_analysis(self, monkeypatch):
         """Readiness is not part of the signal's display projection."""

--- a/tests/test_ai_plan.py
+++ b/tests/test_ai_plan.py
@@ -275,6 +275,31 @@ class TestPlannedTodayContext:
             "alternatives": ["Walk only"],
         }
 
+    def test_recent_training_keeps_at_most_twelve_weeks(self, monkeypatch):
+        from api.ai import _build_context_from_data
+        from analysis.config import UserConfig
+
+        monkeypatch.setattr("api.ai.load_config", lambda: UserConfig())
+        today = date.today()
+        data = self._empty_data([])
+        data["activities"] = [
+            {
+                "date": (today - timedelta(weeks=11)).isoformat(),
+                "distance_km": 10.0,
+                "rss": 50.0,
+            },
+            {
+                "date": (today - timedelta(weeks=13)).isoformat(),
+                "distance_km": 20.0,
+                "rss": 100.0,
+            },
+        ]
+
+        recent = _build_context_from_data(data)["recent_training"]
+
+        assert [session["distance_km"] for session in recent["sessions"]] == [10.0]
+        assert sum(week["sessions"] for week in recent["weekly_summary"]) == 1
+
     def test_readiness_comes_from_recovery_analysis(self, monkeypatch):
         """Readiness is not part of the signal's display projection."""
         from api.ai import _build_context_from_data

--- a/tests/test_insights_generator.py
+++ b/tests/test_insights_generator.py
@@ -233,6 +233,8 @@ def test_race_forecast_returns_payload(monkeypatch):
     assert payload is not None
     user_msg = json.loads(fake.chat.completions.last_call["messages"][1]["content"])
     assert user_msg["goal"]["target_time_sec"] == 10800
+    assert "recent_training" not in user_msg
+    assert "sessions" not in user_msg
 
 
 def test_system_prompt_cites_pillar_names_by_name(monkeypatch):

--- a/tests/test_insights_runner.py
+++ b/tests/test_insights_runner.py
@@ -171,6 +171,28 @@ def test_skips_when_no_new_rows(db_session, stub_context, stub_pillars):
     assert db_session.query(AiInsight).count() == 0
 
 
+def test_requests_twelve_week_context_for_insight_reviews(
+    db_session, stub_context, stub_pillars, monkeypatch,
+):
+    captured: dict = {}
+
+    def _build_context(**kwargs):
+        captured.update(kwargs)
+        return stub_context
+
+    monkeypatch.setattr("api.ai.build_training_context", _build_context)
+    monkeypatch.setattr(llm, "get_client", lambda: None)
+
+    insights_runner.run_insights_for_user(
+        USER_ID,
+        db_session,
+        {"activities": 1},
+        _session=db_session,
+    )
+
+    assert captured["recent_training_weeks"] == 12
+
+
 def test_generates_both_durable_insights_when_hash_differs(
     db_session, stub_context, stub_pillars, monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- keep the shared training and plan-generation context at its existing 8-week default
- let the post-sync insight runner explicitly request a rolling review window capped at 12 weeks
- align the training-review prompt with that review ceiling
- lock race forecasts to goal and fitness inputs without raw session history
- preserve the deterministic daily brief path, which sends no session history to an LLM

The 12-week value is an insight-review ceiling, not a recommendation for managed-plan duration.

Closes #219

## Validation

- `.venv\Scripts\python.exe -m pytest tests\test_ai_plan.py tests\test_insights_generator.py tests\test_insights_runner.py -q` — 74 passed
- `.venv\Scripts\python.exe -m pytest tests\` — 1889 passed, 3 skipped, 4 unrelated failures:
  - `tests/test_garmin_token_isolation.py::test_startup_preserves_plaintext_when_encryption_key_is_ephemeral`
  - two `tests/test_mcp_managed_plan_integration.py` failures associated with the pre-existing modified `plugins/praxys` submodule
  - `tests/test_ui_quality_harness.py::test_ui_mcp_configs_are_pinned_and_cloud_safe`
