### PR TITLE
Add Labs environment-response backend

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_labs_environment_response.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_labs_environment_response.py
@@ -1,0 +1,77 @@
+"""add Labs environmental-response lifecycle
+
+Revision ID: a1b2c3d4e5f6
+Revises: 7a8192b3c4d5
+Create Date: 2026-08-08
+
+Stores explicit experiment consent, aggregate-only results, and withdrawal
+tombstones. Raw activities, samples, dates, routes, and per-activity research
+rows are never persisted in these tables.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "7a8192b3c4d5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "labs_experiment_enrollments",
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.String(length=80), nullable=False),
+        sa.Column("consent_version", sa.String(length=40), nullable=False),
+        sa.Column("consented_at", sa.DateTime(), nullable=False),
+        sa.Column("adult_attested_at", sa.DateTime(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("model_version", sa.String(length=80), nullable=False),
+        sa.Column("source_revision", sa.String(length=100), nullable=False),
+        sa.Column("correlation_id", sa.String(length=36), nullable=False),
+        sa.Column("availability_reason", sa.JSON(), nullable=True),
+        sa.Column("queued_at", sa.DateTime(), nullable=False),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('queued','processing','available','unavailable','failed','stale')",
+            name="ck_labs_enrollment_status",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "experiment_id"),
+    )
+    op.create_table(
+        "labs_experiment_results",
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.String(length=80), nullable=False),
+        sa.Column("model_version", sa.String(length=80), nullable=False),
+        sa.Column("source_revision", sa.String(length=100), nullable=False),
+        sa.Column("result_state", sa.String(length=40), nullable=False),
+        sa.Column("eligibility_counts", sa.JSON(), nullable=False),
+        sa.Column("aggregate_curve_points", sa.JSON(), nullable=False),
+        sa.Column("aggregate_uncertainty", sa.JSON(), nullable=False),
+        sa.Column("gate_statuses", sa.JSON(), nullable=False),
+        sa.Column("prediction_status", sa.String(length=40), nullable=False),
+        sa.Column("power_regime", sa.String(length=60), nullable=False),
+        sa.Column("computed_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "experiment_id"),
+    )
+    op.create_table(
+        "labs_deletion_tombstones",
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("experiment_id", sa.String(length=80), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "experiment_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("labs_deletion_tombstones")
+    op.drop_table("labs_experiment_results")
+    op.drop_table("labs_experiment_enrollments")

--- a/analysis/environment_response.py
+++ b/analysis/environment_response.py
@@ -1,0 +1,444 @@
+"""Pure aggregate analysis for the Labs environmental-response experiment."""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from analysis.heat_response_validation import (
+    HeatValidationConfig,
+    MODEL_VERSION,
+    _analyze_rows,
+    _fit_model,
+    _flatten_dataset,
+    _prepare_dataset,
+    validate_heat_response,
+)
+
+
+LABS_ENVIRONMENT_MODEL_VERSION = f"{MODEL_VERSION}-labs-v1"
+POWER_REGIME = "stryd_continuous_samples"
+# Product guardrails below are accepted governance estimates from
+# data/science/decisions/sdr-environmental-performance-v2.yaml. They are not
+# published physiological constants.
+
+
+@dataclass(frozen=True)
+class LabsEnvironmentConfig:
+    """Accepted V1 display-support and influence guardrails."""
+
+    curve_domain_percentiles: tuple[float, float] = (10.0, 90.0)
+    curve_support_bin_count: int = 5
+    minimum_activities_per_curve_bin: int = 5
+    minimum_segments_per_curve_bin: int = 10
+    reference_power_pct_cp: tuple[float, float] = (75.0, 85.0)
+    minimum_reference_power_activities_per_curve_bin: int = 5
+    maximum_bootstrap_width_ratio: float = 1.0
+    minimum_leave_one_out_sign_agreement: float = 0.8
+    maximum_leave_one_out_relative_change: float = 0.5
+
+
+_PREDICTION_GATES = frozenset({
+    "chronological_holdout_performance",
+    "no_heat_baseline_falsification",
+    "permuted_negative_control_falsification",
+})
+_DATA_SUPPORT_GATES = frozenset({
+    "complete_export",
+    "minimum_activities",
+    "minimum_segments",
+    "chronological_holdout",
+    "environmental_spread",
+    "holdout_environmental_spread",
+    "provider_regime_consistency",
+    "environment_source_consistency",
+})
+
+
+def build_environment_response_result(
+    dataset: dict[str, Any],
+    *,
+    config: LabsEnvironmentConfig | None = None,
+    validation_config: HeatValidationConfig | None = None,
+) -> dict[str, Any]:
+    """Return the aggregate-only result authorized by the accepted V1 SDR."""
+    selected = config or LabsEnvironmentConfig()
+    heat_config = validation_config or HeatValidationConfig()
+    report = validate_heat_response(dataset, heat_config)
+    gate_statuses = {
+        name: gate["status"]
+        for name, gate in report["gates"].items()
+    }
+    coverage = report["data_coverage"]
+    exclusions = report["exclusions"]
+    exclusion_reason_counts = dict(
+        Counter(exclusions["excluded_activity_reason_counts"])
+        + Counter(exclusions["excluded_segment_reason_counts"])
+    )
+    eligibility_counts = {
+        "input_activity_count": coverage["input_activity_count"],
+        "input_segment_count": coverage["input_segment_count"],
+        "eligible_activity_count": coverage["eligible_activity_count"],
+        "eligible_segment_count": coverage["eligible_segment_count"],
+        "exclusion_reason_counts": exclusion_reason_counts,
+        "provider_regimes": coverage["provider_regimes"]["combinations"],
+    }
+    provider_combinations = coverage["provider_regimes"]["combinations"]
+    stryd_regime_pass = bool(
+        len(provider_combinations) == 1
+        and str(provider_combinations[0]["label"]).startswith("power=stryd|")
+    )
+    gate_statuses["stryd_power_regime"] = (
+        "pass" if stryd_regime_pass else "fail"
+    )
+    model = report["model"]
+    association_gates_pass = stryd_regime_pass and all(
+        gate["status"] == "pass"
+        for name, gate in report["gates"].items()
+        if gate["decision_required"] and name not in _PREDICTION_GATES
+    )
+    prediction_gates = [
+        report["gates"][name]
+        for name in sorted(_PREDICTION_GATES)
+    ]
+    if any(gate["status"] == "unavailable" for gate in prediction_gates):
+        prediction_status = "unavailable"
+    elif all(gate["status"] == "pass" for gate in prediction_gates):
+        prediction_status = "passed_research_diagnostics"
+    else:
+        prediction_status = "failed_research_diagnostics"
+
+    if model["status"] != "available":
+        return _withheld_result(
+            result_state="insufficient_data",
+            prediction_status=prediction_status,
+            eligibility_counts=eligibility_counts,
+            gate_statuses=gate_statuses,
+            report=report,
+        )
+
+    combined, export = _prepare_dataset(dataset)
+    flattened = _flatten_dataset(combined, heat_config, export=export)
+    primary = _analyze_rows(
+        flattened,
+        heat_config,
+        heat_representation="wet_bulb_c",
+        include_bootstrap=False,
+    )
+    internal = primary["_internal"]
+    train_rows = internal["train_rows"]
+    test_rows = internal["test_rows"]
+    feature_names = internal["feature_names"]
+    heat_center = internal["heat_center"]
+
+    activity_environment: dict[str, list[float]] = {}
+    for row in train_rows:
+        activity_environment.setdefault(row.activity_key, []).append(row.wet_bulb_c)
+    activity_wet_bulb = {
+        key: float(np.mean(values))
+        for key, values in activity_environment.items()
+    }
+    activity_values = np.array(list(activity_wet_bulb.values()), dtype=float)
+    lower_pct, upper_pct = selected.curve_domain_percentiles
+    domain_low, domain_high = np.percentile(
+        activity_values,
+        [lower_pct, upper_pct],
+    )
+    edges = np.linspace(
+        float(domain_low),
+        float(domain_high),
+        selected.curve_support_bin_count + 1,
+    )
+    support_bins: list[dict[str, Any]] = []
+    for index in range(selected.curve_support_bin_count):
+        low = float(edges[index])
+        high = float(edges[index + 1])
+        in_bin = [
+            row
+            for row in train_rows
+            if row.wet_bulb_c >= low
+            and (
+                row.wet_bulb_c < high
+                or (
+                    index == selected.curve_support_bin_count - 1
+                    and row.wet_bulb_c <= high
+                )
+            )
+        ]
+        activity_count = len({row.activity_key for row in in_bin})
+        reference_activity_count = len({
+            row.activity_key
+            for row in in_bin
+            if selected.reference_power_pct_cp[0]
+            <= row.mean_pct_cp
+            <= selected.reference_power_pct_cp[1]
+        })
+        support_bins.append({
+            "lower_wet_bulb_c": round(low, 4),
+            "upper_wet_bulb_c": round(high, 4),
+            "activity_count": activity_count,
+            "segment_count": len(in_bin),
+            "reference_power_activity_count": reference_activity_count,
+        })
+
+    curve_support_pass = all(
+        item["activity_count"] >= selected.minimum_activities_per_curve_bin
+        and item["segment_count"] >= selected.minimum_segments_per_curve_bin
+        for item in support_bins
+    )
+    reference_overlap_pass = all(
+        item["reference_power_activity_count"]
+        >= selected.minimum_reference_power_activities_per_curve_bin
+        for item in support_bins
+    )
+    coefficient = model["heat_stress_coefficient"]
+    estimate = float(coefficient["estimate_bpm_per_c"])
+    interval = coefficient["uncertainty_interval_bpm_per_c"]
+    interval_available = all(value is not None for value in interval)
+    # SDR environmental-performance-v2: the descriptive activity-cluster
+    # interval must exclude zero and its width may not exceed |estimate|.
+    interval_excludes_zero = bool(
+        interval_available
+        and (float(interval[0]) > 0.0 or float(interval[1]) < 0.0)
+    )
+    width_ratio = (
+        (float(interval[1]) - float(interval[0])) / abs(estimate)
+        if interval_available and abs(estimate) > 1e-12
+        else None
+    )
+    interval_width_pass = bool(
+        width_ratio is not None
+        and width_ratio <= selected.maximum_bootstrap_width_ratio
+    )
+    leave_one_out = _leave_one_activity_out(
+        train_rows,
+        test_rows,
+        feature_names,
+        heat_center,
+        heat_config,
+        estimate,
+    )
+    influence_pass = bool(
+        leave_one_out["sign_agreement"]
+        >= selected.minimum_leave_one_out_sign_agreement
+        and leave_one_out["maximum_relative_change"] is not None
+        and leave_one_out["maximum_relative_change"]
+        <= selected.maximum_leave_one_out_relative_change
+    )
+
+    product_gates = {
+        "curve_bin_support": "pass" if curve_support_pass else "fail",
+        "reference_power_overlap": (
+            "pass" if reference_overlap_pass else "fail"
+        ),
+        "bootstrap_interval_excludes_zero": (
+            "pass" if interval_excludes_zero else "fail"
+        ),
+        "bootstrap_interval_width": (
+            "pass" if interval_width_pass else "fail"
+        ),
+        "leave_one_activity_out_influence": (
+            "pass" if influence_pass else "fail"
+        ),
+        "stryd_power_regime": "pass" if stryd_regime_pass else "fail",
+    }
+    gate_statuses.update(product_gates)
+    product_gates_pass = all(status == "pass" for status in product_gates.values())
+
+    if not association_gates_pass or not product_gates_pass:
+        failed_data_gate = any(
+            gate_statuses.get(name) != "pass"
+            for name in _DATA_SUPPORT_GATES
+        ) or not curve_support_pass or not reference_overlap_pass or not stryd_regime_pass
+        return _withheld_result(
+            result_state=(
+                "insufficient_data"
+                if failed_data_gate
+                else "unstable_association"
+            ),
+            prediction_status=prediction_status,
+            eligibility_counts={
+                **eligibility_counts,
+                "curve_support_bins": support_bins,
+            },
+            gate_statuses=gate_statuses,
+            report=report,
+            uncertainty={
+                "estimate_bpm_per_c": estimate,
+                "interval_bpm_per_c": interval,
+                "interval_width_to_absolute_estimate_ratio": (
+                    round(width_ratio, 4)
+                    if width_ratio is not None
+                    else None
+                ),
+                "leave_one_activity_out": leave_one_out,
+            },
+        )
+    if prediction_status == "unavailable":
+        return _withheld_result(
+            result_state="prediction_unavailable",
+            prediction_status=prediction_status,
+            eligibility_counts={
+                **eligibility_counts,
+                "curve_support_bins": support_bins,
+            },
+            gate_statuses=gate_statuses,
+            report=report,
+        )
+
+    curve_points = _curve_points(
+        train_rows,
+        model,
+        feature_names,
+        float(domain_low),
+        float(domain_high),
+        interval,
+        selected.curve_support_bin_count,
+    )
+    return {
+        "model_version": LABS_ENVIRONMENT_MODEL_VERSION,
+        "power_regime": POWER_REGIME,
+        "result_state": "historical_association_only",
+        "prediction_status": prediction_status,
+        "eligibility_counts": {
+            **eligibility_counts,
+            "observed_wet_bulb_domain_c": [
+                round(float(domain_low), 4),
+                round(float(domain_high), 4),
+            ],
+            "curve_support_bins": support_bins,
+        },
+        "aggregate_curve_points": curve_points,
+        "aggregate_uncertainty": {
+            "estimate_bpm_per_c": estimate,
+            "interval_bpm_per_c": interval,
+            "interval_method": coefficient["uncertainty_method"],
+            "interval_width_to_absolute_estimate_ratio": round(width_ratio, 4),
+            "leave_one_activity_out": leave_one_out,
+        },
+        "gate_statuses": gate_statuses,
+        "limitations": [
+            "historical_association_not_causal",
+            "not_predictively_validated_for_product_use",
+            "psychrometric_wet_bulb_proxy_not_wbgt",
+            "no_extrapolation_beyond_observed_domain",
+        ],
+    }
+
+
+def _leave_one_activity_out(
+    train_rows: list[Any],
+    test_rows: list[Any],
+    feature_names: tuple[str, ...],
+    heat_center: float,
+    config: HeatValidationConfig,
+    primary_estimate: float,
+) -> dict[str, Any]:
+    # Influence formulas and the 0.8 / 0.5 release bounds are accepted product
+    # guardrails in sdr-environmental-performance-v2, not inferential tests.
+    estimates: list[float] = []
+    heat_index = feature_names.index("wet_bulb_c")
+    for activity_key in sorted({row.activity_key for row in train_rows}):
+        reduced = [row for row in train_rows if row.activity_key != activity_key]
+        if not reduced:
+            continue
+        fit = _fit_model(
+            reduced,
+            test_rows,
+            feature_names,
+            heat_representation="wet_bulb_c",
+            heat_center=heat_center,
+            ridge_alpha=config.ridge_alpha,
+        )
+        estimates.append(float(fit.coefficients[heat_index]))
+    primary_sign = np.sign(primary_estimate)
+    sign_agreement = (
+        sum(np.sign(value) == primary_sign for value in estimates) / len(estimates)
+        if estimates and primary_sign != 0
+        else 0.0
+    )
+    maximum_relative_change = (
+        max(abs(value - primary_estimate) / abs(primary_estimate) for value in estimates)
+        if estimates and abs(primary_estimate) > 1e-12
+        else float("inf")
+    )
+    return {
+        "evaluated_activity_count": len(estimates),
+        "sign_agreement": round(float(sign_agreement), 4),
+        "maximum_relative_change": (
+            round(float(maximum_relative_change), 4)
+            if np.isfinite(maximum_relative_change)
+            else None
+        ),
+    }
+
+
+def _curve_points(
+    train_rows: list[Any],
+    model: dict[str, Any],
+    feature_names: tuple[str, ...],
+    domain_low: float,
+    domain_high: float,
+    interval: list[float | None],
+    point_count: int,
+) -> list[dict[str, float]]:
+    # SDR environmental-performance-v2 fixes training medians as the reference
+    # profile and prohibits extrapolation beyond the 10th-90th percentile
+    # activity-level wet-bulb domain.
+    coefficients = model["coefficients"]
+    reference_values: dict[str, float] = {}
+    for feature in feature_names:
+        if feature == "wet_bulb_c":
+            continue
+        reference_values[feature] = float(np.median([
+            getattr(row, feature)
+            for row in train_rows
+        ]))
+    reference_wet_bulb = float(np.median([
+        row.wet_bulb_c
+        for row in train_rows
+    ]))
+    baseline = float(model["intercept_bpm"])
+    for feature, value in reference_values.items():
+        baseline += float(coefficients[feature]) * value
+    baseline += float(coefficients["wet_bulb_c"]) * reference_wet_bulb
+    lower_slope = float(interval[0])
+    upper_slope = float(interval[1])
+    points: list[dict[str, float]] = []
+    for wet_bulb in np.linspace(domain_low, domain_high, point_count):
+        delta = float(wet_bulb - reference_wet_bulb)
+        relative = float(coefficients["wet_bulb_c"]) * delta
+        relative_bounds = sorted((lower_slope * delta, upper_slope * delta))
+        points.append({
+            "wet_bulb_c": round(float(wet_bulb), 4),
+            "modeled_hr_bpm": round(baseline + relative, 4),
+            "relative_hr_bpm": round(relative, 4),
+            "relative_lower_bpm": round(relative_bounds[0], 4),
+            "relative_upper_bpm": round(relative_bounds[1], 4),
+            "reference_wet_bulb_c": round(reference_wet_bulb, 4),
+        })
+    return points
+
+
+def _withheld_result(
+    *,
+    result_state: str,
+    prediction_status: str,
+    eligibility_counts: dict[str, Any],
+    gate_statuses: dict[str, str],
+    report: dict[str, Any],
+    uncertainty: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "model_version": LABS_ENVIRONMENT_MODEL_VERSION,
+        "power_regime": POWER_REGIME,
+        "result_state": result_state,
+        "prediction_status": prediction_status,
+        "eligibility_counts": eligibility_counts,
+        "aggregate_curve_points": [],
+        "aggregate_uncertainty": uncertainty or {},
+        "gate_statuses": gate_statuses,
+        "limitations": report["limitations"],
+    }

--- a/analysis/heat_response_validation.py
+++ b/analysis/heat_response_validation.py
@@ -2413,20 +2413,37 @@ def _cluster_bootstrap(
             )
         if not sampled_rows:
             continue
-        fit = _fit_model(
+        # SDR environmental-performance-v2 requires filtering and model
+        # specification to be refit inside every activity-cluster draw rather
+        # than freezing optional complete-case predictors from the primary fit.
+        draw_features, _ = _select_features(
             sampled_rows,
-            sampled_rows,
-            feature_names,
             heat_representation=heat_representation,
-            heat_center=heat_center,
+        )
+        filtered_rows, _, _ = _filter_evaluation_rows(
+            sampled_rows,
+            draw_features,
+        )
+        if not filtered_rows:
+            continue
+        draw_heat_center = float(np.mean([
+            _heat_value(row, heat_representation)
+            for row in filtered_rows
+        ]))
+        fit = _fit_model(
+            filtered_rows,
+            filtered_rows,
+            draw_features,
+            heat_representation=heat_representation,
+            heat_center=draw_heat_center,
             ridge_alpha=config.ridge_alpha,
         )
         for name, value in zip(
-            feature_names,
+            draw_features,
             fit.coefficients,
             strict=True,
         ):
-            if math.isfinite(float(value)):
+            if name in samples and math.isfinite(float(value)):
                 samples[name].append(float(value))
     return samples
 

--- a/api/account_deletion.py
+++ b/api/account_deletion.py
@@ -24,6 +24,9 @@ from db.models import (
     Feedback,
     FitnessData,
     Invitation,
+    LabsDeletionTombstone,
+    LabsExperimentEnrollment,
+    LabsExperimentResult,
     PlanDelivery,
     PlanDeliveryAttempt,
     PlanRevision,
@@ -117,6 +120,9 @@ def _delete_user_owned_rows(db: Session, user_id: str) -> None:
         AiInsight,
         CacheRevision,
         DashboardCache,
+        LabsExperimentResult,
+        LabsExperimentEnrollment,
+        LabsDeletionTombstone,
         Feedback,
     ):
         db.query(model).filter(model.user_id == user_id).delete(synchronize_session=False)

--- a/api/feedback_storage.py
+++ b/api/feedback_storage.py
@@ -205,6 +205,16 @@ def is_blob_configured() -> bool:
     return _use_blob() and _blob_container_client() is not None
 
 
+def private_blob_enabled() -> bool:
+    """Return whether the shared private Blob backend is configured."""
+    return _use_blob()
+
+
+def private_container_client():
+    """Return the shared private container client, or ``None`` if unavailable."""
+    return _blob_container_client()
+
+
 # ---------------------------------------------------------------------------
 # Store / load
 # ---------------------------------------------------------------------------

--- a/api/labs_environment.py
+++ b/api/labs_environment.py
@@ -1,0 +1,668 @@
+"""Consent, aggregate persistence, and private processing for Labs V1."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from analysis.environment_response import (
+    LABS_ENVIRONMENT_MODEL_VERSION,
+    POWER_REGIME,
+    build_environment_response_result,
+)
+from analysis.heat_response_validation import build_research_dataset_bundle
+from analysis.metrics import ACTIVITY_RESEARCH_SCHEMA_VERSION
+from api.etag import ENDPOINT_SCOPES, compute_revision_token
+from api.packs import (
+    RequestContext,
+    get_activity_research_pack,
+    get_analysis_response_version,
+)
+from api.views import utc_isoformat
+from api import labs_tombstone_storage
+from db.models import (
+    LabsDeletionTombstone,
+    LabsExperimentEnrollment,
+    LabsExperimentResult,
+    User,
+)
+from db.session import begin_serialized_write
+
+logger = logging.getLogger(__name__)
+
+EXPERIMENT_ID = "environment-response-v1"
+CONSENT_VERSION = "environment-response-consent-v1"
+_SNAPSHOT_SALT = (
+    "analysis-export&v="
+    f"{get_analysis_response_version(ACTIVITY_RESEARCH_SCHEMA_VERSION)}"
+)
+
+
+class StaleSourceRevision(RuntimeError):
+    """Raised when source data changes during private snapshot construction."""
+
+
+def _locked_enrollment(
+    db: Session,
+    user_id: str,
+    experiment_id: str,
+) -> LabsExperimentEnrollment | None:
+    return (
+        db.query(LabsExperimentEnrollment)
+        .filter(
+            LabsExperimentEnrollment.user_id == user_id,
+            LabsExperimentEnrollment.experiment_id == experiment_id,
+        )
+        .with_for_update()
+        .one_or_none()
+    )
+
+
+def source_revision(db: Session, user_id: str) -> str:
+    """Return the owner-bound source revision used to fence one computation."""
+    return compute_revision_token(
+        db,
+        user_id,
+        ENDPOINT_SCOPES["analysis"],
+        salt=_SNAPSHOT_SALT,
+    )
+
+
+def enroll(
+    db: Session,
+    user_id: str,
+    *,
+    adult_attested: bool,
+    consent_version: str,
+) -> LabsExperimentEnrollment:
+    """Create or replace explicit consent and queue aggregate computation."""
+    if not adult_attested:
+        raise ValueError("adult_eligibility_not_confirmed")
+    if consent_version != CONSENT_VERSION:
+        raise ValueError("consent_version_stale")
+    begin_serialized_write(db)
+    now = datetime.utcnow()
+    revision = source_revision(db, user_id)
+    row = _locked_enrollment(db, user_id, EXPERIMENT_ID)
+    if row is None:
+        row = LabsExperimentEnrollment(
+            user_id=user_id,
+            experiment_id=EXPERIMENT_ID,
+            consent_version=CONSENT_VERSION,
+            consented_at=now,
+            adult_attested_at=now,
+            status="queued",
+            model_version=LABS_ENVIRONMENT_MODEL_VERSION,
+            source_revision=revision,
+            correlation_id=str(uuid4()),
+            queued_at=now,
+            updated_at=now,
+        )
+        db.add(row)
+    else:
+        row.consent_version = CONSENT_VERSION
+        row.consented_at = now
+        row.adult_attested_at = now
+        row.status = "queued"
+        row.model_version = LABS_ENVIRONMENT_MODEL_VERSION
+        row.source_revision = revision
+        row.correlation_id = str(uuid4())
+        row.availability_reason = None
+        row.queued_at = now
+        row.started_at = None
+        row.completed_at = None
+        row.updated_at = now
+    db.query(LabsExperimentResult).filter(
+        LabsExperimentResult.user_id == user_id,
+        LabsExperimentResult.experiment_id == EXPERIMENT_ID,
+    ).delete(synchronize_session=False)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def queue_recompute(
+    db: Session,
+    user_id: str,
+) -> LabsExperimentEnrollment | None:
+    """Queue a fresh computation without changing the active consent time."""
+    begin_serialized_write(db)
+    row = _locked_enrollment(db, user_id, EXPERIMENT_ID)
+    if row is None:
+        db.rollback()
+        return None
+    now = datetime.utcnow()
+    row.status = "queued"
+    row.model_version = LABS_ENVIRONMENT_MODEL_VERSION
+    row.source_revision = source_revision(db, user_id)
+    row.correlation_id = str(uuid4())
+    row.availability_reason = None
+    row.queued_at = now
+    row.started_at = None
+    row.completed_at = None
+    row.updated_at = now
+    db.query(LabsExperimentResult).filter(
+        LabsExperimentResult.user_id == user_id,
+        LabsExperimentResult.experiment_id == EXPERIMENT_ID,
+    ).delete(synchronize_session=False)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def recover_interrupted_jobs(
+    db: Session,
+    *,
+    user_id: str | None = None,
+    all_processing: bool = False,
+) -> int:
+    """Return abandoned in-process work to the durable queued state."""
+    begin_serialized_write(db)
+    query = db.query(LabsExperimentEnrollment).filter(
+        LabsExperimentEnrollment.status == "processing",
+    )
+    if not all_processing:
+        cutoff = datetime.utcnow() - timedelta(minutes=30)
+        query = query.filter(
+            (LabsExperimentEnrollment.started_at.is_(None))
+            | (LabsExperimentEnrollment.started_at <= cutoff)
+        )
+    if user_id is not None:
+        query = query.filter(LabsExperimentEnrollment.user_id == user_id)
+    rows = query.with_for_update().all()
+    now = datetime.utcnow()
+    for row in rows:
+        row.status = "queued"
+        row.correlation_id = str(uuid4())
+        row.availability_reason = None
+        row.queued_at = now
+        row.started_at = None
+        row.completed_at = None
+        row.updated_at = now
+    db.commit()
+    return len(rows)
+
+
+def withdraw(db: Session, user_id: str) -> bool:
+    """Delete active consent and aggregate result, retaining only a tombstone."""
+    begin_serialized_write(db)
+    enrollment = _locked_enrollment(db, user_id, EXPERIMENT_ID)
+    deleted_at = datetime.utcnow()
+    labs_tombstone_storage.store(
+        user_id,
+        EXPERIMENT_ID,
+        deleted_at,
+    )
+    existed = enrollment is not None or (
+        db.get(LabsExperimentResult, (user_id, EXPERIMENT_ID)) is not None
+    )
+    db.query(LabsExperimentResult).filter(
+        LabsExperimentResult.user_id == user_id,
+        LabsExperimentResult.experiment_id == EXPERIMENT_ID,
+    ).delete(synchronize_session=False)
+    db.query(LabsExperimentEnrollment).filter(
+        LabsExperimentEnrollment.user_id == user_id,
+        LabsExperimentEnrollment.experiment_id == EXPERIMENT_ID,
+    ).delete(synchronize_session=False)
+    tombstone = db.get(LabsDeletionTombstone, (user_id, EXPERIMENT_ID))
+    if tombstone is None:
+        db.add(LabsDeletionTombstone(
+            user_id=user_id,
+            experiment_id=EXPERIMENT_ID,
+            deleted_at=deleted_at,
+        ))
+    else:
+        tombstone.deleted_at = deleted_at
+    db.commit()
+    return existed
+
+
+def replay_deletion_tombstones(db: Session) -> int:
+    """Reapply withdrawals after a point-in-time database restore."""
+    for external in labs_tombstone_storage.iter_active():
+        identity = (
+            str(external["user_id"]),
+            str(external["experiment_id"]),
+        )
+        if db.get(User, identity[0]) is None:
+            continue
+        tombstone = db.get(LabsDeletionTombstone, identity)
+        deleted_at = external["deleted_at"]
+        if tombstone is None:
+            db.add(LabsDeletionTombstone(
+                user_id=identity[0],
+                experiment_id=identity[1],
+                deleted_at=deleted_at,
+            ))
+        elif tombstone.deleted_at < deleted_at:
+            tombstone.deleted_at = deleted_at
+    db.flush()
+    deleted = 0
+    for tombstone in db.query(LabsDeletionTombstone).all():
+        deleted += db.query(LabsExperimentResult).filter(
+            LabsExperimentResult.user_id == tombstone.user_id,
+            LabsExperimentResult.experiment_id == tombstone.experiment_id,
+            LabsExperimentResult.computed_at <= tombstone.deleted_at,
+        ).delete(synchronize_session=False)
+        deleted += db.query(LabsExperimentEnrollment).filter(
+            LabsExperimentEnrollment.user_id == tombstone.user_id,
+            LabsExperimentEnrollment.experiment_id == tombstone.experiment_id,
+            LabsExperimentEnrollment.consented_at <= tombstone.deleted_at,
+        ).delete(synchronize_session=False)
+    db.commit()
+    return deleted
+
+
+def process_environment_response_job(
+    user_id: str,
+    experiment_id: str,
+    model_version: str,
+    expected_source_revision: str,
+) -> None:
+    """Compute one queued job using only privacy-minimized identifiers."""
+    from db import session as db_session
+
+    db = db_session.SessionLocal()
+    correlation_id = "unknown"
+    try:
+        begin_serialized_write(db)
+        row = _locked_enrollment(db, user_id, experiment_id)
+        if (
+            row is None
+            or row.status != "queued"
+            or row.model_version != model_version
+            or row.source_revision != expected_source_revision
+        ):
+            return
+        correlation_id = row.correlation_id
+        row.status = "processing"
+        row.started_at = datetime.utcnow()
+        row.updated_at = datetime.utcnow()
+        db.commit()
+
+        try:
+            bundle = _build_private_dataset_bundle(
+                db,
+                user_id,
+                expected_source_revision,
+            )
+        except StaleSourceRevision:
+            _persist_unavailable(
+                db,
+                user_id,
+                experiment_id,
+                model_version,
+                expected_source_revision,
+                correlation_id,
+                "stale_source_revision",
+                "stale",
+            )
+            return
+        if source_revision(db, user_id) != expected_source_revision:
+            _persist_unavailable(
+                db,
+                user_id,
+                experiment_id,
+                model_version,
+                expected_source_revision,
+                correlation_id,
+                "stale_source_revision",
+                "stale",
+            )
+            return
+        aggregate = build_environment_response_result(bundle)
+        if source_revision(db, user_id) != expected_source_revision:
+            _persist_unavailable(
+                db,
+                user_id,
+                experiment_id,
+                model_version,
+                expected_source_revision,
+                correlation_id,
+                "stale_source_revision",
+                "stale",
+            )
+            return
+
+        db.rollback()
+        db.expire_all()
+        begin_serialized_write(db)
+        row = _locked_enrollment(db, user_id, experiment_id)
+        if (
+            row is None
+            or row.status != "processing"
+            or row.model_version != model_version
+            or row.source_revision != expected_source_revision
+            or row.correlation_id != correlation_id
+        ):
+            return
+        tombstone = db.get(LabsDeletionTombstone, (user_id, experiment_id))
+        if tombstone is not None and tombstone.deleted_at >= row.consented_at:
+            return
+        result = db.get(LabsExperimentResult, (user_id, experiment_id))
+        if result is None:
+            result = LabsExperimentResult(
+                user_id=user_id,
+                experiment_id=experiment_id,
+            )
+            db.add(result)
+        result.model_version = model_version
+        result.source_revision = expected_source_revision
+        result.result_state = aggregate["result_state"]
+        result.eligibility_counts = aggregate["eligibility_counts"]
+        result.aggregate_curve_points = aggregate["aggregate_curve_points"]
+        result.aggregate_uncertainty = aggregate["aggregate_uncertainty"]
+        result.gate_statuses = aggregate["gate_statuses"]
+        result.prediction_status = aggregate["prediction_status"]
+        result.power_regime = aggregate["power_regime"]
+        result.computed_at = datetime.utcnow()
+        row.status = (
+            "available"
+            if aggregate["aggregate_curve_points"]
+            else "unavailable"
+        )
+        row.availability_reason = (
+            None
+            if row.status == "available"
+            else availability_reason(
+                aggregate,
+                correlation_id=correlation_id,
+            )
+        )
+        row.completed_at = datetime.utcnow()
+        row.updated_at = datetime.utcnow()
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "Labs environment-response processing failed "
+            "correlation_id=%s stage=analysis model=%s regime=%s",
+            correlation_id,
+            model_version,
+            POWER_REGIME,
+        )
+        try:
+            _persist_unavailable(
+                db,
+                user_id,
+                experiment_id,
+                model_version,
+                expected_source_revision,
+                correlation_id,
+                "analysis_failed",
+                "failed",
+            )
+        except Exception:
+            db.rollback()
+            logger.exception(
+                "Labs failure state persistence failed correlation_id=%s",
+                correlation_id,
+            )
+    finally:
+        db.close()
+
+
+def _build_private_dataset_bundle(
+    db: Session,
+    user_id: str,
+    expected_source_revision: str,
+) -> dict[str, Any]:
+    pages: list[dict[str, Any]] = []
+    offset = 0
+    limit = 50
+    ctx = RequestContext(user_id=user_id, db=db)
+    while True:
+        if source_revision(db, user_id) != expected_source_revision:
+            raise StaleSourceRevision
+        page = get_activity_research_pack(
+            ctx,
+            export_snapshot_id=expected_source_revision,
+            limit=limit,
+            offset=offset,
+        )
+        pages.append(page)
+        offset += limit
+        if offset >= page["total"]:
+            break
+    return build_research_dataset_bundle(pages)
+
+
+def _persist_unavailable(
+    db: Session,
+    user_id: str,
+    experiment_id: str,
+    model_version: str,
+    expected_source_revision: str,
+    correlation_id: str,
+    code: str,
+    status: str,
+) -> None:
+    db.rollback()
+    db.expire_all()
+    begin_serialized_write(db)
+    row = _locked_enrollment(db, user_id, experiment_id)
+    if (
+        row is None
+        or row.model_version != model_version
+        or row.source_revision != expected_source_revision
+        or row.correlation_id != correlation_id
+        or row.status != "processing"
+    ):
+        return
+    row.status = status
+    row.availability_reason = _reason(
+        code,
+        correlation_id=correlation_id,
+    )
+    row.completed_at = datetime.utcnow()
+    row.updated_at = datetime.utcnow()
+    db.commit()
+
+
+def availability_reason(
+    aggregate: dict[str, Any],
+    *,
+    correlation_id: str,
+) -> dict[str, Any]:
+    """Map aggregate gate failures to the stable public diagnostic taxonomy."""
+    gates = aggregate["gate_statuses"]
+    exclusions = aggregate.get("eligibility_counts", {}).get(
+        "exclusion_reason_counts",
+        {},
+    )
+    exclusion_priority = (
+        (
+            (
+                "power_missing_or_invalid",
+                "split_fallback_excluded",
+                "stable_segments_unavailable",
+            ),
+            "missing_continuous_sample_power",
+        ),
+        (
+            ("mean_hr_missing_or_invalid", "heart_rate_provider_missing"),
+            "missing_continuous_heart_rate",
+        ),
+        (
+            ("temperature_missing_or_invalid",),
+            "missing_temperature",
+        ),
+        (
+            ("relative_humidity_missing_or_invalid",),
+            "missing_relative_humidity",
+        ),
+        (
+            (
+                "critical_power_contract_missing",
+                "critical_power_unavailable",
+                "critical_power_value_missing_or_invalid",
+                "critical_power_provider_missing",
+            ),
+            "missing_provider_aligned_critical_power",
+        ),
+        (
+            (
+                "critical_power_provider_mismatch",
+                "mean_pct_cp_critical_power_mismatch",
+                "provider_mismatch_reason_code",
+            ),
+            "critical_power_provider_mismatch",
+        ),
+        (
+            (
+                "activity_sample_coverage_missing",
+                "activity_sample_coverage_low",
+                "segment_sample_coverage_missing",
+                "segment_sample_coverage_low",
+            ),
+            "insufficient_sample_coverage",
+        ),
+    )
+    priority = (
+        ("complete_export", "incomplete_export"),
+        ("minimum_activities", "insufficient_activities"),
+        ("minimum_segments", "insufficient_segments"),
+        ("environmental_spread", "insufficient_environmental_spread"),
+        ("chronological_holdout", "insufficient_holdout"),
+        ("holdout_environmental_spread", "insufficient_holdout"),
+        ("curve_bin_support", "insufficient_curve_bin_support"),
+        ("reference_power_overlap", "insufficient_reference_power_overlap"),
+        ("provider_regime_consistency", "mixed_power_regime"),
+        ("bootstrap_interval_excludes_zero", "bootstrap_unstable"),
+        ("bootstrap_interval_width", "bootstrap_unstable"),
+        ("sensitivity_analysis_coverage", "sensitivity_unstable"),
+        ("coefficient_stability", "sensitivity_unstable"),
+        ("leave_one_activity_out_influence", "influential_activity"),
+    )
+    exclusion_code = next(
+        (
+            mapped
+            for reason_names, mapped in exclusion_priority
+            if any(exclusions.get(name, 0) for name in reason_names)
+        ),
+        None,
+    )
+    if exclusion_code is not None:
+        code = exclusion_code
+    elif gates.get("stryd_power_regime") == "fail":
+        combinations = aggregate.get("eligibility_counts", {}).get(
+            "provider_regimes",
+            [],
+        )
+        code = (
+            "unverified_garmin_wrist_power"
+            if any("power=garmin|" in str(item) for item in combinations)
+            else "unsupported_power_provider"
+        )
+    elif aggregate["result_state"] == "prediction_unavailable":
+        code = "prediction_unavailable"
+    else:
+        code = next(
+            (
+                mapped
+                for gate_name, mapped in priority
+                if gates.get(gate_name) != "pass"
+            ),
+            "analysis_failed",
+        )
+    counts = aggregate.get("eligibility_counts", {})
+    observed = {
+        key: counts[key]
+        for key in (
+            "eligible_activity_count",
+            "eligible_segment_count",
+            "observed_wet_bulb_domain_c",
+        )
+        if key in counts
+    }
+    return _reason(
+        code,
+        correlation_id=correlation_id,
+        observed_aggregate=observed or None,
+    )
+
+
+def _reason(
+    code: str,
+    *,
+    correlation_id: str,
+    observed_aggregate: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    category = (
+        "processing"
+        if code == "analysis_failed"
+        else "eligibility"
+        if code == "adult_eligibility_not_confirmed"
+        else "data_support"
+    )
+    return {
+        "code": code,
+        "category": category,
+        "public_message_key": f"labs.environment.reason.{code}",
+        "observed_aggregate": observed_aggregate,
+        "required_guardrail": code,
+        "user_actionable": code not in {
+            "analysis_failed",
+            "bootstrap_unstable",
+            "sensitivity_unstable",
+            "influential_activity",
+        },
+        "suggested_action_key": f"labs.environment.action.{code}",
+        "analysis_stage": "environment_response",
+        "power_regime": POWER_REGIME,
+        "model_version": LABS_ENVIRONMENT_MODEL_VERSION,
+        "correlation_id": correlation_id,
+    }
+
+
+def adult_eligibility_reason() -> dict[str, Any]:
+    """Return a structured diagnostic for a rejected adult attestation."""
+    return _reason(
+        "adult_eligibility_not_confirmed",
+        correlation_id=str(uuid4()),
+    )
+
+
+def public_state(db: Session, user_id: str) -> dict[str, Any]:
+    """Return the authenticated, aggregate-only experiment state."""
+    row = db.get(LabsExperimentEnrollment, (user_id, EXPERIMENT_ID))
+    base = {
+        "experiment_id": EXPERIMENT_ID,
+        "consent_version": CONSENT_VERSION,
+        "model_version": LABS_ENVIRONMENT_MODEL_VERSION,
+        "enrolled": row is not None,
+        "status": "not_enrolled" if row is None else row.status,
+        "adult_attestation_required": True,
+        "power_regime": POWER_REGIME,
+        "availability_reason": None if row is None else row.availability_reason,
+        "result": None,
+    }
+    if row is None:
+        return base
+    base.update({
+        "consented_at": utc_isoformat(row.consented_at),
+        "adult_attested_at": utc_isoformat(row.adult_attested_at),
+        "source_revision": row.source_revision,
+        "correlation_id": row.correlation_id,
+        "queued_at": utc_isoformat(row.queued_at),
+        "started_at": utc_isoformat(row.started_at),
+        "completed_at": utc_isoformat(row.completed_at),
+    })
+    result = db.get(LabsExperimentResult, (user_id, EXPERIMENT_ID))
+    if result is not None:
+        base["result"] = {
+            "result_state": result.result_state,
+            "prediction_status": result.prediction_status,
+            "eligibility_counts": result.eligibility_counts,
+            "aggregate_curve_points": result.aggregate_curve_points,
+            "aggregate_uncertainty": result.aggregate_uncertainty,
+            "gate_statuses": result.gate_statuses,
+            "computed_at": utc_isoformat(result.computed_at),
+            "source_revision": result.source_revision,
+            "model_version": result.model_version,
+            "power_regime": result.power_regime,
+        }
+    return base

--- a/api/labs_tombstone_storage.py
+++ b/api/labs_tombstone_storage.py
@@ -1,0 +1,121 @@
+"""Restore-safe private storage for Labs withdrawal tombstones."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterator
+
+from api import feedback_storage
+
+RETENTION_DAYS = 14
+_PREFIX = "labs-deletions"
+
+
+class TombstoneStorageError(RuntimeError):
+    """Raised when a withdrawal marker cannot be durably stored."""
+
+
+def _owner_key(user_id: str) -> str:
+    return hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+
+
+def _blob_key(user_id: str, experiment_id: str) -> str:
+    return f"{_PREFIX}/{_owner_key(user_id)}/{experiment_id}.json"
+
+
+def _local_dir() -> Path:
+    from db.session import get_data_dir
+
+    return Path(get_data_dir()) / "labs_deletion_tombstones"
+
+
+def store(user_id: str, experiment_id: str, deleted_at: datetime) -> None:
+    """Durably write a tombstone before deleting active consent/results."""
+    payload = json.dumps(
+        {
+            "user_id": user_id,
+            "experiment_id": experiment_id,
+            "deleted_at": deleted_at.isoformat(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    key = _blob_key(user_id, experiment_id)
+    if feedback_storage.private_blob_enabled():
+        client = feedback_storage.private_container_client()
+        if client is None:
+            raise TombstoneStorageError("Private Blob storage is unavailable")
+        try:
+            client.upload_blob(
+                name=key,
+                data=payload,
+                overwrite=True,
+            )
+            return
+        except Exception as exc:
+            raise TombstoneStorageError(
+                "Could not persist the Labs withdrawal tombstone"
+            ) from exc
+    path = _local_dir() / _owner_key(user_id) / f"{experiment_id}.json"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_bytes(payload)
+        os.replace(temporary, path)
+    except OSError as exc:
+        raise TombstoneStorageError(
+            "Could not persist the Labs withdrawal tombstone"
+        ) from exc
+
+
+def iter_active(now: datetime | None = None) -> Iterator[dict[str, object]]:
+    """Yield valid tombstones within the production backup-retention window."""
+    cutoff = (now or datetime.utcnow()) - timedelta(days=RETENTION_DAYS)
+    if feedback_storage.private_blob_enabled():
+        client = feedback_storage.private_container_client()
+        if client is None:
+            raise TombstoneStorageError("Private Blob storage is unavailable")
+        try:
+            for item in client.list_blobs(name_starts_with=f"{_PREFIX}/"):
+                blob = client.get_blob_client(item.name)
+                payload = _decode(blob.download_blob().readall())
+                if payload["deleted_at"] >= cutoff:
+                    yield payload
+                else:
+                    blob.delete_blob()
+            return
+        except TombstoneStorageError:
+            raise
+        except Exception as exc:
+            raise TombstoneStorageError(
+                "Could not replay Labs withdrawal tombstones"
+            ) from exc
+    root = _local_dir()
+    if not root.exists():
+        return
+    for path in root.glob("*/*.json"):
+        payload = _decode(path.read_bytes())
+        if payload["deleted_at"] >= cutoff:
+            yield payload
+        else:
+            path.unlink(missing_ok=True)
+
+
+def _decode(raw: bytes) -> dict[str, object]:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+        deleted_at = datetime.fromisoformat(str(payload["deleted_at"]))
+        user_id = str(payload["user_id"])
+        experiment_id = str(payload["experiment_id"])
+    except (KeyError, TypeError, ValueError, UnicodeDecodeError) as exc:
+        raise TombstoneStorageError("Invalid Labs withdrawal tombstone") from exc
+    if not user_id or not experiment_id:
+        raise TombstoneStorageError("Invalid Labs withdrawal tombstone")
+    return {
+        "user_id": user_id,
+        "experiment_id": experiment_id,
+        "deleted_at": deleted_at,
+    }

--- a/api/main.py
+++ b/api/main.py
@@ -81,6 +81,15 @@ from db.session import init_db
 async def lifespan(app: FastAPI):
     """Initialize database on startup."""
     init_db()
+    from api.labs_environment import (
+        recover_interrupted_jobs,
+        replay_deletion_tombstones,
+    )
+    from db.session import SessionLocal
+
+    with SessionLocal() as labs_db:
+        replay_deletion_tombstones(labs_db)
+        recover_interrupted_jobs(labs_db)
     from api.routes.sync import migrate_legacy_garmin_tokenstores
 
     migrate_legacy_garmin_tokenstores()
@@ -211,10 +220,10 @@ app.include_router(feedback_router, prefix="/api", tags=["feedback"])
 
 # Data routes
 from api.routes import analysis as activity_analysis_routes
-from api.routes import today, training, goal, history, plan, settings, sync, science, insights, product_events, status
+from api.routes import today, training, goal, history, labs, plan, settings, sync, science, insights, product_events, status
 from api.routes import ai as ai_routes
 
-for router_module in [today, training, goal, history, activity_analysis_routes, plan, settings, sync, science, ai_routes, insights, product_events, status]:
+for router_module in [today, training, goal, history, activity_analysis_routes, labs, plan, settings, sync, science, ai_routes, insights, product_events, status]:
     app.include_router(router_module.router, prefix="/api")
 
 

--- a/api/routes/labs.py
+++ b/api/routes/labs.py
@@ -1,0 +1,301 @@
+"""Authenticated lifecycle endpoints for Praxys Labs experiments."""
+from typing import Literal
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from api.auth import get_current_user_id, require_write_access
+from api.labs_environment import (
+    CONSENT_VERSION,
+    EXPERIMENT_ID,
+    adult_eligibility_reason,
+    enroll,
+    process_environment_response_job,
+    public_state,
+    queue_recompute,
+    recover_interrupted_jobs,
+    withdraw,
+)
+from api.labs_tombstone_storage import TombstoneStorageError
+from db.models import LabsExperimentEnrollment
+from db.session import get_db
+
+router = APIRouter()
+
+
+class EnvironmentEnrollmentRequest(BaseModel):
+    """Explicit consent submitted against the currently displayed text."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    adult_attested: bool
+    consent_version: str
+
+
+class EnvironmentObservedAggregate(BaseModel):
+    """Small non-identifying counts included in availability diagnostics."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    eligible_activity_count: int | None = None
+    eligible_segment_count: int | None = None
+    observed_wet_bulb_domain_c: list[float] | None = None
+
+
+class EnvironmentAvailabilityReason(BaseModel):
+    """Privacy-safe diagnostic returned when no curve is available."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    category: str
+    public_message_key: str
+    observed_aggregate: EnvironmentObservedAggregate | None
+    required_guardrail: str
+    user_actionable: bool
+    suggested_action_key: str
+    analysis_stage: str
+    power_regime: str
+    model_version: str
+    correlation_id: str
+
+
+class EnvironmentCurvePoint(BaseModel):
+    """One aggregate modeled point within observed environmental support."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    wet_bulb_c: float
+    modeled_hr_bpm: float
+    relative_hr_bpm: float
+    relative_lower_bpm: float
+    relative_upper_bpm: float
+    reference_wet_bulb_c: float
+
+
+class EnvironmentProviderRegime(BaseModel):
+    """Aggregate provider combination count, never an activity identity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    activity_count: int
+    segment_count: int
+
+
+class EnvironmentCurveSupportBin(BaseModel):
+    """Aggregate display-domain support for one prespecified bin."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    lower_wet_bulb_c: float
+    upper_wet_bulb_c: float
+    activity_count: int
+    segment_count: int
+    reference_power_activity_count: int
+
+
+class EnvironmentEligibilityCounts(BaseModel):
+    """Aggregate-only coverage retained for audit and explanation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_activity_count: int
+    input_segment_count: int
+    eligible_activity_count: int
+    eligible_segment_count: int
+    exclusion_reason_counts: dict[str, int]
+    provider_regimes: list[EnvironmentProviderRegime]
+    observed_wet_bulb_domain_c: list[float] | None = None
+    curve_support_bins: list[EnvironmentCurveSupportBin] | None = None
+
+
+class EnvironmentLeaveOneOut(BaseModel):
+    """Aggregate activity-influence diagnostic."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    evaluated_activity_count: int
+    sign_agreement: float
+    maximum_relative_change: float | None
+
+
+class EnvironmentUncertainty(BaseModel):
+    """Descriptive coefficient uncertainty; fields are absent when unevaluable."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    estimate_bpm_per_c: float | None = None
+    interval_bpm_per_c: list[float | None] | None = None
+    interval_method: str | None = None
+    interval_width_to_absolute_estimate_ratio: float | None = None
+    leave_one_activity_out: EnvironmentLeaveOneOut | None = None
+
+
+class EnvironmentResult(BaseModel):
+    """Aggregate-only persisted result."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    result_state: Literal[
+        "historical_association_only",
+        "insufficient_data",
+        "unstable_association",
+        "prediction_unavailable",
+    ]
+    prediction_status: Literal[
+        "unavailable",
+        "passed_research_diagnostics",
+        "failed_research_diagnostics",
+    ]
+    eligibility_counts: EnvironmentEligibilityCounts
+    aggregate_curve_points: list[EnvironmentCurvePoint]
+    aggregate_uncertainty: EnvironmentUncertainty
+    gate_statuses: dict[str, Literal["pass", "fail", "unavailable"]]
+    computed_at: str
+    source_revision: str
+    model_version: str
+    power_regime: str
+
+
+class EnvironmentResponseState(BaseModel):
+    """Stable state contract shared by read and mutation responses."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    experiment_id: str
+    consent_version: str
+    model_version: str
+    enrolled: bool
+    status: Literal[
+        "not_enrolled",
+        "queued",
+        "processing",
+        "available",
+        "unavailable",
+        "failed",
+        "stale",
+    ]
+    adult_attestation_required: bool
+    power_regime: str
+    availability_reason: EnvironmentAvailabilityReason | None
+    result: EnvironmentResult | None
+    consented_at: str | None = None
+    adult_attested_at: str | None = None
+    source_revision: str | None = None
+    correlation_id: str | None = None
+    queued_at: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+
+
+def _schedule(
+    background_tasks: BackgroundTasks,
+    row,
+) -> None:
+    background_tasks.add_task(
+        process_environment_response_job,
+        row.user_id,
+        EXPERIMENT_ID,
+        row.model_version,
+        row.source_revision,
+    )
+
+
+@router.get(
+    "/labs/environment-response",
+    response_model=EnvironmentResponseState,
+)
+def get_environment_response(
+    background_tasks: BackgroundTasks,
+    user_id: str = Depends(get_current_user_id),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return consent, processing, diagnostics, and aggregate result state."""
+    state = public_state(db, user_id)
+    if state["status"] == "processing":
+        recover_interrupted_jobs(db, user_id=user_id)
+        state = public_state(db, user_id)
+    if state["status"] == "queued":
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, EXPERIMENT_ID),
+        )
+        if row is not None:
+            _schedule(background_tasks, row)
+    return state
+
+
+@router.post(
+    "/labs/environment-response",
+    status_code=202,
+    response_model=EnvironmentResponseState,
+)
+def enroll_environment_response(
+    body: EnvironmentEnrollmentRequest,
+    background_tasks: BackgroundTasks,
+    user_id: str = Depends(require_write_access),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Record explicit consent and queue private aggregate computation."""
+    try:
+        row = enroll(
+            db,
+            user_id,
+            adult_attested=body.adult_attested,
+            consent_version=body.consent_version,
+        )
+    except ValueError as exc:
+        code = str(exc)
+        if code == "adult_eligibility_not_confirmed":
+            raise HTTPException(
+                422,
+                detail=adult_eligibility_reason(),
+            ) from exc
+        if code == "consent_version_stale":
+            raise HTTPException(
+                409,
+                detail={
+                    "code": code,
+                    "current_consent_version": CONSENT_VERSION,
+                },
+            ) from exc
+        raise
+    _schedule(background_tasks, row)
+    return public_state(db, user_id)
+
+
+@router.post(
+    "/labs/environment-response/recompute",
+    status_code=202,
+    response_model=EnvironmentResponseState,
+)
+def recompute_environment_response(
+    background_tasks: BackgroundTasks,
+    user_id: str = Depends(require_write_access),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Queue a fresh result under the existing explicit consent."""
+    row = queue_recompute(db, user_id)
+    if row is None:
+        raise HTTPException(409, detail="LABS_ENVIRONMENT_NOT_ENROLLED")
+    _schedule(background_tasks, row)
+    return public_state(db, user_id)
+
+
+@router.delete("/labs/environment-response", status_code=204)
+def withdraw_environment_response(
+    user_id: str = Depends(require_write_access),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Withdraw consent and immediately delete the aggregate result."""
+    try:
+        withdraw(db, user_id)
+    except TombstoneStorageError as exc:
+        db.rollback()
+        raise HTTPException(
+            503,
+            detail="LABS_WITHDRAWAL_STORAGE_UNAVAILABLE",
+        ) from exc
+    return Response(status_code=204)

--- a/db/models.py
+++ b/db/models.py
@@ -374,6 +374,80 @@ class AiInsightFeedback(Base):
     )
 
 
+class LabsExperimentEnrollment(Base):
+    """Active opt-in and processing state for one Labs experiment."""
+
+    __tablename__ = "labs_experiment_enrollments"
+
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    experiment_id = Column(String(80), primary_key=True)
+    consent_version = Column(String(40), nullable=False)
+    consented_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    adult_attested_at = Column(DateTime, nullable=False)
+    status = Column(String(20), nullable=False, default="queued")
+    model_version = Column(String(80), nullable=False)
+    source_revision = Column(String(100), nullable=False)
+    correlation_id = Column(String(36), nullable=False)
+    availability_reason = Column(JSON, nullable=True)
+    queued_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('queued','processing','available','unavailable','failed','stale')",
+            name="ck_labs_enrollment_status",
+        ),
+    )
+
+
+class LabsExperimentResult(Base):
+    """Aggregate-only output for one consented Labs experiment."""
+
+    __tablename__ = "labs_experiment_results"
+
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    experiment_id = Column(String(80), primary_key=True)
+    model_version = Column(String(80), nullable=False)
+    source_revision = Column(String(100), nullable=False)
+    result_state = Column(String(40), nullable=False)
+    eligibility_counts = Column(JSON, nullable=False, default=dict)
+    aggregate_curve_points = Column(JSON, nullable=False, default=list)
+    aggregate_uncertainty = Column(JSON, nullable=False, default=dict)
+    gate_statuses = Column(JSON, nullable=False, default=dict)
+    prediction_status = Column(String(40), nullable=False)
+    power_regime = Column(String(60), nullable=False)
+    computed_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class LabsDeletionTombstone(Base):
+    """Withdrawal marker replayed after backup restores."""
+
+    __tablename__ = "labs_deletion_tombstones"
+
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    experiment_id = Column(String(80), primary_key=True)
+    deleted_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
 class CacheRevision(Base):
     """Per-(user, scope) monotonic counter for HTTP cache revalidation (issue #147).
 

--- a/docs/dev/api-reference.md
+++ b/docs/dev/api-reference.md
@@ -995,6 +995,52 @@ The private export can be evaluated locally with the research-only
 pipeline does not add a personal estimate to this endpoint and does not alter
 the accepted environmental-performance SDR.
 
+## Labs environmental response
+
+All endpoints are owner-authenticated. Demo accounts may read their state but
+cannot enroll, recompute, or withdraw.
+
+### GET /api/labs/environment-response
+
+Returns the current consent version, enrollment and processing state,
+privacy-safe availability reason, and any aggregate result. A result contains
+only eligibility counts, five aggregate curve points, aggregate coefficient
+uncertainty, gate statuses, model/source versions, power regime, prediction
+diagnostic status, and timestamps. It never contains activity IDs, dates,
+routes, GPS, sample rows, or per-activity values.
+
+### POST /api/labs/environment-response
+
+Records explicit V1 consent and queues private processing.
+
+```json
+{
+  "adult_attested": true,
+  "consent_version": "environment-response-consent-v1"
+}
+```
+
+The adult attestation is required because the reviewed evidence is adult-only;
+no date of birth is collected. A stale consent version returns `409`. The
+`202` response is the current queued state. The background payload contains
+only owner ID, experiment ID, model version, and source revision. Raw research
+pages are assembled in worker memory and are never persisted or returned.
+Startup and authenticated state reads return processing rows older than 30
+minutes to `queued`; the queued job is then rescheduled on the state read.
+
+### POST /api/labs/environment-response/recompute
+
+Deletes the prior aggregate result and queues a fresh computation under the
+existing active consent. Returns `409` when the user is not enrolled.
+
+### DELETE /api/labs/environment-response
+
+First records a restore-safe private withdrawal marker, then immediately
+deletes active consent and aggregate results. A running computation rechecks
+consent before writing, so withdrawal cannot be followed by a late result
+publication. Returns `204`; if the private marker cannot be stored, returns
+`503` without deleting consent so the user can retry safely.
+
 ### GET /api/ai/context
 
 Returns the structured dashboard summary used for AI plan generation. The

--- a/docs/ops/backup-and-restore.md
+++ b/docs/ops/backup-and-restore.md
@@ -45,6 +45,16 @@ az postgres flexible-server restore \
 # Verify the clone, then repoint PRAXYS_DATABASE_URL at it and re-deploy.
 ```
 
+After any restore, start the backend before reopening traffic. Labs withdrawals
+are written first to the private Blob container configured by
+`PRAXYS_FEEDBACK_BLOB_*` (local `DATA_DIR/labs_deletion_tombstones` in
+self-hosted development), then to `labs_deletion_tombstones` in the database.
+Startup replays private markers retained for the same 14-day PITR window:
+consent/results whose timestamps predate a withdrawal are deleted again, while
+a genuinely newer re-consent is preserved. Startup fails closed if configured
+private Blob storage cannot be read. Verify that withdrawn experiments remain
+absent before cutover.
+
 **Portable / off-Azure copy** (optional long-retention archive, or a future
 Tencent COS move) uses a logical dump - run it from inside the trust boundary
 (App Service SSH or an Azure job in the VNet), not GitHub runners:

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -47,8 +47,8 @@ transient — the next deploy overwrites them.**
 | `TRANSLATE_MODEL` (`gpt-5.4-mini`) | Optional deployment override for translating newly extracted UI strings and science copy. | `i18n.yml`; script default applies when unset |
 | `TRANSLATE_REVIEW_MODEL` (`gpt-5.4`) | Optional stronger deployment override for the weekly native-Chinese catalog review. | `i18n.yml`; script default applies when unset |
 | `KEY_VAULT_URL` / `KEY_VAULT_KEY_NAME` | Key Vault + RSA key name | App Service setting |
-| `PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL` (`https://stperftrainsight.blob.core.windows.net`) | Private Blob store for feedback screenshots (keyless via MI) | App Service setting (backend) |
-| `PRAXYS_FEEDBACK_BLOB_CONTAINER` (`feedback-screenshots`) | Blob container for screenshots | App Service setting (backend) |
+| `PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL` (`https://stperftrainsight.blob.core.windows.net`) | Private Blob store for feedback screenshots and 14-day Labs withdrawal tombstones (keyless via MI) | App Service setting (backend) |
+| `PRAXYS_FEEDBACK_BLOB_CONTAINER` (`feedback-screenshots`) | Private container for screenshots and restore-safe Labs withdrawal markers | App Service setting (backend) |
 | `PRAXYS_SMTP_HOST` / `PRAXYS_SMTP_PORT` / `PRAXYS_SMTP_USER` / `PRAXYS_SMTP_FROM` / `PRAXYS_SMTP_STARTTLS` | SMTP transport for verification + invitation emails (non-secret; the password is the secret above). **Optional.** | App Service setting (backend) |
 | `PRAXYS_APP_BASE_URL` (`https://praxys.run`) | Public origin for verify/invite links in those emails | App Service setting (backend) |
 | `PRAXYS_DB_AUTH` (`entra` or unset) | Postgres auth mode: `entra` = AAD token via managed identity, no password. **Optional.** | App Service setting (backend) |
@@ -643,10 +643,13 @@ gh variable set PRAXYS_FEEDBACK_BLOB_ACCOUNT_URL --body "https://stperftrainsigh
 gh variable set PRAXYS_FEEDBACK_BLOB_CONTAINER   --body "feedback-screenshots"
 ```
 
-The two `PRAXYS_FEEDBACK_BLOB_*` variables above point the app at it. Unset them
-and the app falls back to local filesystem storage under `DATA_DIR` (persistent
-on `/home`, but not the recommended long-term home). `api/feedback_storage.py`
-selects the backend and authenticates with `DefaultAzureCredential`.
+The two `PRAXYS_FEEDBACK_BLOB_*` variables above point the app at it. The same
+private container stores `labs-deletions/` withdrawal markers for 14 days so a
+PITR restore cannot resurrect consent or an aggregate Labs result. Unset the
+variables and the app falls back to local filesystem storage under `DATA_DIR`
+(persistent on `/home`, but not the recommended long-term home).
+`api/feedback_storage.py` selects the shared private backend and authenticates
+with `DefaultAzureCredential`.
 
 ### The change loop — coding-agent labels & assignment (issue #362)
 

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -102,6 +102,9 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         Feedback,
         FitnessData,
         Invitation,
+        LabsDeletionTombstone,
+        LabsExperimentEnrollment,
+        LabsExperimentResult,
         PlanDelivery,
         PlanDeliveryAttempt,
         PlanRevision,
@@ -186,6 +189,33 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
         ))
         db.add(CacheRevision(user_id=user_id, scope="activities", revision=1))
         db.add(DashboardCache(user_id=user_id, section="today", source_version="v1", payload_json=b"{}"))
+        db.add(LabsExperimentEnrollment(
+            user_id=user_id,
+            experiment_id="environment-response-v1",
+            consent_version="environment-response-consent-v1",
+            adult_attested_at=datetime.utcnow(),
+            status="available",
+            model_version="labs-v1",
+            source_revision="rev1:test",
+            correlation_id="labs-correlation",
+        ))
+        db.add(LabsExperimentResult(
+            user_id=user_id,
+            experiment_id="environment-response-v1",
+            model_version="labs-v1",
+            source_revision="rev1:test",
+            result_state="historical_association_only",
+            eligibility_counts={},
+            aggregate_curve_points=[],
+            aggregate_uncertainty={},
+            gate_statuses={},
+            prediction_status="failed_research_diagnostics",
+            power_regime="stryd_continuous_samples",
+        ))
+        db.add(LabsDeletionTombstone(
+            user_id=user_id,
+            experiment_id="older-experiment",
+        ))
         feedback = Feedback(
             user_id=user_id,
             kind="bug",
@@ -252,6 +282,9 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
         Feedback,
         FitnessData,
         Invitation,
+        LabsDeletionTombstone,
+        LabsExperimentEnrollment,
+        LabsExperimentResult,
         PlanDelivery,
         PlanDeliveryAttempt,
         PlanRevision,
@@ -278,6 +311,9 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
             DashboardCache,
             Feedback,
             FitnessData,
+            LabsDeletionTombstone,
+            LabsExperimentEnrollment,
+            LabsExperimentResult,
             PlanTargetCalendarSync,
             PlanTargetWorkout,
             PlanDelivery,

--- a/tests/test_heat_response_validation.py
+++ b/tests/test_heat_response_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import replace
 from datetime import date, timedelta
 import hashlib
 import json
@@ -331,6 +332,219 @@ def test_recovers_reviewable_heat_signal_with_activity_holdout() -> None:
     ] is True
     assert report["input_contract"]["report_includes_activity_ids"] is False
     assert report["input_contract"]["report_includes_activity_dates"] is False
+
+
+def test_builds_aggregate_labs_curve_without_private_activity_fields() -> None:
+    from analysis.environment_response import (
+        LabsEnvironmentConfig,
+        build_environment_response_result,
+    )
+
+    result = build_environment_response_result(
+        synthetic_research_dataset(),
+        config=LabsEnvironmentConfig(
+            minimum_activities_per_curve_bin=1,
+            minimum_segments_per_curve_bin=1,
+            minimum_reference_power_activities_per_curve_bin=1,
+            maximum_bootstrap_width_ratio=10.0,
+            maximum_leave_one_out_relative_change=10.0,
+        ),
+        validation_config=TEST_CONFIG,
+    )
+
+    assert result["result_state"] == "historical_association_only"
+    assert len(result["aggregate_curve_points"]) == 5
+    assert result["aggregate_uncertainty"]["leave_one_activity_out"][
+        "sign_agreement"
+    ] == 1.0
+    serialized = json.dumps(result, sort_keys=True)
+    for forbidden in (
+        '"activity_id"',
+        '"activity_date"',
+        '"route"',
+        '"lat"',
+        '"lng"',
+    ):
+        assert forbidden not in serialized
+
+
+def test_labs_default_curve_support_guardrails_withhold_sparse_bins() -> None:
+    from analysis.environment_response import build_environment_response_result
+
+    result = build_environment_response_result(
+        synthetic_research_dataset(),
+        validation_config=TEST_CONFIG,
+    )
+
+    assert result["result_state"] == "insufficient_data"
+    assert result["aggregate_curve_points"] == []
+    assert result["gate_statuses"]["curve_bin_support"] == "fail"
+
+
+def test_labs_bootstrap_width_and_influence_guardrails_withhold_curve() -> None:
+    from analysis.environment_response import (
+        LabsEnvironmentConfig,
+        build_environment_response_result,
+    )
+
+    common = dict(
+        minimum_activities_per_curve_bin=1,
+        minimum_segments_per_curve_bin=1,
+        minimum_reference_power_activities_per_curve_bin=1,
+    )
+    width = build_environment_response_result(
+        synthetic_research_dataset(),
+        config=LabsEnvironmentConfig(
+            **common,
+            maximum_bootstrap_width_ratio=0.01,
+            maximum_leave_one_out_relative_change=10.0,
+        ),
+        validation_config=TEST_CONFIG,
+    )
+    influence = build_environment_response_result(
+        synthetic_research_dataset(),
+        config=LabsEnvironmentConfig(
+            **common,
+            maximum_bootstrap_width_ratio=10.0,
+            maximum_leave_one_out_relative_change=0.0,
+        ),
+        validation_config=TEST_CONFIG,
+    )
+
+    assert width["result_state"] == "unstable_association"
+    assert width["gate_statuses"]["bootstrap_interval_width"] == "fail"
+    assert influence["result_state"] == "unstable_association"
+    assert influence["gate_statuses"]["leave_one_activity_out_influence"] == "fail"
+
+
+def test_labs_prediction_unavailable_withholds_curve(monkeypatch) -> None:
+    from analysis import environment_response
+
+    real_validate = environment_response.validate_heat_response
+
+    def unavailable_prediction(dataset, config):
+        report = real_validate(dataset, config)
+        report["gates"]["chronological_holdout_performance"]["status"] = (
+            "unavailable"
+        )
+        report["gates"]["chronological_holdout_performance"]["evaluated"] = False
+        return report
+
+    monkeypatch.setattr(
+        environment_response,
+        "validate_heat_response",
+        unavailable_prediction,
+    )
+    result = environment_response.build_environment_response_result(
+        synthetic_research_dataset(),
+        config=environment_response.LabsEnvironmentConfig(
+            minimum_activities_per_curve_bin=1,
+            minimum_segments_per_curve_bin=1,
+            minimum_reference_power_activities_per_curve_bin=1,
+            maximum_bootstrap_width_ratio=10.0,
+            maximum_leave_one_out_relative_change=10.0,
+        ),
+        validation_config=TEST_CONFIG,
+    )
+
+    assert result["result_state"] == "prediction_unavailable"
+    assert result["aggregate_curve_points"] == []
+
+
+def test_labs_rejects_non_stryd_power_regime() -> None:
+    from analysis.environment_response import (
+        LabsEnvironmentConfig,
+        build_environment_response_result,
+    )
+
+    dataset = synthetic_research_dataset()
+    for record in dataset["records"]:
+        record["pre_activity_context"]["critical_power"][
+            "power_provider"
+        ] = "garmin"
+        for segment in record["stable_segments"]["segments"]:
+            segment["power_provider"] = "garmin"
+            segment["heart_rate_provider"] = "garmin"
+    _refresh_dataset_hash(dataset)
+
+    result = build_environment_response_result(
+        dataset,
+        config=LabsEnvironmentConfig(
+            minimum_activities_per_curve_bin=1,
+            minimum_segments_per_curve_bin=1,
+            minimum_reference_power_activities_per_curve_bin=1,
+            maximum_bootstrap_width_ratio=10.0,
+            maximum_leave_one_out_relative_change=10.0,
+        ),
+        validation_config=TEST_CONFIG,
+    )
+
+    assert result["result_state"] == "insufficient_data"
+    assert result["gate_statuses"]["stryd_power_regime"] == "fail"
+    assert result["aggregate_curve_points"] == []
+
+
+def test_cluster_bootstrap_refits_filtering_inside_each_draw(
+    monkeypatch,
+) -> None:
+    dataset = synthetic_research_dataset()
+    combined, export = heat_validation._prepare_dataset(dataset)
+    config = replace(TEST_CONFIG, bootstrap_iterations=3)
+    flattened = heat_validation._flatten_dataset(
+        combined,
+        config,
+        export=export,
+    )
+    primary = heat_validation._analyze_rows(
+        flattened,
+        config,
+        heat_representation="wet_bulb_c",
+        include_bootstrap=False,
+    )
+    internal = primary["_internal"]
+    real_select = heat_validation._select_features
+    calls = {"count": 0}
+
+    def counted_select(*args, **kwargs):
+        calls["count"] += 1
+        return real_select(*args, **kwargs)
+
+    monkeypatch.setattr(
+        heat_validation,
+        "_select_features",
+        counted_select,
+    )
+    heat_validation._cluster_bootstrap(
+        internal["train_rows"],
+        internal["feature_names"],
+        heat_representation="wet_bulb_c",
+        heat_center=internal["heat_center"],
+        config=config,
+    )
+
+    assert calls["count"] == config.bootstrap_iterations
+
+
+def test_missing_environment_reason_wins_over_empty_provider_regime() -> None:
+    from analysis.environment_response import build_environment_response_result
+    from api.labs_environment import availability_reason
+
+    dataset = synthetic_research_dataset()
+    for record in dataset["records"]:
+        record["activity"]["environment"]["temperature_c"] = None
+    _refresh_dataset_hash(dataset)
+
+    result = build_environment_response_result(
+        dataset,
+        validation_config=TEST_CONFIG,
+    )
+    reason = availability_reason(
+        result,
+        correlation_id="correlation",
+    )
+
+    assert result["gate_statuses"]["stryd_power_regime"] == "fail"
+    assert reason["code"] == "missing_temperature"
 
 
 def test_insufficient_observations_and_spread_are_unavailable() -> None:

--- a/tests/test_labs_environment.py
+++ b/tests/test_labs_environment.py
@@ -1,0 +1,593 @@
+"""Backend contract tests for the Labs environmental-response experiment."""
+from __future__ import annotations
+
+import tempfile
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def labs_client(monkeypatch):
+    """Yield an authenticated client backed by an isolated SQLite database."""
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", tmpdir.name)
+    monkeypatch.setenv("PRAXYS_SYNC_SCHEDULER", "false")
+    monkeypatch.setenv("PRAXYS_AUTH_RATE_LIMIT_DISABLED", "true")
+    monkeypatch.setenv(
+        "PRAXYS_LOCAL_ENCRYPTION_KEY",
+        "JKkx_5SVHKQDr0HSMrwl0KQHcA0pl5pxsYSLEAQDB4o=",
+    )
+
+    from db import session as db_session
+
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+
+    from api.auth import get_current_user_id, require_write_access
+    from api.main import app
+    from api.routes import labs as labs_routes
+    from db.models import User
+    from db.session import get_db
+
+    user_id = "labs-owner"
+    with db_session.SessionLocal() as db:
+        db.add(User(
+            id=user_id,
+            email="labs-owner@example.com",
+            hashed_password="x",
+        ))
+        db.commit()
+
+    def override_user() -> str:
+        return user_id
+
+    def override_db():
+        db = db_session.SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    monkeypatch.setattr(
+        labs_routes,
+        "process_environment_response_job",
+        lambda *_args: None,
+    )
+    app.dependency_overrides[get_current_user_id] = override_user
+    app.dependency_overrides[require_write_access] = override_user
+    app.dependency_overrides[get_db] = override_db
+    try:
+        yield TestClient(app), db_session, user_id
+    finally:
+        app.dependency_overrides.clear()
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _aggregate_result() -> dict:
+    return {
+        "model_version": "within-athlete-ridge-mean-hr-v1-labs-v1",
+        "power_regime": "stryd_continuous_samples",
+        "result_state": "historical_association_only",
+        "prediction_status": "failed_research_diagnostics",
+        "eligibility_counts": {
+            "input_activity_count": 24,
+            "input_segment_count": 96,
+            "eligible_activity_count": 20,
+            "eligible_segment_count": 80,
+            "exclusion_reason_counts": {},
+            "provider_regimes": [{
+                "label": "power=stryd|heart_rate=stryd",
+                "activity_count": 20,
+                "segment_count": 80,
+            }],
+        },
+        "aggregate_curve_points": [
+            {
+                "wet_bulb_c": 20.0,
+                "modeled_hr_bpm": 150.0,
+                "relative_hr_bpm": 0.0,
+                "relative_lower_bpm": 0.0,
+                "relative_upper_bpm": 0.0,
+                "reference_wet_bulb_c": 20.0,
+            },
+        ],
+        "aggregate_uncertainty": {
+            "estimate_bpm_per_c": 0.3,
+            "interval_bpm_per_c": [0.1, 0.4],
+        },
+        "gate_statuses": {"minimum_activities": "pass"},
+        "limitations": ["historical_association_not_causal"],
+    }
+
+
+def test_enrollment_requires_current_consent_and_adult_attestation(
+    labs_client,
+) -> None:
+    client, _, _ = labs_client
+
+    adult = client.post(
+        "/api/labs/environment-response",
+        json={
+            "adult_attested": False,
+            "consent_version": "environment-response-consent-v1",
+        },
+    )
+    stale = client.post(
+        "/api/labs/environment-response",
+        json={
+            "adult_attested": True,
+            "consent_version": "old",
+        },
+    )
+
+    assert adult.status_code == 422
+    assert adult.json()["detail"]["code"] == "adult_eligibility_not_confirmed"
+    assert adult.json()["detail"]["correlation_id"]
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "consent_version_stale"
+
+
+def test_enroll_get_withdraw_and_rejoin_lifecycle(labs_client) -> None:
+    client, db_session, user_id = labs_client
+    from db.models import (
+        LabsDeletionTombstone,
+        LabsExperimentEnrollment,
+    )
+
+    enrolled = client.post(
+        "/api/labs/environment-response",
+        json={
+            "adult_attested": True,
+            "consent_version": "environment-response-consent-v1",
+        },
+    )
+    state = client.get("/api/labs/environment-response")
+    withdrawn = client.delete("/api/labs/environment-response")
+
+    assert enrolled.status_code == 202
+    assert enrolled.json()["status"] == "queued"
+    assert state.status_code == 200
+    assert state.json()["enrolled"] is True
+    assert withdrawn.status_code == 204
+    with db_session.SessionLocal() as db:
+        assert db.get(
+            LabsExperimentEnrollment,
+            (user_id, "environment-response-v1"),
+        ) is None
+        assert db.get(
+            LabsDeletionTombstone,
+            (user_id, "environment-response-v1"),
+        ) is not None
+
+    rejoined = client.post(
+        "/api/labs/environment-response",
+        json={
+            "adult_attested": True,
+            "consent_version": "environment-response-consent-v1",
+        },
+    )
+    assert rejoined.status_code == 202
+    assert rejoined.json()["enrolled"] is True
+
+
+def test_withdrawal_fails_closed_when_tombstone_storage_is_unavailable(
+    labs_client,
+    monkeypatch,
+) -> None:
+    client, db_session, user_id = labs_client
+    from api import labs_tombstone_storage
+    from db.models import LabsExperimentEnrollment
+
+    client.post(
+        "/api/labs/environment-response",
+        json={
+            "adult_attested": True,
+            "consent_version": "environment-response-consent-v1",
+        },
+    )
+    monkeypatch.setattr(
+        labs_tombstone_storage,
+        "store",
+        lambda *_args: (_ for _ in ()).throw(
+            labs_tombstone_storage.TombstoneStorageError("unavailable")
+        ),
+    )
+
+    response = client.delete("/api/labs/environment-response")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "LABS_WITHDRAWAL_STORAGE_UNAVAILABLE"
+    with db_session.SessionLocal() as db:
+        assert db.get(
+            LabsExperimentEnrollment,
+            (user_id, "environment-response-v1"),
+        ) is not None
+
+
+def test_worker_persists_only_aggregate_result(labs_client, monkeypatch) -> None:
+    client, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsExperimentResult
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        args = (
+            row.user_id,
+            row.experiment_id,
+            row.model_version,
+            row.source_revision,
+        )
+
+    monkeypatch.setattr(
+        labs_environment,
+        "_build_private_dataset_bundle",
+        lambda *_args: {"private": "never persisted"},
+    )
+    monkeypatch.setattr(
+        labs_environment,
+        "build_environment_response_result",
+        lambda *_args: _aggregate_result(),
+    )
+    labs_environment.process_environment_response_job(*args)
+
+    with db_session.SessionLocal() as db:
+        result = db.get(
+            LabsExperimentResult,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        assert result is not None
+        assert result.result_state == "historical_association_only"
+        serialized = json.dumps({
+            "counts": result.eligibility_counts,
+            "curve": result.aggregate_curve_points,
+            "uncertainty": result.aggregate_uncertainty,
+            "gates": result.gate_statuses,
+        }, sort_keys=True)
+        for forbidden in ("activity_id", "date", "route", "lat", "lng", "private"):
+            assert f'"{forbidden}"' not in serialized
+    response = client.get("/api/labs/environment-response")
+    assert response.status_code == 200
+    assert response.json()["result"]["result_state"] == (
+        "historical_association_only"
+    )
+
+
+def test_running_job_rechecks_withdrawal_before_persist(
+    labs_client,
+    monkeypatch,
+) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsExperimentResult
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        args = (
+            row.user_id,
+            row.experiment_id,
+            row.model_version,
+            row.source_revision,
+        )
+
+    monkeypatch.setattr(
+        labs_environment,
+        "_build_private_dataset_bundle",
+        lambda *_args: {},
+    )
+
+    def withdraw_during_analysis(_dataset):
+        with db_session.SessionLocal() as other:
+            labs_environment.withdraw(other, user_id)
+        return _aggregate_result()
+
+    monkeypatch.setattr(
+        labs_environment,
+        "build_environment_response_result",
+        withdraw_during_analysis,
+    )
+    labs_environment.process_environment_response_job(*args)
+
+    with db_session.SessionLocal() as db:
+        assert db.get(
+            LabsExperimentResult,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        ) is None
+
+
+def test_stale_source_revision_is_explicit_unavailable_state(
+    labs_client,
+    monkeypatch,
+) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsExperimentEnrollment
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        args = (
+            row.user_id,
+            row.experiment_id,
+            row.model_version,
+            row.source_revision,
+        )
+    monkeypatch.setattr(
+        labs_environment,
+        "_build_private_dataset_bundle",
+        lambda *_args: (_ for _ in ()).throw(
+            labs_environment.StaleSourceRevision()
+        ),
+    )
+
+    labs_environment.process_environment_response_job(*args)
+
+    with db_session.SessionLocal() as db:
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        assert row.status == "stale"
+        assert row.availability_reason["code"] == "stale_source_revision"
+        assert row.availability_reason["correlation_id"] == row.correlation_id
+
+
+def test_source_revision_change_during_analysis_withholds_result(
+    labs_client,
+    monkeypatch,
+) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsExperimentEnrollment, LabsExperimentResult
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        args = (
+            row.user_id,
+            row.experiment_id,
+            row.model_version,
+            row.source_revision,
+        )
+    monkeypatch.setattr(
+        labs_environment,
+        "_build_private_dataset_bundle",
+        lambda *_args: {},
+    )
+    monkeypatch.setattr(
+        labs_environment,
+        "build_environment_response_result",
+        lambda *_args: _aggregate_result(),
+    )
+    monkeypatch.setattr(
+        labs_environment,
+        "source_revision",
+        lambda *_args: "rev1:changed",
+    )
+
+    labs_environment.process_environment_response_job(*args)
+
+    with db_session.SessionLocal() as db:
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        assert row.status == "stale"
+        assert row.availability_reason["code"] == "stale_source_revision"
+        assert db.get(
+            LabsExperimentResult,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        ) is None
+
+
+def test_obsolete_worker_cannot_overwrite_newer_queue(labs_client) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsExperimentEnrollment
+
+    with db_session.SessionLocal() as db:
+        old = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        old_correlation = old.correlation_id
+        newer = labs_environment.queue_recompute(db, user_id)
+        labs_environment._persist_unavailable(
+            db,
+            user_id,
+            labs_environment.EXPERIMENT_ID,
+            newer.model_version,
+            newer.source_revision,
+            old_correlation,
+            "analysis_failed",
+            "failed",
+        )
+
+    with db_session.SessionLocal() as db:
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        assert row.status == "queued"
+        assert row.correlation_id != old_correlation
+
+
+def test_get_recovers_only_abandoned_processing_job(labs_client) -> None:
+    client, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsExperimentEnrollment
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        row.status = "processing"
+        row.started_at = datetime.utcnow() - timedelta(minutes=31)
+        db.commit()
+
+    response = client.get("/api/labs/environment-response")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "queued"
+    with db_session.SessionLocal() as db:
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        assert row.started_at is None
+
+
+def test_tombstone_replay_preserves_newer_reconsent(labs_client) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsDeletionTombstone, LabsExperimentEnrollment
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        tombstone = LabsDeletionTombstone(
+            user_id=user_id,
+            experiment_id=labs_environment.EXPERIMENT_ID,
+            deleted_at=datetime.utcnow() - timedelta(minutes=1),
+        )
+        db.add(tombstone)
+        db.commit()
+        assert row.consented_at > tombstone.deleted_at
+        assert labs_environment.replay_deletion_tombstones(db) == 0
+        assert db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        ) is not None
+
+
+def test_external_tombstone_replays_after_database_restore(labs_client) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment, labs_tombstone_storage
+    from db.models import LabsDeletionTombstone, LabsExperimentEnrollment
+
+    with db_session.SessionLocal() as db:
+        row = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+        )
+        deleted_at = row.consented_at + timedelta(seconds=1)
+        labs_tombstone_storage.store(
+            user_id,
+            labs_environment.EXPERIMENT_ID,
+            deleted_at,
+        )
+        db.query(LabsDeletionTombstone).delete()
+        db.commit()
+
+        assert labs_environment.replay_deletion_tombstones(db) == 1
+        assert db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        ) is None
+
+
+@pytest.mark.parametrize(
+    ("exclusion", "expected"),
+    [
+        ("power_missing_or_invalid", "missing_continuous_sample_power"),
+        ("mean_hr_missing_or_invalid", "missing_continuous_heart_rate"),
+        ("temperature_missing_or_invalid", "missing_temperature"),
+        ("relative_humidity_missing_or_invalid", "missing_relative_humidity"),
+        (
+            "critical_power_value_missing_or_invalid",
+            "missing_provider_aligned_critical_power",
+        ),
+        (
+            "critical_power_provider_mismatch",
+            "critical_power_provider_mismatch",
+        ),
+        ("segment_sample_coverage_low", "insufficient_sample_coverage"),
+    ],
+)
+def test_availability_reason_preserves_data_quality_category(
+    exclusion,
+    expected,
+) -> None:
+    from api.labs_environment import availability_reason
+
+    aggregate = {
+        "result_state": "insufficient_data",
+        "gate_statuses": {
+            "minimum_activities": "fail",
+            "stryd_power_regime": "pass",
+        },
+        "eligibility_counts": {
+            "eligible_activity_count": 0,
+            "eligible_segment_count": 0,
+            "exclusion_reason_counts": {exclusion: 2},
+        },
+    }
+
+    reason = availability_reason(
+        aggregate,
+        correlation_id="correlation",
+    )
+
+    assert reason["code"] == expected
+
+
+def test_openapi_exposes_strict_labs_response_schema(labs_client) -> None:
+    client, _, _ = labs_client
+
+    schema = client.get("/openapi.json").json()
+    response = schema["paths"]["/api/labs/environment-response"]["get"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+
+    assert response["$ref"].endswith("/EnvironmentResponseState")
+    state = schema["components"]["schemas"]["EnvironmentResponseState"]
+    assert state["additionalProperties"] is False
+    assert "status" in state["properties"]
+    assert "availability_reason" in state["properties"]
+    assert "result" in state["properties"]
+    eligibility = schema["components"]["schemas"][
+        "EnvironmentEligibilityCounts"
+    ]
+    uncertainty = schema["components"]["schemas"]["EnvironmentUncertainty"]
+    assert eligibility["additionalProperties"] is False
+    assert uncertainty["additionalProperties"] is False

--- a/tests/test_plan_ledger.py
+++ b/tests/test_plan_ledger.py
@@ -114,13 +114,13 @@ def test_sqlite_init_adds_ledger_tables_to_existing_database(tmp_path, monkeypat
         db_session.AsyncSessionLocal = None
 
 
-def test_alembic_head_includes_plan_ledger():
+def test_alembic_head_includes_labs_environment_lifecycle():
     from alembic.config import Config
     from alembic.script import ScriptDirectory
 
     config = Config("alembic.ini")
     script = ScriptDirectory.from_config(config)
-    assert script.get_current_head() == "7a8192b3c4d5"
+    assert script.get_current_head() == "a1b2c3d4e5f6"
 
 
 def test_alembic_canonical_default_supports_old_worker_inserts(


### PR DESCRIPTION
## Summary

Implements the approved backend stage of #590 without shipping a user-visible Labs surface.

- Adds explicit opt-in, 18-plus attestation, recompute, state, and withdrawal endpoints under `/api/labs/environment-response`.
- Adds a pure Stryd-only aggregate analysis implementing the accepted V1 curve-domain, support-bin, reference-power, bootstrap, sensitivity, influence, and prediction-diagnostic guardrails.
- Persists only aggregate counts, five curve points, uncertainty, gate states, versions, and timestamps.
- Returns strict OpenAPI schemas and privacy-safe structured availability reasons; no activity IDs, dates, routes, GPS, sample rows, or per-activity values reach storage or clients.
- Fences source revisions before export, after export, and after analysis; stale/obsolete/interrupted jobs cannot publish.
- Adds immediate withdrawal deletion plus a private Blob-backed 14-day tombstone ledger so PITR restores replay withdrawals without deleting a genuinely newer re-consent.
- Extends account deletion, Alembic, API documentation, and restore/config runbooks.

## Scientific boundary

- Governing decision: accepted `sdr-environmental-performance-v2`.
- Initially qualified regime: continuous Stryd sample power with provider-aligned CP.
- Activity-average power, pace/GAP fallback, Garmin wrist power, cross-user pooling, forecasts, corrections, training decisions, adaptation claims, and safety claims remain prohibited.
- A displayed curve is always `historical_association_only`. Failed prediction diagnostics produce the required non-predictive state; unavailable prediction withholds the curve.

## Privacy and lifecycle

- Background payload: owner ID, experiment ID, model version, source revision only.
- Raw research pages exist only in worker memory.
- Withdrawal writes the restore-safe marker before deleting consent/result and fails closed if private storage is unavailable.
- Running work rechecks consent, correlation, model, source revision, and tombstone state before persistence.
- Startup/state reads recover abandoned processing rows older than 30 minutes.

## Validation

- Focused final suite: 194 passed.
- Expanded Labs/privacy regression suite: 193 passed.
- Full backend suite reached 2043 passed / 3 skipped; its only failure was the pre-existing hardcoded Alembic-head expectation, updated in this PR and then passed in the focused final suite.
- `alembic heads`: one head, `a1b2c3d4e5f6`.
- Fresh SQLite `alembic upgrade head`: passed.
- Science review: all findings resolved.
- Metric-delivery review: all findings resolved.
- API-contract review: all findings resolved, including strict nested OpenAPI schemas.

Advances #590. Garmin qualification remains #595; pace/GAP remains #596; cohort contribution remains #591.
