### PR TITLE
Add dynamic Labs recompute policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,7 @@ PRAXYS_GARMIN_PLAN_DELIVERY_ENABLED=false
 # config callers keep their environment/default fallback.
 # STATSIG_SDK_KEY=
 # STATSIG_ENV=development                    # development | staging | production
+# Console config: labs_environment_recompute_policy (defaults remain 6h / 24h / 3)
 
 # Optional: In-app feedback → GitHub issue auto-filing.
 # When a user submits feedback (bug / feature / other) from the web app or

--- a/api/labs_environment.py
+++ b/api/labs_environment.py
@@ -34,6 +34,7 @@ from api.packs import (
     get_activity_research_pack,
     get_analysis_response_version,
 )
+from api.statsig_client import get_config, get_statsig_user_for_account
 from api.views import utc_isoformat
 from api import labs_tombstone_storage
 from db.cache_revision import lock_revision_writes
@@ -44,6 +45,7 @@ from db.models import (
     LabsExperimentEnrollment,
     LabsExperimentResult,
     User,
+    UserConfig,
 )
 from db.session import begin_serialized_write
 
@@ -52,9 +54,10 @@ logger = logging.getLogger(__name__)
 EXPERIMENT_ID = "environment-response-v1"
 CONSENT_VERSION = "environment-response-consent-v1"
 ACTIVE_JOB_STATUSES = ("queued", "dispatched", "processing", "retrying")
-MANUAL_RECOMPUTE_COOLDOWN = timedelta(hours=6)
-MANUAL_RECOMPUTE_WINDOW = timedelta(hours=24)
-MANUAL_RECOMPUTE_LIMIT = 3
+MANUAL_RECOMPUTE_CONFIG_NAME = "labs_environment_recompute_policy"
+MANUAL_RECOMPUTE_DEFAULT_COOLDOWN_HOURS = 6
+MANUAL_RECOMPUTE_DEFAULT_WINDOW_HOURS = 24
+MANUAL_RECOMPUTE_DEFAULT_LIMIT = 3
 JOB_LEASE_DURATION = timedelta(minutes=30)
 MAX_JOB_ATTEMPTS = 3
 _IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
@@ -79,6 +82,76 @@ class RecomputeLimitError(RuntimeError):
         super().__init__(code)
         self.code = code
         self.available_at = available_at
+
+
+@dataclass(frozen=True)
+class ManualRecomputePolicy:
+    """Validated per-user Labs manual recompute limits."""
+
+    cooldown: timedelta
+    window: timedelta
+    limit: int
+
+
+DEFAULT_MANUAL_RECOMPUTE_POLICY = ManualRecomputePolicy(
+    cooldown=timedelta(hours=MANUAL_RECOMPUTE_DEFAULT_COOLDOWN_HOURS),
+    window=timedelta(hours=MANUAL_RECOMPUTE_DEFAULT_WINDOW_HOURS),
+    limit=MANUAL_RECOMPUTE_DEFAULT_LIMIT,
+)
+
+
+def _manual_recompute_policy(
+    db: Session,
+    user_id: str,
+) -> ManualRecomputePolicy:
+    config_row = db.get(UserConfig, user_id)
+    statsig_user = get_statsig_user_for_account(
+        db,
+        user_id=user_id,
+        training_base=(
+            config_row.training_base if config_row is not None else None
+        ),
+        language=config_row.language if config_row is not None else None,
+    )
+    fallback = {
+        "cooldown_hours": MANUAL_RECOMPUTE_DEFAULT_COOLDOWN_HOURS,
+        "window_hours": MANUAL_RECOMPUTE_DEFAULT_WINDOW_HOURS,
+        "max_requests": MANUAL_RECOMPUTE_DEFAULT_LIMIT,
+    }
+    configured = get_config(
+        MANUAL_RECOMPUTE_CONFIG_NAME,
+        statsig_user,
+        fallback,
+    )
+    if not isinstance(configured, dict):
+        logger.warning(
+            "Invalid Labs recompute config; using defaults: config=%s",
+            MANUAL_RECOMPUTE_CONFIG_NAME,
+        )
+        return DEFAULT_MANUAL_RECOMPUTE_POLICY
+    cooldown_hours = configured.get("cooldown_hours")
+    window_hours = configured.get("window_hours")
+    limit = configured.get("max_requests")
+    valid = (
+        type(cooldown_hours) is int
+        and type(window_hours) is int
+        and type(limit) is int
+        and 0 <= cooldown_hours <= 168
+        and 1 <= window_hours <= 168
+        and cooldown_hours <= window_hours
+        and 1 <= limit <= 100
+    )
+    if not valid:
+        logger.warning(
+            "Invalid Labs recompute config values; using defaults: config=%s",
+            MANUAL_RECOMPUTE_CONFIG_NAME,
+        )
+        return DEFAULT_MANUAL_RECOMPUTE_POLICY
+    return ManualRecomputePolicy(
+        cooldown=timedelta(hours=cooldown_hours),
+        window=timedelta(hours=window_hours),
+        limit=limit,
+    )
 
 
 @dataclass(frozen=True)
@@ -618,6 +691,7 @@ def _manual_recompute_limit(
     user_id: str,
     *,
     now: datetime,
+    policy: ManualRecomputePolicy,
 ) -> RecomputeLimitError | None:
     jobs = (
         db.query(LabsAnalysisJob)
@@ -625,7 +699,7 @@ def _manual_recompute_limit(
             LabsAnalysisJob.user_id == user_id,
             LabsAnalysisJob.experiment_id == EXPERIMENT_ID,
             LabsAnalysisJob.trigger == "manual_recompute",
-            LabsAnalysisJob.requested_at > now - MANUAL_RECOMPUTE_WINDOW,
+            LabsAnalysisJob.requested_at > now - policy.window,
         )
         .order_by(LabsAnalysisJob.requested_at)
         .all()
@@ -633,12 +707,12 @@ def _manual_recompute_limit(
     code: Literal["cooldown", "daily_limit"] | None = None
     available_at: datetime | None = None
     if jobs:
-        cooldown_at = jobs[-1].requested_at + MANUAL_RECOMPUTE_COOLDOWN
+        cooldown_at = jobs[-1].requested_at + policy.cooldown
         if cooldown_at > now:
             code = "cooldown"
             available_at = cooldown_at
-    if len(jobs) >= MANUAL_RECOMPUTE_LIMIT:
-        daily_at = jobs[0].requested_at + MANUAL_RECOMPUTE_WINDOW
+    if len(jobs) >= policy.limit:
+        daily_at = jobs[0].requested_at + policy.window
         if daily_at > now and (
             available_at is None or daily_at > available_at
         ):
@@ -663,6 +737,7 @@ def queue_recompute(
     key = _normalize_idempotency_key(idempotency_key)
     current_time = now or datetime.utcnow()
     begin_serialized_write(db)
+    policy = _manual_recompute_policy(db, user_id)
     lock_revision_writes(db, user_id)
     row = _locked_enrollment(db, user_id, EXPERIMENT_ID)
     if not _has_current_consent(row):
@@ -683,7 +758,12 @@ def queue_recompute(
     if active is not None:
         db.commit()
         return QueueDecision(row, active, False, idempotent=True)
-    limited = _manual_recompute_limit(db, user_id, now=current_time)
+    limited = _manual_recompute_limit(
+        db,
+        user_id,
+        now=current_time,
+        policy=policy,
+    )
     if limited is not None:
         db.rollback()
         raise limited
@@ -1740,6 +1820,7 @@ def _recompute_policy_state(
     *,
     now: datetime,
 ) -> dict[str, Any]:
+    policy = _manual_recompute_policy(db, user_id)
     active = _active_job(db, user_id, EXPERIMENT_ID)
     window_jobs = (
         db.query(LabsAnalysisJob)
@@ -1747,12 +1828,12 @@ def _recompute_policy_state(
             LabsAnalysisJob.user_id == user_id,
             LabsAnalysisJob.experiment_id == EXPERIMENT_ID,
             LabsAnalysisJob.trigger == "manual_recompute",
-            LabsAnalysisJob.requested_at > now - MANUAL_RECOMPUTE_WINDOW,
+            LabsAnalysisJob.requested_at > now - policy.window,
         )
         .order_by(LabsAnalysisJob.requested_at)
         .all()
     )
-    remaining = max(0, MANUAL_RECOMPUTE_LIMIT - len(window_jobs))
+    remaining = max(0, policy.limit - len(window_jobs))
     reason: str | None = None
     available_at: datetime | None = None
     if row is None:
@@ -1762,14 +1843,14 @@ def _recompute_policy_state(
     else:
         if window_jobs:
             cooldown_at = (
-                window_jobs[-1].requested_at + MANUAL_RECOMPUTE_COOLDOWN
+                window_jobs[-1].requested_at + policy.cooldown
             )
             if cooldown_at > now:
                 reason = "cooldown"
                 available_at = cooldown_at
-        if len(window_jobs) >= MANUAL_RECOMPUTE_LIMIT:
+        if len(window_jobs) >= policy.limit:
             daily_at = (
-                window_jobs[0].requested_at + MANUAL_RECOMPUTE_WINDOW
+                window_jobs[0].requested_at + policy.window
             )
             if daily_at > now and (
                 available_at is None or daily_at > available_at
@@ -1787,10 +1868,8 @@ def _recompute_policy_state(
         "available_at": utc_isoformat(available_at),
         "retry_after_seconds": retry_after_seconds,
         "remaining_requests": remaining,
-        "window_hours": int(MANUAL_RECOMPUTE_WINDOW.total_seconds() / 3600),
-        "cooldown_hours": int(
-            MANUAL_RECOMPUTE_COOLDOWN.total_seconds() / 3600
-        ),
+        "window_hours": int(policy.window.total_seconds() / 3600),
+        "cooldown_hours": int(policy.cooldown.total_seconds() / 3600),
     }
 
 

--- a/api/labs_environment.py
+++ b/api/labs_environment.py
@@ -712,7 +712,7 @@ def _manual_recompute_limit(
             code = "cooldown"
             available_at = cooldown_at
     if len(jobs) >= policy.limit:
-        daily_at = jobs[0].requested_at + policy.window
+        daily_at = _rolling_limit_available_at(jobs, policy)
         if daily_at > now and (
             available_at is None or daily_at > available_at
         ):
@@ -723,6 +723,13 @@ def _manual_recompute_limit(
         if code is None or available_at is None
         else RecomputeLimitError(code, available_at)
     )
+
+
+def _rolling_limit_available_at(
+    jobs: list[LabsAnalysisJob],
+    policy: ManualRecomputePolicy,
+) -> datetime:
+    return jobs[len(jobs) - policy.limit].requested_at + policy.window
 
 
 def queue_recompute(
@@ -1849,9 +1856,7 @@ def _recompute_policy_state(
                 reason = "cooldown"
                 available_at = cooldown_at
         if len(window_jobs) >= policy.limit:
-            daily_at = (
-                window_jobs[0].requested_at + policy.window
-            )
+            daily_at = _rolling_limit_available_at(window_jobs, policy)
             if daily_at > now and (
                 available_at is None or daily_at > available_at
             ):

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -334,6 +334,7 @@ The final Statsig Console state owned by this integration is exactly:
 |---|---|---|---|
 | Feature gate | `garmin_plan_delivery_eligible` | `false` in every environment | Optional reviewed allow rule matching only dedicated users by internal Praxys UUID. Never add a global pass rule. |
 | Dynamic config | `insight_daily_cap` | `{"value": 30}` where `value` is an integer | No experiment assignment. Runtime rules may return another validated positive integer. |
+| Dynamic config | `labs_environment_recompute_policy` | `{"value":{"cooldown_hours":6,"window_hours":24,"max_requests":3}}`; all fields are integers | No experiment assignment. A reviewed per-user UUID rule may set `cooldown_hours` to `0` for targeted testing. Keep `window_hours` between 1 and 168, `cooldown_hours` between 0 and `window_hours`, and `max_requests` between 1 and 100. |
 
 Repository-level Console automation uses the official `statsig` HTTP server in
 `.mcp.json`. The entry intentionally contains an empty `headers` object and no
@@ -355,7 +356,12 @@ account-generation/region fence. Remove superseded issue-251 resources from
 the Statsig project; do not create an experiment for this integration.
 
 When Statsig is unavailable or the dynamic-config property is absent, the
-backend keeps `PRAXYS_INSIGHT_DAILY_CAP` and then `30` as the fallback.
+backend keeps `PRAXYS_INSIGHT_DAILY_CAP` and then `30` as the insight fallback.
+The Labs recompute policy keeps its code-owned 6-hour cooldown, 24-hour rolling
+window, and three-request limit. Invalid Labs values fail back to that complete
+default policy rather than partially applying a malformed rule. A zero-hour
+targeted cooldown bypasses only the time delay: active-job single-flight and
+the configured rolling request limit remain authoritative.
 `AZURE_AI_ENDPOINT` remains the hard infrastructure prerequisite for model
 calls. There is no AI feature gate.
 
@@ -373,8 +379,10 @@ gh variable set VITE_STATSIG_CLIENT_KEY --repo praxys-run/praxys
 Verify the backend App Service contains `STATSIG_SDK_KEY` and `STATSIG_ENV`
 without printing their values, and inspect the built SPA only for the expected
 public `client-*` key. Removing `STATSIG_SDK_KEY` and redeploying is a
-fail-closed rollback for Garmin eligibility; the dynamic config resumes its
-documented fallback.
+fail-closed rollback for Garmin eligibility; both dynamic configs resume their
+documented fallbacks. To roll back only a Labs exception, remove its targeted
+rule and confirm the API again reports `cooldown_hours: 6`,
+`window_hours: 24`, and `remaining_requests` against a three-request window.
 
 ### Azure Key Vault (`kv-trainsight`)
 - RSA key `trainsight-master-key` — the master key that wraps the per-user

--- a/tests/test_labs_environment.py
+++ b/tests/test_labs_environment.py
@@ -1391,6 +1391,70 @@ def test_manual_recompute_enforces_rolling_daily_limit(
         assert policy["remaining_requests"] == 0
 
 
+def test_lowered_recompute_limit_reports_when_enough_requests_expire(
+    labs_client,
+    monkeypatch,
+) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+    from api.views import utc_isoformat
+
+    configured = {
+        "cooldown_hours": 0,
+        "window_hours": 24,
+        "max_requests": 10,
+    }
+    monkeypatch.setattr(
+        labs_environment,
+        "get_config",
+        lambda *_args: configured,
+    )
+    base = datetime(2026, 8, 9, 0, 0, 0)
+    with db_session.SessionLocal() as db:
+        enrolled = labs_environment.enroll(
+            db,
+            user_id,
+            adult_attested=True,
+            consent_version=labs_environment.CONSENT_VERSION,
+            now=base - timedelta(hours=1),
+        )
+        enrolled.job.status = "succeeded"
+        enrolled.enrollment.status = "unavailable"
+        db.commit()
+        for index in range(5):
+            decision = labs_environment.queue_recompute(
+                db,
+                user_id,
+                idempotency_key=f"manual-lowered-limit-{index}",
+                now=base + timedelta(hours=index),
+            )
+            decision.job.status = "succeeded"
+            decision.enrollment.status = "unavailable"
+            db.commit()
+
+        configured["max_requests"] = 3
+        expected_available_at = base + timedelta(hours=26)
+        with pytest.raises(
+            labs_environment.RecomputeLimitError,
+            match="daily_limit",
+        ) as exc_info:
+            labs_environment.queue_recompute(
+                db,
+                user_id,
+                idempotency_key="manual-lowered-limit-blocked",
+                now=base + timedelta(hours=5),
+            )
+
+        assert exc_info.value.available_at == expected_available_at
+        policy = labs_environment.public_state(
+            db,
+            user_id,
+            now=base + timedelta(hours=5),
+        )["execution"]["recompute"]
+        assert policy["reason"] == "daily_limit"
+        assert policy["available_at"] == utc_isoformat(expected_available_at)
+
+
 def test_withdrawal_fails_closed_when_tombstone_storage_is_unavailable(
     labs_client,
     monkeypatch,

--- a/tests/test_labs_environment.py
+++ b/tests/test_labs_environment.py
@@ -314,6 +314,114 @@ def test_recompute_not_enrolled_returns_structured_error(labs_client) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    "configured",
+    [
+        None,
+        {"cooldown_hours": True, "window_hours": 24, "max_requests": 3},
+        {"cooldown_hours": -1, "window_hours": 24, "max_requests": 3},
+        {"cooldown_hours": 25, "window_hours": 24, "max_requests": 3},
+        {"cooldown_hours": 6, "window_hours": 0, "max_requests": 3},
+        {"cooldown_hours": 6, "window_hours": 24, "max_requests": 0},
+    ],
+)
+def test_invalid_recompute_dynamic_config_uses_defaults(
+    labs_client,
+    monkeypatch,
+    configured,
+) -> None:
+    _, db_session, user_id = labs_client
+    from api import labs_environment
+
+    monkeypatch.setattr(
+        labs_environment,
+        "get_config",
+        lambda *_args: configured,
+    )
+
+    with db_session.SessionLocal() as db:
+        policy = labs_environment._manual_recompute_policy(db, user_id)
+
+    assert policy == labs_environment.DEFAULT_MANUAL_RECOMPUTE_POLICY
+
+
+def test_recompute_dynamic_config_can_bypass_cooldown(
+    labs_client,
+    monkeypatch,
+) -> None:
+    client, db_session, user_id = labs_client
+    from api import labs_environment
+    from db.models import LabsAnalysisJob, LabsExperimentEnrollment
+
+    monkeypatch.setattr(
+        labs_environment,
+        "get_config",
+        lambda *_args: {
+            "cooldown_hours": 0,
+            "window_hours": 12,
+            "max_requests": 10,
+        },
+    )
+    enrolled = client.post(
+        "/api/labs/environment-response",
+        headers={"Idempotency-Key": "enroll-config-bypass-1"},
+        json={
+            "adult_attested": True,
+            "consent_version": labs_environment.CONSENT_VERSION,
+        },
+    )
+    assert enrolled.status_code == 202
+    with db_session.SessionLocal() as db:
+        job = db.query(LabsAnalysisJob).filter(
+            LabsAnalysisJob.user_id == user_id,
+        ).one()
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        job.status = "succeeded"
+        job.completed_at = datetime.utcnow()
+        row.status = "unavailable"
+        row.completed_at = job.completed_at
+        db.commit()
+
+    first = client.post(
+        "/api/labs/environment-response/recompute",
+        headers={"Idempotency-Key": "config-bypass-manual-1"},
+    )
+    assert first.status_code == 202
+    with db_session.SessionLocal() as db:
+        job = db.query(LabsAnalysisJob).filter(
+            LabsAnalysisJob.idempotency_key == "config-bypass-manual-1",
+        ).one()
+        row = db.get(
+            LabsExperimentEnrollment,
+            (user_id, labs_environment.EXPERIMENT_ID),
+        )
+        job.status = "succeeded"
+        job.completed_at = datetime.utcnow()
+        row.status = "unavailable"
+        row.completed_at = job.completed_at
+        db.commit()
+
+    state = client.get("/api/labs/environment-response")
+    policy = state.json()["execution"]["recompute"]
+    assert policy == {
+        "allowed": True,
+        "reason": None,
+        "available_at": None,
+        "retry_after_seconds": None,
+        "remaining_requests": 9,
+        "window_hours": 12,
+        "cooldown_hours": 0,
+    }
+    second = client.post(
+        "/api/labs/environment-response/recompute",
+        headers={"Idempotency-Key": "config-bypass-manual-2"},
+    )
+    assert second.status_code == 202
+
+
 def test_recompute_api_returns_retry_after_during_cooldown(
     labs_client,
 ) -> None:


### PR DESCRIPTION
## Summary

- Resolve the Labs environmental-response manual recompute cooldown, rolling window, and request limit from the per-user Statsig dynamic config `labs_environment_recompute_policy`.
- Preserve the current 6-hour / 24-hour / 3-request policy as the complete fail-safe fallback when Statsig is unavailable or values are malformed.
- Allow reviewed user-ID rules to set `cooldown_hours` to `0` without bypassing active-job single-flight or the rolling request cap.
- Keep enforcement and the public API policy state aligned, including correct retry timing if a live rule lowers the cap below existing request history.
- Document the Console schema, validation bounds, provisioning, verification, and rollback behavior in the operations handbook.

The Statsig Console resource has been provisioned with the default fallback-equivalent value and no targeting rules. A production bypass rule is intentionally not active before this code deploys.

## Validation

- `python -m pytest tests/test_labs_environment.py tests/test_statsig_client.py -q`
- `python scripts/agent_preflight.py --base origin/main`
  - 2221 passed, 3 skipped
- Code review finding for lowered live request limits was fixed with a regression test.
