### PR TITLE
Speed up authenticated dashboard startup

### DIFF
--- a/web/src/hooks/useApi.ts
+++ b/web/src/hooks/useApi.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { KEYS, getCompatItem, removeCompatItem } from '../lib/storage-compat';
+import { initialDashboardUrl } from '../lib/dashboard-prefetch';
+import { tokenCacheScope } from '../lib/auth-cache-scope';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
@@ -30,6 +32,12 @@ function getAuthHeaders(): HeadersInit {
   return {};
 }
 
+function getAuthCacheScope(): string {
+  return tokenCacheScope(
+    getCompatItem(KEYS.authToken.new, KEYS.authToken.legacy),
+  );
+}
+
 async function apiFetch(url: string, init: RequestInit = {}): Promise<Response> {
   const fullUrl = url.startsWith('http') ? url : `${API_BASE}${url}`;
   const headers = new Headers(init.headers);
@@ -54,11 +62,29 @@ async function apiFetch(url: string, init: RequestInit = {}): Promise<Response> 
   return res;
 }
 
+const prefetchedResponses = new Map<string, Promise<Response | null>>();
+
+function startInitialDashboardPrefetch(): void {
+  if (typeof window === 'undefined') return;
+  const token = getCompatItem(KEYS.authToken.new, KEYS.authToken.legacy);
+  const url = initialDashboardUrl(window.location.pathname, Boolean(token));
+  if (!url) return;
+
+  // Auth verification and dashboard data are independent authenticated reads.
+  // Start both during module evaluation so the page does not pay one
+  // cross-border round trip before beginning the next.
+  prefetchedResponses.set(url, apiFetch(url).catch(() => null));
+}
+
 async function apiFetcher<T>(url: string): Promise<T> {
-  const res = await apiFetch(url);
+  const prefetched = prefetchedResponses.get(url);
+  if (prefetched) prefetchedResponses.delete(url);
+  const res = (prefetched ? await prefetched : null) ?? await apiFetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
+
+startInitialDashboardPrefetch();
 
 /**
  * Pull a human-readable error message out of a non-2xx fetch Response.
@@ -85,11 +111,18 @@ async function extractErrorMessage(res: Response, fallback: string): Promise<str
   return fallback;
 }
 
-export { API_BASE, getAuthHeaders, apiFetch, apiFetcher, extractErrorMessage };
+export {
+  API_BASE,
+  getAuthHeaders,
+  getAuthCacheScope,
+  apiFetch,
+  apiFetcher,
+  extractErrorMessage,
+};
 
 export function useApi<T>(url: string, options?: UseApiOptions): UseApiResult<T> {
   const { data, isLoading, isStale, error, refetch } = useQuery<T, Error>({
-    queryKey: [url],
+    queryKey: [url, getAuthCacheScope()],
     queryFn: () => apiFetcher<T>(url),
     ...(options?.refetchInterval !== undefined
       ? { refetchInterval: options.refetchInterval }

--- a/web/src/hooks/useSetupStatus.ts
+++ b/web/src/hooks/useSetupStatus.ts
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useSettings } from '@/contexts/SettingsContext';
-import { API_BASE, getAuthHeaders } from '@/hooks/useApi';
+import {
+  API_BASE,
+  apiFetch,
+  getAuthCacheScope,
+} from '@/hooks/useApi';
 import type { SyncStatusResponse } from '@/types/api';
 
 const SETUP_DONE_KEY = 'praxys-setup-done';
@@ -62,6 +67,22 @@ export interface SetupStatus {
   refetch: () => void;
 }
 
+interface ConnectionsResponse {
+  connections?: Record<string, unknown>;
+}
+
+async function fetchConnections(): Promise<ConnectionsResponse> {
+  const response = await apiFetch(`${API_BASE}/api/settings/connections`);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.json();
+}
+
+async function fetchSyncStatus(): Promise<SyncStatusResponse> {
+  const response = await apiFetch(`${API_BASE}/api/sync/status`);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.json();
+}
+
 /**
  * Derives onboarding setup status from SettingsContext + connections API.
  * Used by the Setup page, nav badge, and redirect logic.
@@ -70,45 +91,26 @@ export function useSetupStatus(): SetupStatus {
   const { config, loading: settingsLoading } = useSettings();
   // Cached flag: if setup was fully complete on a prior load, skip the
   // blocking API calls so TodayOrSetup renders Today immediately.
-  // fetchKey > 0 (manual refetch) always re-runs the blocking path.
   const [cachedDone] = useState(() => getCachedSetupDone());
-  const [connectedPlatforms, setConnectedPlatforms] = useState<string[]>([]);
-  const [syncStatus, setSyncStatus] = useState<SyncStatusResponse>({});
-  const [connectionsLoading, setConnectionsLoading] = useState(true);
-  const [fetchKey, setFetchKey] = useState(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    const isBackgroundRefresh = cachedDone && fetchKey === 0;
-
-    if (!isBackgroundRefresh) setConnectionsLoading(true);
-
-    Promise.all([
-      fetch(`${API_BASE}/api/settings/connections`, { headers: getAuthHeaders() })
-        .then((r) => r.ok ? r.json() : { connections: {} }),
-      fetch(`${API_BASE}/api/sync/status`, { headers: getAuthHeaders() })
-        .then((r) => r.ok ? r.json() : {}),
-    ])
-      .then(([connData, syncData]) => {
-        if (cancelled) return;
-        // Real connections = platforms with stored credentials
-        const platforms = Object.keys(connData.connections || {});
-        setConnectedPlatforms(platforms);
-        setSyncStatus(syncData);
-        if (!isBackgroundRefresh) setConnectionsLoading(false);
-      })
-      .catch(() => {
-        if (!cancelled && !isBackgroundRefresh) setConnectionsLoading(false);
-      });
-
-    return () => { cancelled = true; };
-  // cachedDone is stable (useState with no setter), so this never
-  // causes extra runs — it's listed to satisfy the exhaustive-deps rule.
-  }, [fetchKey, cachedDone]);
+  const authScope = getAuthCacheScope();
+  const connectionsQuery = useQuery({
+    queryKey: ['setup', 'connections', authScope],
+    queryFn: fetchConnections,
+  });
+  const syncStatusQuery = useQuery({
+    queryKey: ['setup', 'sync-status', authScope],
+    queryFn: fetchSyncStatus,
+  });
+  const connectedPlatforms = Object.keys(
+    connectionsQuery.data?.connections ?? {},
+  );
+  const syncStatus = syncStatusQuery.data ?? {};
 
   // When the cache says setup was complete and this is the initial load,
   // skip the blocking wait so TodayOrSetup renders Today immediately.
-  const loading = (cachedDone && fetchKey === 0) ? false : (settingsLoading || connectionsLoading);
+  const loading = cachedDone
+    ? false
+    : settingsLoading || connectionsQuery.isLoading || syncStatusQuery.isLoading;
 
   // Derive step completion
   const hasConnection = connectedPlatforms.length > 0;
@@ -161,27 +163,51 @@ export function useSetupStatus(): SetupStatus {
 
   const completed = steps.filter((s) => s.done).length;
   const isActuallyDone = completed === steps.length;
+  const liveStatusValidated = (
+    !settingsLoading
+    && connectionsQuery.isSuccess
+    && syncStatusQuery.isSuccess
+  );
 
   // Keep the cache in sync with live state: set on completion, clear when
   // a platform is disconnected or setup regresses (e.g. after logout on a
   // shared browser or account switch).
   useEffect(() => {
-    if (isActuallyDone) setCachedSetupDone();
-    else clearCachedSetupDone();
-  }, [isActuallyDone]);
+    if (
+      settingsLoading
+      || !connectionsQuery.isSuccess
+      || !syncStatusQuery.isSuccess
+    ) {
+      return;
+    }
+    if (isActuallyDone) {
+      setCachedSetupDone();
+    } else {
+      clearCachedSetupDone();
+    }
+  }, [
+    connectionsQuery.isSuccess,
+    isActuallyDone,
+    settingsLoading,
+    syncStatusQuery.isSuccess,
+  ]);
 
   return {
     loading,
     steps,
     completed,
     total: steps.length,
-    allDone: (cachedDone && fetchKey === 0) || isActuallyDone,
+    allDone: (cachedDone && !liveStatusValidated) || isActuallyDone,
     hasConnection,
     hasSyncedData,
     connectedPlatforms,
     syncStatus,
     // Clear cache on manual refetch (e.g. after disconnecting a platform)
     // so the next render re-checks live state instead of using stale cache.
-    refetch: () => { clearCachedSetupDone(); setFetchKey((k) => k + 1); },
+    refetch: () => {
+      clearCachedSetupDone();
+      void connectionsQuery.refetch();
+      void syncStatusQuery.refetch();
+    },
   };
 }

--- a/web/src/lib/auth-cache-scope.ts
+++ b/web/src/lib/auth-cache-scope.ts
@@ -1,0 +1,10 @@
+export function tokenCacheScope(token: string | null): string {
+  if (!token) return 'anonymous';
+
+  let hash = 2166136261;
+  for (let index = 0; index < token.length; index += 1) {
+    hash ^= token.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `auth-${(hash >>> 0).toString(16)}`;
+}

--- a/web/src/lib/dashboard-prefetch.ts
+++ b/web/src/lib/dashboard-prefetch.ts
@@ -1,0 +1,9 @@
+export function initialDashboardUrl(
+  pathname: string,
+  hasToken: boolean,
+): '/api/today' | '/api/training' | null {
+  if (!hasToken) return null;
+  if (pathname === '/' || pathname === '/today') return '/api/today';
+  if (pathname === '/training') return '/api/training';
+  return null;
+}

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -18,7 +18,7 @@ msgid " · "
 msgstr " · "
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
-#: src/pages/Training.tsx:367
+#: src/pages/Training.tsx:362
 msgid "· last {0} weeks"
 msgstr "· last {0} weeks"
 
@@ -155,7 +155,7 @@ msgstr "{0} shadow decisions · {1} labels applied · {2} durable outcomes"
 #~ msgstr "{0} work min · {1} effective min"
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
-#: src/pages/Training.tsx:317
+#: src/pages/Training.tsx:312
 msgid "{0}-week average"
 msgstr "{0}-week average"
 
@@ -271,7 +271,7 @@ msgid "{minutes} effective min"
 msgstr "{minutes} effective min"
 
 #: src/components/RecoveryPanel.tsx:159
-#: src/pages/Today.tsx:602
+#: src/pages/Today.tsx:599
 msgid "{observationCount}-observation Trend"
 msgstr "{observationCount}-observation Trend"
 
@@ -623,11 +623,11 @@ msgstr "Activity-summary weather"
 msgid "Actual"
 msgstr "Actual"
 
-#: src/pages/Training.tsx:299
+#: src/pages/Training.tsx:294
 msgid "Actual and planned weekly load across the recent training window."
 msgstr "Actual and planned weekly load across the recent training window."
 
-#: src/pages/Training.tsx:296
+#: src/pages/Training.tsx:291
 msgid "actual vs planned, avg"
 msgstr "actual vs planned, avg"
 
@@ -1725,7 +1725,7 @@ msgstr "Cycling"
 msgid "Daily brief"
 msgstr "Daily brief"
 
-#: src/pages/Today.tsx:420
+#: src/pages/Today.tsx:417
 msgid "daily score"
 msgstr "daily score"
 
@@ -1972,8 +1972,8 @@ msgstr "Developing"
 msgid "Diagnose Praxys-owned workout delivery without exposing athlete identity or provider workout data."
 msgstr "Diagnose Praxys-owned workout delivery without exposing athlete identity or provider workout data."
 
-#: src/pages/Training.tsx:363
-#: src/pages/Training.tsx:365
+#: src/pages/Training.tsx:358
+#: src/pages/Training.tsx:360
 msgid "Diagnosis"
 msgstr "Diagnosis"
 
@@ -2067,7 +2067,7 @@ msgstr "Distance (km)"
 #~ msgid "Distribution deviates from target"
 #~ msgstr "Distribution deviates from target"
 
-#: src/pages/Training.tsx:264
+#: src/pages/Training.tsx:259
 msgid "Distribution match"
 msgstr "Distribution match"
 
@@ -2438,7 +2438,7 @@ msgstr "Failed to delete user."
 msgid "Failed to generate invitation code."
 msgstr "Failed to generate invitation code."
 
-#: src/pages/Today.tsx:352
+#: src/pages/Today.tsx:349
 msgid "Failed to load"
 msgstr "Failed to load"
 
@@ -2462,7 +2462,7 @@ msgstr "Failed to load science data."
 msgid "Failed to load settings"
 msgstr "Failed to load settings"
 
-#: src/pages/Training.tsx:178
+#: src/pages/Training.tsx:173
 msgid "Failed to load training data"
 msgstr "Failed to load training data"
 
@@ -2642,7 +2642,7 @@ msgstr "Fourteen-day activity record"
 #~ msgid "Freshened up — good window for racing or testing."
 #~ msgstr "Freshened up — good window for racing or testing."
 
-#: src/pages/Today.tsx:549
+#: src/pages/Today.tsx:546
 msgid "From {dataAsOfLabel}"
 msgstr "From {dataAsOfLabel}"
 
@@ -2791,8 +2791,8 @@ msgstr "Heart-rate maximum (bpm)"
 msgid "Heart-rate minimum (bpm)"
 msgstr "Heart-rate minimum (bpm)"
 
-#: src/pages/Training.tsx:346
-#: src/pages/Training.tsx:349
+#: src/pages/Training.tsx:341
+#: src/pages/Training.tsx:344
 msgid "Heat adaptation"
 msgstr "Heat adaptation"
 
@@ -3254,7 +3254,7 @@ msgstr "Keep workout"
 #~ msgid "km / week, {0}wk avg"
 #~ msgstr "km / week, {0}wk avg"
 
-#: src/pages/Training.tsx:316
+#: src/pages/Training.tsx:311
 msgid "km/wk"
 msgstr "km/wk"
 
@@ -3449,7 +3449,7 @@ msgstr "Load & Fitness"
 
 #: src/components/charts/FitnessFatigueChart.tsx:87
 #: src/components/charts/FitnessFatigueChart.tsx:235
-#: src/pages/Training.tsx:244
+#: src/pages/Training.tsx:239
 msgid "Load balance"
 msgstr "Load balance"
 
@@ -3457,8 +3457,8 @@ msgstr "Load balance"
 msgid "Load balance (TSB)"
 msgstr "Load balance (TSB)"
 
-#: src/pages/Training.tsx:293
-#: src/pages/Training.tsx:297
+#: src/pages/Training.tsx:288
+#: src/pages/Training.tsx:292
 msgid "Load compliance"
 msgstr "Load compliance"
 
@@ -3504,7 +3504,7 @@ msgstr "Long-term and recent modeled loads are near balance."
 msgid "Long-term load"
 msgstr "Long-term load"
 
-#: src/pages/Training.tsx:240
+#: src/pages/Training.tsx:235
 msgid "long-term load above recent load"
 msgstr "long-term load above recent load"
 
@@ -3512,7 +3512,7 @@ msgstr "long-term load above recent load"
 #~ msgid "long-term load higher"
 #~ msgstr "long-term load higher"
 
-#: src/pages/Training.tsx:246
+#: src/pages/Training.tsx:241
 msgid "Long-term load, recent load, and their modeled balance over time."
 msgstr "Long-term load, recent load, and their modeled balance over time."
 
@@ -3749,11 +3749,11 @@ msgstr "Mixed providers"
 msgid "Mode"
 msgstr "Mode"
 
-#: src/pages/Training.tsx:238
+#: src/pages/Training.tsx:233
 msgid "modeled balance (CTL−ATL)"
 msgstr "modeled balance (CTL−ATL)"
 
-#: src/pages/Training.tsx:243
+#: src/pages/Training.tsx:238
 msgid "modeled loads balanced"
 msgstr "modeled loads balanced"
 
@@ -3827,7 +3827,7 @@ msgstr "near baseline"
 msgid "Near baseline"
 msgstr "Near baseline"
 
-#: src/pages/Training.tsx:306
+#: src/pages/Training.tsx:301
 msgid "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
 msgstr "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
 
@@ -3865,7 +3865,7 @@ msgstr "Needs review"
 msgid "Needs review: {0}. Failed: {1}. Critical: {2}. High: {3}."
 msgstr "Needs review: {0}. Failed: {1}. Critical: {2}. High: {3}."
 
-#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:428
 msgid "negative balance"
 msgstr "negative balance"
 
@@ -4006,12 +4006,12 @@ msgstr "No current classification"
 msgid "No current qualifying condition range yet"
 msgstr "No current qualifying condition range yet"
 
-#: src/pages/Today.tsx:399
+#: src/pages/Today.tsx:396
+#: src/pages/Today.tsx:409
 #: src/pages/Today.tsx:412
 #: src/pages/Today.tsx:415
 #: src/pages/Today.tsx:418
-#: src/pages/Today.tsx:421
-#: src/pages/Today.tsx:602
+#: src/pages/Today.tsx:599
 msgid "no data"
 msgstr "no data"
 
@@ -4072,7 +4072,7 @@ msgstr "No managed deliveries need operator action."
 msgid "No MFA"
 msgstr "No MFA"
 
-#: src/pages/Today.tsx:525
+#: src/pages/Today.tsx:522
 msgid "No new HRV, sleep, or activity since."
 msgstr "No new HRV, sleep, or activity since."
 
@@ -4184,7 +4184,7 @@ msgstr "No users found."
 msgid "No waitlist signups yet."
 msgstr "No waitlist signups yet."
 
-#: src/pages/Training.tsx:331
+#: src/pages/Training.tsx:326
 msgid "No weekly distance history yet"
 msgstr "No weekly distance history yet"
 
@@ -4213,7 +4213,7 @@ msgstr "No workout is scheduled. Add a session only if it fits your broader plan
 msgid "No Workout Scheduled"
 msgstr "No Workout Scheduled"
 
-#: src/pages/Today.tsx:433
+#: src/pages/Today.tsx:430
 msgid "No workout scheduled."
 msgstr "No workout scheduled."
 
@@ -4250,7 +4250,7 @@ msgstr "Not actionable"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/pages/Training.tsx:278
+#: src/pages/Training.tsx:273
 msgid "Not enough complete intensity data for zone comparison"
 msgstr "Not enough complete intensity data for zone comparison"
 
@@ -4274,15 +4274,15 @@ msgstr "Not enough data to show CP trend"
 #~ msgid "Not enough data yet for accurate fitness tracking"
 #~ msgstr "Not enough data yet for accurate fitness tracking"
 
-#: src/pages/Training.tsx:252
+#: src/pages/Training.tsx:247
 msgid "Not enough data yet for stable load tracking"
 msgstr "Not enough data yet for stable load tracking"
 
-#: src/pages/Training.tsx:305
+#: src/pages/Training.tsx:300
 msgid "Not enough data yet for weekly load comparison"
 msgstr "Not enough data yet for weekly load comparison"
 
-#: src/pages/Today.tsx:427
+#: src/pages/Today.tsx:424
 msgid "not enough load history"
 msgstr "not enough load history"
 
@@ -4324,7 +4324,7 @@ msgstr "Now open · Create your account"
 msgid "Observed"
 msgstr "Observed"
 
-#: src/pages/Training.tsx:272
+#: src/pages/Training.tsx:267
 msgid "Observed time in each intensity zone compared with the selected training theory."
 msgstr "Observed time in each intensity zone compared with the selected training theory."
 
@@ -4528,7 +4528,7 @@ msgstr "Outage"
 msgid "Outstanding codes"
 msgstr "Outstanding codes"
 
-#: src/pages/Today.tsx:417
+#: src/pages/Today.tsx:414
 msgid "overnight score"
 msgstr "overnight score"
 
@@ -4607,7 +4607,7 @@ msgstr "Pausing…"
 msgid "Peak Interval {intensityLabel}"
 msgstr "Peak Interval {intensityLabel}"
 
-#: src/pages/Training.tsx:375
+#: src/pages/Training.tsx:370
 msgid "Peer metrics"
 msgstr "Peer metrics"
 
@@ -4646,7 +4646,7 @@ msgstr "Plan window"
 msgid "Planned"
 msgstr "Planned"
 
-#: src/pages/Today.tsx:610
+#: src/pages/Today.tsx:607
 msgid "Planned · Today"
 msgstr "Planned · Today"
 
@@ -4700,7 +4700,7 @@ msgstr "Policy-gated auto-merge"
 #~ msgid "positive"
 #~ msgstr "positive"
 
-#: src/pages/Today.tsx:428
+#: src/pages/Today.tsx:425
 msgid "positive balance"
 msgstr "positive balance"
 
@@ -5182,7 +5182,7 @@ msgid "Read-only accounts that mirror your dashboard data."
 msgstr "Read-only accounts that mirror your dashboard data."
 
 #: src/components/RecoveryPanel.tsx:199
-#: src/pages/Today.tsx:606
+#: src/pages/Today.tsx:603
 msgid "Readiness"
 msgstr "Readiness"
 
@@ -5261,7 +5261,7 @@ msgstr "Recent HRV observations have no measurable variation, so Praxys cannot f
 msgid "Recent load"
 msgstr "Recent load"
 
-#: src/pages/Training.tsx:242
+#: src/pages/Training.tsx:237
 msgid "recent load above long-term load"
 msgstr "recent load above long-term load"
 
@@ -5376,7 +5376,7 @@ msgstr "Record judgment"
 msgid "Record maintainer judgment"
 msgstr "Record maintainer judgment"
 
-#: src/pages/Training.tsx:320
+#: src/pages/Training.tsx:315
 msgid "Recorded distance in non-overlapping seven-day buckets, including weeks with no recorded distance."
 msgstr "Recorded distance in non-overlapping seven-day buckets, including weeks with no recorded distance."
 
@@ -5419,7 +5419,7 @@ msgstr "Recovery could not be completed. Refresh the queue and try again."
 msgid "Recovery could not start because the delivery state changed. Review the refreshed queue."
 msgstr "Recovery could not start because the delivery state changed. Review the refreshed queue."
 
-#: src/pages/Today.tsx:566
+#: src/pages/Today.tsx:563
 msgid "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 msgstr "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 
@@ -5492,7 +5492,7 @@ msgstr "Refresh"
 msgid "Refresh delivery state"
 msgstr "Refresh delivery state"
 
-#: src/pages/Today.tsx:511
+#: src/pages/Today.tsx:508
 msgid "Refresh failed"
 msgstr "Refresh failed"
 
@@ -5723,9 +5723,9 @@ msgstr "Resume managed delivery?"
 #: src/pages/Goal.tsx:444
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:332
-#: src/pages/Today.tsx:355
-#: src/pages/Today.tsx:514
-#: src/pages/Training.tsx:181
+#: src/pages/Today.tsx:352
+#: src/pages/Today.tsx:511
+#: src/pages/Training.tsx:176
 msgid "Retry"
 msgstr "Retry"
 
@@ -5825,7 +5825,7 @@ msgstr "Revoke"
 msgid "Revoked"
 msgstr "Revoked"
 
-#: src/pages/Today.tsx:603
+#: src/pages/Today.tsx:600
 msgid "RHR"
 msgstr "RHR"
 
@@ -5975,7 +5975,7 @@ msgstr "Securely signing in to Garmin. This can take 15-30 seconds because Garmi
 msgid "Select a day to inspect what entered the estimate."
 msgstr "Select a day to inspect what entered the estimate."
 
-#: src/pages/Training.tsx:378
+#: src/pages/Training.tsx:373
 msgid "Select a metric to inspect its chart or evidence."
 msgstr "Select a metric to inspect its chart or evidence."
 
@@ -6156,7 +6156,7 @@ msgstr "Should not be agent-ready — sensitivity or privacy gate"
 #~ msgid "Show {0} more workouts"
 #~ msgstr "Show {0} more workouts"
 
-#: src/pages/Today.tsx:541
+#: src/pages/Today.tsx:538
 msgid "Show anyway"
 msgstr "Show anyway"
 
@@ -6172,11 +6172,11 @@ msgstr "Show methodology details"
 msgid "Showing"
 msgstr "Showing"
 
-#: src/pages/Today.tsx:513
+#: src/pages/Today.tsx:510
 msgid "Showing the last available data."
 msgstr "Showing the last available data."
 
-#: src/pages/Today.tsx:522
+#: src/pages/Today.tsx:519
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 
@@ -6207,7 +6207,7 @@ msgid "Skip for now"
 msgstr "Skip for now"
 
 #: src/components/RecoveryPanel.tsx:190
-#: src/pages/Today.tsx:604
+#: src/pages/Today.tsx:601
 msgid "Sleep"
 msgstr "Sleep"
 
@@ -6233,11 +6233,11 @@ msgstr "Sleep score, HRV, readiness"
 msgid "Sleep, HRV, readiness"
 msgstr "Sleep, HRV, readiness"
 
-#: src/pages/Today.tsx:430
+#: src/pages/Today.tsx:427
 msgid "slightly negative"
 msgstr "slightly negative"
 
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:426
 msgid "slightly positive"
 msgstr "slightly positive"
 
@@ -6450,8 +6450,8 @@ msgstr "Sync from:"
 msgid "Sync history"
 msgstr "Sync history"
 
-#: src/pages/Today.tsx:534
-#: src/pages/Today.tsx:556
+#: src/pages/Today.tsx:531
+#: src/pages/Today.tsx:553
 msgid "Sync now"
 msgstr "Sync now"
 
@@ -6459,7 +6459,7 @@ msgstr "Sync now"
 msgid "Sync power-source metadata so Praxys can verify that activity and threshold power are comparable."
 msgstr "Sync power-source metadata so Praxys can verify that activity and threshold power are comparable."
 
-#: src/pages/Training.tsx:336
+#: src/pages/Training.tsx:331
 msgid "Sync recent activities to populate the weekly distance series."
 msgstr "Sync recent activities to populate the weekly distance series."
 
@@ -6475,7 +6475,7 @@ msgstr "Sync reliability"
 #~ msgid "Sync sample or split power so workload can contribute."
 #~ msgstr "Sync sample or split power so workload can contribute."
 
-#: src/pages/Training.tsx:279
+#: src/pages/Training.tsx:274
 msgid "Sync split or sample data with enough duration coverage to compare against the selected theory."
 msgstr "Sync split or sample data with enough duration coverage to compare against the selected theory."
 
@@ -6525,8 +6525,8 @@ msgstr "Syncing"
 msgid "Syncing..."
 msgstr "Syncing..."
 
-#: src/pages/Today.tsx:534
-#: src/pages/Today.tsx:556
+#: src/pages/Today.tsx:531
+#: src/pages/Today.tsx:553
 msgid "Syncing…"
 msgstr "Syncing…"
 
@@ -6612,7 +6612,7 @@ msgstr "Thanks for the feedback!"
 msgid "That date is now completed history and can no longer be changed."
 msgstr "That date is now completed history and can no longer be changed."
 
-#: src/pages/Training.tsx:253
+#: src/pages/Training.tsx:248
 msgid "The active load model uses a {loadTimeConstantDays}-day long-term time constant. Need {daysToPmc} more days of history."
 msgstr "The active load model uses a {loadTimeConstantDays}-day long-term time constant. Need {daysToPmc} more days of history."
 
@@ -6730,7 +6730,7 @@ msgstr "The target version is unavailable."
 msgid "The thresholds are Praxys operational estimates grounded in heat-acclimatization research, not a direct physiological measurement."
 msgstr "The thresholds are Praxys operational estimates grounded in heat-acclimatization research, not a direct physiological measurement."
 
-#: src/pages/Training.tsx:335
+#: src/pages/Training.tsx:330
 msgid "The weekly history will appear after the data service update completes."
 msgstr "The weekly history will appear after the data service update completes."
 
@@ -6884,7 +6884,7 @@ msgstr "To target"
 #: src/components/HeatAdaptationPanel.tsx:193
 #: src/components/RecoveryPanel.tsx:136
 #: src/pages/Today.tsx:25
-#: src/pages/Today.tsx:508
+#: src/pages/Today.tsx:505
 msgid "Today"
 msgstr "Today"
 
@@ -6916,7 +6916,7 @@ msgstr "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is
 msgid "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is <2>{dirLabel}</2>."
 msgstr "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is <2>{dirLabel}</2>."
 
-#: src/pages/Today.tsx:447
+#: src/pages/Today.tsx:444
 msgid "Today's recommendation combines the scheduled workout with Praxys operational adaptations of your active recovery and load models. HRV requires a current reading, while TSB is modeled load balance rather than a direct measure of fatigue. Praxys TSB display labels and the one-CTL-window history gate are operational estimates, not validated cutoffs. These coaching guardrails are not a medical diagnosis."
 msgstr "Today's recommendation combines the scheduled workout with Praxys operational adaptations of your active recovery and load models. HRV requires a current reading, while TSB is modeled load balance rather than a direct measure of fatigue. Praxys TSB display labels and the one-CTL-window history gate are operational estimates, not validated cutoffs. These coaching guardrails are not a medical diagnosis."
 
@@ -6953,7 +6953,7 @@ msgid "Train toward a specific race date"
 msgstr "Train toward a specific race date"
 
 #: src/components/AppSidebar.tsx:125
-#: src/pages/Training.tsx:360
+#: src/pages/Training.tsx:355
 msgid "Training"
 msgstr "Training"
 
@@ -7018,7 +7018,7 @@ msgstr "Try a longer window above."
 msgid "Try another filter or sync again after new reports arrive."
 msgstr "Try another filter or sync again after new reports arrive."
 
-#: src/pages/Training.tsx:233
+#: src/pages/Training.tsx:228
 msgid "TSB"
 msgstr "TSB"
 
@@ -7296,17 +7296,17 @@ msgstr "VO2max"
 msgid "VO2max, CP, LTHR, training status"
 msgstr "VO2max, CP, LTHR, training status"
 
-#: src/pages/Training.tsx:314
+#: src/pages/Training.tsx:309
 msgid "Volume"
 msgstr "Volume"
 
 #. placeholder {0}: data.diagnosis.theory_name
-#: src/pages/Training.tsx:268
+#: src/pages/Training.tsx:263
 msgid "vs {0}"
 msgstr "vs {0}"
 
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
-#: src/pages/Today.tsx:399
+#: src/pages/Today.tsx:396
 msgid "vs {0} baseline"
 msgstr "vs {0} baseline"
 
@@ -7314,7 +7314,7 @@ msgstr "vs {0} baseline"
 msgid "vs {theoryName}"
 msgstr "vs {theoryName}"
 
-#: src/pages/Training.tsx:269
+#: src/pages/Training.tsx:264
 msgid "vs target zones"
 msgstr "vs target zones"
 
@@ -7386,11 +7386,11 @@ msgstr "Week ending {0}"
 msgid "Weekly average"
 msgstr "Weekly average"
 
-#: src/pages/Training.tsx:330
+#: src/pages/Training.tsx:325
 msgid "Weekly chart temporarily unavailable"
 msgstr "Weekly chart temporarily unavailable"
 
-#: src/pages/Training.tsx:199
+#: src/pages/Training.tsx:194
 msgid "Weekly diagnosis ready."
 msgstr "Weekly diagnosis ready."
 
@@ -7406,7 +7406,7 @@ msgstr "Weekly Load"
 #~ msgid "Weekly Review"
 #~ msgstr "Weekly Review"
 
-#: src/pages/Training.tsx:318
+#: src/pages/Training.tsx:313
 msgid "Weekly volume"
 msgstr "Weekly volume"
 
@@ -7576,7 +7576,7 @@ msgstr "Zone 3 (Hard)"
 #~ msgid "Zone Analysis"
 #~ msgstr "Zone Analysis"
 
-#: src/pages/Training.tsx:270
+#: src/pages/Training.tsx:265
 msgid "Zone distribution"
 msgstr "Zone distribution"
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -18,7 +18,7 @@ msgid " · "
 msgstr " · "
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
-#: src/pages/Training.tsx:367
+#: src/pages/Training.tsx:362
 msgid "· last {0} weeks"
 msgstr "· 最近 {0} 周"
 
@@ -155,7 +155,7 @@ msgstr "{0} 个影子决策 · 已应用 {1} 个标签 · {2} 个持久化结果
 #~ msgstr "运动 {0} 分钟 · 加权 {1} 分钟"
 
 #. placeholder {0}: data.diagnosis.lookback_weeks
-#: src/pages/Training.tsx:317
+#: src/pages/Training.tsx:312
 msgid "{0}-week average"
 msgstr "{0}周平均"
 
@@ -271,7 +271,7 @@ msgid "{minutes} effective min"
 msgstr "等效热暴露 {minutes} 分钟"
 
 #: src/components/RecoveryPanel.tsx:159
-#: src/pages/Today.tsx:602
+#: src/pages/Today.tsx:599
 msgid "{observationCount}-observation Trend"
 msgstr "{observationCount}次观测趋势"
 
@@ -622,11 +622,11 @@ msgstr "活动汇总天气"
 msgid "Actual"
 msgstr "实际"
 
-#: src/pages/Training.tsx:299
+#: src/pages/Training.tsx:294
 msgid "Actual and planned weekly load across the recent training window."
 msgstr "近期训练窗口内每周实际负荷与计划负荷的对比。"
 
-#: src/pages/Training.tsx:296
+#: src/pages/Training.tsx:291
 msgid "actual vs planned, avg"
 msgstr "实际/计划比均值"
 
@@ -1724,7 +1724,7 @@ msgstr "骑行"
 msgid "Daily brief"
 msgstr "每日简报"
 
-#: src/pages/Today.tsx:420
+#: src/pages/Today.tsx:417
 msgid "daily score"
 msgstr "每日评分"
 
@@ -1971,8 +1971,8 @@ msgstr "形成中"
 msgid "Diagnose Praxys-owned workout delivery without exposing athlete identity or provider workout data."
 msgstr "诊断 Praxys 管理的训练下发问题，同时不暴露运动员身份或数据来源中的训练信息。"
 
-#: src/pages/Training.tsx:363
-#: src/pages/Training.tsx:365
+#: src/pages/Training.tsx:358
+#: src/pages/Training.tsx:360
 msgid "Diagnosis"
 msgstr "诊断"
 
@@ -2066,7 +2066,7 @@ msgstr "距离（公里）"
 #~ msgid "Distribution deviates from target"
 #~ msgstr "分布偏离目标"
 
-#: src/pages/Training.tsx:264
+#: src/pages/Training.tsx:259
 msgid "Distribution match"
 msgstr "分布匹配度"
 
@@ -2445,7 +2445,7 @@ msgstr "删除用户失败。"
 msgid "Failed to generate invitation code."
 msgstr "生成邀请码失败。"
 
-#: src/pages/Today.tsx:352
+#: src/pages/Today.tsx:349
 msgid "Failed to load"
 msgstr "加载失败"
 
@@ -2469,7 +2469,7 @@ msgstr "加载科学数据失败。"
 msgid "Failed to load settings"
 msgstr "加载设置失败"
 
-#: src/pages/Training.tsx:178
+#: src/pages/Training.tsx:173
 msgid "Failed to load training data"
 msgstr "训练数据加载失败"
 
@@ -2649,7 +2649,7 @@ msgstr "14天活动记录"
 #~ msgid "Freshened up — good window for racing or testing."
 #~ msgstr "充分恢复——适合比赛或测试的好时机。"
 
-#: src/pages/Today.tsx:549
+#: src/pages/Today.tsx:546
 msgid "From {dataAsOfLabel}"
 msgstr "数据截至 {dataAsOfLabel}"
 
@@ -2798,8 +2798,8 @@ msgstr "最高心率（bpm）"
 msgid "Heart-rate minimum (bpm)"
 msgstr "最低心率（bpm）"
 
-#: src/pages/Training.tsx:346
-#: src/pages/Training.tsx:349
+#: src/pages/Training.tsx:341
+#: src/pages/Training.tsx:344
 msgid "Heat adaptation"
 msgstr "热适应"
 
@@ -3301,7 +3301,7 @@ msgstr "保留训练"
 #~ msgid "km / week, {0}wk avg"
 #~ msgstr "公里 / 周，{0} 周均值"
 
-#: src/pages/Training.tsx:316
+#: src/pages/Training.tsx:311
 msgid "km/wk"
 msgstr "公里/周"
 
@@ -3496,7 +3496,7 @@ msgstr "负荷与体能"
 
 #: src/components/charts/FitnessFatigueChart.tsx:87
 #: src/components/charts/FitnessFatigueChart.tsx:235
-#: src/pages/Training.tsx:244
+#: src/pages/Training.tsx:239
 msgid "Load balance"
 msgstr "负荷平衡"
 
@@ -3504,8 +3504,8 @@ msgstr "负荷平衡"
 msgid "Load balance (TSB)"
 msgstr "负荷平衡（TSB）"
 
-#: src/pages/Training.tsx:293
-#: src/pages/Training.tsx:297
+#: src/pages/Training.tsx:288
+#: src/pages/Training.tsx:292
 msgid "Load compliance"
 msgstr "计划完成度"
 
@@ -3551,7 +3551,7 @@ msgstr "长期与近期模型负荷接近平衡。"
 msgid "Long-term load"
 msgstr "长期负荷"
 
-#: src/pages/Training.tsx:240
+#: src/pages/Training.tsx:235
 msgid "long-term load above recent load"
 msgstr "长期负荷高于近期负荷"
 
@@ -3559,7 +3559,7 @@ msgstr "长期负荷高于近期负荷"
 #~ msgid "long-term load higher"
 #~ msgstr "长期负荷较高"
 
-#: src/pages/Training.tsx:246
+#: src/pages/Training.tsx:241
 msgid "Long-term load, recent load, and their modeled balance over time."
 msgstr "长期负荷、近期负荷及两者随时间变化的模型平衡。"
 
@@ -3800,11 +3800,11 @@ msgstr "数据来源混合"
 msgid "Mode"
 msgstr "模式"
 
-#: src/pages/Training.tsx:238
+#: src/pages/Training.tsx:233
 msgid "modeled balance (CTL−ATL)"
 msgstr "模型估算平衡（CTL−ATL）"
 
-#: src/pages/Training.tsx:243
+#: src/pages/Training.tsx:238
 msgid "modeled loads balanced"
 msgstr "模型估算负荷处于平衡"
 
@@ -3878,7 +3878,7 @@ msgstr "接近基准"
 msgid "Near baseline"
 msgstr "接近基准"
 
-#: src/pages/Training.tsx:306
+#: src/pages/Training.tsx:301
 msgid "Need 2 weeks of synced activity to compare planned vs actual. {daysToCompare} more days to go."
 msgstr "需要 2 周已同步的活动数据才能对比计划与实际。还需 {daysToCompare} 天。"
 
@@ -3916,7 +3916,7 @@ msgstr "需审核"
 msgid "Needs review: {0}. Failed: {1}. Critical: {2}. High: {3}."
 msgstr "待审核：{0}。失败：{1}。严重：{2}。高优先级：{3}。"
 
-#: src/pages/Today.tsx:431
+#: src/pages/Today.tsx:428
 msgid "negative balance"
 msgstr "负平衡"
 
@@ -4061,12 +4061,12 @@ msgstr "当前暂无分类"
 msgid "No current qualifying condition range yet"
 msgstr "目前尚无符合条件的环境范围"
 
-#: src/pages/Today.tsx:399
+#: src/pages/Today.tsx:396
+#: src/pages/Today.tsx:409
 #: src/pages/Today.tsx:412
 #: src/pages/Today.tsx:415
 #: src/pages/Today.tsx:418
-#: src/pages/Today.tsx:421
-#: src/pages/Today.tsx:602
+#: src/pages/Today.tsx:599
 msgid "no data"
 msgstr "暂无数据"
 
@@ -4127,7 +4127,7 @@ msgstr "当前没有需要运维处理的托管下发任务。"
 msgid "No MFA"
 msgstr "无需 MFA"
 
-#: src/pages/Today.tsx:525
+#: src/pages/Today.tsx:522
 msgid "No new HRV, sleep, or activity since."
 msgstr "此后无新的 HRV、睡眠或活动数据。"
 
@@ -4239,7 +4239,7 @@ msgstr "未找到用户。"
 msgid "No waitlist signups yet."
 msgstr "候补名单里还没人报名。"
 
-#: src/pages/Training.tsx:331
+#: src/pages/Training.tsx:326
 msgid "No weekly distance history yet"
 msgstr "暂无每周距离历史"
 
@@ -4280,7 +4280,7 @@ msgstr "今天没有安排训练。仅在符合整体计划时增加训练。"
 msgid "No Workout Scheduled"
 msgstr "今日无训练安排"
 
-#: src/pages/Today.tsx:433
+#: src/pages/Today.tsx:430
 msgid "No workout scheduled."
 msgstr "今日无训练安排。"
 
@@ -4317,7 +4317,7 @@ msgstr "不可直接处理"
 msgid "Not connected"
 msgstr "未连接"
 
-#: src/pages/Training.tsx:278
+#: src/pages/Training.tsx:273
 msgid "Not enough complete intensity data for zone comparison"
 msgstr "完整强度数据不足，暂无法比较分区"
 
@@ -4341,15 +4341,15 @@ msgstr "数据不足，无法显示 CP 趋势"
 #~ msgid "Not enough data yet for accurate fitness tracking"
 #~ msgstr "数据不足，暂无法准确跟踪体能"
 
-#: src/pages/Training.tsx:252
+#: src/pages/Training.tsx:247
 msgid "Not enough data yet for stable load tracking"
 msgstr "数据不足，暂无法稳定跟踪负荷"
 
-#: src/pages/Training.tsx:305
+#: src/pages/Training.tsx:300
 msgid "Not enough data yet for weekly load comparison"
 msgstr "数据不足，暂无法对比每周负荷"
 
-#: src/pages/Today.tsx:427
+#: src/pages/Today.tsx:424
 msgid "not enough load history"
 msgstr "负荷历史不足"
 
@@ -4391,7 +4391,7 @@ msgstr "现已开放 · 创建账号"
 msgid "Observed"
 msgstr "已记录"
 
-#: src/pages/Training.tsx:272
+#: src/pages/Training.tsx:267
 msgid "Observed time in each intensity zone compared with the selected training theory."
 msgstr "将各强度分区的实际用时与所选训练理论进行比较。"
 
@@ -4595,7 +4595,7 @@ msgstr "服务中断"
 msgid "Outstanding codes"
 msgstr "未使用的邀请码"
 
-#: src/pages/Today.tsx:417
+#: src/pages/Today.tsx:414
 msgid "overnight score"
 msgstr "夜间评分"
 
@@ -4674,7 +4674,7 @@ msgstr "正在暂停…"
 msgid "Peak Interval {intensityLabel}"
 msgstr "峰值间歇 {intensityLabel}"
 
-#: src/pages/Training.tsx:375
+#: src/pages/Training.tsx:370
 msgid "Peer metrics"
 msgstr "训练指标"
 
@@ -4713,7 +4713,7 @@ msgstr "计划范围"
 msgid "Planned"
 msgstr "计划"
 
-#: src/pages/Today.tsx:610
+#: src/pages/Today.tsx:607
 msgid "Planned · Today"
 msgstr "今日计划"
 
@@ -4767,7 +4767,7 @@ msgstr "策略门禁自动合并"
 #~ msgid "positive"
 #~ msgstr "状态良好"
 
-#: src/pages/Today.tsx:428
+#: src/pages/Today.tsx:425
 msgid "positive balance"
 msgstr "正平衡"
 
@@ -5269,7 +5269,7 @@ msgid "Read-only accounts that mirror your dashboard data."
 msgstr "镜像主页数据的只读账号。"
 
 #: src/components/RecoveryPanel.tsx:199
-#: src/pages/Today.tsx:606
+#: src/pages/Today.tsx:603
 msgid "Readiness"
 msgstr "准备度"
 
@@ -5348,7 +5348,7 @@ msgstr "近期 HRV 观测值没有可测波动，因此 Praxys 暂时还无法�
 msgid "Recent load"
 msgstr "近期负荷"
 
-#: src/pages/Training.tsx:242
+#: src/pages/Training.tsx:237
 msgid "recent load above long-term load"
 msgstr "近期负荷高于长期负荷"
 
@@ -5463,7 +5463,7 @@ msgstr "记录判断"
 msgid "Record maintainer judgment"
 msgstr "记录维护者判断"
 
-#: src/pages/Training.tsx:320
+#: src/pages/Training.tsx:315
 msgid "Recorded distance in non-overlapping seven-day buckets, including weeks with no recorded distance."
 msgstr "按不重叠的 7 天区间统计已记录距离，包括没有距离记录的周。"
 
@@ -5506,7 +5506,7 @@ msgstr "恢复未能完成。请刷新队列后重试。"
 msgid "Recovery could not start because the delivery state changed. Review the refreshed queue."
 msgstr "恢复未能开始，因为下发状态已变更。请查看已刷新的队列。"
 
-#: src/pages/Today.tsx:566
+#: src/pages/Today.tsx:563
 msgid "Recovery data hasn't synced yet. Showing the latest reading from {recoveryLatestLabel}."
 msgstr "恢复数据尚未同步，当前显示最近一次读数（{recoveryLatestLabel}）。"
 
@@ -5591,7 +5591,7 @@ msgstr "刷新"
 msgid "Refresh delivery state"
 msgstr "刷新下发状态"
 
-#: src/pages/Today.tsx:511
+#: src/pages/Today.tsx:508
 msgid "Refresh failed"
 msgstr "刷新失败"
 
@@ -5838,9 +5838,9 @@ msgstr "恢复托管下发？"
 #: src/pages/Goal.tsx:444
 #: src/pages/History.tsx:53
 #: src/pages/Settings.tsx:332
-#: src/pages/Today.tsx:355
-#: src/pages/Today.tsx:514
-#: src/pages/Training.tsx:181
+#: src/pages/Today.tsx:352
+#: src/pages/Today.tsx:511
+#: src/pages/Training.tsx:176
 msgid "Retry"
 msgstr "重试"
 
@@ -5940,7 +5940,7 @@ msgstr "撤销"
 msgid "Revoked"
 msgstr "已撤销"
 
-#: src/pages/Today.tsx:603
+#: src/pages/Today.tsx:600
 msgid "RHR"
 msgstr "静息心率"
 
@@ -6102,7 +6102,7 @@ msgstr "正在安全登录 Garmin。由于 Garmin 会限制自动登录频率，
 msgid "Select a day to inspect what entered the estimate."
 msgstr "选择一天，查看当天哪些训练被纳入估算。"
 
-#: src/pages/Training.tsx:378
+#: src/pages/Training.tsx:373
 msgid "Select a metric to inspect its chart or evidence."
 msgstr "选择一个指标，查看图表或依据。"
 
@@ -6287,7 +6287,7 @@ msgstr "不应标记为 agent-ready：触发敏感或隐私限制"
 #~ msgid "Show {0} more workouts"
 #~ msgstr "显示另外 {0} 项训练"
 
-#: src/pages/Today.tsx:541
+#: src/pages/Today.tsx:538
 msgid "Show anyway"
 msgstr "仍要查看"
 
@@ -6303,7 +6303,7 @@ msgstr "展开方法论详情"
 msgid "Showing"
 msgstr "显示第"
 
-#: src/pages/Today.tsx:513
+#: src/pages/Today.tsx:510
 msgid "Showing the last available data."
 msgstr "当前显示的是最近一次可用数据。"
 
@@ -6311,7 +6311,7 @@ msgstr "当前显示的是最近一次可用数据。"
 #~ msgid "Showing the last available data.\" \"正在显示最近一次可用数据。"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:522
+#: src/pages/Today.tsx:519
 msgid "Showing yesterday's snapshot. Last reading {dataAsOfLabel}."
 msgstr "显示的是昨天的快照。最近一次读数 {dataAsOfLabel}。"
 
@@ -6342,7 +6342,7 @@ msgid "Skip for now"
 msgstr "先跳过"
 
 #: src/components/RecoveryPanel.tsx:190
-#: src/pages/Today.tsx:604
+#: src/pages/Today.tsx:601
 msgid "Sleep"
 msgstr "睡眠"
 
@@ -6372,7 +6372,7 @@ msgstr "睡眠得分、HRV、准备度"
 msgid "Sleep, HRV, readiness"
 msgstr "睡眠、HRV、准备度"
 
-#: src/pages/Today.tsx:430
+#: src/pages/Today.tsx:427
 msgid "slightly negative"
 msgstr "轻微负平衡"
 
@@ -6380,7 +6380,7 @@ msgstr "轻微负平衡"
 #~ msgid "slightly negative\" \"轻度负平衡"
 #~ msgstr ""
 
-#: src/pages/Today.tsx:429
+#: src/pages/Today.tsx:426
 msgid "slightly positive"
 msgstr "轻微正平衡"
 
@@ -6601,8 +6601,8 @@ msgstr "同步起始日期："
 msgid "Sync history"
 msgstr "同步历史数据"
 
-#: src/pages/Today.tsx:534
-#: src/pages/Today.tsx:556
+#: src/pages/Today.tsx:531
+#: src/pages/Today.tsx:553
 msgid "Sync now"
 msgstr "立即同步"
 
@@ -6610,7 +6610,7 @@ msgstr "立即同步"
 msgid "Sync power-source metadata so Praxys can verify that activity and threshold power are comparable."
 msgstr "同步功率数据来源信息，Praxys 才能验证活动功率与阈值功率是否可比。"
 
-#: src/pages/Training.tsx:336
+#: src/pages/Training.tsx:331
 msgid "Sync recent activities to populate the weekly distance series."
 msgstr "同步近期活动以生成每周距离序列。"
 
@@ -6626,7 +6626,7 @@ msgstr "同步可靠性"
 #~ msgid "Sync sample or split power so workload can contribute."
 #~ msgstr "同步逐秒样本或分段功率后，训练负荷才能计入。"
 
-#: src/pages/Training.tsx:279
+#: src/pages/Training.tsx:274
 msgid "Sync split or sample data with enough duration coverage to compare against the selected theory."
 msgstr "同步覆盖时长足够的分段或采样数据，以便与所选理论比较。"
 
@@ -6676,8 +6676,8 @@ msgstr "同步中"
 msgid "Syncing..."
 msgstr "同步中…"
 
-#: src/pages/Today.tsx:534
-#: src/pages/Today.tsx:556
+#: src/pages/Today.tsx:531
+#: src/pages/Today.tsx:553
 msgid "Syncing…"
 msgstr "同步中…"
 
@@ -6763,7 +6763,7 @@ msgstr "感谢你的反馈！"
 msgid "That date is now completed history and can no longer be changed."
 msgstr "这一天已归入已完成记录，无法再修改。"
 
-#: src/pages/Training.tsx:253
+#: src/pages/Training.tsx:248
 msgid "The active load model uses a {loadTimeConstantDays}-day long-term time constant. Need {daysToPmc} more days of history."
 msgstr "当前负荷模型的长期时间常数为 {loadTimeConstantDays} 天，还需要 {daysToPmc} 天历史数据。"
 
@@ -6888,7 +6888,7 @@ msgstr "目标平台版本不可用。"
 msgid "The thresholds are Praxys operational estimates grounded in heat-acclimatization research, not a direct physiological measurement."
 msgstr "这些阈值是 Praxys 基于热适应研究设定的操作性估计，并非直接的生理测量。"
 
-#: src/pages/Training.tsx:335
+#: src/pages/Training.tsx:330
 msgid "The weekly history will appear after the data service update completes."
 msgstr "数据服务更新完成后，每周历史图表将自动显示。"
 
@@ -7042,7 +7042,7 @@ msgstr "距目标"
 #: src/components/HeatAdaptationPanel.tsx:193
 #: src/components/RecoveryPanel.tsx:136
 #: src/pages/Today.tsx:25
-#: src/pages/Today.tsx:508
+#: src/pages/Today.tsx:505
 msgid "Today"
 msgstr "今日"
 
@@ -7074,7 +7074,7 @@ msgstr "今日 <0>{distLabel}</0> 预计成绩为 <1>{predicted}</1>。{abbrev} 
 msgid "Today's <0>{distLabel}</0> prediction is <1>{predicted}</1>. {abbrev} is <2>{dirLabel}</2>."
 msgstr "今日 <0>{distLabel}</0> 预计成绩为 <1>{predicted}</1>。{abbrev} 呈 <2>{dirLabel}</2>趋势。"
 
-#: src/pages/Today.tsx:447
+#: src/pages/Today.tsx:444
 msgid "Today's recommendation combines the scheduled workout with Praxys operational adaptations of your active recovery and load models. HRV requires a current reading, while TSB is modeled load balance rather than a direct measure of fatigue. Praxys TSB display labels and the one-CTL-window history gate are operational estimates, not validated cutoffs. These coaching guardrails are not a medical diagnosis."
 msgstr "今日建议将计划训练与 Praxys 对当前恢复模型和负荷模型的操作性调整相结合。HRV 需要最新读数，而 TSB 是模型化的负荷平衡，并非疲劳的直接测量。Praxys 的 TSB 显示标签和一个 CTL 时间常数的历史门槛属于操作性估算，并非经验证的阈值。这些训练指导不构成医疗诊断。"
 
@@ -7115,7 +7115,7 @@ msgid "Train toward a specific race date"
 msgstr "围绕某场比赛备赛"
 
 #: src/components/AppSidebar.tsx:125
-#: src/pages/Training.tsx:360
+#: src/pages/Training.tsx:355
 msgid "Training"
 msgstr "训练"
 
@@ -7180,7 +7180,7 @@ msgstr "试试上方更长的时间窗口。"
 msgid "Try another filter or sync again after new reports arrive."
 msgstr "试试其他筛选条件，或等有新报告后再同步。"
 
-#: src/pages/Training.tsx:233
+#: src/pages/Training.tsx:228
 msgid "TSB"
 msgstr "TSB"
 
@@ -7458,17 +7458,17 @@ msgstr "VO2max"
 msgid "VO2max, CP, LTHR, training status"
 msgstr "VO2max、CP、LTHR、训练状态"
 
-#: src/pages/Training.tsx:314
+#: src/pages/Training.tsx:309
 msgid "Volume"
 msgstr "里程"
 
 #. placeholder {0}: data.diagnosis.theory_name
-#: src/pages/Training.tsx:268
+#: src/pages/Training.tsx:263
 msgid "vs {0}"
 msgstr "对比{0}"
 
 #. placeholder {0}: hrv.baseline_mean_ln.toFixed(2)
-#: src/pages/Today.tsx:399
+#: src/pages/Today.tsx:396
 msgid "vs {0} baseline"
 msgstr "对比基准 {0}"
 
@@ -7476,7 +7476,7 @@ msgstr "对比基准 {0}"
 msgid "vs {theoryName}"
 msgstr "对比 {theoryName}"
 
-#: src/pages/Training.tsx:269
+#: src/pages/Training.tsx:264
 msgid "vs target zones"
 msgstr "对比目标区间"
 
@@ -7548,11 +7548,11 @@ msgstr "截至 {0} 的一周"
 msgid "Weekly average"
 msgstr "周平均"
 
-#: src/pages/Training.tsx:330
+#: src/pages/Training.tsx:325
 msgid "Weekly chart temporarily unavailable"
 msgstr "每周图表暂时不可用"
 
-#: src/pages/Training.tsx:199
+#: src/pages/Training.tsx:194
 msgid "Weekly diagnosis ready."
 msgstr "周度诊断已就绪。"
 
@@ -7568,7 +7568,7 @@ msgstr "周训练负荷"
 #~ msgid "Weekly Review"
 #~ msgstr "周度回顾"
 
-#: src/pages/Training.tsx:318
+#: src/pages/Training.tsx:313
 msgid "Weekly volume"
 msgstr "周里程"
 
@@ -7738,7 +7738,7 @@ msgstr "第 3 区（高强度）"
 #~ msgid "Zone Analysis"
 #~ msgstr "区间分析"
 
-#: src/pages/Training.tsx:270
+#: src/pages/Training.tsx:265
 msgid "Zone distribution"
 msgstr "区间分布"
 

--- a/web/src/pages/Today.tsx
+++ b/web/src/pages/Today.tsx
@@ -317,10 +317,7 @@ function localizedSignalAlternatives(signal: TrainingSignal, i18n: I18n): string
   }).filter(Boolean);
 }
 export default function Today() {
-  const { data, loading, error, refetch } = useApi<TodayResponse>('/api/today', {
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: 'always',
-  });
+  const { data, loading, error, refetch } = useApi<TodayResponse>('/api/today');
   const { locale } = useLocale();
   const { i18n } = useLingui();
 

--- a/web/src/pages/Training.tsx
+++ b/web/src/pages/Training.tsx
@@ -136,13 +136,8 @@ function TrainingSkeleton() {
 }
 
 export default function Training() {
-  const { data, loading, error, refetch } = useApi<TrainingResponse>(
-    '/api/training',
-    {
-      refetchOnMount: 'always',
-      refetchOnWindowFocus: 'always',
-    },
-  );
+  const { data, loading, error, refetch } =
+    useApi<TrainingResponse>('/api/training');
   const { display } = useSettings();
   const { t } = useLingui();
   const location = useLocation();

--- a/web/tests/performance.test.mjs
+++ b/web/tests/performance.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { tokenCacheScope } from '../src/lib/auth-cache-scope.ts';
+import { initialDashboardUrl } from '../src/lib/dashboard-prefetch.ts';
+
+test('prefetches the authenticated cold-load dashboard route', () => {
+  assert.equal(initialDashboardUrl('/today', true), '/api/today');
+  assert.equal(initialDashboardUrl('/training', true), '/api/training');
+  assert.equal(initialDashboardUrl('/', true), '/api/today');
+  assert.equal(initialDashboardUrl('/today', false), null);
+  assert.equal(initialDashboardUrl('/settings', true), null);
+});
+
+test('scopes cached API data to the active authentication token', () => {
+  assert.equal(tokenCacheScope(null), 'anonymous');
+  assert.equal(tokenCacheScope('token-a'), tokenCacheScope('token-a'));
+  assert.notEqual(tokenCacheScope('token-a'), tokenCacheScope('token-b'));
+  assert.doesNotMatch(tokenCacheScope('secret-token'), /secret-token/);
+});
+
+test('setup status shares React Query requests across consumers', async () => {
+  const source = await readFile(
+    new URL('../src/hooks/useSetupStatus.ts', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(source, /queryKey: \['setup', 'connections', authScope\]/);
+  assert.match(source, /queryKey: \['setup', 'sync-status', authScope\]/);
+  assert.doesNotMatch(source, /Promise\.all\(\[/);
+});
+
+test('daily pages use the app freshness policy instead of forced focus fetches', async () => {
+  const sources = await Promise.all(
+    ['Today.tsx', 'Training.tsx'].map((name) =>
+      readFile(new URL(`../src/pages/${name}`, import.meta.url), 'utf8'),
+    ),
+  );
+
+  for (const source of sources) {
+    assert.doesNotMatch(source, /refetchOnMount:\s*'always'/);
+    assert.doesNotMatch(source, /refetchOnWindowFocus:\s*'always'/);
+  }
+});


### PR DESCRIPTION
## Summary

- start the initial Today or Training request alongside authentication verification
- deduplicate setup status requests across route and sidebar consumers
- scope React Query data by authentication token and rely on the app freshness policy instead of forced mobile-focus refetches

Closes #571

## Validation

- deterministic agent preflight
- frontend build and TypeScript compilation
- frontend unit and request-lifecycle contract tests
- targeted ESLint

## UI quality
- Impeccable: `optimize web/src/App.tsx`
- Visual review: desktop 1440x900; mobile 390x844 under Fast 4G and 4x CPU throttling
- States checked: cold loading, empty setup, Today success/empty data, Training success/empty data
- Accessibility: semantic snapshots retained landmarks and named controls; responsive touch layout checked; no console errors or warnings
- Design system impact: none - existing design system already covers the change
- Miniapp parity: not applicable - web-only request orchestration; API behavior is unchanged
- Exceptions: long-content and zh rendering not repeated because no copy, markup, or styling changed