### PR TITLE
Harden Copilot PR readiness enforcement

### DIFF
--- a/.github/agents/praxys-change-loop.agent.md
+++ b/.github/agents/praxys-change-loop.agent.md
@@ -56,12 +56,20 @@ files, rendered review, PR body, and final diff are stable.
    If preflight regenerates catalogs or other tracked files, review and commit
    them, then rerun preflight until it passes with a clean worktree.
 8. Complete the PR body with factual validation and UI evidence before the
-   ready-for-review handoff. Keep the PR draft when any required evidence is
-   unavailable.
+   ready-for-review handoff. Record
+   `python scripts/agent_preflight.py --base origin/main` in `## Validation`
+   after it passes, followed by `Preflight head: <full git rev-parse HEAD SHA>`
+   so the handoff is tied to the validated commit. Keep the PR draft when any
+   required evidence is unavailable.
 9. Inspect the required GitHub checks on the final head. Repair PR-caused
    failures and rerun preflight. Do not request review while required checks are
    failing or pending; leave the PR draft with the concrete blocker if the
    session cannot finish the repair.
+
+For miniapp UI changes, WeChat DevTools/Skyline rendered evidence remains a
+human-capable boundary when that runtime is unavailable in the cloud session.
+Fill every UI evidence field truthfully and leave the PR draft. Draft CI accepts
+explicitly pending evidence, but the ready-for-review gate remains strict.
 
 Do not merge or approve your own PR. Independent repository policy owns review
 and merge.

--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -90,6 +90,7 @@ jobs:
           # The coding agent is assignable only when it is enabled for the repo.
           # It surfaces in suggestedActors as the Bot login "copilot-swe-agent".
           id="$(gh api graphql \
+            -H 'GraphQL-Features: issues_copilot_assignment_api_support' \
             -f query='query($owner:String!,$name:String!){
               repository(owner:$owner,name:$name){
                 suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100){
@@ -107,7 +108,7 @@ jobs:
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "actor_id=$id" >> "$GITHUB_OUTPUT"
 
-      - name: Assign the issue to Copilot
+      - name: Assign the issue to the Praxys change-loop agent
         if: steps.token.outputs.have == 'true' && steps.copilot.outputs.found == 'true'
         env:
           # MUST be the user token — the built-in token is forbidden here.
@@ -115,19 +116,39 @@ jobs:
           ISSUE_ID: ${{ github.event.issue.node_id }}
           ACTOR_ID: ${{ steps.copilot.outputs.actor_id }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          TARGET_REPOSITORY_ID: ${{ github.event.repository.node_id }}
         run: |
           set -euo pipefail
-          # replaceActorsForAssignable sets the assignee set to exactly Copilot.
-          # Change loop issues are freshly auto-filed and unassigned, so this is
-          # the documented, idempotent way to hand one off; re-adding the label
-          # is a harmless no-op.
+          # The assignment API must name the checked-in custom agent explicitly.
+          # Assigning only the generic actor does not guarantee that the Praxys
+          # change-loop profile, preflight, or UI handoff policy is used.
           gh api graphql \
-            -f query='mutation($assignableId:ID!,$actorIds:[ID!]!){
-              replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}){
+            -H 'GraphQL-Features: issues_copilot_assignment_api_support' \
+            -f query='mutation(
+              $assignableId:ID!,
+              $actorIds:[ID!]!,
+              $targetRepositoryId:ID!,
+              $baseRef:String!,
+              $customAgent:String!
+            ){
+              replaceActorsForAssignable(input:{
+                assignableId:$assignableId,
+                actorIds:$actorIds,
+                agentAssignment:{
+                  targetRepositoryId:$targetRepositoryId,
+                  baseRef:$baseRef,
+                  customAgent:$customAgent
+                }
+              }){
                 assignable{ ... on Issue { number assignees(first:10){ nodes{ login } } } }
               }
-            }' -F assignableId="$ISSUE_ID" -F actorIds="$ACTOR_ID"
-          echo "Assigned issue #$ISSUE_NUMBER to the Copilot coding agent." >> "$GITHUB_STEP_SUMMARY"
+            }' \
+            -F assignableId="$ISSUE_ID" \
+            -F actorIds="$ACTOR_ID" \
+            -F targetRepositoryId="$TARGET_REPOSITORY_ID" \
+            -F baseRef=main \
+            -F customAgent=praxys-change-loop
+          echo "Assigned issue #$ISSUE_NUMBER to the Praxys Change Loop custom agent." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report assignment failure on the issue
         # Only for a genuine assignment error (token was present) — the

--- a/.github/workflows/ci-premerge.yml
+++ b/.github/workflows/ci-premerge.yml
@@ -95,11 +95,13 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           UI_PR_BODY: ${{ github.event.pull_request.body }}
+          UI_DRAFT_EVIDENCE_FLAG: ${{ github.event.pull_request.draft && github.event.pull_request.user.login == 'Copilot' && '--allow-unverified-draft' || '' }}
         run: >-
           python scripts/check_ui_quality.py
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"
           --pr-body-env UI_PR_BODY
+          $UI_DRAFT_EVIDENCE_FLAG
 
       - name: Smoke-test the gate on manual runs
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/copilot-pr-readiness.yml
+++ b/.github/workflows/copilot-pr-readiness.yml
@@ -1,0 +1,134 @@
+name: Copilot PR readiness guard
+
+on:
+  pull_request_target:
+    types: [ready_for_review, synchronize]
+
+# This workflow never checks out or executes pull-request code.
+permissions:
+  checks: read
+  contents: read
+  pull-requests: write
+  statuses: read
+
+concurrency:
+  group: copilot-pr-readiness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enforce:
+    if: >-
+      github.repository == 'praxys-run/praxys' &&
+      github.event.pull_request.user.login == 'Copilot' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Return changed ready PRs to draft
+        if: github.event.action == 'synchronize'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr ready "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --undo
+          echo "A new commit invalidated the prior handoff; returned the PR to draft." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require final preflight evidence
+        if: github.event.action == 'ready_for_review'
+        id: preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')"
+          if ! grep -Fq 'python scripts/agent_preflight.py --base origin/main' <<< "$body" ||
+            ! grep -Fq "Preflight head: \`$HEAD_SHA\`" <<< "$body"; then
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            echo "::error::PR validation must record the final preflight command and current head SHA."
+            exit 0
+          fi
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for required checks
+        if: >-
+          github.event.action == 'ready_for_review' &&
+          steps.preflight.outputs.verified == 'true'
+        id: checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          READY_AT: ${{ github.event.pull_request.updated_at }}
+          REQUIRED_CHECKS_JSON: '["backend-tests","frontend-quality"]'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # ready_for_review starts a fresh pre-merge run. Wait briefly for the
+          # required contexts for this event to replace the draft-mode results.
+          expected="$(jq 'length' <<< "$REQUIRED_CHECKS_JSON")"
+          for attempt in {1..72}; do
+            set +e
+            checks="$(
+              gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                --json name,startedAt,bucket
+            )"
+            checks_status=$?
+            set -e
+            if [[ "$checks_status" -ne 0 && "$checks_status" -ne 8 ]]; then
+              echo "::error::Could not read pull-request checks."
+              exit "$checks_status"
+            fi
+            fresh="$(
+              jq --arg ready "$READY_AT" --argjson required "$REQUIRED_CHECKS_JSON" \
+                '[.[] | . as $check | select(
+                  $check.startedAt != null and
+                  $check.startedAt >= $ready and
+                  (($required | index($check.name)) != null)
+                )]' \
+                <<< "$checks"
+            )"
+            count="$(jq '[.[].name] | unique | length' <<< "$fresh")"
+            if [[ "$count" -ge "$expected" ]]; then
+              failures="$(
+                jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' \
+                  <<< "$fresh"
+              )"
+              passes="$(jq '[.[] | select(.bucket == "pass")] | length' <<< "$fresh")"
+              if [[ "$failures" -gt 0 ]]; then
+                echo "passed=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              if [[ "$passes" -ge "$expected" ]]; then
+                echo "passed=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+            sleep 5
+          done
+          echo "passed=false" >> "$GITHUB_OUTPUT"
+          echo "::error::Fresh required checks did not complete for the ready PR."
+
+      - name: Return incomplete handoff to draft
+        if: >-
+          always() &&
+          github.event.action == 'ready_for_review' &&
+          (
+            steps.preflight.outputs.verified != 'true' ||
+            steps.checks.outputs.passed != 'true'
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr ready "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --undo
+          echo "Required preflight evidence or checks are incomplete; returned the PR to draft." \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/change-loop.md
+++ b/docs/ops/change-loop.md
@@ -58,6 +58,21 @@ own PR can merge. The target state is selective review: a separate risk policy
 can eventually route repeatedly proven narrow changes to policy-owned auto-merge,
 while sensitive, broad, uncertain, or failing changes still require a human.
 
+The assignment uses GitHub's agent-assignment API with
+`customAgent=praxys-change-loop`, so every eligible issue starts with the
+checked-in `.github/agents/praxys-change-loop.agent.md` profile rather than the
+generic Copilot profile.
+
+Copilot PRs stay draft until the final preflight command and validated head SHA
+are recorded and the required branch checks pass.
+`.github/workflows/copilot-pr-readiness.yml` automatically
+returns a ready PR to draft when either condition is missing, and any new commit
+also invalidates the prior ready handoff. Draft Copilot PRs may truthfully mark
+rendered UI evidence pending; strict evidence validation resumes when the PR is
+marked ready. This is especially important for miniapp work when the cloud
+session lacks a WeChat DevTools/Skyline runtime: a human completes that rendered
+review, updates the PR body, waits for draft CI, and then marks the PR ready.
+
 ### Shadow mode
 
 Set `PRAXYS_AGENT_READY_SHADOW=true` (App Service setting) to compute the
@@ -524,7 +539,12 @@ and the cost is low).
 
 - Label a **qualifying bug** `agent-ready` → the `Change loop — assign
   agent-ready issues to Copilot` workflow runs and the issue gets
-  `copilot-swe-agent` as an assignee; a draft PR follows.
+  `copilot-swe-agent` as an assignee using the `praxys-change-loop` custom
+  agent; a draft PR follows.
+- Mark a Copilot PR ready without the recorded final preflight or with a failing
+  required check → `Copilot PR readiness guard` returns it to draft.
+- Push a new commit to a ready Copilot PR → the readiness guard returns it to
+  draft until validation is rerun on the new head.
 - A **feature**, a **not-actionable** bug, a `backlog`/`later` bug, or a
   `needs_review`/sensitive report is never auto-assigned.
 - Shadow mode on → no label is applied, but the decision is durably recorded

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -655,7 +655,8 @@ with `DefaultAzureCredential`.
 
 `agent-ready` (auto-added to qualifying, actionable bugs by `api/feedback_triage.py`, or added
 by hand) triggers `.github/workflows/assign-copilot.yml`, which assigns the issue
-to the Copilot coding agent. These are **repo settings, not deploy-managed**:
+to the Copilot coding agent with the checked-in `praxys-change-loop` custom
+agent profile. These are **repo settings, not deploy-managed**:
 
 - **Labels** `agent-ready` and `backlog` (optionally `later`) are created once
   with `gh label create` — see [change-loop.md](./change-loop.md).
@@ -684,6 +685,10 @@ to the Copilot coding agent. These are **repo settings, not deploy-managed**:
   triage.
 - **Agent environment:** `.github/workflows/copilot-setup-steps.yml` preinstalls
   the toolchain so the agent can run `pytest` / `npm` deterministically.
+- **PR readiness enforcement:** `.github/workflows/copilot-pr-readiness.yml`
+  uses the repository `GITHUB_TOKEN` only; it requires no additional secret.
+  It returns Copilot PRs to draft after new commits, missing final-preflight
+  evidence for the current head SHA, or failed required checks.
 - **Versioned policy metadata:** `config/agent-loop-policies.json` is committed
   code config. It names the active assignment policy, narrow candidate classes,
   protected paths, evidence thresholds, and promoted classes. Promotion is

--- a/scripts/check_ui_quality.py
+++ b/scripts/check_ui_quality.py
@@ -292,6 +292,7 @@ def validate_ui_evidence(
     has_web: bool,
     has_miniapp: bool,
     changed_paths: Iterable[str] = (),
+    allow_unverified: bool = False,
 ) -> list[str]:
     """Return PR evidence errors for a rendered UI change."""
     section = _ui_quality_section(body)
@@ -299,6 +300,13 @@ def validate_ui_evidence(
         return ["PR body is missing the required '## UI quality' section."]
 
     values = _evidence_values(section)
+    if allow_unverified:
+        return [
+            f"UI quality field '{field}' is missing from the draft evidence block."
+            for field in _EVIDENCE_FIELDS
+            if field not in values
+        ]
+
     errors: list[str] = []
     for field in _EVIDENCE_FIELDS:
         value = values.get(field, "")
@@ -483,6 +491,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Skip PR body evidence validation for local smoke checks.",
     )
     parser.add_argument(
+        "--allow-unverified-draft",
+        action="store_true",
+        help=(
+            "Allow explicitly incomplete evidence values while a Copilot PR "
+            "remains draft; all evidence fields must still be present."
+        ),
+    )
+    parser.add_argument(
         "--skip-detector",
         action="store_true",
         help="Skip the Impeccable detector.",
@@ -530,6 +546,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 has_web="web" in surfaces,
                 has_miniapp="miniapp" in surfaces,
                 changed_paths=paths,
+                allow_unverified=args.allow_unverified_draft,
             )
         )
 

--- a/tests/test_assign_copilot_workflow.py
+++ b/tests/test_assign_copilot_workflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = ROOT / ".github" / "workflows" / "assign-copilot.yml"
+READINESS_WORKFLOW = ROOT / ".github" / "workflows" / "copilot-pr-readiness.yml"
 
 
 def test_assignment_deduplication_is_job_scoped() -> None:
@@ -19,3 +20,31 @@ def test_assignment_deduplication_is_job_scoped() -> None:
     )
     assert "group: assign-copilot-${{ github.event.issue.number }}" in assignment_job
     assert "cancel-in-progress: true" in assignment_job
+
+
+def test_assignment_selects_the_praxys_change_loop_custom_agent() -> None:
+    """Agent-ready issues must not fall back to the generic Copilot profile."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "GraphQL-Features: issues_copilot_assignment_api_support" in workflow
+    assert "agentAssignment:" in workflow
+    assert "customAgent:$customAgent" in workflow
+    assert "-F customAgent=praxys-change-loop" in workflow
+    assert "-F baseRef=main" in workflow
+
+
+def test_copilot_readiness_guard_restores_draft_invariants() -> None:
+    """Ready Copilot PRs must have preflight evidence and green required checks."""
+    workflow = READINESS_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "types: [ready_for_review, synchronize]" in workflow
+    assert "github.event.pull_request.user.login == 'Copilot'" in workflow
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in workflow
+    assert "python scripts/agent_preflight.py --base origin/main" in workflow
+    assert "Preflight head:" in workflow
+    assert "github.event.pull_request.head.sha" in workflow
+    assert "github.event.pull_request.updated_at" in workflow
+    assert 'REQUIRED_CHECKS_JSON: \'["backend-tests","frontend-quality"]\'' in workflow
+    assert "always() &&" in workflow
+    assert workflow.count('gh pr ready "$PR_NUMBER"') == 2
+    assert workflow.count("--undo") == 2

--- a/tests/test_ui_quality_harness.py
+++ b/tests/test_ui_quality_harness.py
@@ -85,6 +85,25 @@ def test_template_placeholders_do_not_count_as_evidence():
     assert any("missing or unverified" in error for error in errors)
 
 
+def test_copilot_draft_can_record_truthful_pending_ui_evidence():
+    """Draft CI may be green without pretending rendered review happened."""
+    draft = (ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert validate_ui_evidence(
+        draft,
+        has_web=False,
+        has_miniapp=True,
+        allow_unverified=True,
+    ) == []
+    assert validate_ui_evidence(
+        draft,
+        has_web=False,
+        has_miniapp=True,
+    )
+
+
 def test_design_system_update_requires_changed_governance_path():
     evidence = VALID_WEB_EVIDENCE.replace(
         "none - existing tokens and components cover this change",
@@ -183,6 +202,7 @@ def test_harness_is_wired_into_agents_and_required_ci():
     assert "needs: [python-tests]" in workflow
     assert "FRONTEND_RESULT" not in workflow
     assert "--pr-body-env UI_PR_BODY" in workflow
+    assert "--allow-unverified-draft" in workflow
     assert "UI Quality Harness (mandatory)" in instructions
     assert "scripts/agent_preflight.py --base origin/main" in instructions
     assert (ROOT / ".github" / "skills" / "ui-quality" / "SKILL.md").is_file()


### PR DESCRIPTION
## Summary

- explicitly assign every `agent-ready` issue to the checked-in `praxys-change-loop` custom agent instead of the generic Copilot profile
- return Copilot PRs to draft after new commits, stale/missing preflight evidence, check API errors, or failed required checks
- allow truthful pending UI evidence only while a Copilot PR remains draft; ready-for-review validation stays strict, including miniapp rendered verification
- update change-loop operations documentation and regression coverage

## Validation

- `python scripts/agent_preflight.py --base origin/main` (2050 passed, 3 skipped)
- targeted workflow/UI policy tests (18 passed)
- changed workflow YAML parsed successfully
- GitHub GraphQL custom-agent assignment input validated against the live schema with a skipped mutation
- Preflight head: `b29caab489701339a6e60ee07f4f164d9558f67c`