### PR TITLE
Reduce authenticated frontend cold-load bundle

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { TooltipProvider } from './components/ui/tooltip';
 import { AuthProvider, useAuth } from './hooks/useAuth';
@@ -23,7 +23,8 @@ import { hasSkippedSetupForSession, useSetupStatus } from './hooks/useSetupStatu
 // Lazy-loaded: secondary routes the user navigates to after landing on
 // Today. Chunks load on first visit to each route; cached immutably
 // thereafter (cache headers set by frontend_server/main.py).
-const Training = lazy(() => import('./pages/Training'));
+const loadTraining = () => import('./pages/Training');
+const Training = lazy(loadTraining);
 const Goal = lazy(() => import('./pages/Goal'));
 const History = lazy(() => import('./pages/History'));
 const Science = lazy(() => import('./pages/Science'));
@@ -119,6 +120,28 @@ function TodayOrSetup() {
   const accountScope = email?.trim().toLowerCase() ?? '';
   const setupSkipped = skippedForAccount === accountScope || hasSkippedSetupForSession(email);
 
+  useEffect(() => {
+    if (setup.loading || (!setup.allDone && !setupSkipped)) return undefined;
+
+    // Keep chart code off Today's critical path, then warm the most common
+    // next route after the first screen has had time to settle.
+    let idleCallbackId: number | undefined;
+    const timer = window.setTimeout(() => {
+      if ('requestIdleCallback' in window) {
+        idleCallbackId = window.requestIdleCallback(
+          () => { void loadTraining(); },
+          { timeout: 5000 },
+        );
+      } else {
+        void loadTraining();
+      }
+    }, 2500);
+    return () => {
+      window.clearTimeout(timer);
+      if (idleCallbackId !== undefined) window.cancelIdleCallback(idleCallbackId);
+    };
+  }, [setup.allDone, setup.loading, setupSkipped]);
+
   if (setup.loading) return null;
   if (!setup.allDone && !setupSkipped) {
     return <Setup onSkip={() => setSkippedForAccount(accountScope)} />;
@@ -159,7 +182,7 @@ function LoginGuard() {
       } else {
         const token = localStorage.getItem('praxys-auth-token') ?? localStorage.getItem('trainsight-auth-token');
         if (token) {
-          window.location.href = `${rawCallback}?token=${encodeURIComponent(token)}`;
+          window.location.assign(`${rawCallback}?token=${encodeURIComponent(token)}`);
           return null;
         }
         console.warn('[login] CLI callback valid but no token in localStorage; falling through to /today');

--- a/web/tests/performance.test.mjs
+++ b/web/tests/performance.test.mjs
@@ -43,3 +43,16 @@ test('daily pages use the app freshness policy instead of forced focus fetches',
     assert.doesNotMatch(source, /refetchOnWindowFocus:\s*'always'/);
   }
 });
+
+test('keeps chart code off the initial Today preload path', async () => {
+  const [appSource, viteSource] = await Promise.all([
+    readFile(new URL('../src/App.tsx', import.meta.url), 'utf8'),
+    readFile(new URL('../vite.config.ts', import.meta.url), 'utf8'),
+  ]);
+
+  assert.match(appSource, /const loadTraining = \(\) => import\('\.\/pages\/Training'\)/);
+  assert.match(appSource, /requestIdleCallback\(/);
+  assert.match(appSource, /cancelIdleCallback\(idleCallbackId\)/);
+  assert.match(viteSource, /context\.hostType !== 'html'/);
+  assert.match(viteSource, /!dependency\.includes\('recharts-'\)/);
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -53,6 +53,18 @@ export default defineConfig({
     },
   },
   build: {
+    modulePreload: {
+      resolveDependencies(_filename, dependencies, context) {
+        if (context.hostType !== 'html') return dependencies
+
+        // Recharts is only used by lazy dashboard routes. Vite otherwise adds
+        // the shared vendor chunk to index.html, making every cold visit pay
+        // ~113 kB gzip before Today can render. Dynamic route imports retain
+        // their own dependency preload list, so charts still load normally
+        // when Training or Goal is requested.
+        return dependencies.filter((dependency) => !dependency.includes('recharts-'))
+      },
+    },
     // Vendor chunks that get their own cacheable file. Splitting helps
     // returning visitors: the app-code chunk changes every deploy (its
     // hash rotates) but recharts / react-markdown / @tanstack/react-query


### PR DESCRIPTION
## Summary

- Keep the 113 kB gzip Recharts vendor chunk out of the HTML preload graph so authenticated Today cold loads do not download chart code before it is needed.
- Idle-prefetch Training after Today/setup settles, and cancel scheduled prefetch work when the route unmounts.
- Add a performance contract test covering the preload filter and idle prefetch lifecycle.

Closes #571.

## Validation

- `npm run build --prefix web`
- `npm exec --prefix web eslint -- web/src/App.tsx web/vite.config.ts`
- `python scripts/agent_preflight.py --base origin/main`
- Confirmed built `dist/index.html` has no Recharts preload while the Training dependency map still references the Recharts chunk.

## UI quality
- Impeccable: `polish web/src/App.tsx`
- Visual review: desktop 1440x900; mobile 390x844
- States checked: authenticated Today with empty-data metrics; Training with empty plan; Fast 4G and 4x CPU
- Accessibility: no visual or interaction changes; existing keyboard, focus, contrast, reduced-motion, and touch-target behavior preserved
- Design system impact: none - existing design system already covers the change
- Miniapp parity: not applicable - this changes only the web bundler and web route prefetch lifecycle
- Exceptions: none
