### PR TITLE
Deploy frontend to Tencent Lighthouse

### DIFF
--- a/.github/workflows/deploy-frontend-appservice.yml
+++ b/.github/workflows/deploy-frontend-appservice.yml
@@ -1,12 +1,14 @@
-name: Deploy Frontend to App Service (praxys-frontend)
+name: Deploy Frontend (Azure + Tencent)
 
 # Region-pinned static SPA host in East Asia (the "F4" perf fix —
 # replaced the SWA-Amsterdam path that added 200-300ms RTT for CN
 # users). Both this site and trainsight-app share plan-trainsight at
 # $0 incremental.
 #
-# Auth: same OIDC Service Principal as deploy-backend.yml
-# (AZURE_CLIENT_ID/TENANT/SUBSCRIPTION secrets, RG-scoped role).
+# The same web/dist build can also deploy to the Tencent Lighthouse
+# mainland-China static origin. That lane is gated by the
+# TENCENT_LIGHTHOUSE_DEPLOY_ENABLED repository variable so Azure remains
+# deployable while the server and ICP filing are being provisioned.
 
 on:
   push:
@@ -46,7 +48,7 @@ jobs:
       - name: Run frontend_server tests
         run: python -m pytest tests/test_frontend_server_spa.py -v
 
-  build_and_deploy:
+  build:
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +58,7 @@ jobs:
         shell: bash
         run: cat .github/azure-observability.env >> "$GITHUB_ENV"
 
-      - name: Azure Login (OIDC)
+      - name: Azure Login for frontend telemetry (OIDC)
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -101,7 +103,14 @@ jobs:
           VITE_API_URL: ${{ vars.VITE_API_URL }}
           VITE_APP_VERSION: ${{ steps.version.outputs.version }}
 
-      - name: Stage deploy package
+      - name: Stamp static health metadata
+        shell: bash
+        run: |
+          printf '%s\n' "${GITHUB_SHA}" > web/dist/deployed_sha.txt
+          printf '{"ok":true,"service":"praxys-frontend","deployed_sha":"%s"}\n' \
+            "${GITHUB_SHA}" > web/dist/healthz
+
+      - name: Stage Azure deploy package
         # The deploy zip mirrors the repo layout that frontend_server.main
         # expects: ``frontend_server/`` and ``web/dist/`` as siblings of
         # ``requirements.txt`` so Oryx installs only the static-server's
@@ -114,9 +123,145 @@ jobs:
           printf '%s\n' "${GITHUB_SHA}" > deploy-pkg/frontend_server/_deployed_sha.txt
           ls -R deploy-pkg | head -50
 
+      - name: Stage Tencent static package
+        shell: bash
+        run: tar -C web/dist -czf praxys-web.tgz .
+
+      - name: Upload Azure package
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-azure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: deploy-pkg
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Tencent package
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-tencent-${{ github.run_id }}-${{ github.run_attempt }}
+          path: praxys-web.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  deploy_azure:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure Login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Download Azure package
+        uses: actions/download-artifact@v8
+        with:
+          name: frontend-azure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: deploy-pkg
+
       - name: Deploy to praxys-frontend
         uses: azure/webapps-deploy@v3
         with:
           app-name: praxys-frontend
           resource-group-name: rg-trainsight
           package: deploy-pkg
+
+  deploy_tencent:
+    if: vars.TENCENT_LIGHTHOUSE_DEPLOY_ENABLED == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      LIGHTHOUSE_HOST: ${{ vars.TENCENT_LIGHTHOUSE_HOST }}
+      LIGHTHOUSE_USER: ${{ vars.TENCENT_LIGHTHOUSE_USER }}
+      LIGHTHOUSE_PORT: ${{ vars.TENCENT_LIGHTHOUSE_SSH_PORT || '22' }}
+    steps:
+      - name: Download Tencent package
+        uses: actions/download-artifact@v8
+        with:
+          name: frontend-tencent-${{ github.run_id }}-${{ github.run_attempt }}
+          path: china-package
+
+      - name: Configure pinned SSH identity
+        env:
+          LIGHTHOUSE_SSH_PRIVATE_KEY: ${{ secrets.TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY }}
+          LIGHTHOUSE_SSH_KNOWN_HOSTS: ${{ secrets.TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${LIGHTHOUSE_HOST}"
+          test -n "${LIGHTHOUSE_USER}"
+          [[ "${LIGHTHOUSE_PORT}" =~ ^[0-9]+$ ]]
+          test -n "${LIGHTHOUSE_SSH_PRIVATE_KEY}"
+          test -n "${LIGHTHOUSE_SSH_KNOWN_HOSTS}"
+
+          install -m 700 -d "${HOME}/.ssh"
+          printf '%s\n' "${LIGHTHOUSE_SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_ed25519"
+          printf '%s\n' "${LIGHTHOUSE_SSH_KNOWN_HOSTS}" > "${HOME}/.ssh/known_hosts"
+          chmod 600 "${HOME}/.ssh/id_ed25519" "${HOME}/.ssh/known_hosts"
+
+      - name: Upload static release
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_id="${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          scp -P "${LIGHTHOUSE_PORT}" \
+            china-package/praxys-web.tgz \
+            "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}:/tmp/praxys-web-${release_id}.tgz"
+
+      - name: Activate static release
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_id="${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          ssh -p "${LIGHTHOUSE_PORT}" \
+            "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}" \
+            "bash -s -- '${release_id}' '${GITHUB_SHA}'" <<'REMOTE'
+          set -euo pipefail
+          release_id="$1"
+          deployed_sha="$2"
+          root="/var/www/praxys"
+          archive="/tmp/praxys-web-${release_id}.tgz"
+          release="${root}/releases/${release_id}"
+          activated=0
+
+          cleanup() {
+            rm -f -- "${archive}"
+            if [[ "${activated}" -eq 0 ]]; then
+              rm -rf -- "${release}"
+            fi
+          }
+          trap cleanup EXIT
+
+          test -f "${archive}"
+          mkdir -p "${release}"
+          tar -xzf "${archive}" -C "${release}"
+          test -s "${release}/index.html"
+          test "$(cat "${release}/deployed_sha.txt")" = "${deployed_sha}"
+
+          ln -sfn "${release}" "${root}/current.next"
+          mv -Tf "${root}/current.next" "${root}/current"
+          activated=1
+
+          find "${root}/releases" -mindepth 1 -maxdepth 1 -type d \
+            -printf '%T@ %p\n' \
+            | sort -nr \
+            | awk 'NR > 5 {sub(/^[^ ]+ /, ""); print}' \
+            | xargs -r rm -rf --
+          REMOTE
+
+      - name: Verify Lighthouse deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          deployed_sha="$(
+            ssh -p "${LIGHTHOUSE_PORT}" \
+              "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}" \
+              "cat /var/www/praxys/current/deployed_sha.txt"
+          )"
+          test "${deployed_sha}" = "${GITHUB_SHA}"
+          ssh -p "${LIGHTHOUSE_PORT}" \
+            "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}" \
+            "curl --fail --silent --show-error --max-time 10 \
+              --header 'Host: www.praxys.run' \
+              http://127.0.0.1/healthz >/dev/null"

--- a/deploy/tencent/nginx-praxys.conf
+++ b/deploy/tencent/nginx-praxys.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name www.praxys.run origin-cn.praxys.run _;
+
+    root /var/www/praxys/current;
+    index index.html;
+
+    location = /healthz {
+        default_type application/json;
+        try_files /healthz =503;
+        add_header Cache-Control "no-store" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    location ^~ /assets/ {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    location ~* \.(?:css|gif|ico|jpe?g|json|png|svg|txt|webmanifest|webp|woff2?|xml)$ {
+        try_files $uri =404;
+        expires 1d;
+        add_header Cache-Control "public, max-age=86400" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "public, max-age=0, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,6 +86,7 @@ The database (`data/trainsight.db`) is created automatically on first startup. N
 | App Service Plan | `plan-trainsight` | Linux B1, hosts both sites |
 | App Service (backend) | `trainsight-app` | FastAPI / API at `api.praxys.run` |
 | App Service (frontend) | `praxys-frontend` | Static SPA at `www.praxys.run` + apex |
+| Tencent Lighthouse (frontend) | Console-assigned | Optional mainland-China static SPA origin |
 | Key Vault | `kv-trainsight` | Per-user DEK wrapping master key |
 
 > **History:** prior versions of this doc referenced an `swa-trainsight` Static Web App. SWA was retired during F4 because Azure SWA Free routes to whichever region the global ASE picks (often Amsterdam), which added 200-300 ms of cold-load latency for CN users. Frontend now lives on a dedicated App Service site in East Asia next to the backend.
@@ -178,6 +179,18 @@ az webapp config appsettings set \
 ```
 
 The `frontend_server/` package (`main.py` + `requirements-frontend.txt`) is shipped by `.github/workflows/deploy-frontend-appservice.yml`.
+
+### 8b. Optional Tencent Lighthouse frontend
+
+The frontend workflow can deploy the same `web/dist` artifact to a
+mainland-China Lighthouse Nginx origin while Azure remains the international
+frontend. Lighthouse provisioning, SSH hardening, Nginx configuration, GitHub
+secrets, verification, and rollback are documented in
+[`docs/ops/tencent-frontend.md`](./ops/tencent-frontend.md).
+
+Leave `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` unset until that runbook's bootstrap
+and ICP prerequisites are complete. The API remains singular at
+`https://api.praxys.run`.
 
 ### 9. Custom domains + managed certs
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -19,6 +19,7 @@ diagnose X". It complements — and links out to — the setup-oriented
 | [environment.md](./environment.md) | You need the canonical Azure resource names / IDs / hostnames. |
 | [config-and-secrets.md](./config-and-secrets.md) | You're adding, changing, or rotating an env var / secret / variable, and need to know **where** it's set. |
 | [deploy.md](./deploy.md) | You're deploying the backend, frontend, or mini program — or need to roll back. |
+| [tencent-frontend.md](./tencent-frontend.md) | Provisioning or operating the mainland-China Lighthouse static frontend. |
 | [org-migration.md](./org-migration.md) | Migrating the repos from `dddtc2005` into the `praxys-run` org (OIDC pre-stage, App reinstall, tokens). |
 | [monitoring-and-alerts.md](./monitoring-and-alerts.md) | You want to query a telemetry signal or wire an email/Teams alert. |
 | [admin-tasks.md](./admin-tasks.md) | You're using `/admin/ops` or a focused admin route for health, incidents, users, feedback, or communications. |
@@ -42,6 +43,7 @@ diagnose X". It complements — and links out to — the setup-oriented
 | Resource group | `rg-trainsight` |
 | Backend (API) | App Service `trainsight-app` → `api.praxys.run` |
 | Frontend (SPA) | App Service `praxys-frontend` → `www.praxys.run` |
+| Mainland frontend origin | Tencent Lighthouse (static-only; gated until ICP-ready) |
 | Secrets at rest | Key Vault `kv-trainsight` (RSA key `credential-encryption-key`) |
 | Observability | Application Insights (signals prefixed `praxys.`) |
 

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -34,6 +34,8 @@ transient — the next deploy overwrites them.**
 | `COPILOT_ASSIGN_TOKEN` | **Required for workflow auto-assign** — fine-grained PAT (*Issues: write*, this repo only, with expiry). Agent assignment needs a user token; the built-in `GITHUB_TOKEN` is forbidden (issue #400). Manual UI assignment doesn't need it. | `assign-copilot.yml` |
 | `PRAXYS_GITHUB_APP_PRIVATE_KEY` | Feedback GitHub App private key. The app has Issues read/write and Pull requests read; tokens are minted on demand. | App Service setting (backend) |
 | `PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY` | Independent selective-review App key. The App has Contents write + Pull requests write solely to approve qualifying PRs and enable normal auto-merge. Optional while every PR is review-required; mandatory only for an autonomous candidate or stale policy-state cleanup. | `selective-review.yml` |
+| `TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY` | Dedicated private key for the restricted Lighthouse static-deploy user. | Tencent lane in `deploy-frontend-appservice.yml` |
+| `TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS` | Pinned Lighthouse SSH host-key line; rotate only after out-of-band fingerprint verification. | Tencent lane in `deploy-frontend-appservice.yml` |
 
 ### GitHub Actions → Variables
 `… → Variables` (non-secret; build variables are inlined into the SPA and ship to browsers)
@@ -60,6 +62,10 @@ transient — the next deploy overwrites them.**
 | `PRAXYS_REVIEW_POLICY_APP_SLUG` | Expected URL slug for the independent App, without `[bot]`; lets pre-credential evaluation recognize only that App's prior blocking reviews and verifies the minted identity. | `selective-review.yml`, `selective-review-emergency-stop.yml` |
 | `PRAXYS_SELECTIVE_REVIEW_ENABLED` | Master enable; absent/anything except `true` keeps every PR review-required. | `selective-review.yml` |
 | `PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH` | Emergency stop; `true` disables approval even when the master enable and class promotion are active. | `selective-review.yml` |
+| `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` | Set `true` only after the Lighthouse Nginx/deploy-user bootstrap is complete. Unset/false skips the China deploy without affecting Azure. | `deploy-frontend-appservice.yml` |
+| `TENCENT_LIGHTHOUSE_HOST` | Lighthouse public IP or stable SSH hostname. | `deploy-frontend-appservice.yml` |
+| `TENCENT_LIGHTHOUSE_USER` (`praxys-deploy`) | Restricted SSH deployment account. | `deploy-frontend-appservice.yml` |
+| `TENCENT_LIGHTHOUSE_SSH_PORT` (`22`) | Lighthouse SSH port. | `deploy-frontend-appservice.yml` |
 
 Changing `PRAXYS_FEEDBACK_GITHUB_REPO` does not reinterpret historical issue
 numbers. Feedback sync and adjudication compare each stored GitHub URL with the

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -9,11 +9,12 @@
 | Surface | Workflow | Triggers | Target |
 |---|---|---|---|
 | Backend (API) | `deploy-backend.yml` | push to `main` touching backend code/tests, observability config/scripts, or the workflow; or `api-*` tag | App Service `trainsight-app` |
-| Frontend (SPA) | `deploy-frontend-appservice.yml` | push to `main` touching the SPA/static server, observability config/scripts, or the workflow; or `web-*` tag | App Service `praxys-frontend` |
+| Frontend (SPA) | `deploy-frontend-appservice.yml` | push to `main` touching the SPA/static server, observability config/scripts, or the workflow; or `web-*` tag | App Service `praxys-frontend`; optionally Tencent Lighthouse |
 | Mini program | `miniapp-publish.yml` | `miniapp-YYYY.MM.MICRO` release tag (robot 1); `main` pushes auto-publish a dev build (robot 5) | WeChat (`miniprogram-ci`) |
 
-All three authenticate to Azure / WeChat via OIDC or the upload key — no
-passwords. Backend + frontend run their test/build gates **before** deploying.
+Targets authenticate through Azure OIDC, the WeChat upload key, or a dedicated
+pinned SSH key for Lighthouse — no account passwords. Backend + frontend run
+their test/build gates **before** deploying.
 
 **Pre-merge gate.** Before any deploy, `ci-premerge.yml` runs independent backend and frontend validation on every PR to `main`. A red required context blocks merge, so regressions never reach deployment (see [environment.md](./environment.md) → Repo governance). `deploy-backend.yml` re-runs the backend suite post-merge as a deploy-time backstop.
 
@@ -40,11 +41,17 @@ Force a deploy without a code change: re-run the latest `deploy-backend.yml` run
 
 ## Frontend deploy
 
-Automatic on merge touching `web/`. Builds `web/dist/` with `VITE_API_URL` baked
-in, packages it with `frontend_server/`, deploys to `praxys-frontend`, then
-bakes `GITHUB_SHA` into the static-server package. `/healthz` returns that
-`deployed_sha`, so re-runs and `web-*` rollbacks report the commit actually
-serving production.
+Automatic on merge touching `web/`. The workflow builds `web/dist/` once with
+`VITE_API_URL` baked in, then fans the same artifact out to:
+
+- Azure `praxys-frontend`, packaged with `frontend_server/`.
+- Tencent Lighthouse when `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=true`, packaged as
+  static files and atomically activated under `/var/www/praxys/current`.
+
+Both deployments expose the same `deployed_sha`. The Tencent lane is disabled
+until the server bootstrap and pinned SSH configuration in
+[tencent-frontend.md](./tencent-frontend.md) are complete. A skipped Tencent
+lane never blocks the existing Azure deployment.
 
 ## Mini program
 
@@ -67,8 +74,8 @@ gh run watch "$(gh run list --workflow=deploy-backend.yml --limit 1 --json datab
 
 ## Rollback / Recovery
 
-There are **no deployment slots** on the B1 plan, so rollback = re-deploy a known
--good revision:
+There are **no deployment slots** on the B1 plan, so Azure rollback = re-deploy
+a known-good revision:
 
 1. **Revert the commit** on `main` (`git revert <sha> && git push`) — the deploy
    workflow re-runs and ships the reverted state. Safest for app bugs.
@@ -92,10 +99,14 @@ There are **no deployment slots** on the B1 plan, so rollback = re-deploy a know
 > Config-only revert (a bad App Service setting): fix the GitHub secret/variable
 > and re-deploy — don't hand-edit the portal (it's overwritten next deploy).
 
+Tencent rollback is independent: atomically repoint
+`/var/www/praxys/current` to one of the retained run-addressed releases. See
+[tencent-frontend.md](./tencent-frontend.md).
+
 ## Related
 
 - [config-and-secrets.md](./config-and-secrets.md) · [monitoring-and-alerts.md](./monitoring-and-alerts.md)
 - `docs/deployment.md` (one-time Azure setup) · `.github/workflows/`
 
 ---
-_Last reviewed: 2026-07-05 · Owner: @dddtc2005_
+_Last reviewed: 2026-08-07 · Owner: @dddtc2005_

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -27,6 +27,12 @@
 | Perf-baseline storage | `stperftrainsight` (RG `rg-trainsight`, East Asia) | `docs/perf-baselines/ci-setup.md` |
 | CI/deploy app registration | `trainsight-cicd` — appId `d3deb736-e95d-400e-b5a5-c2f76b23ae25` (OIDC federated creds `github-deploy`, `i18n`) | live `az ad app` |
 
+## Tencent
+
+| Thing | Value | Source |
+|---|---|---|
+| Mainland frontend origin | Lighthouse static Nginx host; exact address sourced from `TENCENT_LIGHTHOUSE_HOST`, disabled until provisioned/ICP-ready | [tencent-frontend.md](./tencent-frontend.md) |
+
 ## Hostnames
 
 | Surface | URL |

--- a/docs/ops/tencent-frontend.md
+++ b/docs/ops/tencent-frontend.md
@@ -1,0 +1,164 @@
+# Tencent Lighthouse frontend
+
+> **Summary:** Provision the mainland-China Nginx origin and connect it to the
+> shared frontend deployment workflow.
+> **Use when:** Creating, replacing, deploying, or rolling back the Tencent
+> Lighthouse static frontend.
+
+## Prerequisites
+
+- Tencent Lighthouse in a mainland-China region, Ubuntu 24.04 LTS, public IP,
+  and non-zero bandwidth. Keep the subscription eligible for the ICP filing.
+- SSH access from an operator workstation with `sudo`.
+- Repository admin access to Actions secrets and variables.
+- The ICP filing must be approved before serving the public mainland hostname.
+
+The Lighthouse host serves only the immutable output of `web/dist`. The API,
+database, sync scheduler, credentials, and AI integrations remain on Azure.
+
+## Steps
+
+### 1. Bootstrap Nginx and the deploy account
+
+Run on the Lighthouse instance:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y nginx curl
+sudo adduser --disabled-password --gecos "" praxys-deploy
+sudo install -d -o praxys-deploy -g www-data -m 0755 \
+  /var/www/praxys /var/www/praxys/releases
+sudo install -d -o praxys-deploy -g praxys-deploy -m 0700 \
+  /home/praxys-deploy/.ssh
+sudo touch /home/praxys-deploy/.ssh/authorized_keys
+sudo chown praxys-deploy:praxys-deploy \
+  /home/praxys-deploy/.ssh/authorized_keys
+sudo chmod 0600 /home/praxys-deploy/.ssh/authorized_keys
+```
+
+Generate a dedicated key on the operator workstation:
+
+```bash
+ssh-keygen -t ed25519 -f praxys-tencent-deploy \
+  -C "praxys GitHub Actions Tencent deploy"
+```
+
+Append `praxys-tencent-deploy.pub` to
+`/home/praxys-deploy/.ssh/authorized_keys`. Disable SSH password login and root
+login after verifying key authentication in a second terminal.
+
+### 2. Install the repository Nginx configuration
+
+From the repository root:
+
+```bash
+scp deploy/tencent/nginx-praxys.conf <operator>@<LIGHTHOUSE_IP>:/tmp/praxys.conf
+ssh <operator>@<LIGHTHOUSE_IP>
+sudo install -m 0644 /tmp/praxys.conf /etc/nginx/sites-available/praxys
+sudo ln -sfn /etc/nginx/sites-available/praxys /etc/nginx/sites-enabled/praxys
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+The config mirrors `frontend_server/main.py`: hashed Vite assets are immutable
+for one year, ordinary assets cache for one day, SPA routes fall back to
+`index.html`, and the shell revalidates on every visit.
+
+This bootstrap exposes HTTP only for local verification and the first CI
+deployment. Do not route public production traffic to it yet. Before the
+EdgeOne cutover, provision a certificate-valid origin hostname and an Nginx
+443 listener, then configure EdgeOne for HTTPS origin pull. The exact
+certificate flow depends on the approved ICP/DNS arrangement and must be
+verified on the provisioned site rather than guessed in this pre-provisioning
+runbook.
+
+### 3. Create the GitHub Actions configuration
+
+Repository variables:
+
+| Variable | Value |
+|---|---|
+| `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` | Leave unset until bootstrap is complete; then set `true`. |
+| `TENCENT_LIGHTHOUSE_HOST` | Lighthouse public IP or stable SSH hostname. |
+| `TENCENT_LIGHTHOUSE_USER` | `praxys-deploy` |
+| `TENCENT_LIGHTHOUSE_SSH_PORT` | SSH port, normally `22`. |
+
+Repository secrets:
+
+| Secret | Value |
+|---|---|
+| `TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY` | Entire contents of the dedicated private key. |
+| `TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS` | Pinned `known_hosts` line for the Lighthouse host. |
+
+Create the host-key value from a trusted workstation:
+
+```bash
+export LIGHTHOUSE_SSH_PORT=22
+ssh-keyscan -H -p "${LIGHTHOUSE_SSH_PORT}" <LIGHTHOUSE_IP> \
+  > lighthouse_known_hosts
+ssh-keygen -lf lighthouse_known_hosts
+```
+
+Compare the fingerprint with the server's host key through the Tencent console
+or an already trusted SSH session before storing the file contents. Never
+replace the pinned key with `StrictHostKeyChecking=no`.
+
+### 4. Enable deployments
+
+Set `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=true`, then manually run
+`deploy-frontend-appservice.yml`. This can be done before public DNS cutover;
+the workflow verifies Nginx over loopback on the server. The workflow:
+
+1. Builds the SPA once.
+2. Deploys the same package to Azure App Service.
+3. Uploads the static package to a run-addressed Lighthouse release stamped
+   with the source commit SHA.
+4. Atomically changes `/var/www/praxys/current`.
+5. Keeps the five newest releases and verifies `/healthz`.
+
+## Verify
+
+On the server:
+
+```bash
+readlink -f /var/www/praxys/current
+cat /var/www/praxys/current/deployed_sha.txt
+curl -sS -H 'Host: www.praxys.run' http://127.0.0.1/healthz
+```
+
+The SHA must match the workflow commit. After EdgeOne and DNS are configured,
+verify the public response and cache headers:
+
+```bash
+curl -I https://www.praxys.run/
+curl -I https://www.praxys.run/assets/<current-hashed-asset>
+```
+
+The shell must revalidate; hashed assets must be immutable.
+
+## Rollback / Recovery
+
+To roll back only the Lighthouse frontend:
+
+```bash
+cd /var/www/praxys
+ls -1t releases
+ln -sfn "/var/www/praxys/releases/<GOOD_RELEASE_ID>" current.next
+mv -Tf current.next current
+curl -sS -H 'Host: www.praxys.run' http://127.0.0.1/healthz
+```
+
+Set `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=false` to stop future Tencent deploys
+without affecting Azure. If the host key changes after a legitimate rebuild,
+verify the new fingerprint out of band before rotating
+`TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS`.
+
+## Related
+
+- [`deploy.md`](./deploy.md) · [`config-and-secrets.md`](./config-and-secrets.md)
+- `.github/workflows/deploy-frontend-appservice.yml`
+- `deploy/tencent/nginx-praxys.conf`
+
+---
+_Last reviewed: 2026-08-07 · Owner: @dddtc2005_


### PR DESCRIPTION
## Summary

- build the frontend once and deploy the identical artifact to Azure App Service and an optional Tencent Lighthouse origin
- add pinned-key SSH deployment with run-addressed atomic releases, failed-release cleanup, verification, and rollback retention
- add the Nginx static-SPA configuration and the complete Lighthouse bootstrap, secrets, deployment, and rollback runbook
- keep the Tencent lane disabled through `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=false` until the first Azure-only deployment succeeds

## Validation

- `.venv\Scripts\python.exe -m pytest tests\test_frontend_server_spa.py -q`
- `cd web && npm run build`
- `.venv\Scripts\python.exe scripts\validate_ops_runbooks.py`
- parsed `.github/workflows/deploy-frontend-appservice.yml` with PyYAML
- `git diff --check`