### PR TITLE
Restore recovery context in Today coach guidance

### DIFF
--- a/miniapp/pages/today/index.ts
+++ b/miniapp/pages/today/index.ts
@@ -70,6 +70,7 @@ interface CoachReceipt {
   /** Deterministic Today guidance has no generation-time stamp. */
   stamp: string;
   headline: string;
+  summary: string;
   hasFindings: boolean;
   findings: CoachFindingRow[];
   hasRecommendations: boolean;
@@ -111,6 +112,20 @@ interface SupportingCell {
    *  would otherwise strand an empty slot). Set during cell assembly,
    *  not at the use site, so WXML doesn't have to know the count. */
   span: boolean;
+}
+
+function localizedRecoverySummary(analysis: RecoveryAnalysis | null): string {
+  switch (analysis?.status) {
+    case 'fresh':
+      return t('HRV is above your Praxys reference band');
+    case 'normal':
+      return t('HRV is within your Praxys reference band');
+    case 'fatigued':
+      return t('HRV is below your Praxys caution band');
+    case 'insufficient_data':
+    default:
+      return t('Insufficient current HRV data for comparison');
+  }
 }
 
 function localizedSignalReason(signal: TrainingSignal): string {
@@ -212,6 +227,7 @@ function buildCoachReceipt(
   return {
     stamp: '',
     headline: localizedSignalReason(response.signal),
+    summary: localizedRecoverySummary(response.recovery_analysis),
     hasFindings: false,
     findings: [],
     hasRecommendations: recommendations.length > 0,

--- a/miniapp/pages/today/index.wxml
+++ b/miniapp/pages/today/index.wxml
@@ -117,6 +117,7 @@
         </view>
         <view class="coach-body">
           <text class="coach-headline">{{coach.headline}}</text>
+          <text class="coach-summary">{{coach.summary}}</text>
 
           <!-- Progressive-disclosure toggle. Default-collapsed; the
                user opts in to the structured detail. Hidden when

--- a/miniapp/styles/coach-receipt.scss
+++ b/miniapp/styles/coach-receipt.scss
@@ -63,6 +63,15 @@
   margin-bottom: 16rpx;
 }
 
+.coach-summary {
+  display: block;
+  max-width: 65ch;
+  margin-bottom: 16rpx;
+  font-size: 25rpx;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
 .coach-label {
   display: block;
   font-size: 20rpx;

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -271,7 +271,7 @@ msgid "{minutes} effective min"
 msgstr "{minutes} effective min"
 
 #: src/components/RecoveryPanel.tsx:159
-#: src/pages/Today.tsx:584
+#: src/pages/Today.tsx:602
 msgid "{observationCount}-observation Trend"
 msgstr "{observationCount}-observation Trend"
 
@@ -1725,7 +1725,7 @@ msgstr "Cycling"
 msgid "Daily brief"
 msgstr "Daily brief"
 
-#: src/pages/Today.tsx:403
+#: src/pages/Today.tsx:420
 msgid "daily score"
 msgstr "daily score"
 
@@ -2095,11 +2095,11 @@ msgstr "Done"
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 msgstr "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 
-#: src/pages/Today.tsx:286
+#: src/pages/Today.tsx:303
 msgid "Drop intensity by one zone"
 msgstr "Drop intensity by one zone"
 
-#: src/pages/Today.tsx:278
+#: src/pages/Today.tsx:295
 msgid "Drop to easy run (keep power in recovery zone)"
 msgstr "Drop to easy run (keep power in recovery zone)"
 
@@ -2438,7 +2438,7 @@ msgstr "Failed to delete user."
 msgid "Failed to generate invitation code."
 msgstr "Failed to generate invitation code."
 
-#: src/pages/Today.tsx:335
+#: src/pages/Today.tsx:352
 msgid "Failed to load"
 msgstr "Failed to load"
 
@@ -2642,7 +2642,7 @@ msgstr "Fourteen-day activity record"
 #~ msgid "Freshened up — good window for racing or testing."
 #~ msgstr "Freshened up — good window for racing or testing."
 
-#: src/pages/Today.tsx:532
+#: src/pages/Today.tsx:549
 msgid "From {dataAsOfLabel}"
 msgstr "From {dataAsOfLabel}"
 
@@ -2963,23 +2963,25 @@ msgstr "HRV Analysis"
 #~ msgid "HRV below your Praxys caution band"
 #~ msgstr "HRV below your Praxys caution band"
 
-#: src/pages/Today.tsx:257
+#: src/pages/Today.tsx:274
 msgid "HRV is above your personal reference band. Follow the plan as written."
 msgstr "HRV is above your personal reference band. Follow the plan as written."
 
 #: src/components/RecoveryPanel.tsx:18
+#: src/pages/Today.tsx:223
 msgid "HRV is above your Praxys reference band"
 msgstr "HRV is above your Praxys reference band"
 
-#: src/pages/Today.tsx:243
+#: src/pages/Today.tsx:260
 msgid "HRV is below your personal caution band. Keep today easy to support recovery."
 msgstr "HRV is below your personal caution band. Keep today easy to support recovery."
 
-#: src/pages/Today.tsx:241
+#: src/pages/Today.tsx:258
 msgid "HRV is below your personal caution band. Treat this as a recovery signal, not a diagnosis."
 msgstr "HRV is below your personal caution band. Treat this as a recovery signal, not a diagnosis."
 
 #: src/components/RecoveryPanel.tsx:20
+#: src/pages/Today.tsx:227
 msgid "HRV is below your Praxys caution band"
 msgstr "HRV is below your Praxys caution band"
 
@@ -2987,11 +2989,12 @@ msgstr "HRV is below your Praxys caution band"
 #~ msgid "HRV is normal but modeled load balance is low (TSB {tsb}). Modify the hard session."
 #~ msgstr "HRV is normal but modeled load balance is low (TSB {tsb}). Modify the hard session."
 
-#: src/pages/Today.tsx:245
+#: src/pages/Today.tsx:262
 msgid "HRV is within your personal reference band, but modeled load balance is low (TSB {tsb}). Modify the hard session."
 msgstr "HRV is within your personal reference band, but modeled load balance is low (TSB {tsb}). Modify the hard session."
 
 #: src/components/RecoveryPanel.tsx:19
+#: src/pages/Today.tsx:225
 msgid "HRV is within your Praxys reference band"
 msgstr "HRV is within your Praxys reference band"
 
@@ -2999,11 +3002,11 @@ msgstr "HRV is within your Praxys reference band"
 #~ msgid "HRV rolling mean is declining. Reduce intensity as a conservative coaching adjustment."
 #~ msgstr "HRV rolling mean is declining. Reduce intensity as a conservative coaching adjustment."
 
-#: src/pages/Today.tsx:247
+#: src/pages/Today.tsx:264
 msgid "HRV rolling mean is lower than its prior window. Reduce intensity as a conservative coaching adjustment."
 msgstr "HRV rolling mean is lower than its prior window. Reduce intensity as a conservative coaching adjustment."
 
-#: src/pages/Today.tsx:249
+#: src/pages/Today.tsx:266
 msgid "HRV rolling mean is lower than its prior window. Stay easy today."
 msgstr "HRV rolling mean is lower than its prior window. Stay easy today."
 
@@ -3011,7 +3014,7 @@ msgstr "HRV rolling mean is lower than its prior window. Stay easy today."
 #~ msgid "HRV trend is declining. Stay easy today."
 #~ msgstr "HRV trend is declining. Stay easy today."
 
-#: src/pages/Today.tsx:251
+#: src/pages/Today.tsx:268
 msgid "HRV variability is high (CV {cv}%), above the selected coaching caution threshold."
 msgstr "HRV variability is high (CV {cv}%), above the selected coaching caution threshold."
 
@@ -3098,6 +3101,7 @@ msgid "Info"
 msgstr "Info"
 
 #: src/components/RecoveryPanel.tsx:21
+#: src/pages/Today.tsx:230
 msgid "Insufficient current HRV data for comparison"
 msgstr "Insufficient current HRV data for comparison"
 
@@ -3221,7 +3225,7 @@ msgstr "Judgment recorded. The linked issue is not open, so no label was added."
 msgid "Judgment recorded. This feedback has no linked GitHub issue."
 msgstr "Judgment recorded. This feedback has no linked GitHub issue."
 
-#: src/pages/Today.tsx:274
+#: src/pages/Today.tsx:291
 msgid "Keep any optional movement easy and short"
 msgstr "Keep any optional movement easy and short"
 
@@ -3571,7 +3575,7 @@ msgstr "Major Outage"
 msgid "Major service outage"
 msgstr "Major service outage"
 
-#: src/pages/Today.tsx:276
+#: src/pages/Today.tsx:293
 msgid "Make today a full recovery day and reassess the hard session tomorrow"
 msgstr "Make today a full recovery day and reassess the hard session tomorrow"
 
@@ -3788,7 +3792,7 @@ msgstr "Monitoring runbook"
 msgid "months"
 msgstr "months"
 
-#: src/pages/Today.tsx:237
+#: src/pages/Today.tsx:254
 msgid "More historical HRV observations are needed before Praxys can form a personal recovery band. Follow the plan without an HRV-based adjustment."
 msgstr "More historical HRV observations are needed before Praxys can form a personal recovery band. Follow the plan without an HRV-based adjustment."
 
@@ -3861,7 +3865,7 @@ msgstr "Needs review"
 msgid "Needs review: {0}. Failed: {1}. Critical: {2}. High: {3}."
 msgstr "Needs review: {0}. Failed: {1}. Critical: {2}. High: {3}."
 
-#: src/pages/Today.tsx:414
+#: src/pages/Today.tsx:431
 msgid "negative balance"
 msgstr "negative balance"
 
@@ -4002,12 +4006,12 @@ msgstr "No current classification"
 msgid "No current qualifying condition range yet"
 msgstr "No current qualifying condition range yet"
 
-#: src/pages/Today.tsx:382
-#: src/pages/Today.tsx:395
-#: src/pages/Today.tsx:398
-#: src/pages/Today.tsx:401
-#: src/pages/Today.tsx:404
-#: src/pages/Today.tsx:584
+#: src/pages/Today.tsx:399
+#: src/pages/Today.tsx:412
+#: src/pages/Today.tsx:415
+#: src/pages/Today.tsx:418
+#: src/pages/Today.tsx:421
+#: src/pages/Today.tsx:602
 msgid "no data"
 msgstr "no data"
 
@@ -4068,7 +4072,7 @@ msgstr "No managed deliveries need operator action."
 msgid "No MFA"
 msgstr "No MFA"
 
-#: src/pages/Today.tsx:508
+#: src/pages/Today.tsx:525
 msgid "No new HRV, sleep, or activity since."
 msgstr "No new HRV, sleep, or activity since."
 
@@ -4192,15 +4196,15 @@ msgstr "No Workout"
 msgid "No workout is present on {target}."
 msgstr "No workout is present on {target}."
 
-#: src/pages/Today.tsx:225
+#: src/pages/Today.tsx:242
 msgid "No workout is scheduled, and HRV is below your personal caution band. Keep the day restorative rather than adding a hard session."
 msgstr "No workout is scheduled, and HRV is below your personal caution band. Keep the day restorative rather than adding a hard session."
 
-#: src/pages/Today.tsx:227
+#: src/pages/Today.tsx:244
 msgid "No workout is scheduled, and modeled load balance is low (TSB {tsb}). Avoid adding intensity today."
 msgstr "No workout is scheduled, and modeled load balance is low (TSB {tsb}). Avoid adding intensity today."
 
-#: src/pages/Today.tsx:229
+#: src/pages/Today.tsx:246
 msgid "No workout is scheduled. Add a session only if it fits your broader plan."
 msgstr "No workout is scheduled. Add a session only if it fits your broader plan."
 
@@ -4209,7 +4213,7 @@ msgstr "No workout is scheduled. Add a session only if it fits your broader plan
 msgid "No Workout Scheduled"
 msgstr "No Workout Scheduled"
 
-#: src/pages/Today.tsx:416
+#: src/pages/Today.tsx:433
 msgid "No workout scheduled."
 msgstr "No workout scheduled."
 
@@ -4278,7 +4282,7 @@ msgstr "Not enough data yet for stable load tracking"
 msgid "Not enough data yet for weekly load comparison"
 msgstr "Not enough data yet for weekly load comparison"
 
-#: src/pages/Today.tsx:410
+#: src/pages/Today.tsx:427
 msgid "not enough load history"
 msgstr "not enough load history"
 
@@ -4524,7 +4528,7 @@ msgstr "Outage"
 msgid "Outstanding codes"
 msgstr "Outstanding codes"
 
-#: src/pages/Today.tsx:400
+#: src/pages/Today.tsx:417
 msgid "overnight score"
 msgstr "overnight score"
 
@@ -4642,7 +4646,7 @@ msgstr "Plan window"
 msgid "Planned"
 msgstr "Planned"
 
-#: src/pages/Today.tsx:592
+#: src/pages/Today.tsx:610
 msgid "Planned · Today"
 msgstr "Planned · Today"
 
@@ -4696,7 +4700,7 @@ msgstr "Policy-gated auto-merge"
 #~ msgid "positive"
 #~ msgstr "positive"
 
-#: src/pages/Today.tsx:411
+#: src/pages/Today.tsx:428
 msgid "positive balance"
 msgstr "positive balance"
 
@@ -4950,7 +4954,7 @@ msgstr "Priority is excluded from readiness evaluation."
 msgid "Private alpha · Invitation only"
 msgstr "Private alpha · Invitation only"
 
-#: src/pages/Today.tsx:296
+#: src/pages/Today.tsx:313
 msgid "Proceed but monitor heart-rate drift during the session"
 msgstr "Proceed but monitor heart-rate drift during the session"
 
@@ -5033,11 +5037,11 @@ msgstr "Publish service updates on the <0>public status page</0>."
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "Pull your latest activities, power data, and recovery metrics"
 
-#: src/pages/Today.tsx:288
+#: src/pages/Today.tsx:305
 msgid "Push {workout} to tomorrow"
 msgstr "Push {workout} to tomorrow"
 
-#: src/pages/Today.tsx:280
+#: src/pages/Today.tsx:297
 msgid "Push {workout} to tomorrow if tomorrow is rest/easy"
 msgstr "Push {workout} to tomorrow if tomorrow is rest/easy"
 
@@ -5178,7 +5182,7 @@ msgid "Read-only accounts that mirror your dashboard data."
 msgstr "Read-only accounts that mirror your dashboard data."
 
 #: src/components/RecoveryPanel.tsx:199
-#: src/pages/Today.tsx:588
+#: src/pages/Today.tsx:606
 msgid "Readiness"
 msgstr "Readiness"
 
@@ -5244,7 +5248,7 @@ msgstr "Recent automatic changes"
 #~ msgid "Recent heat cadence"
 #~ msgstr "Recent heat cadence"
 
-#: src/pages/Today.tsx:235
+#: src/pages/Today.tsx:252
 msgid "Recent HRV observations have no measurable variation, so Praxys cannot form a reliable recovery band yet. Follow the plan without an HRV-based adjustment."
 msgstr "Recent HRV observations have no measurable variation, so Praxys cannot form a reliable recovery band yet. Follow the plan without an HRV-based adjustment."
 
@@ -5415,7 +5419,7 @@ msgstr "Recovery could not be completed. Refresh the queue and try again."
 msgid "Recovery could not start because the delivery state changed. Review the refreshed queue."
 msgstr "Recovery could not start because the delivery state changed. Review the refreshed queue."
 
-#: src/pages/Today.tsx:549
+#: src/pages/Today.tsx:566
 msgid "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 msgstr "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 
@@ -5428,7 +5432,7 @@ msgstr "Recovery Day"
 msgid "Recovery requires current HRV data from a compatible device (for example Oura Ring or an HRV-capable chest strap). Connect or sync one to enable recovery status and suggestions."
 msgstr "Recovery requires current HRV data from a compatible device (for example Oura Ring or an HRV-capable chest strap). Connect or sync one to enable recovery status and suggestions."
 
-#: src/pages/Today.tsx:239
+#: src/pages/Today.tsx:256
 msgid "Recovery requires current HRV data. Connect or sync an HRV-capable device to receive recovery suggestions."
 msgstr "Recovery requires current HRV data. Connect or sync an HRV-capable device to receive recovery suggestions."
 
@@ -5436,7 +5440,7 @@ msgstr "Recovery requires current HRV data. Connect or sync an HRV-capable devic
 #~ msgid "Recovery requires HRV data from a compatible device (for example Oura Ring or an HRV-capable chest strap). Connect one to enable recovery status and suggestions."
 #~ msgstr "Recovery requires HRV data from a compatible device (for example Oura Ring or an HRV-capable chest strap). Connect one to enable recovery status and suggestions."
 
-#: src/pages/Today.tsx:259
+#: src/pages/Today.tsx:276
 msgid "Recovery signals are within their recent reference bands. Follow the plan as written."
 msgstr "Recovery signals are within their recent reference bands. Follow the plan as written."
 
@@ -5488,7 +5492,7 @@ msgstr "Refresh"
 msgid "Refresh delivery state"
 msgstr "Refresh delivery state"
 
-#: src/pages/Today.tsx:494
+#: src/pages/Today.tsx:511
 msgid "Refresh failed"
 msgstr "Refresh failed"
 
@@ -5658,7 +5662,7 @@ msgstr "Rest"
 msgid "REST"
 msgstr "REST"
 
-#: src/pages/Today.tsx:231
+#: src/pages/Today.tsx:248
 msgid "Rest day scheduled. Follow the plan and prioritize recovery."
 msgstr "Rest day scheduled. Follow the plan and prioritize recovery."
 
@@ -5666,11 +5670,11 @@ msgstr "Rest day scheduled. Follow the plan and prioritize recovery."
 #~ msgid "Rest day. No workout scheduled."
 #~ msgstr "Rest day. No workout scheduled."
 
-#: src/pages/Today.tsx:272
+#: src/pages/Today.tsx:289
 msgid "Rest, walk, or do gentle mobility"
 msgstr "Rest, walk, or do gentle mobility"
 
-#: src/pages/Today.tsx:255
+#: src/pages/Today.tsx:272
 msgid "Resting heart rate is elevated above your baseline. This can be a caution signal, but it is not diagnostic."
 msgstr "Resting heart rate is elevated above your baseline. This can be a caution signal, but it is not diagnostic."
 
@@ -5719,8 +5723,8 @@ msgstr "Resume managed delivery?"
 #: src/pages/Goal.tsx:444
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:332
-#: src/pages/Today.tsx:338
-#: src/pages/Today.tsx:497
+#: src/pages/Today.tsx:355
+#: src/pages/Today.tsx:514
 #: src/pages/Training.tsx:181
 msgid "Retry"
 msgstr "Retry"
@@ -5821,7 +5825,7 @@ msgstr "Revoke"
 msgid "Revoked"
 msgstr "Revoked"
 
-#: src/pages/Today.tsx:585
+#: src/pages/Today.tsx:603
 msgid "RHR"
 msgstr "RHR"
 
@@ -5854,15 +5858,15 @@ msgstr "Run"
 msgid "Run <0>/praxys:{skillName}</0> in Claude Code for deeper analysis"
 msgstr "Run <0>/praxys:{skillName}</0> in Claude Code for deeper analysis"
 
-#: src/pages/Today.tsx:282
+#: src/pages/Today.tsx:299
 msgid "Run as planned but cap at low end of power range"
 msgstr "Run as planned but cap at low end of power range"
 
-#: src/pages/Today.tsx:290
+#: src/pages/Today.tsx:307
 msgid "Run as planned but monitor how you feel"
 msgstr "Run as planned but monitor how you feel"
 
-#: src/pages/Today.tsx:294
+#: src/pages/Today.tsx:311
 msgid "Run easy instead"
 msgstr "Run easy instead"
 
@@ -6108,7 +6112,7 @@ msgstr "Settings"
 msgid "Setup"
 msgstr "Setup"
 
-#: src/pages/Today.tsx:292
+#: src/pages/Today.tsx:309
 msgid "Shorten the session if fatigue develops"
 msgstr "Shorten the session if fatigue develops"
 
@@ -6152,7 +6156,7 @@ msgstr "Should not be agent-ready — sensitivity or privacy gate"
 #~ msgid "Show {0} more workouts"
 #~ msgstr "Show {0} more workouts"
 
-#: src/pages/Today.tsx:524
+#: src/pages/Today.tsx:541
 msgid "Show anyway"
 msgstr "Show anyway"
 
@@ -6168,11 +6172,11 @@ msgstr "Show methodology details"
 msgid "Showing"
 msgstr "Showing"
 
-#: src/pages/Today.tsx:496
+#: src/pages/Today.tsx:513
 msgid "Showing the last available data."
 msgstr "Showing the last available data."
 
-#: src/pages/Today.tsx:505
+#: src/pages/Today.tsx:522
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 
@@ -6203,7 +6207,7 @@ msgid "Skip for now"
 msgstr "Skip for now"
 
 #: src/components/RecoveryPanel.tsx:190
-#: src/pages/Today.tsx:586
+#: src/pages/Today.tsx:604
 msgid "Sleep"
 msgstr "Sleep"
 
@@ -6213,7 +6217,7 @@ msgstr "Sleep"
 msgid "Sleep Score"
 msgstr "Sleep Score"
 
-#: src/pages/Today.tsx:253
+#: src/pages/Today.tsx:270
 msgid "Sleep score is low ({sleep}). Consider reducing today's intensity."
 msgstr "Sleep score is low ({sleep}). Consider reducing today's intensity."
 
@@ -6229,11 +6233,11 @@ msgstr "Sleep score, HRV, readiness"
 msgid "Sleep, HRV, readiness"
 msgstr "Sleep, HRV, readiness"
 
-#: src/pages/Today.tsx:413
+#: src/pages/Today.tsx:430
 msgid "slightly negative"
 msgstr "slightly negative"
 
-#: src/pages/Today.tsx:412
+#: src/pages/Today.tsx:429
 msgid "slightly positive"
 msgstr "slightly positive"
 
@@ -6375,7 +6379,7 @@ msgstr "Suggestions"
 msgid "Summary window"
 msgstr "Summary window"
 
-#: src/pages/Today.tsx:284
+#: src/pages/Today.tsx:301
 msgid "Swap {workout} for easy run"
 msgstr "Swap {workout} for easy run"
 
@@ -6446,8 +6450,8 @@ msgstr "Sync from:"
 msgid "Sync history"
 msgstr "Sync history"
 
-#: src/pages/Today.tsx:517
-#: src/pages/Today.tsx:539
+#: src/pages/Today.tsx:534
+#: src/pages/Today.tsx:556
 msgid "Sync now"
 msgstr "Sync now"
 
@@ -6521,8 +6525,8 @@ msgstr "Syncing"
 msgid "Syncing..."
 msgstr "Syncing..."
 
-#: src/pages/Today.tsx:517
-#: src/pages/Today.tsx:539
+#: src/pages/Today.tsx:534
+#: src/pages/Today.tsx:556
 msgid "Syncing…"
 msgstr "Syncing…"
 
@@ -6660,7 +6664,7 @@ msgstr "The incident aggregate could not be refreshed."
 #~ msgid "The last qualifying block is beyond the initial retention window, so retained evidence is declining. The range shown here describes current qualifying evidence, not that prior block."
 #~ msgstr "The last qualifying block is beyond the initial retention window, so retained evidence is declining. The range shown here describes current qualifying evidence, not that prior block."
 
-#: src/pages/Today.tsx:233
+#: src/pages/Today.tsx:250
 msgid "The latest HRV reading is out of date. Follow the plan without an HRV-based recovery adjustment."
 msgstr "The latest HRV reading is out of date. Follow the plan without an HRV-based recovery adjustment."
 
@@ -6880,7 +6884,7 @@ msgstr "To target"
 #: src/components/HeatAdaptationPanel.tsx:193
 #: src/components/RecoveryPanel.tsx:136
 #: src/pages/Today.tsx:25
-#: src/pages/Today.tsx:491
+#: src/pages/Today.tsx:508
 msgid "Today"
 msgstr "Today"
 
@@ -6912,7 +6916,7 @@ msgstr "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is
 msgid "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is <2>{dirLabel}</2>."
 msgstr "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is <2>{dirLabel}</2>."
 
-#: src/pages/Today.tsx:430
+#: src/pages/Today.tsx:447
 msgid "Today's recommendation combines the scheduled workout with Praxys operational adaptations of your active recovery and load models. HRV requires a current reading, while TSB is modeled load balance rather than a direct measure of fatigue. Praxys TSB display labels and the one-CTL-window history gate are operational estimates, not validated cutoffs. These coaching guardrails are not a medical diagnosis."
 msgstr "Today's recommendation combines the scheduled workout with Praxys operational adaptations of your active recovery and load models. HRV requires a current reading, while TSB is modeled load balance rather than a direct measure of fatigue. Praxys TSB display labels and the one-CTL-window history gate are operational estimates, not validated cutoffs. These coaching guardrails are not a medical diagnosis."
 
@@ -7302,7 +7306,7 @@ msgid "vs {0}"
 msgstr "vs {0}"
 
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
-#: src/pages/Today.tsx:382
+#: src/pages/Today.tsx:399
 msgid "vs {0} baseline"
 msgstr "vs {0} baseline"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -271,7 +271,7 @@ msgid "{minutes} effective min"
 msgstr "等效热暴露 {minutes} 分钟"
 
 #: src/components/RecoveryPanel.tsx:159
-#: src/pages/Today.tsx:584
+#: src/pages/Today.tsx:602
 msgid "{observationCount}-observation Trend"
 msgstr "{observationCount}次观测趋势"
 
@@ -1724,7 +1724,7 @@ msgstr "骑行"
 msgid "Daily brief"
 msgstr "每日简报"
 
-#: src/pages/Today.tsx:403
+#: src/pages/Today.tsx:420
 msgid "daily score"
 msgstr "每日评分"
 
@@ -2094,7 +2094,7 @@ msgstr "完成"
 msgid "Drive your zone calculations and training load. Values come from connected sources; pick which source to use when you have more than one."
 msgstr "用于区间计算和训练负荷。数值来自已连接的数据来源；有多个时，选择要使用的来源。"
 
-#: src/pages/Today.tsx:286
+#: src/pages/Today.tsx:303
 msgid "Drop intensity by one zone"
 msgstr "强度下调一个区间"
 
@@ -2102,7 +2102,7 @@ msgstr "强度下调一个区间"
 #~ msgid "Drop intensity by one zone\" \"降低一个训练区间的强度"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:278
+#: src/pages/Today.tsx:295
 msgid "Drop to easy run (keep power in recovery zone)"
 msgstr "改为轻松跑（功率保持在恢复区间）"
 
@@ -2445,7 +2445,7 @@ msgstr "删除用户失败。"
 msgid "Failed to generate invitation code."
 msgstr "生成邀请码失败。"
 
-#: src/pages/Today.tsx:335
+#: src/pages/Today.tsx:352
 msgid "Failed to load"
 msgstr "加载失败"
 
@@ -2649,7 +2649,7 @@ msgstr "14天活动记录"
 #~ msgid "Freshened up — good window for racing or testing."
 #~ msgstr "充分恢复——适合比赛或测试的好时机。"
 
-#: src/pages/Today.tsx:532
+#: src/pages/Today.tsx:549
 msgid "From {dataAsOfLabel}"
 msgstr "数据截至 {dataAsOfLabel}"
 
@@ -2978,7 +2978,7 @@ msgstr "HRV 分析"
 #~ msgid "HRV below your Praxys caution band\" \"HRV 低于您的 Praxys 警戒区间"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:257
+#: src/pages/Today.tsx:274
 msgid "HRV is above your personal reference band. Follow the plan as written."
 msgstr "HRV 高于你的个人参考区间。按计划训练。"
 
@@ -2987,10 +2987,11 @@ msgstr "HRV 高于你的个人参考区间。按计划训练。"
 #~ msgstr ""
 
 #: src/components/RecoveryPanel.tsx:18
+#: src/pages/Today.tsx:223
 msgid "HRV is above your Praxys reference band"
 msgstr "HRV 高于你的 Praxys 参考区间"
 
-#: src/pages/Today.tsx:243
+#: src/pages/Today.tsx:260
 msgid "HRV is below your personal caution band. Keep today easy to support recovery."
 msgstr "HRV 低于你的个人警戒区间。今天轻松练，帮助恢复。"
 
@@ -2998,7 +2999,7 @@ msgstr "HRV 低于你的个人警戒区间。今天轻松练，帮助恢复。"
 #~ msgid "HRV is below your personal caution band. Keep today easy to support recovery.\" \"HRV 低于您的个人警戒区间。今天保持轻松，以支持恢复。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:241
+#: src/pages/Today.tsx:258
 msgid "HRV is below your personal caution band. Treat this as a recovery signal, not a diagnosis."
 msgstr "HRV 低于你的个人警戒区间。这是恢复信号，不是诊断。"
 
@@ -3007,6 +3008,7 @@ msgstr "HRV 低于你的个人警戒区间。这是恢复信号，不是诊断�
 #~ msgstr ""
 
 #: src/components/RecoveryPanel.tsx:20
+#: src/pages/Today.tsx:227
 msgid "HRV is below your Praxys caution band"
 msgstr "HRV 低于你的 Praxys 警戒区间"
 
@@ -3018,11 +3020,12 @@ msgstr "HRV 低于你的 Praxys 警戒区间"
 #~ msgid "HRV is normal but modeled load balance is low (TSB {tsb}). Modify the hard session.\" \"HRV 正常，但模型估算的负荷平衡偏低（TSB {tsb}）。请调整高强度训练。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:245
+#: src/pages/Today.tsx:262
 msgid "HRV is within your personal reference band, but modeled load balance is low (TSB {tsb}). Modify the hard session."
 msgstr "HRV 处于你的个人参考区间内，但模型估算的负荷平衡偏低（TSB {tsb}）。调整高强度训练。"
 
 #: src/components/RecoveryPanel.tsx:19
+#: src/pages/Today.tsx:225
 msgid "HRV is within your Praxys reference band"
 msgstr "HRV 处于你的 Praxys 参考区间内"
 
@@ -3034,11 +3037,11 @@ msgstr "HRV 处于你的 Praxys 参考区间内"
 #~ msgid "HRV rolling mean is declining. Reduce intensity as a conservative coaching adjustment.\" \"HRV 滚动均值正在下降。作为保守的训练调整，请降低强度。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:247
+#: src/pages/Today.tsx:264
 msgid "HRV rolling mean is lower than its prior window. Reduce intensity as a conservative coaching adjustment."
 msgstr "HRV 滚动均值低于前一个窗口。保守起见，降低强度。"
 
-#: src/pages/Today.tsx:249
+#: src/pages/Today.tsx:266
 msgid "HRV rolling mean is lower than its prior window. Stay easy today."
 msgstr "HRV 滚动均值低于前一窗口。今天轻松训练。"
 
@@ -3050,7 +3053,7 @@ msgstr "HRV 滚动均值低于前一窗口。今天轻松训练。"
 #~ msgid "HRV trend is declining. Stay easy today.\" \"HRV 趋势正在下降。今天保持轻松。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:251
+#: src/pages/Today.tsx:268
 msgid "HRV variability is high (CV {cv}%), above the selected coaching caution threshold."
 msgstr "HRV 变异性偏高（CV {cv}%），高于所设训练警戒阈值。"
 
@@ -3141,6 +3144,7 @@ msgid "Info"
 msgstr "信息"
 
 #: src/components/RecoveryPanel.tsx:21
+#: src/pages/Today.tsx:230
 msgid "Insufficient current HRV data for comparison"
 msgstr "当前 HRV 数据不足，无法比较"
 
@@ -3264,7 +3268,7 @@ msgstr "判断已记录。关联议题未开启，因此未添加标签。"
 msgid "Judgment recorded. This feedback has no linked GitHub issue."
 msgstr "判断已记录。此反馈尚未关联 GitHub 议题。"
 
-#: src/pages/Today.tsx:274
+#: src/pages/Today.tsx:291
 msgid "Keep any optional movement easy and short"
 msgstr "如有可选活动，请保持轻松且简短"
 
@@ -3618,7 +3622,7 @@ msgstr "大范围服务中断"
 msgid "Major service outage"
 msgstr "大范围服务中断"
 
-#: src/pages/Today.tsx:276
+#: src/pages/Today.tsx:293
 msgid "Make today a full recovery day and reassess the hard session tomorrow"
 msgstr "今天作为恢复日，明天再评估高强度训练"
 
@@ -3839,7 +3843,7 @@ msgstr "监控手册"
 msgid "months"
 msgstr "月"
 
-#: src/pages/Today.tsx:237
+#: src/pages/Today.tsx:254
 msgid "More historical HRV observations are needed before Praxys can form a personal recovery band. Follow the plan without an HRV-based adjustment."
 msgstr "需要更多历史 HRV 观测值才能建立个人恢复区间。请按计划训练，暂不进行基于 HRV 的调整。"
 
@@ -3912,7 +3916,7 @@ msgstr "需审核"
 msgid "Needs review: {0}. Failed: {1}. Critical: {2}. High: {3}."
 msgstr "待审核：{0}。失败：{1}。严重：{2}。高优先级：{3}。"
 
-#: src/pages/Today.tsx:414
+#: src/pages/Today.tsx:431
 msgid "negative balance"
 msgstr "负平衡"
 
@@ -4057,12 +4061,12 @@ msgstr "当前暂无分类"
 msgid "No current qualifying condition range yet"
 msgstr "目前尚无符合条件的环境范围"
 
-#: src/pages/Today.tsx:382
-#: src/pages/Today.tsx:395
-#: src/pages/Today.tsx:398
-#: src/pages/Today.tsx:401
-#: src/pages/Today.tsx:404
-#: src/pages/Today.tsx:584
+#: src/pages/Today.tsx:399
+#: src/pages/Today.tsx:412
+#: src/pages/Today.tsx:415
+#: src/pages/Today.tsx:418
+#: src/pages/Today.tsx:421
+#: src/pages/Today.tsx:602
 msgid "no data"
 msgstr "暂无数据"
 
@@ -4123,7 +4127,7 @@ msgstr "当前没有需要运维处理的托管下发任务。"
 msgid "No MFA"
 msgstr "无需 MFA"
 
-#: src/pages/Today.tsx:508
+#: src/pages/Today.tsx:525
 msgid "No new HRV, sleep, or activity since."
 msgstr "此后无新的 HRV、睡眠或活动数据。"
 
@@ -4247,7 +4251,7 @@ msgstr "无训练安排"
 msgid "No workout is present on {target}."
 msgstr "{target} 上没有此训练。"
 
-#: src/pages/Today.tsx:225
+#: src/pages/Today.tsx:242
 msgid "No workout is scheduled, and HRV is below your personal caution band. Keep the day restorative rather than adding a hard session."
 msgstr "今天没有安排训练，且 HRV 低于你的个人警戒区间。今天以恢复为主，不要额外加高强度训练。"
 
@@ -4255,7 +4259,7 @@ msgstr "今天没有安排训练，且 HRV 低于你的个人警戒区间。今�
 #~ msgid "No workout is scheduled, and HRV is below your personal caution band. Keep the day restorative rather than adding a hard session.\" \"今天没有安排训练，且 HRV 低于您的个人警戒区间。请以恢复为主，不要额外增加高强度训练。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:227
+#: src/pages/Today.tsx:244
 msgid "No workout is scheduled, and modeled load balance is low (TSB {tsb}). Avoid adding intensity today."
 msgstr "今天没有安排训练，且负荷平衡偏低（TSB {tsb}）。今天不要额外加强度。"
 
@@ -4263,7 +4267,7 @@ msgstr "今天没有安排训练，且负荷平衡偏低（TSB {tsb}）。今天
 #~ msgid "No workout is scheduled, and modeled load balance is low (TSB {tsb}). Avoid adding intensity today.\" \"今天没有安排训练，且模型估算的负荷平衡偏低（TSB {tsb}）。今天不要额外增加强度。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:229
+#: src/pages/Today.tsx:246
 msgid "No workout is scheduled. Add a session only if it fits your broader plan."
 msgstr "今天没有安排训练。仅在符合整体计划时增加训练。"
 
@@ -4276,7 +4280,7 @@ msgstr "今天没有安排训练。仅在符合整体计划时增加训练。"
 msgid "No Workout Scheduled"
 msgstr "今日无训练安排"
 
-#: src/pages/Today.tsx:416
+#: src/pages/Today.tsx:433
 msgid "No workout scheduled."
 msgstr "今日无训练安排。"
 
@@ -4345,7 +4349,7 @@ msgstr "数据不足，暂无法稳定跟踪负荷"
 msgid "Not enough data yet for weekly load comparison"
 msgstr "数据不足，暂无法对比每周负荷"
 
-#: src/pages/Today.tsx:410
+#: src/pages/Today.tsx:427
 msgid "not enough load history"
 msgstr "负荷历史不足"
 
@@ -4591,7 +4595,7 @@ msgstr "服务中断"
 msgid "Outstanding codes"
 msgstr "未使用的邀请码"
 
-#: src/pages/Today.tsx:400
+#: src/pages/Today.tsx:417
 msgid "overnight score"
 msgstr "夜间评分"
 
@@ -4709,7 +4713,7 @@ msgstr "计划范围"
 msgid "Planned"
 msgstr "计划"
 
-#: src/pages/Today.tsx:592
+#: src/pages/Today.tsx:610
 msgid "Planned · Today"
 msgstr "今日计划"
 
@@ -4763,7 +4767,7 @@ msgstr "策略门禁自动合并"
 #~ msgid "positive"
 #~ msgstr "状态良好"
 
-#: src/pages/Today.tsx:411
+#: src/pages/Today.tsx:428
 msgid "positive balance"
 msgstr "正平衡"
 
@@ -5025,7 +5029,7 @@ msgstr "就绪评估不使用优先级。"
 msgid "Private alpha · Invitation only"
 msgstr "内测中 · 仅限邀请"
 
-#: src/pages/Today.tsx:296
+#: src/pages/Today.tsx:313
 msgid "Proceed but monitor heart-rate drift during the session"
 msgstr "继续训练，但注意观察训练中的心率漂移"
 
@@ -5112,11 +5116,11 @@ msgstr "在<0>公开状态页</0>发布服务动态。"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "同步最新活动、功率数据和恢复指标"
 
-#: src/pages/Today.tsx:288
+#: src/pages/Today.tsx:305
 msgid "Push {workout} to tomorrow"
 msgstr "将 {workout} 推迟到明天"
 
-#: src/pages/Today.tsx:280
+#: src/pages/Today.tsx:297
 msgid "Push {workout} to tomorrow if tomorrow is rest/easy"
 msgstr "如果明天安排休息或轻松训练，把 {workout} 挪到明天"
 
@@ -5265,7 +5269,7 @@ msgid "Read-only accounts that mirror your dashboard data."
 msgstr "镜像主页数据的只读账号。"
 
 #: src/components/RecoveryPanel.tsx:199
-#: src/pages/Today.tsx:588
+#: src/pages/Today.tsx:606
 msgid "Readiness"
 msgstr "准备度"
 
@@ -5331,7 +5335,7 @@ msgstr "最近的自动调整"
 #~ msgid "Recent heat cadence"
 #~ msgstr "近期热暴露节奏"
 
-#: src/pages/Today.tsx:235
+#: src/pages/Today.tsx:252
 msgid "Recent HRV observations have no measurable variation, so Praxys cannot form a reliable recovery band yet. Follow the plan without an HRV-based adjustment."
 msgstr "近期 HRV 观测值没有可测变化，Praxys 暂时无法建立可靠的恢复区间。请按计划训练，暂不进行基于 HRV 的调整。"
 
@@ -5502,7 +5506,7 @@ msgstr "恢复未能完成。请刷新队列后重试。"
 msgid "Recovery could not start because the delivery state changed. Review the refreshed queue."
 msgstr "恢复未能开始，因为下发状态已变更。请查看已刷新的队列。"
 
-#: src/pages/Today.tsx:549
+#: src/pages/Today.tsx:566
 msgid "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 msgstr "恢复数据尚未同步，当前显示最近一次读数（{recoveryLatestLabel}）。"
 
@@ -5519,7 +5523,7 @@ msgstr "恢复分析需要兼容设备（例如 Oura Ring 或支持 HRV 的胸�
 #~ msgid "Recovery requires current HRV data from a compatible device (for example Oura Ring or an HRV-capable chest strap). Connect or sync one to enable recovery status and suggestions.\" \"恢复评估需要兼容设备提供的当前 HRV 数据（例如 Oura Ring 或支持 HRV 的心率带）。连接或同步设备后即可启用恢复状态和建议。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:239
+#: src/pages/Today.tsx:256
 msgid "Recovery requires current HRV data. Connect or sync an HRV-capable device to receive recovery suggestions."
 msgstr "恢复分析需要当前 HRV 数据。请连接或同步支持 HRV 的设备以获取恢复建议。"
 
@@ -5531,7 +5535,7 @@ msgstr "恢复分析需要当前 HRV 数据。请连接或同步支持 HRV 的�
 #~ msgid "Recovery requires HRV data from a compatible device (for example Oura Ring or an HRV-capable chest strap). Connect one to enable recovery status and suggestions."
 #~ msgstr "恢复需要来自兼容设备的 HRV 数据（例如 Oura Ring 或支持 HRV 的心率带）。连接一个设备以启用恢复状态和建议。"
 
-#: src/pages/Today.tsx:259
+#: src/pages/Today.tsx:276
 msgid "Recovery signals are within their recent reference bands. Follow the plan as written."
 msgstr "恢复信号都在近期参考区间内。按计划训练。"
 
@@ -5587,7 +5591,7 @@ msgstr "刷新"
 msgid "Refresh delivery state"
 msgstr "刷新下发状态"
 
-#: src/pages/Today.tsx:494
+#: src/pages/Today.tsx:511
 msgid "Refresh failed"
 msgstr "刷新失败"
 
@@ -5761,7 +5765,7 @@ msgstr "休息"
 msgid "REST"
 msgstr "休息"
 
-#: src/pages/Today.tsx:231
+#: src/pages/Today.tsx:248
 msgid "Rest day scheduled. Follow the plan and prioritize recovery."
 msgstr "已安排休息日。按计划休息并优先恢复。"
 
@@ -5773,7 +5777,7 @@ msgstr "已安排休息日。按计划休息并优先恢复。"
 #~ msgid "Rest day. No workout scheduled."
 #~ msgstr "休息日。今日无训练安排。"
 
-#: src/pages/Today.tsx:272
+#: src/pages/Today.tsx:289
 msgid "Rest, walk, or do gentle mobility"
 msgstr "休息、散步或做些轻柔的活动度练习"
 
@@ -5781,7 +5785,7 @@ msgstr "休息、散步或做些轻柔的活动度练习"
 #~ msgid "Rest, walk, or do gentle mobility\" \"休息、散步或进行轻柔的活动度练习"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:255
+#: src/pages/Today.tsx:272
 msgid "Resting heart rate is elevated above your baseline. This can be a caution signal, but it is not diagnostic."
 msgstr "静息心率高于你的基准。这可能是提醒信号，但不能作为诊断依据。"
 
@@ -5834,8 +5838,8 @@ msgstr "恢复托管下发？"
 #: src/pages/Goal.tsx:444
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:332
-#: src/pages/Today.tsx:338
-#: src/pages/Today.tsx:497
+#: src/pages/Today.tsx:355
+#: src/pages/Today.tsx:514
 #: src/pages/Training.tsx:181
 msgid "Retry"
 msgstr "重试"
@@ -5936,7 +5940,7 @@ msgstr "撤销"
 msgid "Revoked"
 msgstr "已撤销"
 
-#: src/pages/Today.tsx:585
+#: src/pages/Today.tsx:603
 msgid "RHR"
 msgstr "静息心率"
 
@@ -5969,7 +5973,7 @@ msgstr "跑步"
 msgid "Run <0>/praxys:{skillName}</0> in Claude Code for deeper analysis"
 msgstr "在 Claude Code 中运行 <0>/praxys:{skillName}</0> 获取深入分析"
 
-#: src/pages/Today.tsx:282
+#: src/pages/Today.tsx:299
 msgid "Run as planned but cap at low end of power range"
 msgstr "按计划跑步，但将功率控制在目标范围下限"
 
@@ -5977,7 +5981,7 @@ msgstr "按计划跑步，但将功率控制在目标范围下限"
 #~ msgid "Run as planned but cap at low end of power range\" \"按计划训练，但将功率控制在目标区间下限"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:290
+#: src/pages/Today.tsx:307
 msgid "Run as planned but monitor how you feel"
 msgstr "按计划跑步，但请留意身体感受"
 
@@ -5985,7 +5989,7 @@ msgstr "按计划跑步，但请留意身体感受"
 #~ msgid "Run as planned but monitor how you feel\" \"按计划训练，但留意身体感受"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:294
+#: src/pages/Today.tsx:311
 msgid "Run easy instead"
 msgstr "改为轻松跑"
 
@@ -6235,7 +6239,7 @@ msgstr "设置"
 msgid "Setup"
 msgstr "设置向导"
 
-#: src/pages/Today.tsx:292
+#: src/pages/Today.tsx:309
 msgid "Shorten the session if fatigue develops"
 msgstr "如果感到疲劳，就缩短训练"
 
@@ -6283,7 +6287,7 @@ msgstr "不应标记为 agent-ready：触发敏感或隐私限制"
 #~ msgid "Show {0} more workouts"
 #~ msgstr "显示另外 {0} 项训练"
 
-#: src/pages/Today.tsx:524
+#: src/pages/Today.tsx:541
 msgid "Show anyway"
 msgstr "仍要查看"
 
@@ -6299,7 +6303,7 @@ msgstr "展开方法论详情"
 msgid "Showing"
 msgstr "显示第"
 
-#: src/pages/Today.tsx:496
+#: src/pages/Today.tsx:513
 msgid "Showing the last available data."
 msgstr "当前显示的是最近一次可用数据。"
 
@@ -6307,7 +6311,7 @@ msgstr "当前显示的是最近一次可用数据。"
 #~ msgid "Showing the last available data.\" \"正在显示最近一次可用数据。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:505
+#: src/pages/Today.tsx:522
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "显示的是昨天的快照。最近一次读数 {dataAsOfLabel}。"
 
@@ -6338,7 +6342,7 @@ msgid "Skip for now"
 msgstr "先跳过"
 
 #: src/components/RecoveryPanel.tsx:190
-#: src/pages/Today.tsx:586
+#: src/pages/Today.tsx:604
 msgid "Sleep"
 msgstr "睡眠"
 
@@ -6348,7 +6352,7 @@ msgstr "睡眠"
 msgid "Sleep Score"
 msgstr "睡眠评分"
 
-#: src/pages/Today.tsx:253
+#: src/pages/Today.tsx:270
 msgid "Sleep score is low ({sleep}). Consider reducing today's intensity."
 msgstr "睡眠评分偏低（{sleep}）。考虑降低今天的训练强度。"
 
@@ -6368,7 +6372,7 @@ msgstr "睡眠得分、HRV、准备度"
 msgid "Sleep, HRV, readiness"
 msgstr "睡眠、HRV、准备度"
 
-#: src/pages/Today.tsx:413
+#: src/pages/Today.tsx:430
 msgid "slightly negative"
 msgstr "轻微负平衡"
 
@@ -6376,7 +6380,7 @@ msgstr "轻微负平衡"
 #~ msgid "slightly negative\" \"轻度负平衡"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:412
+#: src/pages/Today.tsx:429
 msgid "slightly positive"
 msgstr "轻微正平衡"
 
@@ -6522,7 +6526,7 @@ msgstr "建议"
 msgid "Summary window"
 msgstr "汇总时间范围"
 
-#: src/pages/Today.tsx:284
+#: src/pages/Today.tsx:301
 msgid "Swap {workout} for easy run"
 msgstr "将 {workout} 改为轻松跑"
 
@@ -6597,8 +6601,8 @@ msgstr "同步起始日期："
 msgid "Sync history"
 msgstr "同步历史数据"
 
-#: src/pages/Today.tsx:517
-#: src/pages/Today.tsx:539
+#: src/pages/Today.tsx:534
+#: src/pages/Today.tsx:556
 msgid "Sync now"
 msgstr "立即同步"
 
@@ -6672,8 +6676,8 @@ msgstr "同步中"
 msgid "Syncing..."
 msgstr "同步中…"
 
-#: src/pages/Today.tsx:517
-#: src/pages/Today.tsx:539
+#: src/pages/Today.tsx:534
+#: src/pages/Today.tsx:556
 msgid "Syncing…"
 msgstr "同步中…"
 
@@ -6810,7 +6814,7 @@ msgstr "无法刷新事件聚合数据。"
 #~ msgid "The last qualifying block is beyond the initial retention window, so retained evidence is declining. The range shown here describes current qualifying evidence, not that prior block."
 #~ msgstr "距上一个符合条件的训练区块已超过初始保留窗口，因此保留证据正在下降。此处显示的范围仅描述当前符合条件的证据，并非先前训练区块的环境范围。"
 
-#: src/pages/Today.tsx:233
+#: src/pages/Today.tsx:250
 msgid "The latest HRV reading is out of date. Follow the plan without an HRV-based recovery adjustment."
 msgstr "最新 HRV 读数已过时。按计划训练，不做基于 HRV 的恢复调整。"
 
@@ -7038,7 +7042,7 @@ msgstr "距目标"
 #: src/components/HeatAdaptationPanel.tsx:193
 #: src/components/RecoveryPanel.tsx:136
 #: src/pages/Today.tsx:25
-#: src/pages/Today.tsx:491
+#: src/pages/Today.tsx:508
 msgid "Today"
 msgstr "今日"
 
@@ -7070,7 +7074,7 @@ msgstr "今日 <0>{distLabel}</0> 预计成绩为 <1>{predicted}</1>。{abbrev} 
 msgid "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is <2>{dirLabel}</2>."
 msgstr "今日 <0>{distLabel}</0> 预计成绩为 <1>{predicted}</1>。{abbrev} 呈 <2>{dirLabel}</2>趋势。"
 
-#: src/pages/Today.tsx:430
+#: src/pages/Today.tsx:447
 msgid "Today's recommendation combines the scheduled workout with Praxys operational adaptations of your active recovery and load models. HRV requires a current reading, while TSB is modeled load balance rather than a direct measure of fatigue. Praxys TSB display labels and the one-CTL-window history gate are operational estimates, not validated cutoffs. These coaching guardrails are not a medical diagnosis."
 msgstr "今日建议将计划训练与 Praxys 对当前恢复模型和负荷模型的操作性调整相结合。HRV 需要最新读数，而 TSB 是模型化的负荷平衡，并非疲劳的直接测量。Praxys 的 TSB 显示标签和一个 CTL 时间常数的历史门槛属于操作性估算，并非经验证的阈值。这些训练指导不构成医疗诊断。"
 
@@ -7464,7 +7468,7 @@ msgid "vs {0}"
 msgstr "对比{0}"
 
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
-#: src/pages/Today.tsx:382
+#: src/pages/Today.tsx:399
 msgid "vs {0} baseline"
 msgstr "对比基准 {0}"
 
@@ -7699,12 +7703,10 @@ msgstr "Praxys 邀请"
 #. placeholder {0}: result.code
 #. placeholder {1}: result.invite_url
 #: src/pages/admin/AdminUsers.tsx:830
-msgid ""
-"Your Praxys invitation code: {0}\n"
+msgid "Your Praxys invitation code: {0}\n"
 "\n"
 "Finish registering here: {1}"
-msgstr ""
-"Praxys 邀请码：{0}\n"
+msgstr "Praxys 邀请码：{0}\n"
 "\n"
 "注册链接：{1}"
 

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -214,6 +214,23 @@ function formatPlan(plan: TrainingSignal['plan']): string | null {
   return parts.join(' · ');
 }
 
+function localizedRecoverySummary(
+  analysis: RecoveryAnalysis | null,
+  i18n: I18n,
+): string {
+  switch (analysis?.status) {
+    case 'fresh':
+      return i18n._(msg`HRV is above your Praxys reference band`);
+    case 'normal':
+      return i18n._(msg`HRV is within your Praxys reference band`);
+    case 'fatigued':
+      return i18n._(msg`HRV is below your Praxys caution band`);
+    case 'insufficient_data':
+    default:
+      return i18n._(msg`Insufficient current HRV data for comparison`);
+  }
+}
+
 function localizedSignalReason(signal: TrainingSignal, i18n: I18n): string {
   const rawTsb = signal.reason_args?.tsb ?? signal.recovery.tsb;
   const tsb = rawTsb == null ? '' : Number(rawTsb).toFixed(0);
@@ -561,7 +578,7 @@ export default function Today() {
             {verdictText}
           </span>
         </div>
-        <p className={`text-xl font-semibold ${tone.text}`}>{verdictSubtitle}</p>
+        <p className={`text-xl font-bold ${tone.text}`}>{verdictSubtitle}</p>
       </div>
       {/* Praxys Coach receipt is deterministic on Today. The daily insight
           slot is intentionally disabled so generated prose can never
@@ -572,6 +589,7 @@ export default function Today() {
         attribution={attribution}
         fallback={{
           headline: localizedReason,
+          summary: localizedRecoverySummary(ra, i18n),
           recommendations: localizedAlternatives,
         } as CoachFallback}
         onDetailsOpen={() => recordProductEventOnce(

--- a/web/tests/today-recovery-guidance.test.mjs
+++ b/web/tests/today-recovery-guidance.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const read = (path) => readFile(new URL(path, import.meta.url), 'utf8');
+
+test('Today coach shows recovery context alongside canonical training advice', async () => {
+  const [webToday, miniToday, miniTemplate] = await Promise.all([
+    read('../src/pages/Today.tsx'),
+    read('../../miniapp/pages/today/index.ts'),
+    read('../../miniapp/pages/today/index.wxml'),
+  ]);
+
+  assert.match(webToday, /summary:\s*localizedRecoverySummary\(ra,\s*i18n\)/);
+  assert.match(webToday, /recommendations:\s*localizedAlternatives/);
+  assert.match(webToday, /fetchInsight=\{false\}/);
+
+  assert.match(
+    miniToday,
+    /summary:\s*localizedRecoverySummary\(response\.recovery_analysis\)/,
+  );
+  assert.match(miniToday, /recommendations,\s*\n\s*attribution,/);
+  assert.match(miniTemplate, /class="coach-summary">\{\{coach\.summary\}\}/);
+});


### PR DESCRIPTION
## Summary

- Restore a localized recovery-status summary beside the deterministic Today training verdict and alternatives.
- Keep free-form `daily_brief` fetching disabled so the canonical same-day signal remains authoritative.
- Match the web behavior in the miniapp and add a cross-client regression test.
- Strengthen the caution subtitle weight after rendered review found an AA contrast defect.

Closes #519

## Validation

- `node --test tests/today-recovery-guidance.test.mjs`
- `npm run build` (`web`)
- `npm run typecheck` (`miniapp`)
- `.venv\Scripts\python.exe scripts\check_ui_quality.py --base origin/main --head HEAD --skip-evidence`
- `.venv\Scripts\python.exe scripts\agent_preflight.py --base origin/main` (1926 passed, 3 skipped; clean worktree)

## UI quality
- Impeccable: `polish web/src/pages/Today.tsx`
- Visual review: web desktop 1440x900 (EN, light) and web mobile 390x844 (zh, light); miniapp WeChat/Skyline native rendering was unavailable in Chrome DevTools
- States checked: success with collapsed and keyboard-expanded recommendations; long EN/zh guidance and plan copy
- Accessibility: Tab/Enter activation and visible focus on Coach details; no horizontal mobile overflow; Lighthouse mobile snapshot accessibility 100; no new motion or touch controls
- Design system impact: none - the existing coach-receipt summary pattern, semantic tokens, and bilingual catalogs cover the change
- Miniapp parity: updated controller, WXML, and shared receipt styling; generated i18n and typecheck passed
- Exceptions: native WeChat/Skyline rendering was not available in Chrome DevTools; miniapp validation was source, catalog, and typecheck based
