### PR TITLE
Validate AI-native operations runbooks

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Validate selective-review promotions
         run: python scripts/validate_review_policy.py
 
+      - name: Validate AI-native operations runbooks
+        run: python scripts/validate_ops_runbooks.py
+
   web-build:
     name: web-build
     runs-on: ubuntu-latest

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -9,6 +9,8 @@ diagnose X". It complements — and links out to — the setup-oriented
 > one-line *Summary*, a **Use when** line, then `Prerequisites · Steps · Verify ·
 > Rollback / Recovery · Related`. Parse the **Use when** line of each runbook in
 > the index below to route a task; the `## Steps` blocks are copy-pasteable.
+> Runbooks with bounded autonomous actions also carry a validated hybrid machine
+> block described in [`ai/README.md`](./ai/README.md).
 
 ## Runbook index
 
@@ -51,12 +53,18 @@ Full detail: [environment.md](./environment.md).
 - Ground every claim in the repo or Azure reality — link the source file/workflow.
 - Commands are copy-pasteable (`az` / `gh` / KQL). Note the auth each step needs.
 - Mark anything not yet verified with `TODO(owner)` rather than guessing.
+- Keep destructive or judgment-heavy procedures prose-only. Structured actions
+  must resolve through [`ai/tool-registry.yaml`](./ai/tool-registry.yaml), state
+  their policy tier, and provide deterministic verification signals.
 
 ## Coverage & roadmap
 
-Incident response, backup/restore, DR, secret rotation, scaling/cost, and sync
-troubleshooting now have runbooks. Remaining open items (on-call/escalation
-definitions, RPO/RTO targets, the Key Vault re-wrap drill, optionally exposing
-runbooks as a `plugins/praxys` skill) are tracked in **praxys-run/praxys#338** and
-flagged inline as `TODO(@dddtc2005)`. Add new runbooks against
-[`_TEMPLATE.md`](./_TEMPLATE.md) and link them from the index above.
+Incident response now validates the first hybrid AI-native runbook schema and
+generates route evaluation fixtures in CI. Severity and escalation ownership
+are defined without publishing private contacts. Production restore timing,
+Key Vault re-wrap, and permanent cost/scale commitments remain explicitly
+deferred at their runbooks because each needs operator approval or production
+tooling; no value is guessed. Runbooks stay repository-owned rather than being
+duplicated into `plugins/praxys` until the contract has at least two autonomous
+consumers. Add new runbooks against [`_TEMPLATE.md`](./_TEMPLATE.md) and link
+them from the index above.

--- a/docs/ops/_TEMPLATE.md
+++ b/docs/ops/_TEMPLATE.md
@@ -3,6 +3,12 @@
 > **Summary:** <one sentence: what this runbook accomplishes.>
 > **Use when:** <the trigger — the task you're doing or the symptom you see.>
 
+<!--
+For a runbook with bounded autonomous actions, add one fenced `ops-runbook`
+YAML block here. Follow docs/ops/ai/README.md and regenerate its eval fixture.
+Escalation-only runbooks should not add a machine block.
+-->
+
 ## Prerequisites
 
 - <Access / role needed, e.g. Contributor on `rg-trainsight`, repo admin, `az login`.>

--- a/docs/ops/ai/README.md
+++ b/docs/ops/ai/README.md
@@ -1,0 +1,41 @@
+# AI-native runbook contract
+
+Praxys uses a **hybrid runbook** format for operational procedures that an
+incident agent may execute. Human-first Markdown remains the source of
+judgment, caveats, escalation guidance, and novel-situation reasoning. A fenced
+`ops-runbook` YAML block in the same file supplies the deterministic skeleton:
+
+- signals the agent can observe;
+- routes from observations to hypotheses and actions;
+- policy-scoped actions;
+- verification signals and the escalation exit.
+
+Only runbooks with bounded autonomous actions need this block. Destructive or
+operator-judgment procedures such as disaster recovery, secret rotation, and
+scaling remain prose-only.
+
+## Validation
+
+`python scripts/validate_ops_runbooks.py` checks every structured block against
+[`tool-registry.yaml`](./tool-registry.yaml), rejects unresolved tools, signals,
+actions, verification checks, or policy tiers, and verifies that committed eval
+fixtures match the routes.
+
+After changing a route, regenerate fixtures:
+
+```bash
+python scripts/validate_ops_runbooks.py --write-fixtures
+```
+
+Fixtures under [`evals/`](./evals/) turn each route's observations into an
+expected action and verification set. They are deliberately simple regression
+oracles: richer incident-agent evaluations can consume them without maintaining
+a second hand-authored decision tree.
+
+## Packaging decision
+
+Runbooks are not currently duplicated into `plugins/praxys`. That plugin is a
+separate public repository and packaging a single pilot there would create a
+second versioned artifact before retrieval semantics are stable. Agent
+retrieval should read these repository-owned artifacts directly; reconsider a
+plugin skill after at least two autonomous runbooks share this contract.

--- a/docs/ops/ai/evals/incident-response.json
+++ b/docs/ops/ai/evals/incident-response.json
@@ -1,0 +1,64 @@
+{
+  "cases": [
+    {
+      "expected": {
+        "action": "restart-backend",
+        "on_failure": "escalate",
+        "verify": [
+          "api-health",
+          "api-ready"
+        ]
+      },
+      "id": "backend-unhealthy",
+      "observations": [
+        {
+          "outcome": "failure",
+          "signal": "api-health"
+        }
+      ]
+    },
+    {
+      "expected": {
+        "action": "restart-frontend",
+        "on_failure": "escalate",
+        "verify": [
+          "frontend-health"
+        ]
+      },
+      "id": "frontend-unhealthy",
+      "observations": [
+        {
+          "outcome": "success",
+          "signal": "api-health"
+        },
+        {
+          "outcome": "failure",
+          "signal": "frontend-health"
+        }
+      ]
+    },
+    {
+      "expected": {
+        "action": "restart-backend",
+        "on_failure": "escalate",
+        "verify": [
+          "api-ready",
+          "api-health"
+        ]
+      },
+      "id": "database-unready",
+      "observations": [
+        {
+          "outcome": "success",
+          "signal": "api-health"
+        },
+        {
+          "outcome": "failure",
+          "signal": "api-ready"
+        }
+      ]
+    }
+  ],
+  "runbook": "incident-response",
+  "schema_version": 1
+}

--- a/docs/ops/ai/tool-registry.yaml
+++ b/docs/ops/ai/tool-registry.yaml
@@ -1,0 +1,20 @@
+version: 1
+
+# Stable capabilities that structured runbook blocks may reference. This is a
+# validation registry, not an authorization grant: the incident agent's policy
+# still decides whether a referenced action may execute.
+tools:
+  http.get:
+    kind: signal
+    executor: shell
+  azure.appservice.show:
+    kind: signal
+    executor: azure
+  azure.appservice.restart:
+    kind: action
+    executor: azure
+
+policies:
+  - observe
+  - autonomous-reversible
+  - human-approval

--- a/docs/ops/backup-and-restore.md
+++ b/docs/ops/backup-and-restore.md
@@ -171,9 +171,19 @@ in code / docs as of the WAL-corruption incident):
 **Take a snapshot before every risky deploy** (this incident had no backup):
 `sqlite3 trainsight.db ".backup '/home/data/backups/pre-deploy-<ts>.db'"`.
 
+## Deferred operator decision
+
+The managed Postgres retention remains 14 days and PITR is the current recovery
+mechanism. A timed production restore drill is intentionally not performed by a
+documentation or CI change: it provisions a billable clone and requires an
+operator-selected maintenance window plus production access. Record the start
+time, restored timestamp, readiness time, data checks, and cleanup time here
+when that window is approved; until then the RTO is **unvalidated**, not
+estimated.
+
 ## Related
 
 - [disaster-recovery.md](./disaster-recovery.md) · [deploy.md](./deploy.md) · `db/session.py` (`init_db`, `_SQLITE_PRAGMAS`)
 
 ---
-_Last reviewed: 2026-06-30 · Owner: @dddtc2005 · TODO(@dddtc2005): pick a backup cadence + retention and (optionally) automate it._
+_Last reviewed: 2026-08-06 · Owner: @dddtc2005_

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -806,7 +806,7 @@ outgrown.
 | Frontend/backend Application Insights routing | Provision the replacement component, update `.github/azure-observability.env`, grant backend MI RBAC if needed, and re-deploy | The workflows fetch fresh routing strings directly from Azure; no GitHub value rotates. |
 | Feedback GitHub App key (`PRAXYS_GITHUB_APP_PRIVATE_KEY`) | Generate a new private key on the app, update the secret, re-deploy (rarely needed). Setup: [setup-github-app.md](./setup-github-app.md). | Issue auto-filing dormant until updated; rest of app unaffected. |
 | SMTP auth code (`PRAXYS_SMTP_PASSWORD`) | Regenerate the 客户端授权码 in the Exmail/WeCom mailbox settings, update the GitHub secret, re-deploy. | Verification + invitation emails fail to send until updated (codes can still be copied by hand). |
-| Key Vault RSA key `trainsight-master-key` | ⚠️ **High-impact** — the per-user DEKs were wrapped with the current key; rotating without a re-wrap/re-encrypt migration makes stored platform credentials undecryptable. **TODO(@dddtc2005):** document the re-wrap drill before rotating. | Users would have to reconnect platforms. |
+| Key Vault RSA key `trainsight-master-key` | ⚠️ **High-impact** — the per-user DEKs were wrapped with the current key; rotating without a re-wrap/re-encrypt migration makes stored platform credentials undecryptable. Treat as non-rotatable until the migration tool and operator-approved drill in [secret-rotation.md](./secret-rotation.md) exist. | Users would have to reconnect platforms. |
 
 ## Related
 

--- a/docs/ops/cost-and-scaling.md
+++ b/docs/ops/cost-and-scaling.md
@@ -10,7 +10,7 @@
   ```bash
   az consumption budget create --budget-name praxys-monthly \
     --amount 50 --time-grain Monthly --category Cost \
-    --resource-group rg-trainsight   # adjust amount; add notifications in the portal
+    --resource-group rg-trainsight   # provisional guardrail; add notifications in the portal
   ```
 - **LLM spend** is the main variable cost. Track it via the `praxys.coach_tokens`
   signal ([monitoring-and-alerts.md](./monitoring-and-alerts.md)) and the per-user
@@ -71,9 +71,18 @@ the cap.
 `az appservice plan show -n plan-trainsight -g rg-trainsight --query sku`.
 Watch CPU/memory in the App Service "Metrics" blade after the change.
 
+## Deferred operator decision
+
+The `$50/month` example is a provisional guardrail, not an approved business
+budget. A permanent amount and numeric scale-up thresholds require an owner to
+review at least 30 days of Azure cost, CPU, memory, p95 latency, database
+connections, and active-user telemetry. Until then, scaling remains a human
+decision using the checks above; an agent may observe and recommend but must not
+change the SKU or worker count.
+
 ## Related
 
 - [monitoring-and-alerts.md](./monitoring-and-alerts.md) · [environment.md](./environment.md)
 
 ---
-_Last reviewed: 2026-07-04 · Owner: @dddtc2005 · TODO(@dddtc2005): set the real budget amount (when-to-scale thresholds now documented above)._
+_Last reviewed: 2026-08-06 · Owner: @dddtc2005_

--- a/docs/ops/disaster-recovery.md
+++ b/docs/ops/disaster-recovery.md
@@ -15,7 +15,9 @@ This runbook is a checklist that chains the others - it doesn't duplicate them.
   - **SQLite (legacy):** the backup cadence (pre-deploy + daily on-demand
     snapshots), so up to ~24h between scheduled snapshots.
 - **RTO** (max acceptable downtime) = provisioning + restore time.
-  **TODO(@dddtc2005): decide** a target and time a drill.
+  No target is claimed until a timed restore drill is run; the current RTO is
+  explicitly **unvalidated**. The drill requires an operator-approved Azure
+  maintenance window because it creates and verifies replacement resources.
 
 ## Steps
 
@@ -55,4 +57,4 @@ see their historical data; a sync succeeds.
   · [secret-rotation.md](./secret-rotation.md)
 
 ---
-_Last reviewed: 2026-07-04 · Owner: @dddtc2005 · TODO(@dddtc2005): run a restore drill and record real RPO/RTO._
+_Last reviewed: 2026-08-06 · Owner: @dddtc2005_

--- a/docs/ops/incident-response.md
+++ b/docs/ops/incident-response.md
@@ -3,6 +3,100 @@
 > **Summary:** First-response triage for "the app is down / erroring".
 > **Use when:** Health checks fail, users report outages, or alerts fire.
 
+```ops-runbook
+version: 1
+id: incident-response
+autonomy: bounded
+summary: Restore backend or frontend availability with reversible restarts.
+signals:
+  - id: api-health
+    tool: http.get
+    policy: observe
+    command: curl -fsS https://api.praxys.run/api/health
+    success:
+      stdout_contains: '"status":"ok"'
+  - id: api-ready
+    tool: http.get
+    policy: observe
+    command: curl -fsS https://api.praxys.run/api/health/ready
+    success:
+      exit_code: 0
+  - id: frontend-health
+    tool: http.get
+    policy: observe
+    command: curl -fsS https://www.praxys.run/healthz
+    success:
+      exit_code: 0
+  - id: backend-state
+    tool: azure.appservice.show
+    policy: observe
+    command: az webapp show -n trainsight-app -g rg-trainsight --query state -o tsv
+    success:
+      stdout_equals: Running
+actions:
+  - id: restart-backend
+    tool: azure.appservice.restart
+    policy: autonomous-reversible
+    command: az webapp restart -n trainsight-app -g rg-trainsight
+    rationale: Clears a failed or wedged API process without changing data or configuration.
+  - id: restart-frontend
+    tool: azure.appservice.restart
+    policy: autonomous-reversible
+    command: az webapp restart -n praxys-frontend -g rg-trainsight
+    rationale: Recycles the static frontend host without changing data or configuration.
+routes:
+  - id: backend-unhealthy
+    when:
+      - signal: api-health
+        outcome: failure
+    hypothesis: The backend process is stopped, crashed, or wedged.
+    action: restart-backend
+    verify:
+      - api-health
+      - api-ready
+    on_failure: escalate
+  - id: frontend-unhealthy
+    when:
+      - signal: api-health
+        outcome: success
+      - signal: frontend-health
+        outcome: failure
+    hypothesis: The frontend App Service is stopped or unhealthy while the API is available.
+    action: restart-frontend
+    verify:
+      - frontend-health
+    on_failure: escalate
+  - id: database-unready
+    when:
+      - signal: api-health
+        outcome: success
+      - signal: api-ready
+        outcome: failure
+    hypothesis: The API process is live but cannot reach the database.
+    action: restart-backend
+    verify:
+      - api-ready
+      - api-health
+    on_failure: escalate
+```
+
+The structured block permits only reversible App Service restarts. PostgreSQL
+restart, restore, rollback, configuration changes, and data operations require
+human approval even when the prose below recommends them.
+
+## Severity and ownership
+
+| Severity | Definition | Handling |
+|---|---|---|
+| SEV-1 | Broad service outage, active data-loss risk, or authentication unavailable for most users. | The operator receiving the `praxys-feedback-ag` action-group alert owns first response; publish a status incident and escalate to `@dddtc2005` before any destructive or data-changing action. |
+| SEV-2 | Material degradation or one platform failing for multiple users while core service remains usable. | Operator investigates during the current operating window and escalates if the blast radius grows or no safe mitigation exists. |
+| SEV-3 | Isolated user issue, non-urgent defect, or alert requiring follow-up but no active service impact. | Track in GitHub and handle through the normal change loop. |
+
+There is no staffed 24x7 rotation yet. The Azure action group is the routing
+source of truth; private contact details stay in Azure rather than this public
+repository. If the owner cannot be reached, preserve data, avoid non-reversible
+actions, update the status page, and leave the incident escalated.
+
 ## Quick triage
 
 ```bash
@@ -113,4 +207,4 @@ user dashboard.
 - [deploy.md](./deploy.md) · [sync-troubleshooting.md](./sync-troubleshooting.md) · [monitoring-and-alerts.md](./monitoring-and-alerts.md)
 
 ---
-_Last reviewed: 2026-07-05 · Owner: @dddtc2005 · TODO(@dddtc2005): define severity levels + escalation contacts._
+_Last reviewed: 2026-08-06 · Owner: @dddtc2005_

--- a/docs/ops/secret-rotation.md
+++ b/docs/ops/secret-rotation.md
@@ -56,9 +56,12 @@ Rotate ~every 90 days (calendar it). See [change-loop.md](./change-loop.md) §3.
 user's data-encryption key; rotating without a re-wrap migration makes stored
 platform credentials undecryptable (users would have to reconnect platforms).
 
-**TODO(@dddtc2005):** document + script the re-wrap drill (enumerate users,
-unwrap DEK with the old key version, re-wrap with the new) before any rotation.
-Until then, treat this key as non-rotatable.
+The re-wrap drill is intentionally deferred until a reviewed migration tool can
+enumerate each encrypted credential, unwrap its DEK with the old key version,
+re-wrap with the new version, verify decryption, and roll back atomically.
+Documentation alone cannot validate that invariant against production
+ciphertext. Until that tooling and an operator-approved maintenance window
+exist, treat this key as **non-rotatable** and escalate every rotation request.
 
 ## OIDC (`AZURE_CLIENT_ID` / federated credential)
 
@@ -70,4 +73,4 @@ rotate trust, update the federated credential subject; see `docs/deployment.md`.
 - [config-and-secrets.md](./config-and-secrets.md) (where each lives) · [deploy.md](./deploy.md)
 
 ---
-_Last reviewed: 2026-06-30 · Owner: @dddtc2005_
+_Last reviewed: 2026-08-06 · Owner: @dddtc2005_

--- a/scripts/validate_ops_runbooks.py
+++ b/scripts/validate_ops_runbooks.py
@@ -1,0 +1,249 @@
+"""Validate AI-native operations runbooks and their generated eval fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OPS_DIR = ROOT / "docs" / "ops"
+AI_DIR = OPS_DIR / "ai"
+REGISTRY_PATH = AI_DIR / "tool-registry.yaml"
+EVAL_DIR = AI_DIR / "evals"
+BLOCK_PATTERN = re.compile(r"```ops-runbook\s*\n(.*?)\n```", re.DOTALL)
+REQUIRED_TOP_LEVEL = {
+    "version",
+    "id",
+    "autonomy",
+    "summary",
+    "signals",
+    "actions",
+    "routes",
+}
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> dict[str, Any]:
+    """Load the structured runbook tool and policy registry."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: registry must be a mapping")
+    return data
+
+
+def extract_runbook(path: Path) -> dict[str, Any] | None:
+    """Return the single structured runbook block from a Markdown file."""
+    matches = BLOCK_PATTERN.findall(path.read_text(encoding="utf-8"))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError(f"{path}: expected one ops-runbook block, found {len(matches)}")
+    data = yaml.safe_load(matches[0])
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: ops-runbook block must be a mapping")
+    return data
+
+
+def _indexed(items: Any, field: str, context: str, errors: list[str]) -> dict[str, Any]:
+    if not isinstance(items, list):
+        errors.append(f"{context}: must be a list")
+        return {}
+    indexed: dict[str, Any] = {}
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"{context}[{index}]: must be a mapping")
+            continue
+        item_id = item.get(field)
+        if not isinstance(item_id, str) or not item_id:
+            errors.append(f"{context}[{index}].{field}: must be a non-empty string")
+            continue
+        if item_id in indexed:
+            errors.append(f"{context}: duplicate {field} {item_id!r}")
+        indexed[item_id] = item
+    return indexed
+
+
+def validate_runbook(
+    runbook: dict[str, Any],
+    registry: dict[str, Any],
+    source: str,
+) -> list[str]:
+    """Validate references and policy boundaries in one runbook block."""
+    errors: list[str] = []
+    missing = REQUIRED_TOP_LEVEL - runbook.keys()
+    if missing:
+        errors.append(f"{source}: missing fields: {', '.join(sorted(missing))}")
+
+    if runbook.get("version") != registry.get("version"):
+        errors.append(f"{source}: version must match registry version")
+    if runbook.get("autonomy") != "bounded":
+        errors.append(f"{source}: autonomy must be 'bounded'")
+
+    tools = registry.get("tools", {})
+    policies = set(registry.get("policies", []))
+    if not isinstance(tools, dict):
+        errors.append("registry tools must be a mapping")
+        tools = {}
+
+    signals = _indexed(runbook.get("signals"), "id", f"{source}.signals", errors)
+    actions = _indexed(runbook.get("actions"), "id", f"{source}.actions", errors)
+    routes = _indexed(runbook.get("routes"), "id", f"{source}.routes", errors)
+
+    for signal_id, signal in signals.items():
+        tool_id = signal.get("tool")
+        tool = tools.get(tool_id)
+        if not isinstance(tool, dict) or tool.get("kind") != "signal":
+            errors.append(f"{source}.signals.{signal_id}: unknown signal tool {tool_id!r}")
+        if signal.get("policy") != "observe":
+            errors.append(f"{source}.signals.{signal_id}: policy must be 'observe'")
+        if not isinstance(signal.get("command"), str) or not signal["command"].strip():
+            errors.append(f"{source}.signals.{signal_id}: command is required")
+        if not isinstance(signal.get("success"), dict):
+            errors.append(f"{source}.signals.{signal_id}: success oracle is required")
+
+    for action_id, action in actions.items():
+        tool_id = action.get("tool")
+        tool = tools.get(tool_id)
+        if not isinstance(tool, dict) or tool.get("kind") != "action":
+            errors.append(f"{source}.actions.{action_id}: unknown action tool {tool_id!r}")
+        policy = action.get("policy")
+        if policy not in policies:
+            errors.append(f"{source}.actions.{action_id}: unknown policy {policy!r}")
+        if policy != "autonomous-reversible":
+            errors.append(
+                f"{source}.actions.{action_id}: pilot actions must be autonomous-reversible"
+            )
+        if not isinstance(action.get("command"), str) or not action["command"].strip():
+            errors.append(f"{source}.actions.{action_id}: command is required")
+
+    for route_id, route in routes.items():
+        observations = route.get("when")
+        if not isinstance(observations, list) or not observations:
+            errors.append(f"{source}.routes.{route_id}: when must be a non-empty list")
+            observations = []
+        for index, observation in enumerate(observations):
+            if not isinstance(observation, dict):
+                errors.append(f"{source}.routes.{route_id}.when[{index}]: must be a mapping")
+                continue
+            signal_id = observation.get("signal")
+            if signal_id not in signals:
+                errors.append(
+                    f"{source}.routes.{route_id}.when[{index}]: "
+                    f"unknown signal {signal_id!r}"
+                )
+            if observation.get("outcome") not in {"success", "failure"}:
+                errors.append(
+                    f"{source}.routes.{route_id}.when[{index}]: "
+                    "outcome must be success or failure"
+                )
+
+        action_id = route.get("action")
+        if action_id not in actions:
+            errors.append(f"{source}.routes.{route_id}: unknown action {action_id!r}")
+        verify = route.get("verify")
+        if not isinstance(verify, list) or not verify:
+            errors.append(f"{source}.routes.{route_id}: verify must be a non-empty list")
+        else:
+            for signal_id in verify:
+                if signal_id not in signals:
+                    errors.append(
+                        f"{source}.routes.{route_id}: unknown verify signal {signal_id!r}"
+                    )
+        if route.get("on_failure") != "escalate":
+            errors.append(f"{source}.routes.{route_id}: on_failure must be 'escalate'")
+        if not isinstance(route.get("hypothesis"), str) or not route["hypothesis"].strip():
+            errors.append(f"{source}.routes.{route_id}: hypothesis is required")
+
+    return errors
+
+
+def build_eval_fixture(runbook: dict[str, Any]) -> dict[str, Any]:
+    """Generate deterministic route fixtures from a validated runbook."""
+    cases = [
+        {
+            "id": route["id"],
+            "observations": route["when"],
+            "expected": {
+                "action": route["action"],
+                "verify": route["verify"],
+                "on_failure": route["on_failure"],
+            },
+        }
+        for route in runbook["routes"]
+    ]
+    return {
+        "runbook": runbook["id"],
+        "schema_version": runbook["version"],
+        "cases": cases,
+    }
+
+
+def discover_runbooks() -> list[tuple[Path, dict[str, Any]]]:
+    """Discover Markdown runbooks containing structured blocks."""
+    discovered: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(OPS_DIR.glob("*.md")):
+        runbook = extract_runbook(path)
+        if runbook is not None:
+            discovered.append((path, runbook))
+    return discovered
+
+
+def _fixture_text(fixture: dict[str, Any]) -> str:
+    return json.dumps(fixture, indent=2, sort_keys=True) + "\n"
+
+
+def validate_all(write_fixtures: bool = False) -> list[str]:
+    """Validate all structured runbooks and check or write their fixtures."""
+    registry = load_registry()
+    errors: list[str] = []
+    discovered = discover_runbooks()
+    if not discovered:
+        return ["no structured operations runbooks found"]
+
+    for path, runbook in discovered:
+        source = path.relative_to(ROOT).as_posix()
+        runbook_errors = validate_runbook(runbook, registry, source)
+        errors.extend(runbook_errors)
+        if runbook_errors:
+            continue
+
+        fixture_path = EVAL_DIR / f"{runbook['id']}.json"
+        expected = _fixture_text(build_eval_fixture(runbook))
+        if write_fixtures:
+            fixture_path.parent.mkdir(parents=True, exist_ok=True)
+            fixture_path.write_text(expected, encoding="utf-8")
+        elif not fixture_path.exists():
+            errors.append(f"{source}: missing eval fixture {fixture_path.relative_to(ROOT)}")
+        elif fixture_path.read_text(encoding="utf-8") != expected:
+            errors.append(
+                f"{source}: stale eval fixture; run "
+                "python scripts/validate_ops_runbooks.py --write-fixtures"
+            )
+    return errors
+
+
+def main() -> int:
+    """Run the command-line validator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write-fixtures",
+        action="store_true",
+        help="Regenerate committed route evaluation fixtures.",
+    )
+    args = parser.parse_args()
+    errors = validate_all(write_fixtures=args.write_fixtures)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Operations runbooks are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ops_runbooks.py
+++ b/tests/test_ops_runbooks.py
@@ -1,0 +1,38 @@
+"""Tests for the AI-native operations runbook contract."""
+
+from copy import deepcopy
+
+from scripts.validate_ops_runbooks import (
+    build_eval_fixture,
+    discover_runbooks,
+    load_registry,
+    validate_all,
+    validate_runbook,
+)
+
+
+def test_structured_ops_runbooks_and_fixtures_are_valid() -> None:
+    assert validate_all() == []
+
+
+def test_routes_generate_action_and_verification_oracles() -> None:
+    runbooks = dict((path.stem, data) for path, data in discover_runbooks())
+    fixture = build_eval_fixture(runbooks["incident-response"])
+    assert fixture["runbook"] == "incident-response"
+    assert fixture["cases"][0]["expected"] == {
+        "action": "restart-backend",
+        "verify": ["api-health", "api-ready"],
+        "on_failure": "escalate",
+    }
+
+
+def test_validator_rejects_unregistered_tool_and_signal_references() -> None:
+    _, runbook = discover_runbooks()[0]
+    invalid = deepcopy(runbook)
+    invalid["actions"][0]["tool"] = "azure.subscription.delete"
+    invalid["routes"][0]["verify"].append("missing-signal")
+
+    errors = validate_runbook(invalid, load_registry(), "test-runbook")
+
+    assert any("unknown action tool" in error for error in errors)
+    assert any("unknown verify signal" in error for error in errors)


### PR DESCRIPTION
## Summary

- add a hybrid `ops-runbook` contract to the incident-response runbook with bounded, reversible restart actions
- validate tool, policy, signal, action, route, and verification references in CI
- generate committed route evaluation fixtures from the structured decision tree
- define severity/escalation ownership and explicitly document production decisions that remain operator-gated instead of guessing values
- defer plugin packaging until multiple autonomous runbooks share the contract, avoiding cross-repository drift

Closes #338

## Validation

- `python scripts/validate_ops_runbooks.py`
- `python -m pytest tests/test_ops_runbooks.py -q`
- `python -m pytest tests/ -q` (`1921 passed, 3 skipped`)
