### PR TITLE
Document China frontend delivery baseline

### DIFF
--- a/deploy/tencent/nginx-praxys.conf
+++ b/deploy/tencent/nginx-praxys.conf
@@ -6,6 +6,21 @@ server {
     root /var/www/praxys/current;
     index index.html;
 
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types
+        application/javascript
+        application/json
+        application/manifest+json
+        application/xml
+        image/svg+xml
+        text/css
+        text/plain
+        text/xml;
+
     location = /healthz {
         default_type application/json;
         try_files /healthz =503;

--- a/docs/ops/tencent-frontend.md
+++ b/docs/ops/tencent-frontend.md
@@ -63,7 +63,10 @@ sudo systemctl reload nginx
 
 The config mirrors `frontend_server/main.py`: hashed Vite assets are immutable
 for one year, ordinary assets cache for one day, SPA routes fall back to
-`index.html`, and the shell revalidates on every visit.
+`index.html`, and the shell revalidates on every visit. Nginx also compresses
+compressible JavaScript, CSS, JSON, XML, SVG, and text responses; keep this
+enabled because Lighthouse egress bandwidth otherwise dominates mainland cold
+loads.
 
 This bootstrap exposes HTTP only for local verification and the first CI
 deployment. Do not route public production traffic to it yet. Before the
@@ -125,10 +128,15 @@ On the server:
 readlink -f /var/www/praxys/current
 cat /var/www/praxys/current/deployed_sha.txt
 curl -sS -H 'Host: www.praxys.run' http://127.0.0.1/healthz
+curl -sSI -H 'Accept-Encoding: gzip' \
+  -H 'Host: www.praxys.run' \
+  http://127.0.0.1/assets/<current-hashed-javascript> \
+  | grep -i '^Content-Encoding: gzip'
 ```
 
-The SHA must match the workflow commit. After EdgeOne and DNS are configured,
-verify the public response and cache headers:
+The SHA must match the workflow commit, and the JavaScript response must include
+`Content-Encoding: gzip`. After EdgeOne and DNS are configured, verify the
+public response and cache headers:
 
 ```bash
 curl -I https://www.praxys.run/

--- a/docs/perf-baselines/2026-08-08-4fa2942-china-delivery/README.md
+++ b/docs/perf-baselines/2026-08-08-4fa2942-china-delivery/README.md
@@ -1,0 +1,172 @@
+# Baseline: 2026-08-08 — China frontend delivery topology
+
+**Purpose:** compare three ways of serving the same Praxys frontend to a
+mainland-China user:
+
+1. Azure App Service East Asia directly.
+2. EdgeOne Global (excluding mainland China), with Azure as origin.
+3. Tencent Lighthouse in mainland China, while the authenticated API remains
+   on Azure East Asia.
+
+**Frontend build:** `4fa29422775bd0065bfe3e8e4c900201b8f785ed` on both Azure
+and Tencent.
+
+**Probe:** operator PC in Shanghai on China Unicom, with the company private
+network disabled and `praxys.run` routed directly rather than through the
+router's Singapore proxy.
+
+**Method:** sitespeed.io 39.5.0 in Docker, Chrome 146, three iterations per
+scenario/device cell. Tables contain the analyzer's representative median
+values. Desktop and 390 × 844 mobile emulation were both measured.
+
+## Delivery paths
+
+| Label | Frontend path | API path |
+|---|---|---|
+| Direct Azure | Shanghai → Azure East Asia App Service | Shanghai → Azure East Asia |
+| EdgeOne | Shanghai → EdgeOne Singapore → Azure East Asia | Shanghai → Azure East Asia |
+| Tencent | Shanghai → Tencent mainland Lighthouse | Shanghai → Azure East Asia |
+
+EdgeOne resolved to Singapore anycast addresses during the test. Hashed assets
+were cache hits, while HTML used origin revalidation. The API hostname was not
+behind EdgeOne.
+
+## Same-build comparison
+
+### S1 — Cold first load, Today page via login
+
+| Frontend | Device | FCP | LCP | HTML TTFB | Static KB | API p50 | API p95 |
+|---|---|---:|---:|---:|---:|---:|---:|
+| Direct Azure | Desktop | 2008 ms | 2008 ms | 397 ms | 677.9 | 167 ms | 1148 ms |
+| Direct Azure | Mobile | 1972 ms | 1972 ms | 400 ms | 677.8 | 243 ms | 2187 ms |
+| EdgeOne | Desktop | 2556 ms | 2556 ms | 961 ms | 679.4 | 328 ms | 1661 ms |
+| EdgeOne | Mobile | 2620 ms | 2620 ms | 962 ms | 679.2 | 254 ms | 1018 ms |
+| Tencent + gzip | Desktop | 664 ms | **664 ms** | 26 ms | 741.1 | 2134 ms | 3917 ms |
+| Tencent + gzip | Mobile | 1548 ms | **1548 ms** | 27 ms | 741.1 | 1661 ms | 5012 ms |
+
+Tencent reduced LCP versus direct Azure by 67% on desktop and 22% on mobile.
+The API tail varied substantially during the Tencent run, but the page still
+painted sooner because the static shell arrived locally.
+
+### S2 — Today to Training navigation
+
+| Frontend | Device | FCP | LCP | HTML TTFB | Static KB | API p50 | API p95 |
+|---|---|---:|---:|---:|---:|---:|---:|
+| Direct Azure | Desktop | 588 ms | 1300 ms | 6 ms | 165.7 | 155 ms | 585 ms |
+| Direct Azure | Mobile | 436 ms | 804 ms | 7 ms | 165.7 | 162 ms | 790 ms |
+| EdgeOne | Desktop | 544 ms | 3008 ms | 10 ms | 166.0 | 172 ms | 1014 ms |
+| EdgeOne | Mobile | 436 ms | 836 ms | 7 ms | 166.0 | 149 ms | 471 ms |
+| Tencent + gzip | Desktop | 464 ms | **1204 ms** | 18 ms | 166.8 | 385 ms | 817 ms |
+| Tencent + gzip | Mobile | 280 ms | **724 ms** | 19 ms | 166.8 | 407 ms | 595 ms |
+
+S2 begins after login and shell loading, so its document timing mostly measures
+an in-app transition. Tencent was 7% faster than direct Azure on desktop and
+10% faster on mobile in the compressed follow-up run. The smaller gap confirms
+that moving only the frontend cannot eliminate an API-bound wait.
+
+### S3 — Warm repeat Today
+
+| Frontend | Device | LCP | HTML TTFB | Static KB | API p50 | API p95 |
+|---|---|---:|---:|---:|---:|---:|
+| Direct Azure | Desktop | 688 ms | 9 ms | 0.4 | 167 ms | 920 ms |
+| Direct Azure | Mobile | 636 ms | 7 ms | 0.4 | 159 ms | 643 ms |
+| EdgeOne | Desktop | **672 ms** | 8 ms | 0.4 | 141 ms | 412 ms |
+| EdgeOne | Mobile | **620 ms** | 7 ms | 0.4 | 151 ms | 418 ms |
+
+The warm result supports the operator's manual perception that EdgeOne can feel
+faster during normal repeat use. Cached static assets avoid the slow
+Singapore-to-Azure origin leg, although the measured LCP advantage was only
+16 ms on both devices and is within normal run-to-run noise.
+
+No Tencent S3 result is reported. Direct HTTP by IP is not a secure context, so
+service-worker/PWA behavior would not be comparable with the production HTTPS
+paths.
+
+### S4 — Anonymous landing page
+
+| Frontend | Device | FCP | LCP | HTML TTFB | Static KB |
+|---|---|---:|---:|---:|---:|
+| Direct Azure | Desktop | 1804 ms | 1924 ms | 413 ms | 1753.0 |
+| Direct Azure | Mobile | 1652 ms | 1772 ms | 435 ms | 1753.1 |
+| EdgeOne | Desktop | 2820 ms | 3020 ms | 1605 ms | 631.0 |
+| EdgeOne | Mobile | 6588 ms | 6884 ms | 5285 ms | 631.0 |
+| Tencent + gzip | Desktop | 1340 ms | **1340 ms** | 32 ms | 626.0 |
+| Tencent + gzip | Mobile | 540 ms | **704 ms** | 26 ms | 626.0 |
+
+Tencent reduced landing LCP versus direct Azure by 30% on desktop and 60% on
+mobile.
+EdgeOne transferred fewer bytes than direct Azure but lost more time waiting
+for HTML revalidation through Singapore. Its mobile result also had a severe
+tail, reinforcing that three runs establish direction rather than a stable SLA.
+
+## Tencent compression experiment
+
+The first Tencent run exposed an Nginx configuration defect: `gzip on` was
+present globally, but the useful MIME types remained commented out. JavaScript
+and CSS therefore crossed the Lighthouse bandwidth cap uncompressed.
+
+| Scenario | Device | Without gzip LCP | With gzip LCP | Change |
+|---|---|---:|---:|---:|
+| Cold Today | Desktop | 4308 ms | 664 ms | **-85%** |
+| Cold Today | Mobile | 3668 ms | 1548 ms | **-58%** |
+| Landing | Desktop | 4620 ms | 1340 ms | **-71%** |
+| Landing | Mobile | 4464 ms | 704 ms | **-84%** |
+
+The main JavaScript response fell from 402,243 bytes to 136,855 bytes on the
+wire. Its direct transfer time fell from approximately 460 ms to 73 ms. This
+baseline therefore updates the committed Tencent Nginx configuration to
+compress JavaScript, CSS, JSON, XML, SVG, and text responses.
+
+## Interpretation
+
+- **Cold path:** the mainland static origin was fastest in every median cell
+  after compression, despite the API remaining in Azure.
+- **Warm path:** EdgeOne was equal or faster in this sample because browser and
+  edge caches removed most origin work.
+- **EdgeOne Global excluding mainland:** this probe reached Singapore, so cold
+  HTML paid a China → Singapore → Azure East Asia detour.
+- **Do not generalize to every mainland ISP:** this is one Shanghai China
+  Unicom probe and three iterations per cell. The result is directional, not a
+  nationwide SLA.
+- **Do not treat the Tencent HTTP test as production validation:** public
+  cutover still requires ICP approval, a certificate-valid hostname, HTTPS
+  origin service, and a repeat S3 test.
+
+## Reproduction notes
+
+The canonical login scripts had stale generated element IDs. This baseline
+changes them to stable semantic selectors:
+
+```text
+input[type="email"]
+input[type="password"]
+```
+
+Direct Azure was forced to the App Service address while preserving
+`www.praxys.run` Host/SNI. Tencent was accessed by IP over HTTP because its
+Nginx listener did not yet have a certificate-valid 443 virtual host. The
+Tencent-only browser profile disabled web-security for the API CORS test and
+disabled Chrome HTTPS upgrades; otherwise Chrome first attempted the nonexistent
+HTTPS IP endpoint and introduced an artificial three-second fallback timeout.
+
+The Tencent HTTP run also disabled video post-processing because sitespeed's
+visual-metrics frame renaming failed on the Windows Docker bind mount. Native
+browser FCP, LCP, TTFB, CLS, and TBT remained available.
+
+## Raw artifacts
+
+HARs are intentionally not committed because authenticated captures contain
+bearer tokens. The operator-session archive contains:
+
+- `perf-edgeone-control-current/`
+- `perf-edgeone-after/`
+- `perf-mainland-http-final/`
+- `perf-mainland-gzip/`
+
+Derived summaries:
+
+- `fixed-azure-control-summary.md`
+- `fixed-edgeone-route-summary.md`
+- `fixed-mainland-uncompressed-summary.md`
+- `fixed-mainland-gzip-summary.md`
+- `fixed-mainland-gzip-s2-summary.md`

--- a/docs/perf-baselines/summary.md
+++ b/docs/perf-baselines/summary.md
@@ -1,4 +1,25 @@
-# Perf arc summary — pre-arc → post-L3
+# Performance baseline summary
+
+## China delivery topology experiment — 2026-08-08
+
+The latest same-build comparison from a direct Shanghai China Unicom path is
+documented in
+[`2026-08-08-4fa2942-china-delivery/`](./2026-08-08-4fa2942-china-delivery/).
+Three iterations were run for each scenario and device.
+
+| Scenario | Direct Azure LCP D/M | EdgeOne global-ex-mainland LCP D/M | Tencent Lighthouse + gzip LCP D/M |
+|---|---:|---:|---:|
+| Cold login → Today | 2.01 / 1.97 s | 2.56 / 2.62 s | **0.66 / 1.55 s** |
+| Today → Training | 1.30 / 0.80 s | 3.01 / 0.84 s | **1.20 / 0.72 s** |
+| Anonymous landing | 1.92 / 1.77 s | 3.02 / 6.88 s | **1.34 / 0.70 s** |
+
+EdgeOne matched direct Azure within 16 ms on the warm Today path because hashed
+assets were already cached, but its Singapore point of presence made cold HTML
+revalidation slower and more variable. The mainland static origin reduced HTML
+TTFB to roughly 20–35 ms. Nginx compression was essential: without it, the
+Lighthouse bandwidth cap made cold LCP 3.7–4.6 seconds.
+
+## Historical optimization arc — pre-arc → post-L3
 
 **TL;DR.** Two weeks of perf work cut user-visible page time by 38–94 % across every login-gated scenario, and turned the cold anonymous-landing experience for CN-without-VPN visitors from "site looks broken" (22 s blank screen) into "site is fast" (1.6 s render). Warm repeat /today is now essentially instant — second-visit API responses return in 0.25 s end-to-end. This doc is the one-page shareable summary; per-anchor detail is in `<YYYY-MM-DD>-<sha>/README.md` directories and the running narrative is in [`2026-04-26-checkpoint.md`](./2026-04-26-checkpoint.md).
 

--- a/scripts/analyze_baseline.py
+++ b/scripts/analyze_baseline.py
@@ -6,10 +6,11 @@ Walks docs/perf-baselines/<date>-<sha>/ for cells named
 prints a markdown table section per scenario that can be pasted into
 TEMPLATE.md.
 
-Everything we need is inside the HAR: sitespeed.io embeds `pageTimings`
-(FCP/LCP/TTI) and `_googleWebVitals` (CLS/TTFB/FID/TBT) on the first page
-entry, so we don't need a separate `browsertime.json` — it's not written
-to disk by default in v39+ anyway.
+Everything we need is inside the HAR: sitespeed.io embeds one page record per
+iteration with `pageTimings` (FCP/LCP/TTI) and `_googleWebVitals`
+(CLS/TTFB/FID/TBT). The analyzer reports the median across those page records,
+so we don't need a separate `browsertime.json` — it isn't written to disk by
+default in v39+ anyway.
 
 Usage:
     python scripts/analyze_baseline.py --baseline-dir docs/perf-baselines/2026-04-24-abc1234
@@ -81,48 +82,84 @@ def extract_metrics(cell_dir: Path) -> dict[str, Any] | None:
     pages = log.get("pages", [])
     entries = log.get("entries", [])
 
-    page = pages[0] if pages else {}
-    page_timings = page.get("pageTimings", {}) or {}
-    gwv = page.get("_googleWebVitals", {}) or {}
+    entries_by_page: dict[str, list[dict[str, Any]]] = {}
+    for entry in entries:
+        entries_by_page.setdefault(entry.get("pageref", ""), []).append(entry)
 
-    # Sitespeed.io underscores internal fields in the HAR; stable public
-    # names live on _googleWebVitals. Fall back between them for safety.
-    fcp = gwv.get("firstContentfulPaint") or page_timings.get("_firstContentfulPaint")
-    lcp = gwv.get("largestContentfulPaint") or page_timings.get("_largestContentfulPaint")
-    # TTI isn't a HAR field — use domInteractiveTime as the closest proxy.
-    tti = page_timings.get("_domInteractiveTime")
-    ttfb = gwv.get("ttfb")
-    num_requests = len(entries)
-    api_entries = [e for e in entries if "/api/" in (e.get("request") or {}).get("url", "")]
-    num_api = len(api_entries)
+    runs: list[dict[str, Any]] = []
+    for page in pages:
+        page_timings = page.get("pageTimings", {}) or {}
+        gwv = page.get("_googleWebVitals", {}) or {}
+        page_entries = entries_by_page.get(page.get("id", ""), [])
 
-    static_bytes = 0
-    api_bytes = 0
-    for e in entries:
-        url = (e.get("request") or {}).get("url", "")
-        size = ((e.get("response") or {}).get("content") or {}).get("size") or 0
-        transferred = (e.get("response") or {}).get("bodySize")
-        if transferred is None or transferred < 0:
-            transferred = size
-        if "/api/" in url:
-            api_bytes += max(0, transferred)
-        else:
-            static_bytes += max(0, transferred)
+        # Sitespeed.io underscores internal fields in the HAR; stable public
+        # names live on _googleWebVitals. Fall back between them for safety.
+        fcp = gwv.get("firstContentfulPaint") or page_timings.get("_firstContentfulPaint")
+        lcp = gwv.get("largestContentfulPaint") or page_timings.get("_largestContentfulPaint")
+        # TTI isn't a HAR field — use domInteractiveTime as the closest proxy.
+        tti = page_timings.get("_domInteractiveTime")
+        api_entries = [
+            e for e in page_entries if "/api/" in (e.get("request") or {}).get("url", "")
+        ]
 
-    api_durations = []
-    for e in api_entries:
-        t = e.get("timings") or {}
-        wait = t.get("wait") or 0
-        receive = t.get("receive") or 0
-        if wait >= 0 and receive >= 0:
-            api_durations.append(wait + receive)
-    api_p50 = statistics.median(api_durations) if api_durations else None
-    api_p95: float | None = None
-    if len(api_durations) >= 2:
-        qs = statistics.quantiles(api_durations, n=20, method="inclusive")
-        api_p95 = qs[-1]
-    elif api_durations:
-        api_p95 = api_durations[0]
+        static_bytes = 0
+        api_bytes = 0
+        for entry in page_entries:
+            url = (entry.get("request") or {}).get("url", "")
+            size = ((entry.get("response") or {}).get("content") or {}).get("size") or 0
+            transferred = (entry.get("response") or {}).get("bodySize")
+            if transferred is None or transferred < 0:
+                transferred = size
+            if "/api/" in url:
+                api_bytes += max(0, transferred)
+            else:
+                static_bytes += max(0, transferred)
+
+        api_durations = []
+        for entry in api_entries:
+            timings = entry.get("timings") or {}
+            wait = timings.get("wait") or 0
+            receive = timings.get("receive") or 0
+            if wait >= 0 and receive >= 0:
+                api_durations.append(wait + receive)
+
+        api_p50 = statistics.median(api_durations) if api_durations else None
+        api_p95: float | None = None
+        if len(api_durations) >= 2:
+            api_p95 = statistics.quantiles(api_durations, n=20, method="inclusive")[-1]
+        elif api_durations:
+            api_p95 = api_durations[0]
+
+        font_css_ttfb: Any = None
+        for entry in page_entries:
+            url = (entry.get("request") or {}).get("url", "")
+            if "fonts.googleapis.com" in url:
+                wait = (entry.get("timings") or {}).get("wait")
+                font_css_ttfb = "timeout" if wait is None or wait < 0 else round(wait)
+                break
+
+        runs.append(
+            {
+                "fcp_ms": fcp,
+                "lcp_ms": lcp,
+                "tti_ms": tti,
+                "ttfb_ms": gwv.get("ttfb"),
+                "static_kb": static_bytes / 1024,
+                "api_kb": api_bytes / 1024,
+                "num_requests": len(page_entries),
+                "num_api": len(api_entries),
+                "api_p50_ms": api_p50,
+                "api_p95_ms": api_p95,
+                "font_css_ttfb": font_css_ttfb,
+            }
+        )
+
+    if not runs:
+        return None
+
+    def median_for(key: str) -> float | None:
+        values = [run[key] for run in runs if isinstance(run.get(key), (int, float))]
+        return statistics.median(values) if values else None
 
     protocols = {((e.get("response") or {}).get("httpVersion") or "").lower() for e in entries}
     protocols.discard("")
@@ -135,33 +172,34 @@ def extract_metrics(cell_dir: Path) -> dict[str, Any] | None:
     else:
         protocol = "?"
 
-    font_css_ttfb: Any = None
-    for e in entries:
-        url = (e.get("request") or {}).get("url", "")
-        if "fonts.googleapis.com" in url:
-            t = e.get("timings") or {}
-            wait = t.get("wait")
-            if wait is None or wait < 0:
-                font_css_ttfb = "timeout"
-            else:
-                font_css_ttfb = round(wait)
-            break
+    font_values = [run["font_css_ttfb"] for run in runs if run["font_css_ttfb"] is not None]
+    if "timeout" in font_values:
+        font_css_ttfb: Any = "timeout"
+    else:
+        numeric_font_values = [value for value in font_values if isinstance(value, (int, float))]
+        font_css_ttfb = (
+            round(statistics.median(numeric_font_values)) if numeric_font_values else None
+        )
 
     # Zero is meaningful signal here, not missing data: S4 (anonymous
     # Landing) legitimately has 0 API requests / 0 API KB, and that's
     # what tells us the anonymous route isn't calling /api/*. So render
     # zeros as 0, not em-dash.
     return {
-        "fcp_ms": round(fcp) if fcp is not None else None,
-        "lcp_ms": round(lcp) if lcp is not None else None,
-        "tti_ms": round(tti) if tti is not None else None,
-        "ttfb_ms": round(ttfb) if ttfb is not None else None,
-        "static_kb": round(static_bytes / 1024, 1),
-        "api_kb": round(api_bytes / 1024, 1),
-        "num_requests": num_requests,
-        "num_api": num_api,
-        "api_p50_ms": round(api_p50) if api_p50 is not None else None,
-        "api_p95_ms": round(api_p95) if api_p95 is not None else None,
+        "fcp_ms": round(value) if (value := median_for("fcp_ms")) is not None else None,
+        "lcp_ms": round(value) if (value := median_for("lcp_ms")) is not None else None,
+        "tti_ms": round(value) if (value := median_for("tti_ms")) is not None else None,
+        "ttfb_ms": round(value) if (value := median_for("ttfb_ms")) is not None else None,
+        "static_kb": round(median_for("static_kb") or 0, 1),
+        "api_kb": round(median_for("api_kb") or 0, 1),
+        "num_requests": round(median_for("num_requests") or 0),
+        "num_api": round(median_for("num_api") or 0),
+        "api_p50_ms": (
+            round(value) if (value := median_for("api_p50_ms")) is not None else None
+        ),
+        "api_p95_ms": (
+            round(value) if (value := median_for("api_p95_ms")) is not None else None
+        ),
         "protocol": protocol,
         "font_css_ttfb": font_css_ttfb,
     }

--- a/scripts/sitespeed_scripts/s1.js
+++ b/scripts/sitespeed_scripts/s1.js
@@ -27,16 +27,16 @@ module.exports = async function (context, commands) {
 
   // Step 1 — get to the login form (not measured).
   await commands.navigate(`${baseUrl}/login`);
-  await commands.wait.byId('login-email', 10000);
+  await commands.wait.bySelector('input[type="email"]', 10000);
 
   // Step 2 — fill credentials. Form is empty on a fresh navigation; no
   // need to clear. Browser autofill is disabled in headless Chrome that
   // sitespeed.io ships, so this stays clean.
-  await commands.click.byId('login-email');
-  await commands.addText.byId(user, 'login-email');
+  await commands.click.bySelector('input[type="email"]');
+  await commands.addText.bySelector(user, 'input[type="email"]');
 
-  await commands.click.byId('login-password');
-  await commands.addText.byId(password, 'login-password');
+  await commands.click.bySelector('input[type="password"]');
+  await commands.addText.bySelector(password, 'input[type="password"]');
 
   // Step 3 — measure the click → /today navigation.
   await commands.measure.start('s1-today-via-login');

--- a/scripts/sitespeed_scripts/s2.js
+++ b/scripts/sitespeed_scripts/s2.js
@@ -15,13 +15,13 @@ module.exports = async function (context, commands) {
 
   // Step 1 — log in (not measured).
   await commands.navigate(`${baseUrl}/login`);
-  await commands.wait.byId('login-email', 10000);
+  await commands.wait.bySelector('input[type="email"]', 10000);
 
-  await commands.click.byId('login-email');
-  await commands.addText.byId(user, 'login-email');
+  await commands.click.bySelector('input[type="email"]');
+  await commands.addText.bySelector(user, 'input[type="email"]');
 
-  await commands.click.byId('login-password');
-  await commands.addText.byId(password, 'login-password');
+  await commands.click.bySelector('input[type="password"]');
+  await commands.addText.bySelector(password, 'input[type="password"]');
 
   await commands.click.bySelector('button[type="submit"]');
   await commands.wait.byCondition(

--- a/scripts/sitespeed_scripts/s3.js
+++ b/scripts/sitespeed_scripts/s3.js
@@ -25,13 +25,13 @@ module.exports = async function (context, commands) {
 
   // Step 1 — log in.
   await commands.navigate(`${baseUrl}/login`);
-  await commands.wait.byId('login-email', 10000);
+  await commands.wait.bySelector('input[type="email"]', 10000);
 
-  await commands.click.byId('login-email');
-  await commands.addText.byId(user, 'login-email');
+  await commands.click.bySelector('input[type="email"]');
+  await commands.addText.bySelector(user, 'input[type="email"]');
 
-  await commands.click.byId('login-password');
-  await commands.addText.byId(password, 'login-password');
+  await commands.click.bySelector('input[type="password"]');
+  await commands.addText.bySelector(password, 'input[type="password"]');
 
   await commands.click.bySelector('button[type="submit"]');
   await commands.wait.byCondition(

--- a/tests/test_analyze_baseline.py
+++ b/tests/test_analyze_baseline.py
@@ -1,0 +1,82 @@
+"""Tests for the sitespeed.io baseline analyzer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.analyze_baseline import extract_metrics
+
+
+def _entry(
+    pageref: str,
+    url: str,
+    *,
+    body_size: int,
+    wait: int,
+    receive: int,
+) -> dict[str, object]:
+    return {
+        "pageref": pageref,
+        "request": {"url": url},
+        "response": {
+            "bodySize": body_size,
+            "content": {"size": body_size},
+            "httpVersion": "h2",
+        },
+        "timings": {"wait": wait, "receive": receive},
+    }
+
+
+def test_extract_metrics_reports_median_across_iterations(tmp_path: Path) -> None:
+    """The analyzer should not report the first Sitespeed iteration."""
+    pages = []
+    entries = []
+    for index, (fcp, lcp, ttfb) in enumerate(
+        [(100, 1000, 10), (300, 3000, 30), (200, 2000, 20)],
+        start=1,
+    ):
+        page_id = f"page_{index}"
+        pages.append(
+            {
+                "id": page_id,
+                "pageTimings": {"_domInteractiveTime": fcp + 50},
+                "_googleWebVitals": {
+                    "firstContentfulPaint": fcp,
+                    "largestContentfulPaint": lcp,
+                    "ttfb": ttfb,
+                },
+            }
+        )
+        entries.extend(
+            [
+                _entry(
+                    page_id,
+                    "https://www.praxys.run/assets/app.js",
+                    body_size=index * 1024,
+                    wait=5,
+                    receive=5,
+                ),
+                _entry(
+                    page_id,
+                    "https://api.praxys.run/api/today",
+                    body_size=index * 100,
+                    wait=index * 10,
+                    receive=index,
+                ),
+            ]
+        )
+
+    har_path = tmp_path / "browsertime.har"
+    har_path.write_text(json.dumps({"log": {"pages": pages, "entries": entries}}))
+
+    metrics = extract_metrics(tmp_path)
+
+    assert metrics is not None
+    assert metrics["fcp_ms"] == 200
+    assert metrics["lcp_ms"] == 2000
+    assert metrics["ttfb_ms"] == 20
+    assert metrics["static_kb"] == 2.0
+    assert metrics["num_requests"] == 2
+    assert metrics["num_api"] == 1
+    assert metrics["api_p50_ms"] == 22


### PR DESCRIPTION
## Summary

- document the same-build mainland comparison between direct Azure, EdgeOne Global excluding mainland, and Tencent Lighthouse
- fix `analyze_baseline.py` to report medians across all Sitespeed iterations instead of reading only the first HAR page
- repair the login scripts to use stable semantic selectors
- enable and document gzip for the Tencent Nginx origin

## Results

Median LCP across three runs per scenario/device:

| Scenario | Direct Azure D/M | EdgeOne D/M | Tencent + gzip D/M |
|---|---:|---:|---:|
| Cold login → Today | 2.01 / 1.97 s | 2.56 / 2.62 s | **0.66 / 1.55 s** |
| Today → Training | 1.30 / 0.80 s | 3.01 / 0.84 s | **1.20 / 0.72 s** |
| Anonymous landing | 1.92 / 1.77 s | 3.02 / 6.88 s | **1.34 / 0.70 s** |

EdgeOne and direct Azure differed by only 16 ms on warm Today. The test therefore supports the manual perception that EdgeOne can feel fast on repeat visits, while still showing a slower and more variable cold path through the Singapore point of presence.

Enabling gzip reduced Tencent cold LCP by 58–85% across Today and Landing. The main JavaScript response fell from 402,243 bytes to 136,855 bytes.

## Validation

- `python -m pytest tests/test_analyze_baseline.py -q`
- `node --check scripts/sitespeed_scripts/s1.js`
- `node --check scripts/sitespeed_scripts/s2.js`
- `node --check scripts/sitespeed_scripts/s3.js`
- `docker run --rm -v <nginx-config>:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t`

## Limitations

- one Shanghai China Unicom probe, three runs per cell
- Tencent was tested directly over HTTP by IP because the mainland origin does not yet have a certificate-valid HTTPS hostname
- Tencent warm/PWA S3 is intentionally excluded because HTTP by IP is not a secure service-worker context
- raw authenticated HAR files are not committed because they contain bearer tokens
