### PR TITLE
Fix backend deploy submodule checkout

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          submodules: true
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -22,7 +22,7 @@ GitHub-hosted Python jobs use `actions/setup-python@v7` to provision the workflo
 ## Backend deploy
 
 Automatic on merge to `main` (for the paths above). The workflow:
-1. Runs `pytest tests/`.
+1. Checks out the Praxys plugin submodule and runs `pytest tests/`.
 2. Stamps `api/_build_version.txt`.
 3. Waits for a compatible live frontend `deployed_sha`.
 4. Uses OIDC to enforce the telemetry boundary, sync App Service settings (see

--- a/tests/test_ui_quality_harness.py
+++ b/tests/test_ui_quality_harness.py
@@ -248,3 +248,11 @@ def test_ui_mcp_configs_are_pinned_and_cloud_safe():
         ROOT / "plugins" / "praxys" / "mcp-server" / "requirements.txt"
     ).read_text(encoding="utf-8")
     assert "mcp==1.28.1" in plugin_requirements.splitlines()
+
+
+def test_backend_deploy_initializes_plugin_submodule():
+    workflow = (
+        ROOT / ".github" / "workflows" / "deploy-backend.yml"
+    ).read_text(encoding="utf-8")
+    test_job = workflow.split("  deploy:", maxsplit=1)[0]
+    assert "submodules: true" in test_job


### PR DESCRIPTION
## Summary
- initialize the Praxys plugin submodule in the backend deployment test job
- add a regression test that keeps the deploy checkout aligned with tests that inspect plugin files
- document the submodule checkout in the backend deploy runbook

## Root cause
Run [31074341265](https://github.com/praxys-run/praxys/actions/runs/31074341265) introduced a test that reads `plugins/praxys/mcp-server/requirements.txt`. Required PR CI already checked out submodules, but `deploy-backend.yml` did not, so every post-merge deployment failed in pytest with `FileNotFoundError` before reaching Azure. Production remained healthy on the last successful deployment (`1218ae5`).

## Validation
- `python -m pytest tests/` (1922 passed, 3 skipped)
