### PR TITLE
Move Tencent deploy to a restricted self-hosted runner

### DIFF
--- a/.github/workflows/deploy-frontend-appservice.yml
+++ b/.github/workflows/deploy-frontend-appservice.yml
@@ -168,13 +168,13 @@ jobs:
           package: deploy-pkg
 
   deploy_tencent:
-    if: vars.TENCENT_LIGHTHOUSE_DEPLOY_ENABLED == 'true'
+    if: >-
+      vars.TENCENT_LIGHTHOUSE_DEPLOY_ENABLED == 'true' &&
+      github.ref == 'refs/heads/main'
     needs: build
-    runs-on: ubuntu-latest
-    env:
-      LIGHTHOUSE_HOST: ${{ vars.TENCENT_LIGHTHOUSE_HOST }}
-      LIGHTHOUSE_USER: ${{ vars.TENCENT_LIGHTHOUSE_USER }}
-      LIGHTHOUSE_PORT: ${{ vars.TENCENT_LIGHTHOUSE_SSH_PORT || '22' }}
+    runs-on:
+      group: praxys-production
+      labels: praxys-cn-frontend
     steps:
       - name: Download Tencent package
         uses: actions/download-artifact@v8
@@ -182,46 +182,13 @@ jobs:
           name: frontend-tencent-${{ github.run_id }}-${{ github.run_attempt }}
           path: china-package
 
-      - name: Configure pinned SSH identity
-        env:
-          LIGHTHOUSE_SSH_PRIVATE_KEY: ${{ secrets.TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY }}
-          LIGHTHOUSE_SSH_KNOWN_HOSTS: ${{ secrets.TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -n "${LIGHTHOUSE_HOST}"
-          test -n "${LIGHTHOUSE_USER}"
-          [[ "${LIGHTHOUSE_PORT}" =~ ^[0-9]+$ ]]
-          test -n "${LIGHTHOUSE_SSH_PRIVATE_KEY}"
-          test -n "${LIGHTHOUSE_SSH_KNOWN_HOSTS}"
-
-          install -m 700 -d "${HOME}/.ssh"
-          printf '%s\n' "${LIGHTHOUSE_SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_ed25519"
-          printf '%s\n' "${LIGHTHOUSE_SSH_KNOWN_HOSTS}" > "${HOME}/.ssh/known_hosts"
-          chmod 600 "${HOME}/.ssh/id_ed25519" "${HOME}/.ssh/known_hosts"
-
-      - name: Upload static release
-        shell: bash
-        run: |
-          set -euo pipefail
-          release_id="${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          scp -P "${LIGHTHOUSE_PORT}" \
-            china-package/praxys-web.tgz \
-            "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}:/tmp/praxys-web-${release_id}.tgz"
-
       - name: Activate static release
         shell: bash
         run: |
           set -euo pipefail
           release_id="${GITHUB_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          ssh -p "${LIGHTHOUSE_PORT}" \
-            "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}" \
-            "bash -s -- '${release_id}' '${GITHUB_SHA}'" <<'REMOTE'
-          set -euo pipefail
-          release_id="$1"
-          deployed_sha="$2"
           root="/var/www/praxys"
-          archive="/tmp/praxys-web-${release_id}.tgz"
+          archive="${GITHUB_WORKSPACE}/china-package/praxys-web.tgz"
           release="${root}/releases/${release_id}"
           activated=0
 
@@ -237,7 +204,7 @@ jobs:
           mkdir -p "${release}"
           tar -xzf "${archive}" -C "${release}"
           test -s "${release}/index.html"
-          test "$(cat "${release}/deployed_sha.txt")" = "${deployed_sha}"
+          test "$(cat "${release}/deployed_sha.txt")" = "${GITHUB_SHA}"
 
           ln -sfn "${release}" "${root}/current.next"
           mv -Tf "${root}/current.next" "${root}/current"
@@ -248,20 +215,13 @@ jobs:
             | sort -nr \
             | awk 'NR > 5 {sub(/^[^ ]+ /, ""); print}' \
             | xargs -r rm -rf --
-          REMOTE
 
       - name: Verify Lighthouse deployment
         shell: bash
         run: |
           set -euo pipefail
-          deployed_sha="$(
-            ssh -p "${LIGHTHOUSE_PORT}" \
-              "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}" \
-              "cat /var/www/praxys/current/deployed_sha.txt"
-          )"
+          deployed_sha="$(cat /var/www/praxys/current/deployed_sha.txt)"
           test "${deployed_sha}" = "${GITHUB_SHA}"
-          ssh -p "${LIGHTHOUSE_PORT}" \
-            "${LIGHTHOUSE_USER}@${LIGHTHOUSE_HOST}" \
-            "curl --fail --silent --show-error --max-time 10 \
-              --header 'Host: www.praxys.run' \
-              http://127.0.0.1/healthz >/dev/null"
+          curl --fail --silent --show-error --max-time 10 \
+            --header 'Host: www.praxys.run' \
+            http://127.0.0.1/healthz >/dev/null

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -184,8 +184,8 @@ The `frontend_server/` package (`main.py` + `requirements-frontend.txt`) is ship
 
 The frontend workflow can deploy the same `web/dist` artifact to a
 mainland-China Lighthouse Nginx origin while Azure remains the international
-frontend. Lighthouse provisioning, SSH hardening, Nginx configuration, GitHub
-secrets, verification, and rollback are documented in
+frontend. Lighthouse provisioning, operator SSH hardening, Nginx configuration,
+the workflow-restricted self-hosted Runner, verification, and rollback are documented in
 [`docs/ops/tencent-frontend.md`](./ops/tencent-frontend.md).
 
 Leave `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` unset until that runbook's bootstrap

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -34,8 +34,6 @@ transient — the next deploy overwrites them.**
 | `COPILOT_ASSIGN_TOKEN` | **Required for workflow auto-assign** — fine-grained PAT (*Issues: write*, this repo only, with expiry). Agent assignment needs a user token; the built-in `GITHUB_TOKEN` is forbidden (issue #400). Manual UI assignment doesn't need it. | `assign-copilot.yml` |
 | `PRAXYS_GITHUB_APP_PRIVATE_KEY` | Feedback GitHub App private key. The app has Issues read/write and Pull requests read; tokens are minted on demand. | App Service setting (backend) |
 | `PRAXYS_REVIEW_POLICY_APP_PRIVATE_KEY` | Independent selective-review App key. The App has Contents write + Pull requests write solely to approve qualifying PRs and enable normal auto-merge. Optional while every PR is review-required; mandatory only for an autonomous candidate or stale policy-state cleanup. | `selective-review.yml` |
-| `TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY` | Dedicated private key for the restricted Lighthouse static-deploy user. | Tencent lane in `deploy-frontend-appservice.yml` |
-| `TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS` | Pinned Lighthouse SSH host-key line; rotate only after out-of-band fingerprint verification. | Tencent lane in `deploy-frontend-appservice.yml` |
 
 ### GitHub Actions → Variables
 `… → Variables` (non-secret; build variables are inlined into the SPA and ship to browsers)
@@ -62,10 +60,7 @@ transient — the next deploy overwrites them.**
 | `PRAXYS_REVIEW_POLICY_APP_SLUG` | Expected URL slug for the independent App, without `[bot]`; lets pre-credential evaluation recognize only that App's prior blocking reviews and verifies the minted identity. | `selective-review.yml`, `selective-review-emergency-stop.yml` |
 | `PRAXYS_SELECTIVE_REVIEW_ENABLED` | Master enable; absent/anything except `true` keeps every PR review-required. | `selective-review.yml` |
 | `PRAXYS_SELECTIVE_REVIEW_KILL_SWITCH` | Emergency stop; `true` disables approval even when the master enable and class promotion are active. | `selective-review.yml` |
-| `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` | Set `true` only after the Lighthouse Nginx/deploy-user bootstrap is complete. Unset/false skips the China deploy without affecting Azure. | `deploy-frontend-appservice.yml` |
-| `TENCENT_LIGHTHOUSE_HOST` | Lighthouse public IP or stable SSH hostname. | `deploy-frontend-appservice.yml` |
-| `TENCENT_LIGHTHOUSE_USER` (`praxys-deploy`) | Restricted SSH deployment account. | `deploy-frontend-appservice.yml` |
-| `TENCENT_LIGHTHOUSE_SSH_PORT` (`22`) | Lighthouse SSH port. | `deploy-frontend-appservice.yml` |
+| `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` | Set `true` only after Nginx and the workflow-restricted `praxys-production` Runner Group are healthy. Unset/false skips the China deploy without affecting Azure. | `deploy-frontend-appservice.yml` |
 
 Changing `PRAXYS_FEEDBACK_GITHUB_REPO` does not reinterpret historical issue
 numbers. Feedback sync and adjudication compare each stored GitHub URL with the

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -12,8 +12,9 @@
 | Frontend (SPA) | `deploy-frontend-appservice.yml` | push to `main` touching the SPA/static server, observability config/scripts, or the workflow; or `web-*` tag | App Service `praxys-frontend`; optionally Tencent Lighthouse |
 | Mini program | `miniapp-publish.yml` | `miniapp-YYYY.MM.MICRO` release tag (robot 1); `main` pushes auto-publish a dev build (robot 5) | WeChat (`miniprogram-ci`) |
 
-Targets authenticate through Azure OIDC, the WeChat upload key, or a dedicated
-pinned SSH key for Lighthouse — no account passwords. Backend + frontend run
+Targets authenticate through Azure OIDC or the WeChat upload key. The Tencent
+lane uses an outbound-only self-hosted Runner restricted to the production
+workflow; GitHub Actions does not SSH into Lighthouse. Backend + frontend run
 their test/build gates **before** deploying.
 
 **Pre-merge gate.** Before any deploy, `ci-premerge.yml` runs independent backend and frontend validation on every PR to `main`. A red required context blocks merge, so regressions never reach deployment (see [environment.md](./environment.md) → Repo governance). `deploy-backend.yml` re-runs the backend suite post-merge as a deploy-time backstop.
@@ -46,10 +47,11 @@ Automatic on merge touching `web/`. The workflow builds `web/dist/` once with
 
 - Azure `praxys-frontend`, packaged with `frontend_server/`.
 - Tencent Lighthouse when `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=true`, packaged as
-  static files and atomically activated under `/var/www/praxys/current`.
+  static files and atomically activated under `/var/www/praxys/current` by the
+  `praxys-cn-frontend` self-hosted Runner.
 
 Both deployments expose the same `deployed_sha`. The Tencent lane is disabled
-until the server bootstrap and pinned SSH configuration in
+until the server bootstrap and workflow-restricted Runner configuration in
 [tencent-frontend.md](./tencent-frontend.md) are complete. A skipped Tencent
 lane never blocks the existing Azure deployment.
 

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -31,7 +31,7 @@
 
 | Thing | Value | Source |
 |---|---|---|
-| Mainland frontend origin | Lighthouse static Nginx host; exact address sourced from `TENCENT_LIGHTHOUSE_HOST`, disabled until provisioned/ICP-ready | [tencent-frontend.md](./tencent-frontend.md) |
+| Mainland frontend origin | Lighthouse static Nginx host with the workflow-restricted `praxys-cn-frontend` Runner; disabled until provisioned/ICP-ready | [tencent-frontend.md](./tencent-frontend.md) |
 
 ## Hostnames
 

--- a/docs/ops/tencent-frontend.md
+++ b/docs/ops/tencent-frontend.md
@@ -10,7 +10,7 @@
 - Tencent Lighthouse in a mainland-China region, Ubuntu 24.04 LTS, public IP,
   and non-zero bandwidth. Keep the subscription eligible for the ICP filing.
 - SSH access from an operator workstation with `sudo`.
-- Repository admin access to Actions secrets and variables.
+- Organization admin access to Actions runner groups and repository variables.
 - The ICP filing must be approved before serving the public mainland hostname.
 
 The Lighthouse host serves only the immutable output of `web/dist`. The API,
@@ -28,24 +28,11 @@ sudo apt-get install -y nginx curl
 sudo adduser --disabled-password --gecos "" praxys-deploy
 sudo install -d -o praxys-deploy -g www-data -m 0755 \
   /var/www/praxys /var/www/praxys/releases
-sudo install -d -o praxys-deploy -g praxys-deploy -m 0700 \
-  /home/praxys-deploy/.ssh
-sudo touch /home/praxys-deploy/.ssh/authorized_keys
-sudo chown praxys-deploy:praxys-deploy \
-  /home/praxys-deploy/.ssh/authorized_keys
-sudo chmod 0600 /home/praxys-deploy/.ssh/authorized_keys
 ```
 
-Generate a dedicated key on the operator workstation:
-
-```bash
-ssh-keygen -t ed25519 -f praxys-tencent-deploy \
-  -C "praxys GitHub Actions Tencent deploy"
-```
-
-Append `praxys-tencent-deploy.pub` to
-`/home/praxys-deploy/.ssh/authorized_keys`. Disable SSH password login and root
-login after verifying key authentication in a second terminal.
+The account runs the deployment Runner and owns release files. Do not grant it
+`sudo`, a password, or an SSH authorized key. Keep operator SSH access on a
+separate administrative account, restricted to known operator IPs.
 
 ### 2. Install the repository Nginx configuration
 
@@ -76,38 +63,65 @@ certificate flow depends on the approved ICP/DNS arrangement and must be
 verified on the provisioned site rather than guessed in this pre-provisioning
 runbook.
 
-### 3. Create the GitHub Actions configuration
+### 3. Create the restricted Runner group
+
+This repository is public. Never register a repository-level self-hosted Runner
+on the production host: a pull-request workflow could otherwise target it.
+
+Under the `praxys-run` organization, create the `praxys-production` Runner
+group with:
+
+- Repository access: selected repository `praxys-run/praxys`.
+- Public repositories: allowed.
+- Workflow access: selected workflow
+  `praxys-run/praxys/.github/workflows/deploy-frontend-appservice.yml@refs/heads/main`.
+
+The workflow restriction is load-bearing. Do not broaden it to all workflows or
+an unpinned ref.
+
+### 4. Install the self-hosted Runner
+
+From **Organization settings → Actions → Runners**, add a Linux x64 Runner to
+the `praxys-production` group. Download the current GitHub Actions Runner,
+verify the SHA-256 digest shown by GitHub, and configure it as
+`praxys-deploy`:
+
+```bash
+sudo install -d -o praxys-deploy -g praxys-deploy -m 0750 \
+  /home/praxys-deploy/actions-runner
+cd /home/praxys-deploy/actions-runner
+
+sudo -u praxys-deploy ./config.sh --unattended \
+  --url https://github.com/praxys-run \
+  --token <SHORT_LIVED_ORG_REGISTRATION_TOKEN> \
+  --runnergroup praxys-production \
+  --name praxys-cn-frontend \
+  --labels praxys-cn-frontend \
+  --work _work
+
+sudo ./svc.sh install praxys-deploy
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+The service connects outbound to GitHub over HTTPS. It does not require GitHub
+Actions to SSH into the host.
+
+### 5. Create the GitHub Actions configuration
 
 Repository variables:
 
 | Variable | Value |
 |---|---|
-| `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` | Leave unset until bootstrap is complete; then set `true`. |
-| `TENCENT_LIGHTHOUSE_HOST` | Lighthouse public IP or stable SSH hostname. |
-| `TENCENT_LIGHTHOUSE_USER` | `praxys-deploy` |
-| `TENCENT_LIGHTHOUSE_SSH_PORT` | SSH port, normally `22`. |
+| `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED` | Leave unset until Nginx and the restricted Runner are healthy; then set `true`. |
 
-Repository secrets:
+The Tencent deployment lane requires no repository secret. After migration,
+delete the obsolete `TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY` and
+`TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS` secrets and the
+`TENCENT_LIGHTHOUSE_HOST`, `TENCENT_LIGHTHOUSE_USER`, and
+`TENCENT_LIGHTHOUSE_SSH_PORT` variables.
 
-| Secret | Value |
-|---|---|
-| `TENCENT_LIGHTHOUSE_SSH_PRIVATE_KEY` | Entire contents of the dedicated private key. |
-| `TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS` | Pinned `known_hosts` line for the Lighthouse host. |
-
-Create the host-key value from a trusted workstation:
-
-```bash
-export LIGHTHOUSE_SSH_PORT=22
-ssh-keyscan -H -p "${LIGHTHOUSE_SSH_PORT}" <LIGHTHOUSE_IP> \
-  > lighthouse_known_hosts
-ssh-keygen -lf lighthouse_known_hosts
-```
-
-Compare the fingerprint with the server's host key through the Tencent console
-or an already trusted SSH session before storing the file contents. Never
-replace the pinned key with `StrictHostKeyChecking=no`.
-
-### 4. Enable deployments
+### 6. Enable deployments
 
 Set `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=true`, then manually run
 `deploy-frontend-appservice.yml`. This can be done before public DNS cutover;
@@ -115,10 +129,14 @@ the workflow verifies Nginx over loopback on the server. The workflow:
 
 1. Builds the SPA once.
 2. Deploys the same package to Azure App Service.
-3. Uploads the static package to a run-addressed Lighthouse release stamped
-   with the source commit SHA.
-4. Atomically changes `/var/www/praxys/current`.
-5. Keeps the five newest releases and verifies `/healthz`.
+3. Lets the restricted Lighthouse Runner download the static package.
+4. Extracts it to a run-addressed release stamped with the source commit SHA.
+5. Atomically changes `/var/www/praxys/current`.
+6. Keeps the five newest releases and verifies `/healthz`.
+
+The Tencent lane runs only for `main`. A `web-*` tag can still deploy Azure,
+but cannot use the production Runner because its Runner Group is pinned to the
+workflow on `refs/heads/main`.
 
 ## Verify
 
@@ -158,9 +176,15 @@ curl -sS -H 'Host: www.praxys.run' http://127.0.0.1/healthz
 ```
 
 Set `TENCENT_LIGHTHOUSE_DEPLOY_ENABLED=false` to stop future Tencent deploys
-without affecting Azure. If the host key changes after a legitimate rebuild,
-verify the new fingerprint out of band before rotating
-`TENCENT_LIGHTHOUSE_SSH_KNOWN_HOSTS`.
+without affecting Azure. To stop the Runner itself:
+
+```bash
+cd /home/praxys-deploy/actions-runner
+sudo ./svc.sh stop
+```
+
+Do not move the Runner into the organization default group as a recovery
+shortcut. Repair the workflow-restricted `praxys-production` group instead.
 
 ## Related
 
@@ -169,4 +193,4 @@ verify the new fingerprint out of band before rotating
 - `deploy/tencent/nginx-praxys.conf`
 
 ---
-_Last reviewed: 2026-08-07 · Owner: @dddtc2005_
+_Last reviewed: 2026-08-09 · Owner: @dddtc2005_


### PR DESCRIPTION
## Summary

- replace GitHub-hosted SSH/SCP deployment with the `praxys-cn-frontend` Lighthouse self-hosted Runner
- restrict the public-repository production Runner through the `praxys-production` group to the main-pinned frontend deployment workflow
- keep artifact activation atomic and document provisioning, access controls, recovery, and obsolete SSH configuration

## Validation

- required GitHub checks passed, including the complete Python suite and `frontend-quality`
- `python -m pytest tests/test_frontend_server_spa.py -q` — 17 passed locally
- workflow YAML parsed successfully with PyYAML
- Lighthouse Runner Group verified as selected-repository and selected-workflow restricted; Runner online under the non-sudo `praxys-deploy` account
- local `agent_preflight.py` reached one unrelated suite-order failure that passes in isolation; clean GitHub CI passed the same complete suite
