### PR TITLE
Fix Labs calculator chart marker

### DIFF
--- a/web/src/lib/labs-environment-chart.ts
+++ b/web/src/lib/labs-environment-chart.ts
@@ -1,0 +1,35 @@
+interface WetBulbDomainBin {
+  lower_wet_bulb_c: number;
+  upper_wet_bulb_c: number;
+}
+
+interface WetBulbPoint {
+  wet_bulb_c: number;
+}
+
+export function getWetBulbChartDomain(
+  supportBins: WetBulbDomainBin[],
+): [number, number] | null {
+  if (supportBins.length === 0) return null;
+  return [
+    Math.min(...supportBins.map((bin) => bin.lower_wet_bulb_c)),
+    Math.max(...supportBins.map((bin) => bin.upper_wet_bulb_c)),
+  ];
+}
+
+export function getWetBulbPointDomain(
+  points: WetBulbPoint[],
+): [number, number] | null {
+  if (points.length === 0) return null;
+  const values = points.map((point) => point.wet_bulb_c);
+  return [Math.min(...values), Math.max(...values)];
+}
+
+export function getMarkerLabelPosition(
+  value: number,
+  domain: [number, number],
+): 'insideTopLeft' | 'insideTopRight' {
+  return value > (domain[0] + domain[1]) / 2
+    ? 'insideTopRight'
+    : 'insideTopLeft';
+}

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -32,7 +32,7 @@ msgid "(optional)"
 msgstr "(optional)"
 
 #. placeholder {0}: bin.reference_power_activity_count
-#: src/pages/LabsEnvironment.tsx:616
+#: src/pages/LabsEnvironment.tsx:629
 msgid "{0, plural, one {# activity} other {# activities}}"
 msgstr "{0, plural, one {# activity} other {# activities}}"
 
@@ -514,15 +514,15 @@ msgstr "A prior qualifying block still informs this qualitative stage, but respo
 msgid "A prior qualifying block still informs this qualitative stage, but response-specific adaptation evidence is declining. The range shown here describes current qualifying evidence, not that prior block."
 msgstr "A prior qualifying block still informs this qualitative stage, but response-specific adaptation evidence is declining. The range shown here describes current qualifying evidence, not that prior block."
 
-#: src/pages/LabsEnvironment.tsx:91
+#: src/pages/LabsEnvironment.tsx:96
 msgid "A single activity has too much influence on the result."
 msgstr "A single activity has too much influence on the result."
 
-#: src/pages/LabsEnvironment.tsx:82
+#: src/pages/LabsEnvironment.tsx:87
 msgid "A Stryd-aligned Critical Power value is required for this experiment."
 msgstr "A Stryd-aligned Critical Power value is required for this experiment."
 
-#: src/pages/LabsEnvironment.tsx:267
+#: src/pages/LabsEnvironment.tsx:272
 msgid "A temporary infrastructure problem interrupted the previous attempt. Praxys kept the request and will retry automatically."
 msgstr "A temporary infrastructure problem interrupted the previous attempt. Praxys kept the request and will retry automatically."
 
@@ -633,7 +633,7 @@ msgstr "Activities"
 msgid "Activities only: runs, rides, pace, heart rate, route data"
 msgstr "Activities only: runs, rides, pace, heart rate, route data"
 
-#: src/pages/LabsEnvironment.tsx:404
+#: src/pages/LabsEnvironment.tsx:409
 msgid "Activities passing quick prerequisites"
 msgstr "Activities passing quick prerequisites"
 
@@ -784,7 +784,7 @@ msgstr "agent-ready candidates"
 #~ msgid "Agent-ready candidates"
 #~ msgstr "Agent-ready candidates"
 
-#: src/pages/LabsEnvironment.tsx:883
+#: src/pages/LabsEnvironment.tsx:896
 msgid "Aggregate storage"
 msgstr "Aggregate storage"
 
@@ -845,7 +845,7 @@ msgstr "All {0} linked ticket(s) already up to date."
 msgid "All components operational"
 msgstr "All components operational"
 
-#: src/pages/LabsEnvironment.tsx:1125
+#: src/pages/LabsEnvironment.tsx:1138
 msgid "All experiments"
 msgstr "All experiments"
 
@@ -894,15 +894,15 @@ msgstr "An external planner overlaps the Praxys plan. Use one planner at a time 
 msgid "An unexpected error occurred."
 msgstr "An unexpected error occurred."
 
-#: src/pages/LabsEnvironment.tsx:1191
+#: src/pages/LabsEnvironment.tsx:1204
 msgid "Analysis needs a manual retry"
 msgstr "Analysis needs a manual retry"
 
-#: src/pages/LabsEnvironment.tsx:263
+#: src/pages/LabsEnvironment.tsx:268
 msgid "Analysis request saved"
 msgstr "Analysis request saved"
 
-#: src/pages/LabsEnvironment.tsx:260
+#: src/pages/LabsEnvironment.tsx:265
 msgid "Analysis worker is running"
 msgstr "Analysis worker is running"
 
@@ -964,7 +964,7 @@ msgstr "Athlete action required"
 msgid "ATL (recent load)"
 msgstr "ATL (recent load)"
 
-#: src/pages/LabsEnvironment.tsx:279
+#: src/pages/LabsEnvironment.tsx:284
 msgid "Attempt"
 msgstr "Attempt"
 
@@ -1036,7 +1036,7 @@ msgid "Availability rate"
 msgstr "Availability rate"
 
 #: src/pages/admin/AdminUsers.tsx:768
-#: src/pages/LabsEnvironment.tsx:159
+#: src/pages/LabsEnvironment.tsx:164
 msgid "Available"
 msgstr "Available"
 
@@ -1204,7 +1204,7 @@ msgstr "Bilingual announcement banners for product-wide communication."
 msgid "Body (optional)"
 msgstr "Body (optional)"
 
-#: src/pages/LabsEnvironment.tsx:1270
+#: src/pages/LabsEnvironment.tsx:1283
 msgid "Bootstrap interval"
 msgstr "Bootstrap interval"
 
@@ -1269,11 +1269,11 @@ msgstr "Building toward <0>{0}</0> {distLabel}. Current {abbrev} <1>{currentStr}
 msgid "by"
 msgstr "by"
 
-#: src/pages/LabsEnvironment.tsx:788
+#: src/pages/LabsEnvironment.tsx:801
 msgid "Calculate proxy"
 msgstr "Calculate proxy"
 
-#: src/pages/LabsEnvironment.tsx:538
+#: src/pages/LabsEnvironment.tsx:551
 msgid "Calculator"
 msgstr "Calculator"
 
@@ -1300,7 +1300,7 @@ msgstr "Calculator"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/LabsEnvironment.tsx:285
+#: src/pages/LabsEnvironment.tsx:290
 msgid "Cancel and withdraw"
 msgstr "Cancel and withdraw"
 
@@ -1387,7 +1387,7 @@ msgstr "Changed what I'll do"
 msgid "Check your credentials in the connection step, then try again."
 msgstr "Check your credentials in the connection step, then try again."
 
-#: src/pages/LabsEnvironment.tsx:352
+#: src/pages/LabsEnvironment.tsx:357
 msgid "Checking data requirements"
 msgstr "Checking data requirements"
 
@@ -1515,7 +1515,7 @@ msgstr "Code"
 msgid "Code {0} created for {1}. Email not sent. Copy it or use the link."
 msgstr "Code {0} created for {1}. Email not sent. Copy it or use the link."
 
-#: src/pages/LabsEnvironment.tsx:762
+#: src/pages/LabsEnvironment.tsx:775
 msgid "Combine air temperature and relative humidity using the same Stull estimate as the experiment."
 msgstr "Combine air temperature and relative humidity using the same Stull estimate as the experiment."
 
@@ -1536,7 +1536,7 @@ msgstr "Committed / cap"
 msgid "Communications"
 msgstr "Communications"
 
-#: src/pages/LabsEnvironment.tsx:577
+#: src/pages/LabsEnvironment.tsx:590
 msgid "Comparable-power activity support"
 msgstr "Comparable-power activity support"
 
@@ -1585,7 +1585,7 @@ msgstr "Confirm one fenced replay. Praxys will refresh the provider calendar and
 msgid "Confirm replay"
 msgstr "Confirm replay"
 
-#: src/pages/LabsEnvironment.tsx:999
+#: src/pages/LabsEnvironment.tsx:1012
 msgid "Confirm that you are 18 or older to join this experiment."
 msgstr "Confirm that you are 18 or older to join this experiment."
 
@@ -1673,7 +1673,7 @@ msgstr "Connection funnel"
 #~ msgid "Connector-provided activity summary"
 #~ msgstr "Connector-provided activity summary"
 
-#: src/pages/LabsEnvironment.tsx:944
+#: src/pages/LabsEnvironment.tsx:957
 msgid "Consent text version"
 msgstr "Consent text version"
 
@@ -1707,7 +1707,7 @@ msgstr "Continue to Strava"
 msgid "Continuous"
 msgstr "Continuous"
 
-#: src/pages/LabsEnvironment.tsx:78
+#: src/pages/LabsEnvironment.tsx:83
 msgid "Continuous heart-rate samples are missing from too much of the eligible history."
 msgstr "Continuous heart-rate samples are missing from too much of the eligible history."
 
@@ -1719,11 +1719,11 @@ msgstr "Continuous Improvement"
 msgid "Continuous improvement configured"
 msgstr "Continuous improvement configured"
 
-#: src/pages/LabsEnvironment.tsx:1281
+#: src/pages/LabsEnvironment.tsx:1294
 msgid "Continuous Stryd sample power"
 msgstr "Continuous Stryd sample power"
 
-#: src/pages/LabsEnvironment.tsx:77
+#: src/pages/LabsEnvironment.tsx:82
 msgid "Continuous Stryd sample power is missing from too much of the eligible history."
 msgstr "Continuous Stryd sample power is missing from too much of the eligible history."
 
@@ -1773,8 +1773,8 @@ msgstr "Correct private context"
 msgid "Could not add this workout"
 msgstr "Could not add this workout"
 
-#: src/pages/LabsEnvironment.tsx:726
-#: src/pages/LabsEnvironment.tsx:734
+#: src/pages/LabsEnvironment.tsx:739
+#: src/pages/LabsEnvironment.tsx:747
 msgid "Could not calculate the wet-bulb proxy."
 msgstr "Could not calculate the wet-bulb proxy."
 
@@ -2324,7 +2324,7 @@ msgstr "Demo accounts"
 #~ msgid "Demo Accounts"
 #~ msgstr "Demo Accounts"
 
-#: src/pages/LabsEnvironment.tsx:928
+#: src/pages/LabsEnvironment.tsx:941
 msgid "Demo accounts are read-only and cannot join Labs."
 msgstr "Demo accounts are read-only and cannot join Labs."
 
@@ -2573,7 +2573,7 @@ msgstr "e.g. 5:45"
 msgid "e.g. 8:00:00"
 msgstr "e.g. 8:00:00"
 
-#: src/pages/LabsEnvironment.tsx:639
+#: src/pages/LabsEnvironment.tsx:652
 msgid "Each activity counts once per environmental range. The comparable-power range is centered on your typical eligible stable training workload; raw sample points alone do not count."
 msgstr "Each activity counts once per environmental range. The comparable-power range is centered on your typical eligible stable training workload; raw sample points alone do not count."
 
@@ -2657,7 +2657,7 @@ msgstr "Elev"
 #~ msgid "Elevated"
 #~ msgstr "Elevated"
 
-#: src/pages/LabsEnvironment.tsx:362
+#: src/pages/LabsEnvironment.tsx:367
 msgid "Eligibility check could not load"
 msgstr "Eligibility check could not load"
 
@@ -2665,7 +2665,7 @@ msgstr "Eligibility check could not load"
 msgid "Eligible"
 msgstr "Eligible"
 
-#: src/pages/LabsEnvironment.tsx:659
+#: src/pages/LabsEnvironment.tsx:672
 msgid "Eligible activities"
 msgstr "Eligible activities"
 
@@ -2743,15 +2743,15 @@ msgstr "Ends"
 msgid "Endurance"
 msgstr "Endurance"
 
-#: src/pages/LabsEnvironment.tsx:85
+#: src/pages/LabsEnvironment.tsx:90
 msgid "Enough activities exist overall, but the required environment, power, and heart-rate data do not overlap on enough of the same runs."
 msgstr "Enough activities exist overall, but the required environment, power, and heart-rate data do not overlap on enough of the same runs."
 
-#: src/pages/LabsEnvironment.tsx:394
+#: src/pages/LabsEnvironment.tsx:399
 msgid "Enough source data to attempt the experiment"
 msgstr "Enough source data to attempt the experiment"
 
-#: src/pages/LabsEnvironment.tsx:709
+#: src/pages/LabsEnvironment.tsx:722
 msgid "Enter numeric temperature and humidity values."
 msgstr "Enter numeric temperature and humidity values."
 
@@ -2761,7 +2761,7 @@ msgid "Environment"
 msgstr "Environment"
 
 #: src/pages/Labs.tsx:69
-#: src/pages/LabsEnvironment.tsx:1127
+#: src/pages/LabsEnvironment.tsx:1140
 msgid "Environmental response"
 msgstr "Environmental response"
 
@@ -2778,7 +2778,7 @@ msgstr "Equipment still available (optional)"
 msgid "Error"
 msgstr "Error"
 
-#: src/pages/LabsEnvironment.tsx:803
+#: src/pages/LabsEnvironment.tsx:816
 msgid "Estimated psychrometric wet-bulb proxy"
 msgstr "Estimated psychrometric wet-bulb proxy"
 
@@ -2910,7 +2910,7 @@ msgstr "Fading"
 
 #: src/pages/admin/AdminFeedback.tsx:98
 #: src/pages/admin/AdminFeedback.tsx:355
-#: src/pages/LabsEnvironment.tsx:161
+#: src/pages/LabsEnvironment.tsx:166
 msgid "Failed"
 msgstr "Failed"
 
@@ -3181,7 +3181,7 @@ msgstr "From activities"
 #~ msgid "From Stryd"
 #~ msgstr "From Stryd"
 
-#: src/pages/LabsEnvironment.tsx:393
+#: src/pages/LabsEnvironment.tsx:398
 msgid "Full analysis must confirm eligibility"
 msgstr "Full analysis must confirm eligibility"
 
@@ -3226,7 +3226,7 @@ msgstr "Garmin native running power reads ~30% higher than Stryd for the same at
 msgid "Garmin workout delivery is duration-only. Workouts with power, pace, or heart-rate targets will stay blocked rather than lose their intended intensity."
 msgstr "Garmin workout delivery is duration-only. Workouts with power, pace, or heart-rate targets will stay blocked rather than lose their intended intensity."
 
-#: src/pages/LabsEnvironment.tsx:88
+#: src/pages/LabsEnvironment.tsx:93
 msgid "Garmin wrist-power origin cannot yet be verified well enough for this experiment."
 msgstr "Garmin wrist-power origin cannot yet be verified well enough for this experiment."
 
@@ -3441,15 +3441,15 @@ msgstr "Hilly"
 msgid "Historical association only · personal aggregate result · continuous Stryd samples required"
 msgstr "Historical association only · personal aggregate result · continuous Stryd samples required"
 
-#: src/pages/LabsEnvironment.tsx:1176
+#: src/pages/LabsEnvironment.tsx:1189
 msgid "Historical association; not predictively validated"
 msgstr "Historical association; not predictively validated"
 
-#: src/pages/LabsEnvironment.tsx:468
+#: src/pages/LabsEnvironment.tsx:481
 msgid "Historical environmental-response curve"
 msgstr "Historical environmental-response curve"
 
-#: src/pages/LabsEnvironment.tsx:1262
+#: src/pages/LabsEnvironment.tsx:1275
 msgid "Historical slope"
 msgstr "Historical slope"
 
@@ -3457,7 +3457,7 @@ msgstr "Historical slope"
 msgid "Historical sync may take several minutes"
 msgstr "Historical sync may take several minutes"
 
-#: src/pages/LabsEnvironment.tsx:329
+#: src/pages/LabsEnvironment.tsx:334
 msgid "hour rolling window"
 msgstr "hour rolling window"
 
@@ -3493,7 +3493,7 @@ msgstr "How often Praxys pulls new data in the background. Lower frequency uses 
 msgid "How this is calculated"
 msgstr "How this is calculated"
 
-#: src/pages/LabsEnvironment.tsx:1289
+#: src/pages/LabsEnvironment.tsx:1302
 msgid "How to read this experiment"
 msgstr "How to read this experiment"
 
@@ -3593,7 +3593,7 @@ msgstr "HRV variability is high (CV {cv}%), above the selected coaching caution 
 #~ msgid "Human overrides"
 #~ msgstr "Human overrides"
 
-#: src/pages/LabsEnvironment.tsx:777
+#: src/pages/LabsEnvironment.tsx:790
 msgid "Humidity (%)"
 msgstr "Humidity (%)"
 
@@ -3601,11 +3601,11 @@ msgstr "Humidity (%)"
 msgid "I agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
 msgstr "I agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
 
-#: src/pages/LabsEnvironment.tsx:906
+#: src/pages/LabsEnvironment.tsx:919
 msgid "I confirm that I am 18 or older. Praxys records this attestation, not my birth date."
 msgstr "I confirm that I am 18 or older. Praxys records this attestation, not my birth date."
 
-#: src/pages/LabsEnvironment.tsx:909
+#: src/pages/LabsEnvironment.tsx:922
 msgid "I understand the purpose, limits, storage, and withdrawal terms above and choose to participate in this experiment."
 msgstr "I understand the purpose, limits, storage, and withdrawal terms above and choose to participate in this experiment."
 
@@ -3712,7 +3712,7 @@ msgstr "Insufficient evidence"
 #~ msgid "Insufficient HRV data for analysis"
 #~ msgstr "Insufficient HRV data for analysis"
 
-#: src/pages/LabsEnvironment.tsx:632
+#: src/pages/LabsEnvironment.tsx:645
 msgid "Insufficient support"
 msgstr "Insufficient support"
 
@@ -3801,7 +3801,7 @@ msgstr "Issue created"
 msgid "It stays in your private history until its purge date, but cannot influence a new assessment."
 msgstr "It stays in your private history until its purge date, but cannot influence a new assessment."
 
-#: src/pages/LabsEnvironment.tsx:924
+#: src/pages/LabsEnvironment.tsx:937
 msgid "Join and analyze my history"
 msgstr "Join and analyze my history"
 
@@ -3811,7 +3811,7 @@ msgstr "Join and analyze my history"
 msgid "Join the waitlist"
 msgstr "Join the waitlist"
 
-#: src/pages/LabsEnvironment.tsx:863
+#: src/pages/LabsEnvironment.tsx:876
 msgid "Join this personal experiment"
 msgstr "Join this personal experiment"
 
@@ -3852,7 +3852,7 @@ msgstr "Keep any optional movement easy and short"
 msgid "Keep future workouts on {targetLabel}"
 msgstr "Keep future workouts on {targetLabel}"
 
-#: src/pages/LabsEnvironment.tsx:1372
+#: src/pages/LabsEnvironment.tsx:1385
 msgid "Keep participating"
 msgstr "Keep participating"
 
@@ -3889,12 +3889,12 @@ msgstr "km/wk"
 msgid "Labs"
 msgstr "Labs"
 
-#: src/pages/LabsEnvironment.tsx:1357
+#: src/pages/LabsEnvironment.tsx:1370
 msgid "Labs action failed"
 msgstr "Labs action failed"
 
 #: src/pages/Labs.tsx:52
-#: src/pages/LabsEnvironment.tsx:1088
+#: src/pages/LabsEnvironment.tsx:1101
 msgid "Labs could not load"
 msgstr "Labs could not load"
 
@@ -4332,7 +4332,7 @@ msgstr "Manual and other-coach workouts remain external and will not be edited o
 msgid "Manual and other-coach workouts stay untouched. Delivery remains paused throughout."
 msgstr "Manual and other-coach workouts stay untouched. Delivery remains paused throughout."
 
-#: src/pages/LabsEnvironment.tsx:326
+#: src/pages/LabsEnvironment.tsx:331
 msgid "manual recomputes remaining"
 msgstr "manual recomputes remaining"
 
@@ -4403,11 +4403,11 @@ msgstr "min"
 msgid "Mini program"
 msgstr "Mini program"
 
-#: src/pages/LabsEnvironment.tsx:410
+#: src/pages/LabsEnvironment.tsx:415
 msgid "minimum"
 msgstr "minimum"
 
-#: src/pages/LabsEnvironment.tsx:588
+#: src/pages/LabsEnvironment.tsx:601
 msgid "minimum {referenceMinimum} per environmental range"
 msgstr "minimum {referenceMinimum} per environmental range"
 
@@ -4451,7 +4451,7 @@ msgstr "Mixed providers"
 msgid "Mode"
 msgstr "Mode"
 
-#: src/pages/LabsEnvironment.tsx:1284
+#: src/pages/LabsEnvironment.tsx:1297
 msgid "Model version"
 msgstr "Model version"
 
@@ -4566,7 +4566,7 @@ msgstr "Need help? {SUPPORT_EMAIL}"
 msgid "Needed {abbrev}"
 msgstr "Needed {abbrev}"
 
-#: src/pages/LabsEnvironment.tsx:631
+#: src/pages/LabsEnvironment.tsx:644
 msgid "Needs {missingReference} more"
 msgstr "Needs {missingReference} more"
 
@@ -4579,11 +4579,11 @@ msgstr "Needs attention"
 #~ msgid "Needs data"
 #~ msgstr "Needs data"
 
-#: src/pages/LabsEnvironment.tsx:162
+#: src/pages/LabsEnvironment.tsx:167
 msgid "Needs recompute"
 msgstr "Needs recompute"
 
-#: src/pages/LabsEnvironment.tsx:152
+#: src/pages/LabsEnvironment.tsx:157
 msgid "Needs retry"
 msgstr "Needs retry"
 
@@ -4641,7 +4641,7 @@ msgstr "Network error. Please email {SUPPORT_EMAIL} directly."
 msgid "Network error. Refresh the queue and try again."
 msgstr "Network error. Refresh the queue and try again."
 
-#: src/pages/LabsEnvironment.tsx:1077
+#: src/pages/LabsEnvironment.tsx:1090
 msgid "Network error. Try again."
 msgstr "Network error. Try again."
 
@@ -4754,7 +4754,7 @@ msgstr "No current classification"
 msgid "No current qualifying condition range yet"
 msgstr "No current qualifying condition range yet"
 
-#: src/pages/LabsEnvironment.tsx:1196
+#: src/pages/LabsEnvironment.tsx:1209
 msgid "No curve is available yet"
 msgstr "No curve is available yet"
 
@@ -5059,12 +5059,12 @@ msgstr "Not enough data yet for weekly load comparison"
 msgid "not enough load history"
 msgstr "not enough load history"
 
-#: src/pages/LabsEnvironment.tsx:391
+#: src/pages/LabsEnvironment.tsx:396
 msgid "Not enough suitable data to start yet"
 msgstr "Not enough suitable data to start yet"
 
-#: src/pages/LabsEnvironment.tsx:156
-#: src/pages/LabsEnvironment.tsx:1008
+#: src/pages/LabsEnvironment.tsx:161
+#: src/pages/LabsEnvironment.tsx:1021
 msgid "Not enrolled"
 msgstr "Not enrolled"
 
@@ -5119,7 +5119,7 @@ msgstr "Now open · Create your account"
 msgid "Observed"
 msgstr "Observed"
 
-#: src/pages/LabsEnvironment.tsx:667
+#: src/pages/LabsEnvironment.tsx:680
 msgid "Observed proxy range"
 msgstr "Observed proxy range"
 
@@ -5173,7 +5173,7 @@ msgstr "Off by default. The note may contain more private detail than the struct
 msgid "On"
 msgstr "On"
 
-#: src/pages/LabsEnvironment.tsx:1181
+#: src/pages/LabsEnvironment.tsx:1194
 msgid "One or more research diagnostics did not support predictive interpretation. Read the curve only as a pattern in eligible past runs."
 msgstr "One or more research diagnostics did not support predictive interpretation. Read the curve only as a pattern in eligible past runs."
 
@@ -5406,7 +5406,7 @@ msgstr "Partial service outage"
 msgid "Participating"
 msgstr "Participating"
 
-#: src/pages/LabsEnvironment.tsx:1175
+#: src/pages/LabsEnvironment.tsx:1188
 msgid "Passed research diagnostics; not a forecast"
 msgstr "Passed research diagnostics; not a forecast"
 
@@ -5468,7 +5468,7 @@ msgstr "Permanently remove your Praxys account, synced data, plans, settings, an
 msgid "Personal Access Token"
 msgstr "Personal Access Token"
 
-#: src/pages/LabsEnvironment.tsx:877
+#: src/pages/LabsEnvironment.tsx:890
 msgid "Personal only"
 msgstr "Personal only"
 
@@ -5607,7 +5607,7 @@ msgstr "Power floor (W)"
 msgid "Power metrics, Critical Power, training plans"
 msgstr "Power metrics, Critical Power, training plans"
 
-#: src/pages/LabsEnvironment.tsx:1280
+#: src/pages/LabsEnvironment.tsx:1293
 msgid "Power regime"
 msgstr "Power regime"
 
@@ -5663,7 +5663,7 @@ msgstr "Praxys becomes canonical for its own and explicitly adopted workouts."
 msgid "Praxys can analyze this schedule, but it will not create, replace, or remove target workouts."
 msgstr "Praxys can analyze this schedule, but it will not create, replace, or remove target workouts."
 
-#: src/pages/LabsEnvironment.tsx:354
+#: src/pages/LabsEnvironment.tsx:359
 msgid "Praxys checks the required environment, Stryd power, heart-rate, and Critical Power coverage before showing enrollment consent or starting analysis."
 msgstr "Praxys checks the required environment, Stryd power, heart-rate, and Critical Power coverage before showing enrollment consent or starting analysis."
 
@@ -5778,11 +5778,11 @@ msgstr "Praxys owns the plan; delivery is paused."
 #~ msgid "Praxys sends duration-only running workouts and verifies both the Garmin template and scheduled calendar instance."
 #~ msgstr "Praxys sends duration-only running workouts and verifies both the Garmin template and scheduled calendar instance."
 
-#: src/pages/LabsEnvironment.tsx:400
+#: src/pages/LabsEnvironment.tsx:405
 msgid "Praxys stopped before consent or long-running analysis. Sync or collect the missing data, then retry this check."
 msgstr "Praxys stopped before consent or long-running analysis. Sync or collect the missing data, then retry this check."
 
-#: src/pages/LabsEnvironment.tsx:885
+#: src/pages/LabsEnvironment.tsx:898
 msgid "Praxys stores curve points, uncertainty, counts, gates, versions, and timestamps—not routes, activity dates, raw samples, or per-activity research rows."
 msgstr "Praxys stores curve points, uncertainty, counts, gates, versions, and timestamps—not routes, activity dates, raw samples, or per-activity research rows."
 
@@ -5790,11 +5790,11 @@ msgstr "Praxys stores curve points, uncertainty, counts, gates, versions, and ti
 msgid "Praxys version"
 msgstr "Praxys version"
 
-#: src/pages/LabsEnvironment.tsx:865
+#: src/pages/LabsEnvironment.tsx:878
 msgid "Praxys will analyze eligible past runs to see whether modeled heart rate varied with temperature-and-humidity conditions at comparable recorded Stryd power."
 msgstr "Praxys will analyze eligible past runs to see whether modeled heart rate varied with temperature-and-humidity conditions at comparable recorded Stryd power."
 
-#: src/pages/LabsEnvironment.tsx:1367
+#: src/pages/LabsEnvironment.tsx:1380
 msgid "Praxys will immediately delete your Labs consent and derived aggregate result. Your underlying account activities are not deleted."
 msgstr "Praxys will immediately delete your Labs consent and derived aggregate result. Your underlying account activities are not deleted."
 
@@ -5806,7 +5806,7 @@ msgstr "Praxys will preserve the reason as unknown. This never counts against yo
 msgid "Praxys will stop changing the target calendar. Your canonical Praxys plan remains available for analysis."
 msgstr "Praxys will stop changing the target calendar. Your canonical Praxys plan remains available for analysis."
 
-#: src/pages/LabsEnvironment.tsx:1294
+#: src/pages/LabsEnvironment.tsx:1307
 msgid "Praxys workload-support review"
 msgstr "Praxys workload-support review"
 
@@ -5911,8 +5911,8 @@ msgstr "Private note (optional)"
 msgid "Proceed but monitor heart-rate drift during the session"
 msgstr "Proceed but monitor heart-rate drift during the session"
 
-#: src/pages/LabsEnvironment.tsx:147
-#: src/pages/LabsEnvironment.tsx:158
+#: src/pages/LabsEnvironment.tsx:152
+#: src/pages/LabsEnvironment.tsx:163
 msgid "Processing"
 msgstr "Processing"
 
@@ -6058,12 +6058,12 @@ msgstr "Qualifying exposure has resumed after a longer gap, but current evidence
 
 #: src/components/UpcomingPlanCard.tsx:499
 #: src/components/UpcomingPlanCard.tsx:519
-#: src/pages/LabsEnvironment.tsx:146
-#: src/pages/LabsEnvironment.tsx:157
+#: src/pages/LabsEnvironment.tsx:151
+#: src/pages/LabsEnvironment.tsx:162
 msgid "Queued"
 msgstr "Queued"
 
-#: src/pages/LabsEnvironment.tsx:262
+#: src/pages/LabsEnvironment.tsx:267
 msgid "Queued for the analysis worker"
 msgstr "Queued for the analysis worker"
 
@@ -6181,7 +6181,7 @@ msgstr "Reads readiness from the body's signals."
 msgid "Realistic alternative targets"
 msgstr "Realistic alternative targets"
 
-#: src/pages/LabsEnvironment.tsx:90
+#: src/pages/LabsEnvironment.tsx:95
 msgid "Reasonable model variations do not preserve the same historical relationship."
 msgstr "Reasonable model variations do not preserve the same historical relationship."
 
@@ -6335,28 +6335,28 @@ msgstr "Recommended"
 msgid "Recommended. Delivered workouts stay on the calendar; Praxys simply stops managing them."
 msgstr "Recommended. Delivered workouts stay on the calendar; Praxys simply stops managing them."
 
-#: src/pages/LabsEnvironment.tsx:1223
+#: src/pages/LabsEnvironment.tsx:1236
 msgid "Recompute"
 msgstr "Recompute"
 
-#: src/pages/LabsEnvironment.tsx:304
-#: src/pages/LabsEnvironment.tsx:316
+#: src/pages/LabsEnvironment.tsx:309
+#: src/pages/LabsEnvironment.tsx:321
 msgid "Recompute available again"
 msgstr "Recompute available again"
 
-#: src/pages/LabsEnvironment.tsx:301
+#: src/pages/LabsEnvironment.tsx:306
 msgid "Recompute cooling down"
 msgstr "Recompute cooling down"
 
-#: src/pages/LabsEnvironment.tsx:990
+#: src/pages/LabsEnvironment.tsx:1003
 msgid "Recompute is cooling down. Try again after {availableAt}."
 msgstr "Recompute is cooling down. Try again after {availableAt}."
 
-#: src/pages/LabsEnvironment.tsx:991
+#: src/pages/LabsEnvironment.tsx:1004
 msgid "Recompute is cooling down. Try again later."
 msgstr "Recompute is cooling down. Try again later."
 
-#: src/pages/LabsEnvironment.tsx:1342
+#: src/pages/LabsEnvironment.tsx:1355
 msgid "Recompute result"
 msgstr "Recompute result"
 
@@ -6588,23 +6588,23 @@ msgstr "Reject"
 msgid "Rejected"
 msgstr "Rejected"
 
-#: src/pages/LabsEnvironment.tsx:80
+#: src/pages/LabsEnvironment.tsx:85
 msgid "Relative humidity is missing from too many otherwise eligible activities."
 msgstr "Relative humidity is missing from too many otherwise eligible activities."
 
-#: src/pages/LabsEnvironment.tsx:1246
+#: src/pages/LabsEnvironment.tsx:1259
 msgid "Relative modeled heart rate across your observed wet-bulb-proxy range, holding the fitted comparison at a common recorded-power reference."
 msgstr "Relative modeled heart rate across your observed wet-bulb-proxy range, holding the fitted comparison at a common recorded-power reference."
 
-#: src/pages/LabsEnvironment.tsx:1245
+#: src/pages/LabsEnvironment.tsx:1258
 msgid "Relative modeled heart rate is shown only in ranges with enough comparable-power evidence. Unsupported ranges remain blank and are never connected."
 msgstr "Relative modeled heart rate is shown only in ranges with enough comparable-power evidence. Unsupported ranges remain blank and are never connected."
 
-#: src/pages/LabsEnvironment.tsx:510
+#: src/pages/LabsEnvironment.tsx:523
 msgid "Relative modeled HR"
 msgstr "Relative modeled HR"
 
-#: src/pages/LabsEnvironment.tsx:491
+#: src/pages/LabsEnvironment.tsx:504
 msgid "Relative modeled HR (bpm)"
 msgstr "Relative modeled HR (bpm)"
 
@@ -6684,7 +6684,7 @@ msgstr "Request and availability telemetry is unavailable."
 msgid "Request expires"
 msgstr "Request expires"
 
-#: src/pages/LabsEnvironment.tsx:1051
+#: src/pages/LabsEnvironment.tsx:1064
 msgid "Request failed. Try again."
 msgstr "Request failed. Try again."
 
@@ -6794,8 +6794,8 @@ msgstr "Resume managed delivery?"
 #: src/pages/Goal.tsx:444
 #: src/pages/History.tsx:53
 #: src/pages/Labs.tsx:56
-#: src/pages/LabsEnvironment.tsx:372
-#: src/pages/LabsEnvironment.tsx:1092
+#: src/pages/LabsEnvironment.tsx:377
+#: src/pages/LabsEnvironment.tsx:1105
 #: src/pages/McpAuthorization.tsx:202
 #: src/pages/Settings.tsx:335
 #: src/pages/Today.tsx:352
@@ -6804,7 +6804,7 @@ msgstr "Resume managed delivery?"
 msgid "Retry"
 msgstr "Retry"
 
-#: src/pages/LabsEnvironment.tsx:364
+#: src/pages/LabsEnvironment.tsx:369
 msgid "Retry before joining. The full analysis has not started."
 msgstr "Retry before joining. The full analysis has not started."
 
@@ -6851,7 +6851,7 @@ msgstr "Retry to load the public status incidents feed."
 msgid "Retry workout action"
 msgstr "Retry workout action"
 
-#: src/pages/LabsEnvironment.tsx:145
+#: src/pages/LabsEnvironment.tsx:150
 msgid "Retrying"
 msgstr "Retrying"
 
@@ -6962,7 +6962,7 @@ msgstr "Role"
 msgid "Rolling 1 / 7 / 30 days"
 msgstr "Rolling 1 / 7 / 30 days"
 
-#: src/pages/LabsEnvironment.tsx:313
+#: src/pages/LabsEnvironment.tsx:318
 msgid "Rolling recompute limit reached"
 msgstr "Rolling recompute limit reached"
 
@@ -7431,7 +7431,7 @@ msgstr "Snapshot {0}"
 msgid "Some adaptation may persist"
 msgstr "Some adaptation may persist"
 
-#: src/pages/LabsEnvironment.tsx:75
+#: src/pages/LabsEnvironment.tsx:80
 msgid "Some parts of the environmental range do not have enough independent activity support."
 msgstr "Some parts of the environmental range do not have enough independent activity support."
 
@@ -7469,7 +7469,7 @@ msgstr "stable"
 msgid "Stable"
 msgstr "Stable"
 
-#: src/pages/LabsEnvironment.tsx:663
+#: src/pages/LabsEnvironment.tsx:676
 msgid "Stable segments"
 msgstr "Stable segments"
 
@@ -7570,7 +7570,7 @@ msgstr "Structured fields sent"
 #~ msgid "Stryd-provided activity weather"
 #~ msgstr "Stryd-provided activity weather"
 
-#: src/pages/LabsEnvironment.tsx:480
+#: src/pages/LabsEnvironment.tsx:493
 msgid "Stull psychrometric wet-bulb proxy (°C)"
 msgstr "Stull psychrometric wet-bulb proxy (°C)"
 
@@ -7615,11 +7615,11 @@ msgstr "Summary window"
 msgid "Sun"
 msgstr "Sun"
 
-#: src/pages/LabsEnvironment.tsx:1204
+#: src/pages/LabsEnvironment.tsx:1217
 msgid "Support ID"
 msgstr "Support ID"
 
-#: src/pages/LabsEnvironment.tsx:629
+#: src/pages/LabsEnvironment.tsx:642
 msgid "Supported"
 msgstr "Supported"
 
@@ -7834,11 +7834,11 @@ msgstr "Target Time"
 #~ msgid "Telemetry trust boundary"
 #~ msgstr "Telemetry trust boundary"
 
-#: src/pages/LabsEnvironment.tsx:768
+#: src/pages/LabsEnvironment.tsx:781
 msgid "Temperature (°C)"
 msgstr "Temperature (°C)"
 
-#: src/pages/LabsEnvironment.tsx:81
+#: src/pages/LabsEnvironment.tsx:86
 msgid "Temperature and humidity are not both present on enough of the same activities."
 msgstr "Temperature and humidity are not both present on enough of the same activities."
 
@@ -7846,7 +7846,7 @@ msgstr "Temperature and humidity are not both present on enough of the same acti
 #~ msgid "Temperature and humidity were not provided by your synced activities."
 #~ msgstr "Temperature and humidity were not provided by your synced activities."
 
-#: src/pages/LabsEnvironment.tsx:79
+#: src/pages/LabsEnvironment.tsx:84
 msgid "Temperature is missing from too many otherwise eligible activities."
 msgstr "Temperature is missing from too many otherwise eligible activities."
 
@@ -7865,7 +7865,7 @@ msgstr "Temporary availability"
 msgid "Temporary context can stay active for at most 90 days."
 msgstr "Temporary context can stay active for at most 90 days."
 
-#: src/pages/LabsEnvironment.tsx:258
+#: src/pages/LabsEnvironment.tsx:263
 msgid "Temporary service issue; retry queued"
 msgstr "Temporary service issue; retry queued"
 
@@ -7889,7 +7889,7 @@ msgstr "That date is now completed history and can no longer be changed."
 msgid "That is a complete state, not missing data. Praxys keeps the reason unknown and does not reduce your standing or invent an explanation."
 msgstr "That is a complete state, not missing data. Praxys keeps the reason unknown and does not reduce your standing or invent an explanation."
 
-#: src/pages/LabsEnvironment.tsx:940
+#: src/pages/LabsEnvironment.tsx:953
 msgid "The accepted Praxys evidence review found controlled support for heat-related cardiovascular drift, but no field study validating a causal or predictive personal Stull wet-bulb response curve. V1 is therefore descriptive and Stryd-only."
 msgstr "The accepted Praxys evidence review found controlled support for heat-related cardiovascular drift, but no field study validating a causal or predictive personal Stull wet-bulb response curve. V1 is therefore descriptive and Stryd-only."
 
@@ -7905,23 +7905,23 @@ msgstr "The agent decision and outcome aggregate could not be refreshed."
 msgid "The alert summary could not be refreshed."
 msgstr "The alert summary could not be refreshed."
 
-#: src/pages/LabsEnvironment.tsx:1195
+#: src/pages/LabsEnvironment.tsx:1208
 msgid "The analysis did not finish"
 msgstr "The analysis did not finish"
 
-#: src/pages/LabsEnvironment.tsx:94
+#: src/pages/LabsEnvironment.tsx:99
 msgid "The analysis did not finish successfully."
 msgstr "The analysis did not finish successfully."
 
-#: src/pages/LabsEnvironment.tsx:93
+#: src/pages/LabsEnvironment.tsx:98
 msgid "The analysis worker could not complete the model after repeated infrastructure attempts."
 msgstr "The analysis worker could not complete the model after repeated infrastructure attempts."
 
-#: src/pages/LabsEnvironment.tsx:83
+#: src/pages/LabsEnvironment.tsx:88
 msgid "The available Critical Power does not match the eligible Stryd power regime."
 msgstr "The available Critical Power does not match the eligible Stryd power regime."
 
-#: src/pages/LabsEnvironment.tsx:68
+#: src/pages/LabsEnvironment.tsx:73
 msgid "The available history could not be analyzed as one complete snapshot."
 msgstr "The available history could not be analyzed as one complete snapshot."
 
@@ -7937,27 +7937,27 @@ msgstr "The bounded operator queue is available, but aggregate delivery health c
 msgid "The canonical Praxys plan is preserved. Existing target workouts stay in place until you resume or leave."
 msgstr "The canonical Praxys plan is preserved. Existing target workouts stay in place until you resume or leave."
 
-#: src/pages/LabsEnvironment.tsx:1180
+#: src/pages/LabsEnvironment.tsx:1193
 msgid "The chronological holdout and sensitivity checks passed, but this personal historical association is still not a clinical claim or future-condition forecast."
 msgstr "The chronological holdout and sensitivity checks passed, but this personal historical association is still not a clinical claim or future-condition forecast."
 
-#: src/pages/LabsEnvironment.tsx:92
+#: src/pages/LabsEnvironment.tsx:97
 msgid "The chronological prediction check could not be evaluated, so Praxys withholds the fitted curve."
 msgstr "The chronological prediction check could not be evaluated, so Praxys withholds the fitted curve."
 
-#: src/pages/LabsEnvironment.tsx:1005
+#: src/pages/LabsEnvironment.tsx:1018
 msgid "The consent text changed. Review and confirm the current version."
 msgstr "The consent text changed. Review and confirm the current version."
 
-#: src/pages/LabsEnvironment.tsx:84
+#: src/pages/LabsEnvironment.tsx:89
 msgid "The continuous sample coverage is too sparse for a stable comparison."
 msgstr "The continuous sample coverage is too sparse for a stable comparison."
 
-#: src/pages/LabsEnvironment.tsx:308
+#: src/pages/LabsEnvironment.tsx:313
 msgid "The cooldown prevents accidental repeat analysis."
 msgstr "The cooldown prevents accidental repeat analysis."
 
-#: src/pages/LabsEnvironment.tsx:86
+#: src/pages/LabsEnvironment.tsx:91
 msgid "The eligible history crosses incompatible power-device or algorithm regimes."
 msgstr "The eligible history crosses incompatible power-device or algorithm regimes."
 
@@ -7973,7 +7973,7 @@ msgstr "The end date must be after the start date."
 #~ msgid "The environmental ramps, effective minutes, stage thresholds, and 7–28 day decay window are Praxys operational estimates. Evidence coverage is not biological certainty. Stop and begin cooling for heat-illness symptoms; seek urgent medical help for confusion, collapse, or altered mental status."
 #~ msgstr "The environmental ramps, effective minutes, stage thresholds, and 7–28 day decay window are Praxys operational estimates. Evidence coverage is not biological certainty. Stop and begin cooling for heat-illness symptoms; seek urgent medical help for confusion, collapse, or altered mental status."
 
-#: src/pages/LabsEnvironment.tsx:89
+#: src/pages/LabsEnvironment.tsx:94
 msgid "The estimated direction changes too much when activities are resampled."
 msgstr "The estimated direction changes too much when activities are resampled."
 
@@ -7985,7 +7985,7 @@ msgstr "The feedback aggregate could not be refreshed."
 msgid "The incident aggregate could not be refreshed."
 msgstr "The incident aggregate could not be refreshed."
 
-#: src/pages/LabsEnvironment.tsx:269
+#: src/pages/LabsEnvironment.tsx:274
 msgid "The isolated worker is building the aggregate response from your eligible activity data."
 msgstr "The isolated worker is building the aggregate response from your eligible activity data."
 
@@ -8009,7 +8009,7 @@ msgstr "The latest HRV reading is out of date. Follow the plan without an HRV-ba
 msgid "The latest HRV reading is too old for a same-day recovery classification. Sync your device to refresh it."
 msgstr "The latest HRV reading is too old for a same-day recovery classification. Sync your device to refresh it."
 
-#: src/pages/LabsEnvironment.tsx:1300
+#: src/pages/LabsEnvironment.tsx:1313
 msgid "The line is a historical model inside supported ranges only. A blank range means comparable stable workload did not pass the display floor; Praxys does not estimate or connect through it. The shaded band shows aggregate uncertainty where the curve is supported. It does not identify a causal personal coefficient and never extrapolates beyond your observed domain. Wind, solar load, clothing, hydration, fatigue, and other unmeasured conditions can still differ between runs."
 msgstr "The line is a historical model inside supported ranges only. A blank range means comparable stable workload did not pass the display floor; Praxys does not estimate or connect through it. The shaded band shows aggregate uncertainty where the curve is supported. It does not identify a causal personal coefficient and never extrapolates beyond your observed domain. Wind, solar load, clothing, hydration, fatigue, and other unmeasured conditions can still differ between runs."
 
@@ -8050,8 +8050,8 @@ msgstr "The previous workout was restored"
 msgid "The public status feed has no unresolved incidents."
 msgstr "The public status feed has no unresolved incidents."
 
-#: src/pages/LabsEnvironment.tsx:382
-#: src/pages/LabsEnvironment.tsx:1002
+#: src/pages/LabsEnvironment.tsx:387
+#: src/pages/LabsEnvironment.tsx:1015
 msgid "The quick check found a data requirement that needs attention."
 msgstr "The quick check found a data requirement that needs attention."
 
@@ -8068,19 +8068,19 @@ msgstr "The rolling 14-day window is delivered to {0}."
 msgid "The rolling exposure threshold is still met, but it does not establish a retention plateau; response-specific adaptations may already be declining."
 msgstr "The rolling exposure threshold is still met, but it does not establish a retention plateau; response-specific adaptations may already be declining."
 
-#: src/pages/LabsEnvironment.tsx:320
+#: src/pages/LabsEnvironment.tsx:325
 msgid "The rolling limit protects the shared analysis capacity from repeated requests."
 msgstr "The rolling limit protects the shared analysis capacity from repeated requests."
 
-#: src/pages/LabsEnvironment.tsx:995
+#: src/pages/LabsEnvironment.tsx:1008
 msgid "The rolling recompute limit has been reached. Try again after {availableAt}."
 msgstr "The rolling recompute limit has been reached. Try again after {availableAt}."
 
-#: src/pages/LabsEnvironment.tsx:996
+#: src/pages/LabsEnvironment.tsx:1009
 msgid "The rolling recompute limit has been reached. Try again later."
 msgstr "The rolling recompute limit has been reached. Try again later."
 
-#: src/pages/LabsEnvironment.tsx:76
+#: src/pages/LabsEnvironment.tsx:81
 msgid "The same comparable-power range is not represented across enough environmental conditions."
 msgstr "The same comparable-power range is not represented across enough environmental conditions."
 
@@ -8108,15 +8108,15 @@ msgstr "The weekly history will appear after the data service update completes."
 msgid "Theme"
 msgstr "Theme"
 
-#: src/pages/LabsEnvironment.tsx:71
+#: src/pages/LabsEnvironment.tsx:76
 msgid "There are not enough eligible Stryd activities yet."
 msgstr "There are not enough eligible Stryd activities yet."
 
-#: src/pages/LabsEnvironment.tsx:72
+#: src/pages/LabsEnvironment.tsx:77
 msgid "There are not enough stable, comparable segments yet."
 msgstr "There are not enough stable, comparable segments yet."
 
-#: src/pages/LabsEnvironment.tsx:74
+#: src/pages/LabsEnvironment.tsx:79
 msgid "There is not enough chronological history to evaluate whether the relationship holds later."
 msgstr "There is not enough chronological history to evaluate whether the relationship holds later."
 
@@ -8132,7 +8132,7 @@ msgstr "This cannot be undone. If this is the last admin account, deletion will 
 msgid "This change used confirmed private context. The private detail is not copied into the plan record."
 msgstr "This change used confirmed private context. The private detail is not copied into the plan record."
 
-#: src/pages/LabsEnvironment.tsx:799
+#: src/pages/LabsEnvironment.tsx:812
 msgid "This combination is outside Praxys’s conservative Stull method domain."
 msgstr "This combination is outside Praxys’s conservative Stull method domain."
 
@@ -8161,11 +8161,11 @@ msgstr "This enters the safety path and stops ordinary performance optimization.
 msgid "This evaluates past training only; it does not assess today's weather or conditions."
 msgstr "This evaluates past training only; it does not assess today's weather or conditions."
 
-#: src/pages/LabsEnvironment.tsx:822
+#: src/pages/LabsEnvironment.tsx:835
 msgid "This falls in an unsupported historical range, so it is not marked on the curve."
 msgstr "This falls in an unsupported historical range, so it is not marked on the curve."
 
-#: src/pages/LabsEnvironment.tsx:87
+#: src/pages/LabsEnvironment.tsx:92
 msgid "This first experiment currently supports continuous Stryd power only."
 msgstr "This first experiment currently supports continuous Stryd power only."
 
@@ -8185,11 +8185,11 @@ msgstr "This guardrail uses individualized HRV guidance and never loads activity
 msgid "This insight changed. Refresh the page before sending feedback."
 msgstr "This insight changed. Refresh the page before sending feedback."
 
-#: src/pages/LabsEnvironment.tsx:899
+#: src/pages/LabsEnvironment.tsx:912
 msgid "This is a retrospective historical association. It does not forecast a future run, prove that heat caused a heart-rate change, prescribe pace, measure adaptation or hydration, or assess heat safety."
 msgstr "This is a retrospective historical association. It does not forecast a future run, prove that heat caused a heart-rate change, prescribe pace, measure adaptation or hydration, or assess heat safety."
 
-#: src/pages/LabsEnvironment.tsx:817
+#: src/pages/LabsEnvironment.tsx:830
 msgid "This is above your displayed historical range, so the curve does not extrapolate to it."
 msgstr "This is above your displayed historical range, so the curve does not extrapolate to it."
 
@@ -8197,7 +8197,7 @@ msgstr "This is above your displayed historical range, so the curve does not ext
 msgid "This is an inference from training evidence in similar conditions, not a direct physiological measurement."
 msgstr "This is an inference from training evidence in similar conditions, not a direct physiological measurement."
 
-#: src/pages/LabsEnvironment.tsx:812
+#: src/pages/LabsEnvironment.tsx:825
 msgid "This is below your displayed historical range, so the curve does not extrapolate to it."
 msgstr "This is below your displayed historical range, so the curve does not extrapolate to it."
 
@@ -8205,7 +8205,7 @@ msgstr "This is below your displayed historical range, so the curve does not ext
 msgid "This is not medical clearance or a personal heat-tolerance assessment."
 msgstr "This is not medical clearance or a personal heat-tolerance assessment."
 
-#: src/pages/LabsEnvironment.tsx:831
+#: src/pages/LabsEnvironment.tsx:844
 msgid "This is Stull’s psychrometric estimate from air temperature and relative humidity. It is not apparent temperature, natural wet bulb, outdoor WBGT, body temperature, or a heat-safety assessment."
 msgstr "This is Stull’s psychrometric estimate from air temperature and relative humidity. It is not apparent temperature, natural wet bulb, outdoor WBGT, body temperature, or a heat-safety assessment."
 
@@ -8238,7 +8238,7 @@ msgstr "This permission is separate from managed delivery. Review the exact boun
 msgid "This queue item no longer exists. Refresh the queue."
 msgstr "This queue item no longer exists. Refresh the queue."
 
-#: src/pages/LabsEnvironment.tsx:401
+#: src/pages/LabsEnvironment.tsx:406
 msgid "This quick check only covers definite prerequisites. The full analysis can still return insufficient support, an unstable association, or no conclusion."
 msgstr "This quick check only covers definite prerequisites. The full analysis can still return insufficient support, an unstable association, or no conclusion."
 
@@ -8246,11 +8246,11 @@ msgstr "This quick check only covers definite prerequisites. The full analysis c
 msgid "This removes the Praxys workout from the canonical plan. Any external workout stays untouched."
 msgstr "This removes the Praxys workout from the canonical plan. Any external workout stays untouched."
 
-#: src/pages/LabsEnvironment.tsx:978
+#: src/pages/LabsEnvironment.tsx:991
 msgid "This result did not pass the experiment’s release guardrails."
 msgstr "This result did not pass the experiment’s release guardrails."
 
-#: src/pages/LabsEnvironment.tsx:70
+#: src/pages/LabsEnvironment.tsx:75
 msgid "This result uses an earlier experiment model and needs to be run again."
 msgstr "This result uses an earlier experiment model and needs to be run again."
 
@@ -8265,7 +8265,7 @@ msgstr "This result uses an earlier experiment model and needs to be run again."
 msgid "This section is unavailable. Other management workflows remain available."
 msgstr "This section is unavailable. Other management workflows remain available."
 
-#: src/pages/LabsEnvironment.tsx:807
+#: src/pages/LabsEnvironment.tsx:820
 msgid "This sits inside your displayed historical range and is marked on the curve."
 msgstr "This sits inside your displayed historical range and is marked on the curve."
 
@@ -8561,7 +8561,7 @@ msgstr "Unable to reach the status service"
 #: src/pages/admin/AdminFeedback.tsx:466
 #: src/pages/admin/AdminFeedback.tsx:493
 #: src/pages/admin/AdminOps.tsx:191
-#: src/pages/LabsEnvironment.tsx:160
+#: src/pages/LabsEnvironment.tsx:165
 msgid "Unavailable"
 msgstr "Unavailable"
 
@@ -8795,7 +8795,7 @@ msgstr "VO2max, CP, LTHR, training status"
 msgid "Volume"
 msgstr "Volume"
 
-#: src/pages/LabsEnvironment.tsx:1129
+#: src/pages/LabsEnvironment.tsx:1142
 msgid "Voluntary experiments that help you inspect your own training history without turning early research into advice."
 msgstr "Voluntary experiments that help you inspect your own training history without turning early research into advice."
 
@@ -8929,11 +8929,11 @@ msgstr "Welcome back."
 #~ msgid "Wet-bulb estimate unavailable"
 #~ msgstr "Wet-bulb estimate unavailable"
 
-#: src/pages/LabsEnvironment.tsx:504
+#: src/pages/LabsEnvironment.tsx:517
 msgid "wet-bulb proxy"
 msgstr "wet-bulb proxy"
 
-#: src/pages/LabsEnvironment.tsx:760
+#: src/pages/LabsEnvironment.tsx:773
 msgid "Wet-bulb proxy calculator"
 msgstr "Wet-bulb proxy calculator"
 
@@ -8961,7 +8961,7 @@ msgstr "What happened, or what would you like to see?"
 msgid "What happened?"
 msgstr "What happened?"
 
-#: src/pages/LabsEnvironment.tsx:897
+#: src/pages/LabsEnvironment.tsx:910
 msgid "What this can—and cannot—tell you"
 msgstr "What this can—and cannot—tell you"
 
@@ -8985,7 +8985,7 @@ msgstr "What's your training goal? (optional)"
 msgid "Why this is conservative"
 msgstr "Why this is conservative"
 
-#: src/pages/LabsEnvironment.tsx:935
+#: src/pages/LabsEnvironment.tsx:948
 msgid "Why this remains experimental"
 msgstr "Why this remains experimental"
 
@@ -8993,7 +8993,7 @@ msgstr "Why this remains experimental"
 msgid "Will sync:"
 msgstr "Will sync:"
 
-#: src/pages/LabsEnvironment.tsx:1226
+#: src/pages/LabsEnvironment.tsx:1239
 msgid "Withdraw"
 msgstr "Withdraw"
 
@@ -9001,27 +9001,27 @@ msgstr "Withdraw"
 msgid "Withdraw AI permission"
 msgstr "Withdraw AI permission"
 
-#: src/pages/LabsEnvironment.tsx:1382
+#: src/pages/LabsEnvironment.tsx:1395
 msgid "Withdraw and delete"
 msgstr "Withdraw and delete"
 
-#: src/pages/LabsEnvironment.tsx:1347
+#: src/pages/LabsEnvironment.tsx:1360
 msgid "Withdraw and delete result"
 msgstr "Withdraw and delete result"
 
-#: src/pages/LabsEnvironment.tsx:889
+#: src/pages/LabsEnvironment.tsx:902
 msgid "Withdraw anytime"
 msgstr "Withdraw anytime"
 
-#: src/pages/LabsEnvironment.tsx:1365
+#: src/pages/LabsEnvironment.tsx:1378
 msgid "Withdraw from this experiment?"
 msgstr "Withdraw from this experiment?"
 
-#: src/pages/LabsEnvironment.tsx:1321
+#: src/pages/LabsEnvironment.tsx:1334
 msgid "Withdrawal deletes the experiment consent and aggregate result. Rejoining later requires new consent and a new computation."
 msgstr "Withdrawal deletes the experiment consent and aggregate result. Rejoining later requires new consent and a new computation."
 
-#: src/pages/LabsEnvironment.tsx:891
+#: src/pages/LabsEnvironment.tsx:904
 msgid "Withdrawal immediately deletes experiment consent and the derived result. Your ordinary account activities remain unchanged."
 msgstr "Withdrawal immediately deletes experiment consent and the derived result. Your ordinary account activities remain unchanged."
 
@@ -9093,7 +9093,7 @@ msgstr "you"
 msgid "You can attach up to 3 images."
 msgstr "You can attach up to 3 images."
 
-#: src/pages/LabsEnvironment.tsx:275
+#: src/pages/LabsEnvironment.tsx:280
 msgid "You can leave this page and return later. No action is needed while the analysis runs."
 msgstr "You can leave this page and return later. No action is needed while the analysis runs."
 
@@ -9101,7 +9101,7 @@ msgstr "You can leave this page and return later. No action is needed while the 
 msgid "You can withdraw before any later request. Withdrawal cannot recall a request the provider already processed. Deleting the item removes local provider-use receipts and dependent private explanations."
 msgstr "You can withdraw before any later request. Withdrawal cannot recall a request the provider already processed. Deleting the item removes local provider-use receipts and dependent private explanations."
 
-#: src/pages/LabsEnvironment.tsx:1319
+#: src/pages/LabsEnvironment.tsx:1332
 msgid "You control this experiment"
 msgstr "You control this experiment"
 
@@ -9123,11 +9123,11 @@ msgstr "you@example.com"
 msgid "Your account is active. You can now sign in."
 msgstr "Your account is active. You can now sign in."
 
-#: src/pages/LabsEnvironment.tsx:676
+#: src/pages/LabsEnvironment.tsx:689
 msgid "Your comparable power range"
 msgstr "Your comparable power range"
 
-#: src/pages/LabsEnvironment.tsx:581
+#: src/pages/LabsEnvironment.tsx:594
 msgid "Your comparable range"
 msgstr "Your comparable range"
 
@@ -9139,7 +9139,7 @@ msgstr "Your data export is downloading."
 #~ msgid "Your descriptive stability checks passed, but the chronological test did not show better future-run prediction. Read the curve only as a pattern in eligible past runs."
 #~ msgstr "Your descriptive stability checks passed, but the chronological test did not show better future-run prediction. Read the curve only as a pattern in eligible past runs."
 
-#: src/pages/LabsEnvironment.tsx:73
+#: src/pages/LabsEnvironment.tsx:78
 msgid "Your eligible runs do not cover enough different temperature-and-humidity conditions."
 msgstr "Your eligible runs do not cover enough different temperature-and-humidity conditions."
 
@@ -9156,11 +9156,11 @@ msgstr "Your external planner remains in control."
 msgid "Your Garmin account has multi-factor authentication enabled. Enter the verification code Garmin sent you to finish connecting."
 msgstr "Your Garmin account has multi-factor authentication enabled. Enter the verification code Garmin sent you to finish connecting."
 
-#: src/pages/LabsEnvironment.tsx:1241
+#: src/pages/LabsEnvironment.tsx:1254
 msgid "Your historical environmental-response curve"
 msgstr "Your historical environmental-response curve"
 
-#: src/pages/LabsEnvironment.tsx:95
+#: src/pages/LabsEnvironment.tsx:100
 msgid "Your history includes enough broad sample coverage, but the full analysis must confirm that power, heart rate, and Critical Power use one compatible Stryd regime."
 msgstr "Your history includes enough broad sample coverage, but the full analysis must confirm that power, heart rate, and Critical Power use one compatible Stryd regime."
 
@@ -9172,11 +9172,11 @@ msgstr "Your identity in Praxys"
 msgid "Your name"
 msgstr "Your name"
 
-#: src/pages/LabsEnvironment.tsx:1240
+#: src/pages/LabsEnvironment.tsx:1253
 msgid "Your partial historical environmental-response curve"
 msgstr "Your partial historical environmental-response curve"
 
-#: src/pages/LabsEnvironment.tsx:1303
+#: src/pages/LabsEnvironment.tsx:1316
 msgid "Your personal comparable-power range controls where the curve can be displayed. The fitted model still uses every otherwise eligible stable segment from 65–95% CP, so the display range does not discard broader model data."
 msgstr "Your personal comparable-power range controls where the curve can be displayed. The fitted model still uses every otherwise eligible stable segment from 65–95% CP, so the display range does not discard broader model data."
 
@@ -9194,19 +9194,19 @@ msgstr "Your Praxys invitation code: {0}\n"
 "\n"
 "Finish registering here: {1}"
 
-#: src/pages/LabsEnvironment.tsx:271
+#: src/pages/LabsEnvironment.tsx:276
 msgid "Your request is stored durably and will run separately from the app."
 msgstr "Your request is stored durably and will run separately from the app."
 
-#: src/pages/LabsEnvironment.tsx:879
+#: src/pages/LabsEnvironment.tsx:892
 msgid "Your result is not pooled with other users and is not donated to cohort research."
 msgstr "Your result is not pooled with other users and is not donated to cohort research."
 
-#: src/pages/LabsEnvironment.tsx:1193
+#: src/pages/LabsEnvironment.tsx:1206
 msgid "Your result needs recomputing"
 msgstr "Your result needs recomputing"
 
-#: src/pages/LabsEnvironment.tsx:69
+#: src/pages/LabsEnvironment.tsx:74
 msgid "Your source data changed while this result was being computed."
 msgstr "Your source data changed while this result was being computed."
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -32,7 +32,7 @@ msgid "(optional)"
 msgstr "（可选）"
 
 #. placeholder {0}: bin.reference_power_activity_count
-#: src/pages/LabsEnvironment.tsx:616
+#: src/pages/LabsEnvironment.tsx:629
 msgid "{0, plural, one {# activity} other {# activities}}"
 msgstr "{0, plural, other {# 项活动}}"
 
@@ -513,15 +513,15 @@ msgstr "此前一段达标训练仍可作为当前定性阶段的依据，但不
 msgid "A prior qualifying block still informs this qualitative stage, but response-specific adaptation evidence is declining. The range shown here describes current qualifying evidence, not that prior block."
 msgstr "此前一段达标训练仍可作为当前定性阶段的依据，但不同适应反应的证据正在减弱。这里显示的是当前达标训练的证据范围，并非此前那段训练。"
 
-#: src/pages/LabsEnvironment.tsx:91
+#: src/pages/LabsEnvironment.tsx:96
 msgid "A single activity has too much influence on the result."
 msgstr "单次活动对结果的影响过大。"
 
-#: src/pages/LabsEnvironment.tsx:82
+#: src/pages/LabsEnvironment.tsx:87
 msgid "A Stryd-aligned Critical Power value is required for this experiment."
 msgstr "此实验需要与 Stryd 数据一致的临界功率值。"
 
-#: src/pages/LabsEnvironment.tsx:267
+#: src/pages/LabsEnvironment.tsx:272
 msgid "A temporary infrastructure problem interrupted the previous attempt. Praxys kept the request and will retry automatically."
 msgstr "上一次尝试因临时基础设施问题中断。Praxys 已保留请求，并会自动重试。"
 
@@ -632,7 +632,7 @@ msgstr "活动"
 msgid "Activities only: runs, rides, pace, heart rate, route data"
 msgstr "仅活动数据：跑步、骑行、配速、心率、路线数据"
 
-#: src/pages/LabsEnvironment.tsx:404
+#: src/pages/LabsEnvironment.tsx:409
 msgid "Activities passing quick prerequisites"
 msgstr "通过快速前置检查的活动"
 
@@ -783,7 +783,7 @@ msgstr "agent-ready 候选"
 #~ msgid "Agent-ready candidates"
 #~ msgstr "可由智能体处理的候选项"
 
-#: src/pages/LabsEnvironment.tsx:883
+#: src/pages/LabsEnvironment.tsx:896
 msgid "Aggregate storage"
 msgstr "仅存储汇总结果"
 
@@ -844,7 +844,7 @@ msgstr "{0} 个关联工单均已是最新状态。"
 msgid "All components operational"
 msgstr "所有组件运行正常"
 
-#: src/pages/LabsEnvironment.tsx:1125
+#: src/pages/LabsEnvironment.tsx:1138
 msgid "All experiments"
 msgstr "所有实验"
 
@@ -893,15 +893,15 @@ msgstr "其他计划源与 Praxys 计划有重叠。建议一次只使用一个�
 msgid "An unexpected error occurred."
 msgstr "发生了意外错误。"
 
-#: src/pages/LabsEnvironment.tsx:1191
+#: src/pages/LabsEnvironment.tsx:1204
 msgid "Analysis needs a manual retry"
 msgstr "分析需要手动重试"
 
-#: src/pages/LabsEnvironment.tsx:263
+#: src/pages/LabsEnvironment.tsx:268
 msgid "Analysis request saved"
 msgstr "分析请求已保存"
 
-#: src/pages/LabsEnvironment.tsx:260
+#: src/pages/LabsEnvironment.tsx:265
 msgid "Analysis worker is running"
 msgstr "分析任务正在运行"
 
@@ -963,7 +963,7 @@ msgstr "需要运动员处理"
 msgid "ATL (recent load)"
 msgstr "ATL（近期负荷）"
 
-#: src/pages/LabsEnvironment.tsx:279
+#: src/pages/LabsEnvironment.tsx:284
 msgid "Attempt"
 msgstr "尝试"
 
@@ -1035,7 +1035,7 @@ msgid "Availability rate"
 msgstr "可用率"
 
 #: src/pages/admin/AdminUsers.tsx:768
-#: src/pages/LabsEnvironment.tsx:159
+#: src/pages/LabsEnvironment.tsx:164
 msgid "Available"
 msgstr "可用"
 
@@ -1203,7 +1203,7 @@ msgstr "面向全产品沟通的双语公告横幅。"
 msgid "Body (optional)"
 msgstr "正文（可选）"
 
-#: src/pages/LabsEnvironment.tsx:1270
+#: src/pages/LabsEnvironment.tsx:1283
 msgid "Bootstrap interval"
 msgstr "Bootstrap 区间"
 
@@ -1268,11 +1268,11 @@ msgstr "目标是 <0>{0}</0> {distLabel}。当前 {abbrev} <1>{currentStr}{unit}
 msgid "by"
 msgstr "作者"
 
-#: src/pages/LabsEnvironment.tsx:788
+#: src/pages/LabsEnvironment.tsx:801
 msgid "Calculate proxy"
 msgstr "计算代理值"
 
-#: src/pages/LabsEnvironment.tsx:538
+#: src/pages/LabsEnvironment.tsx:551
 msgid "Calculator"
 msgstr "计算器"
 
@@ -1299,7 +1299,7 @@ msgstr "计算器"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/pages/LabsEnvironment.tsx:285
+#: src/pages/LabsEnvironment.tsx:290
 msgid "Cancel and withdraw"
 msgstr "取消并退出"
 
@@ -1386,7 +1386,7 @@ msgstr "调整了今天的训练安排"
 msgid "Check your credentials in the connection step, then try again."
 msgstr "请在连接步骤检查账号信息，然后重试。"
 
-#: src/pages/LabsEnvironment.tsx:352
+#: src/pages/LabsEnvironment.tsx:357
 msgid "Checking data requirements"
 msgstr "正在检查数据要求"
 
@@ -1514,7 +1514,7 @@ msgstr "代码"
 msgid "Code {0} created for {1}. Email not sent. Copy it or use the link."
 msgstr "已为 {1} 创建代码 {0}。邮件未发送，请复制代码或使用链接。"
 
-#: src/pages/LabsEnvironment.tsx:762
+#: src/pages/LabsEnvironment.tsx:775
 msgid "Combine air temperature and relative humidity using the same Stull estimate as the experiment."
 msgstr "使用与实验相同的 Stull 估算式，将气温和相对湿度合并为代理值。"
 
@@ -1535,7 +1535,7 @@ msgstr "已承诺 / 上限"
 msgid "Communications"
 msgstr "公告"
 
-#: src/pages/LabsEnvironment.tsx:577
+#: src/pages/LabsEnvironment.tsx:590
 msgid "Comparable-power activity support"
 msgstr "可比功率活动支持"
 
@@ -1584,7 +1584,7 @@ msgstr "确认执行一次受保护的重试。Praxys 会先刷新数据来源�
 msgid "Confirm replay"
 msgstr "确认重试"
 
-#: src/pages/LabsEnvironment.tsx:999
+#: src/pages/LabsEnvironment.tsx:1012
 msgid "Confirm that you are 18 or older to join this experiment."
 msgstr "确认已满 18 周岁后才能加入此实验。"
 
@@ -1672,7 +1672,7 @@ msgstr "连接转化漏斗"
 #~ msgid "Connector-provided activity summary"
 #~ msgstr "连接器提供的活动摘要"
 
-#: src/pages/LabsEnvironment.tsx:944
+#: src/pages/LabsEnvironment.tsx:957
 msgid "Consent text version"
 msgstr "同意文本版本"
 
@@ -1706,7 +1706,7 @@ msgstr "前往 Strava"
 msgid "Continuous"
 msgstr "持续提升"
 
-#: src/pages/LabsEnvironment.tsx:78
+#: src/pages/LabsEnvironment.tsx:83
 msgid "Continuous heart-rate samples are missing from too much of the eligible history."
 msgstr "符合条件的历史数据中，连续心率采样缺失过多。"
 
@@ -1718,11 +1718,11 @@ msgstr "持续提升"
 msgid "Continuous improvement configured"
 msgstr "已设置持续提升目标"
 
-#: src/pages/LabsEnvironment.tsx:1281
+#: src/pages/LabsEnvironment.tsx:1294
 msgid "Continuous Stryd sample power"
 msgstr "连续 Stryd 采样功率"
 
-#: src/pages/LabsEnvironment.tsx:77
+#: src/pages/LabsEnvironment.tsx:82
 msgid "Continuous Stryd sample power is missing from too much of the eligible history."
 msgstr "符合条件的历史数据中，连续 Stryd 功率采样缺失过多。"
 
@@ -1772,8 +1772,8 @@ msgstr "更正计划个性化信息"
 msgid "Could not add this workout"
 msgstr "无法添加这项训练"
 
-#: src/pages/LabsEnvironment.tsx:726
-#: src/pages/LabsEnvironment.tsx:734
+#: src/pages/LabsEnvironment.tsx:739
+#: src/pages/LabsEnvironment.tsx:747
 msgid "Could not calculate the wet-bulb proxy."
 msgstr "无法计算湿球温度代理值。"
 
@@ -2323,7 +2323,7 @@ msgstr "演示账号"
 #~ msgid "Demo Accounts"
 #~ msgstr "演示账号"
 
-#: src/pages/LabsEnvironment.tsx:928
+#: src/pages/LabsEnvironment.tsx:941
 msgid "Demo accounts are read-only and cannot join Labs."
 msgstr "演示账号为只读状态，无法加入 Labs。"
 
@@ -2580,7 +2580,7 @@ msgstr "例如 5:45"
 msgid "e.g. 8:00:00"
 msgstr "例如 8:00:00"
 
-#: src/pages/LabsEnvironment.tsx:639
+#: src/pages/LabsEnvironment.tsx:652
 msgid "Each activity counts once per environmental range. The comparable-power range is centered on your typical eligible stable training workload; raw sample points alone do not count."
 msgstr "每个环境区间内，每次活动只计一次。可比功率范围以符合条件的稳定训练负荷中位数为中心；仅有原始采样点不计入。"
 
@@ -2664,7 +2664,7 @@ msgstr "爬升"
 #~ msgid "Elevated"
 #~ msgstr "升高"
 
-#: src/pages/LabsEnvironment.tsx:362
+#: src/pages/LabsEnvironment.tsx:367
 msgid "Eligibility check could not load"
 msgstr "无法加载资格检查"
 
@@ -2672,7 +2672,7 @@ msgstr "无法加载资格检查"
 msgid "Eligible"
 msgstr "符合条件"
 
-#: src/pages/LabsEnvironment.tsx:659
+#: src/pages/LabsEnvironment.tsx:672
 msgid "Eligible activities"
 msgstr "符合条件的活动"
 
@@ -2750,15 +2750,15 @@ msgstr "结束日期"
 msgid "Endurance"
 msgstr "耐力"
 
-#: src/pages/LabsEnvironment.tsx:85
+#: src/pages/LabsEnvironment.tsx:90
 msgid "Enough activities exist overall, but the required environment, power, and heart-rate data do not overlap on enough of the same runs."
 msgstr "活动总数足够，但环境、功率和心率数据没有在足够多的同一批跑步中同时出现。"
 
-#: src/pages/LabsEnvironment.tsx:394
+#: src/pages/LabsEnvironment.tsx:399
 msgid "Enough source data to attempt the experiment"
 msgstr "源数据足以尝试这项实验"
 
-#: src/pages/LabsEnvironment.tsx:709
+#: src/pages/LabsEnvironment.tsx:722
 msgid "Enter numeric temperature and humidity values."
 msgstr "请输入有效的温度和湿度数值。"
 
@@ -2768,7 +2768,7 @@ msgid "Environment"
 msgstr "环境"
 
 #: src/pages/Labs.tsx:69
-#: src/pages/LabsEnvironment.tsx:1127
+#: src/pages/LabsEnvironment.tsx:1140
 msgid "Environmental response"
 msgstr "环境响应"
 
@@ -2785,7 +2785,7 @@ msgstr "仍可使用的装备（可多选）"
 msgid "Error"
 msgstr "错误"
 
-#: src/pages/LabsEnvironment.tsx:803
+#: src/pages/LabsEnvironment.tsx:816
 msgid "Estimated psychrometric wet-bulb proxy"
 msgstr "估算的湿球温度代理值"
 
@@ -2917,7 +2917,7 @@ msgstr "减退中"
 
 #: src/pages/admin/AdminFeedback.tsx:98
 #: src/pages/admin/AdminFeedback.tsx:355
-#: src/pages/LabsEnvironment.tsx:161
+#: src/pages/LabsEnvironment.tsx:166
 msgid "Failed"
 msgstr "失败"
 
@@ -3188,7 +3188,7 @@ msgstr "来自活动"
 #~ msgid "From Stryd"
 #~ msgstr "来自 Stryd"
 
-#: src/pages/LabsEnvironment.tsx:393
+#: src/pages/LabsEnvironment.tsx:398
 msgid "Full analysis must confirm eligibility"
 msgstr "需要完整分析确认是否符合条件"
 
@@ -3233,7 +3233,7 @@ msgstr "对同一位运动员，Garmin 原生跑步功率通常比 Stryd 高约 
 msgid "Garmin workout delivery is duration-only. Workouts with power, pace, or heart-rate targets will stay blocked rather than lose their intended intensity."
 msgstr "Garmin 训练下发仅支持时长。包含功率、配速或心率目标的训练不会被下发，以免丢失预期强度。"
 
-#: src/pages/LabsEnvironment.tsx:88
+#: src/pages/LabsEnvironment.tsx:93
 msgid "Garmin wrist-power origin cannot yet be verified well enough for this experiment."
 msgstr "目前尚无法充分验证 Garmin 腕部功率来源，因此不能用于此实验。"
 
@@ -3448,15 +3448,15 @@ msgstr "起伏路"
 msgid "Historical association only · personal aggregate result · continuous Stryd samples required"
 msgstr "仅描述历史关联 · 个人聚合结果 · 需要连续 Stryd 样本"
 
-#: src/pages/LabsEnvironment.tsx:1176
+#: src/pages/LabsEnvironment.tsx:1189
 msgid "Historical association; not predictively validated"
 msgstr "存在历史关联；尚未通过预测验证"
 
-#: src/pages/LabsEnvironment.tsx:468
+#: src/pages/LabsEnvironment.tsx:481
 msgid "Historical environmental-response curve"
 msgstr "历史环境响应曲线"
 
-#: src/pages/LabsEnvironment.tsx:1262
+#: src/pages/LabsEnvironment.tsx:1275
 msgid "Historical slope"
 msgstr "历史斜率"
 
@@ -3464,7 +3464,7 @@ msgstr "历史斜率"
 msgid "Historical sync may take several minutes"
 msgstr "历史同步可能需要几分钟"
 
-#: src/pages/LabsEnvironment.tsx:329
+#: src/pages/LabsEnvironment.tsx:334
 msgid "hour rolling window"
 msgstr "小时滚动窗口"
 
@@ -3500,7 +3500,7 @@ msgstr "Praxys 在后台同步新数据的频率。降低频率可减少网络�
 msgid "How this is calculated"
 msgstr "计算方式"
 
-#: src/pages/LabsEnvironment.tsx:1289
+#: src/pages/LabsEnvironment.tsx:1302
 msgid "How to read this experiment"
 msgstr "如何解读此实验"
 
@@ -3636,7 +3636,7 @@ msgstr "HRV 变异性偏高（CV {cv}%），高于所设训练警戒阈值。"
 #~ msgid "Human overrides"
 #~ msgstr "人工改判"
 
-#: src/pages/LabsEnvironment.tsx:777
+#: src/pages/LabsEnvironment.tsx:790
 msgid "Humidity (%)"
 msgstr "湿度（%）"
 
@@ -3644,11 +3644,11 @@ msgstr "湿度（%）"
 msgid "I agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
 msgstr "我同意<0>服务条款</0>和<1>隐私政策</1>。"
 
-#: src/pages/LabsEnvironment.tsx:906
+#: src/pages/LabsEnvironment.tsx:919
 msgid "I confirm that I am 18 or older. Praxys records this attestation, not my birth date."
 msgstr "确认已满 18 周岁。Praxys 仅记录此声明，不收集出生日期。"
 
-#: src/pages/LabsEnvironment.tsx:909
+#: src/pages/LabsEnvironment.tsx:922
 msgid "I understand the purpose, limits, storage, and withdrawal terms above and choose to participate in this experiment."
 msgstr "已了解上述实验目的、限制、存储和退出条款，并自愿参加此实验。"
 
@@ -3755,7 +3755,7 @@ msgstr "证据不足"
 #~ msgid "Insufficient HRV data for analysis"
 #~ msgstr "用于分析的 HRV 数据不足"
 
-#: src/pages/LabsEnvironment.tsx:632
+#: src/pages/LabsEnvironment.tsx:645
 msgid "Insufficient support"
 msgstr "支持数据不足"
 
@@ -3844,7 +3844,7 @@ msgstr "已创建 Issue"
 msgid "It stays in your private history until its purge date, but cannot influence a new assessment."
 msgstr "信息会保留到原定删除时间，但不会再用于新的评估。"
 
-#: src/pages/LabsEnvironment.tsx:924
+#: src/pages/LabsEnvironment.tsx:937
 msgid "Join and analyze my history"
 msgstr "加入并分析我的历史数据"
 
@@ -3854,7 +3854,7 @@ msgstr "加入并分析我的历史数据"
 msgid "Join the waitlist"
 msgstr "加入候补名单"
 
-#: src/pages/LabsEnvironment.tsx:863
+#: src/pages/LabsEnvironment.tsx:876
 msgid "Join this personal experiment"
 msgstr "加入此个人实验"
 
@@ -3899,7 +3899,7 @@ msgstr "如有可选活动，请保持轻松且简短"
 msgid "Keep future workouts on {targetLabel}"
 msgstr "保留 {targetLabel} 上的未来训练"
 
-#: src/pages/LabsEnvironment.tsx:1372
+#: src/pages/LabsEnvironment.tsx:1385
 msgid "Keep participating"
 msgstr "继续参加"
 
@@ -3936,12 +3936,12 @@ msgstr "公里/周"
 msgid "Labs"
 msgstr "实验室"
 
-#: src/pages/LabsEnvironment.tsx:1357
+#: src/pages/LabsEnvironment.tsx:1370
 msgid "Labs action failed"
 msgstr "Labs 操作失败"
 
 #: src/pages/Labs.tsx:52
-#: src/pages/LabsEnvironment.tsx:1088
+#: src/pages/LabsEnvironment.tsx:1101
 msgid "Labs could not load"
 msgstr "无法加载 Labs"
 
@@ -4383,7 +4383,7 @@ msgstr "手动添加及其他教练安排的训练仍属于外部训练，不会
 msgid "Manual and other-coach workouts stay untouched. Delivery remains paused throughout."
 msgstr "手动创建和其他教练安排的训练不受影响。整个过程都不会恢复下发。"
 
-#: src/pages/LabsEnvironment.tsx:326
+#: src/pages/LabsEnvironment.tsx:331
 msgid "manual recomputes remaining"
 msgstr "次手动重新计算机会"
 
@@ -4454,11 +4454,11 @@ msgstr "分钟"
 msgid "Mini program"
 msgstr "小程序"
 
-#: src/pages/LabsEnvironment.tsx:410
+#: src/pages/LabsEnvironment.tsx:415
 msgid "minimum"
 msgstr "最低要求"
 
-#: src/pages/LabsEnvironment.tsx:588
+#: src/pages/LabsEnvironment.tsx:601
 msgid "minimum {referenceMinimum} per environmental range"
 msgstr "每个环境区间至少 {referenceMinimum} 次"
 
@@ -4502,7 +4502,7 @@ msgstr "数据来源混合"
 msgid "Mode"
 msgstr "模式"
 
-#: src/pages/LabsEnvironment.tsx:1284
+#: src/pages/LabsEnvironment.tsx:1297
 msgid "Model version"
 msgstr "模型版本"
 
@@ -4617,7 +4617,7 @@ msgstr "需要帮助？{SUPPORT_EMAIL}"
 msgid "Needed {abbrev}"
 msgstr "所需{abbrev}"
 
-#: src/pages/LabsEnvironment.tsx:631
+#: src/pages/LabsEnvironment.tsx:644
 msgid "Needs {missingReference} more"
 msgstr "还需 {missingReference} 次"
 
@@ -4630,11 +4630,11 @@ msgstr "需要关注"
 #~ msgid "Needs data"
 #~ msgstr "需要更多数据"
 
-#: src/pages/LabsEnvironment.tsx:162
+#: src/pages/LabsEnvironment.tsx:167
 msgid "Needs recompute"
 msgstr "需要重新计算"
 
-#: src/pages/LabsEnvironment.tsx:152
+#: src/pages/LabsEnvironment.tsx:157
 msgid "Needs retry"
 msgstr "需要重试"
 
@@ -4696,7 +4696,7 @@ msgstr "网络错误。请直接发邮件到 {SUPPORT_EMAIL}。"
 msgid "Network error. Refresh the queue and try again."
 msgstr "网络错误。请刷新队列后重试。"
 
-#: src/pages/LabsEnvironment.tsx:1077
+#: src/pages/LabsEnvironment.tsx:1090
 msgid "Network error. Try again."
 msgstr "网络错误，请重试。"
 
@@ -4809,7 +4809,7 @@ msgstr "当前暂无分类"
 msgid "No current qualifying condition range yet"
 msgstr "目前尚无符合条件的环境范围"
 
-#: src/pages/LabsEnvironment.tsx:1196
+#: src/pages/LabsEnvironment.tsx:1209
 msgid "No curve is available yet"
 msgstr "暂时无法生成曲线"
 
@@ -5126,12 +5126,12 @@ msgstr "数据不足，暂无法对比每周负荷"
 msgid "not enough load history"
 msgstr "负荷历史不足"
 
-#: src/pages/LabsEnvironment.tsx:391
+#: src/pages/LabsEnvironment.tsx:396
 msgid "Not enough suitable data to start yet"
 msgstr "合适的数据暂时不足，无法开始"
 
-#: src/pages/LabsEnvironment.tsx:156
-#: src/pages/LabsEnvironment.tsx:1008
+#: src/pages/LabsEnvironment.tsx:161
+#: src/pages/LabsEnvironment.tsx:1021
 msgid "Not enrolled"
 msgstr "未加入"
 
@@ -5186,7 +5186,7 @@ msgstr "现已开放 · 创建账号"
 msgid "Observed"
 msgstr "已记录"
 
-#: src/pages/LabsEnvironment.tsx:667
+#: src/pages/LabsEnvironment.tsx:680
 msgid "Observed proxy range"
 msgstr "已观测代理值范围"
 
@@ -5240,7 +5240,7 @@ msgstr "默认不发送。补充说明可能包含比上方字段更多的隐私
 msgid "On"
 msgstr "开"
 
-#: src/pages/LabsEnvironment.tsx:1181
+#: src/pages/LabsEnvironment.tsx:1194
 msgid "One or more research diagnostics did not support predictive interpretation. Read the curve only as a pattern in eligible past runs."
 msgstr "一项或多项研究诊断不支持预测性解读。请仅将曲线视为合格历史跑步中的关联模式。"
 
@@ -5473,7 +5473,7 @@ msgstr "部分服务中断"
 msgid "Participating"
 msgstr "已参与"
 
-#: src/pages/LabsEnvironment.tsx:1175
+#: src/pages/LabsEnvironment.tsx:1188
 msgid "Passed research diagnostics; not a forecast"
 msgstr "已通过研究诊断；并非预测"
 
@@ -5535,7 +5535,7 @@ msgstr "永久删除 Praxys 账号、已同步数据、计划、设置和加密�
 msgid "Personal Access Token"
 msgstr "个人访问令牌"
 
-#: src/pages/LabsEnvironment.tsx:877
+#: src/pages/LabsEnvironment.tsx:890
 msgid "Personal only"
 msgstr "仅供个人使用"
 
@@ -5678,7 +5678,7 @@ msgstr "功率下限（W）"
 msgid "Power metrics, Critical Power, training plans"
 msgstr "功率指标、阈值功率、训练计划"
 
-#: src/pages/LabsEnvironment.tsx:1280
+#: src/pages/LabsEnvironment.tsx:1293
 msgid "Power regime"
 msgstr "功率数据体系"
 
@@ -5738,7 +5738,7 @@ msgstr "Praxys 创建或明确采纳的训练将以 Praxys 版本为准。"
 msgid "Praxys can analyze this schedule, but it will not create, replace, or remove target workouts."
 msgstr "Praxys 可以分析此日程，但不会在目标平台创建、替换或移除训练。"
 
-#: src/pages/LabsEnvironment.tsx:354
+#: src/pages/LabsEnvironment.tsx:359
 msgid "Praxys checks the required environment, Stryd power, heart-rate, and Critical Power coverage before showing enrollment consent or starting analysis."
 msgstr "Praxys 会在显示参与同意或开始分析前，检查所需的环境、Stryd 功率、心率和临界功率覆盖情况。"
 
@@ -5853,11 +5853,11 @@ msgstr "计划仍由 Praxys 管理，下发已暂停。"
 #~ msgid "Praxys sends duration-only running workouts and verifies both the Garmin template and scheduled calendar instance."
 #~ msgstr "Praxys 仅发送按时长执行的跑步训练，并核验 Garmin 训练模板和日历排期实例。"
 
-#: src/pages/LabsEnvironment.tsx:400
+#: src/pages/LabsEnvironment.tsx:405
 msgid "Praxys stopped before consent or long-running analysis. Sync or collect the missing data, then retry this check."
 msgstr "Praxys 已在记录同意或启动耗时分析前停止。同步或积累缺少的数据后，再重新检查。"
 
-#: src/pages/LabsEnvironment.tsx:885
+#: src/pages/LabsEnvironment.tsx:898
 msgid "Praxys stores curve points, uncertainty, counts, gates, versions, and timestamps—not routes, activity dates, raw samples, or per-activity research rows."
 msgstr "Praxys 仅存储曲线点、不确定性、计数、门槛状态、版本和时间戳，不存储路线、活动日期、原始采样或逐活动研究记录。"
 
@@ -5865,11 +5865,11 @@ msgstr "Praxys 仅存储曲线点、不确定性、计数、门槛状态、版�
 msgid "Praxys version"
 msgstr "Praxys 版本"
 
-#: src/pages/LabsEnvironment.tsx:865
+#: src/pages/LabsEnvironment.tsx:878
 msgid "Praxys will analyze eligible past runs to see whether modeled heart rate varied with temperature-and-humidity conditions at comparable recorded Stryd power."
 msgstr "Praxys 将分析符合条件的历史跑步，观察在可比的 Stryd 记录功率下，模型心率是否随温湿度条件变化。"
 
-#: src/pages/LabsEnvironment.tsx:1367
+#: src/pages/LabsEnvironment.tsx:1380
 msgid "Praxys will immediately delete your Labs consent and derived aggregate result. Your underlying account activities are not deleted."
 msgstr "Praxys 将立即删除 Labs 同意记录和派生汇总结果，但不会删除账号中的原始活动。"
 
@@ -5881,7 +5881,7 @@ msgstr "Praxys 会将原因保留为“未知”，不会因此作出负面判�
 msgid "Praxys will stop changing the target calendar. Your canonical Praxys plan remains available for analysis."
 msgstr "Praxys 将停止更改目标日历。Praxys 计划仍会保留，可继续用于分析。"
 
-#: src/pages/LabsEnvironment.tsx:1294
+#: src/pages/LabsEnvironment.tsx:1307
 msgid "Praxys workload-support review"
 msgstr "Praxys 训练负荷支持证据综述"
 
@@ -5990,8 +5990,8 @@ msgstr "继续训练，但注意观察训练中的心率漂移"
 #~ msgid "Proceed but monitor heart-rate drift during the session\" \"继续训练，但监测训练中的心率漂移"
 #~ msgstr ""
 
-#: src/pages/LabsEnvironment.tsx:147
-#: src/pages/LabsEnvironment.tsx:158
+#: src/pages/LabsEnvironment.tsx:152
+#: src/pages/LabsEnvironment.tsx:163
 msgid "Processing"
 msgstr "处理中"
 
@@ -6145,12 +6145,12 @@ msgstr "较长间隔后已恢复达标热暴露，但当前证据仍然有限。
 
 #: src/components/UpcomingPlanCard.tsx:499
 #: src/components/UpcomingPlanCard.tsx:519
-#: src/pages/LabsEnvironment.tsx:146
-#: src/pages/LabsEnvironment.tsx:157
+#: src/pages/LabsEnvironment.tsx:151
+#: src/pages/LabsEnvironment.tsx:162
 msgid "Queued"
 msgstr "等待下发"
 
-#: src/pages/LabsEnvironment.tsx:262
+#: src/pages/LabsEnvironment.tsx:267
 msgid "Queued for the analysis worker"
 msgstr "已进入分析队列"
 
@@ -6268,7 +6268,7 @@ msgstr "根据身体信号判断准备度。"
 msgid "Realistic alternative targets"
 msgstr "可行的替代目标"
 
-#: src/pages/LabsEnvironment.tsx:90
+#: src/pages/LabsEnvironment.tsx:95
 msgid "Reasonable model variations do not preserve the same historical relationship."
 msgstr "在合理的模型变化下，历史关系无法保持一致。"
 
@@ -6422,28 +6422,28 @@ msgstr "推荐"
 msgid "Recommended. Delivered workouts stay on the calendar; Praxys simply stops managing them."
 msgstr "推荐。已下发的训练会保留在日历中，Praxys 只停止继续管理。"
 
-#: src/pages/LabsEnvironment.tsx:1223
+#: src/pages/LabsEnvironment.tsx:1236
 msgid "Recompute"
 msgstr "重新计算"
 
-#: src/pages/LabsEnvironment.tsx:304
-#: src/pages/LabsEnvironment.tsx:316
+#: src/pages/LabsEnvironment.tsx:309
+#: src/pages/LabsEnvironment.tsx:321
 msgid "Recompute available again"
 msgstr "可再次重新计算"
 
-#: src/pages/LabsEnvironment.tsx:301
+#: src/pages/LabsEnvironment.tsx:306
 msgid "Recompute cooling down"
 msgstr "重新计算冷却中"
 
-#: src/pages/LabsEnvironment.tsx:990
+#: src/pages/LabsEnvironment.tsx:1003
 msgid "Recompute is cooling down. Try again after {availableAt}."
 msgstr "重新计算仍在冷却中，请在 {availableAt} 后重试。"
 
-#: src/pages/LabsEnvironment.tsx:991
+#: src/pages/LabsEnvironment.tsx:1004
 msgid "Recompute is cooling down. Try again later."
 msgstr "重新计算仍在冷却中，请稍后重试。"
 
-#: src/pages/LabsEnvironment.tsx:1342
+#: src/pages/LabsEnvironment.tsx:1355
 msgid "Recompute result"
 msgstr "重新计算结果"
 
@@ -6691,23 +6691,23 @@ msgstr "驳回"
 msgid "Rejected"
 msgstr "已拒绝"
 
-#: src/pages/LabsEnvironment.tsx:80
+#: src/pages/LabsEnvironment.tsx:85
 msgid "Relative humidity is missing from too many otherwise eligible activities."
 msgstr "其他条件合格的活动中，相对湿度缺失过多。"
 
-#: src/pages/LabsEnvironment.tsx:1246
+#: src/pages/LabsEnvironment.tsx:1259
 msgid "Relative modeled heart rate across your observed wet-bulb-proxy range, holding the fitted comparison at a common recorded-power reference."
 msgstr "在已观测湿球温度代理值范围内，以共同记录功率为参照显示相对模型心率。"
 
-#: src/pages/LabsEnvironment.tsx:1245
+#: src/pages/LabsEnvironment.tsx:1258
 msgid "Relative modeled heart rate is shown only in ranges with enough comparable-power evidence. Unsupported ranges remain blank and are never connected."
 msgstr "仅在可比功率证据充足的区间显示相对模型心率。支持不足的区间保持空白，且不会连接。"
 
-#: src/pages/LabsEnvironment.tsx:510
+#: src/pages/LabsEnvironment.tsx:523
 msgid "Relative modeled HR"
 msgstr "相对模型心率"
 
-#: src/pages/LabsEnvironment.tsx:491
+#: src/pages/LabsEnvironment.tsx:504
 msgid "Relative modeled HR (bpm)"
 msgstr "相对模型心率（bpm）"
 
@@ -6787,7 +6787,7 @@ msgstr "请求和可用性遥测数据暂不可用。"
 msgid "Request expires"
 msgstr "请求到期时间"
 
-#: src/pages/LabsEnvironment.tsx:1051
+#: src/pages/LabsEnvironment.tsx:1064
 msgid "Request failed. Try again."
 msgstr "请求失败，请重试。"
 
@@ -6909,8 +6909,8 @@ msgstr "恢复托管下发？"
 #: src/pages/Goal.tsx:444
 #: src/pages/History.tsx:53
 #: src/pages/Labs.tsx:56
-#: src/pages/LabsEnvironment.tsx:372
-#: src/pages/LabsEnvironment.tsx:1092
+#: src/pages/LabsEnvironment.tsx:377
+#: src/pages/LabsEnvironment.tsx:1105
 #: src/pages/McpAuthorization.tsx:202
 #: src/pages/Settings.tsx:335
 #: src/pages/Today.tsx:352
@@ -6919,7 +6919,7 @@ msgstr "恢复托管下发？"
 msgid "Retry"
 msgstr "重试"
 
-#: src/pages/LabsEnvironment.tsx:364
+#: src/pages/LabsEnvironment.tsx:369
 msgid "Retry before joining. The full analysis has not started."
 msgstr "请在参与前重试；完整分析尚未开始。"
 
@@ -6966,7 +6966,7 @@ msgstr "重试加载公开状态页的事件列表。"
 msgid "Retry workout action"
 msgstr "重试此训练操作"
 
-#: src/pages/LabsEnvironment.tsx:145
+#: src/pages/LabsEnvironment.tsx:150
 msgid "Retrying"
 msgstr "正在重试"
 
@@ -7077,7 +7077,7 @@ msgstr "角色"
 msgid "Rolling 1 / 7 / 30 days"
 msgstr "滚动 1 / 7 / 30 天"
 
-#: src/pages/LabsEnvironment.tsx:313
+#: src/pages/LabsEnvironment.tsx:318
 msgid "Rolling recompute limit reached"
 msgstr "已达到滚动重新计算上限"
 
@@ -7578,7 +7578,7 @@ msgstr "快照 {0}"
 msgid "Some adaptation may persist"
 msgstr "部分适应可能仍然存在"
 
-#: src/pages/LabsEnvironment.tsx:75
+#: src/pages/LabsEnvironment.tsx:80
 msgid "Some parts of the environmental range do not have enough independent activity support."
 msgstr "环境范围的部分区间缺少足够的独立活动支持。"
 
@@ -7616,7 +7616,7 @@ msgstr "平稳"
 msgid "Stable"
 msgstr "稳定"
 
-#: src/pages/LabsEnvironment.tsx:663
+#: src/pages/LabsEnvironment.tsx:676
 msgid "Stable segments"
 msgstr "稳定分段"
 
@@ -7717,7 +7717,7 @@ msgstr "将发送的信息"
 #~ msgid "Stryd-provided activity weather"
 #~ msgstr "Stryd 提供的活动天气"
 
-#: src/pages/LabsEnvironment.tsx:480
+#: src/pages/LabsEnvironment.tsx:493
 msgid "Stull psychrometric wet-bulb proxy (°C)"
 msgstr "Stull 湿球温度代理值（°C）"
 
@@ -7762,11 +7762,11 @@ msgstr "汇总时间范围"
 msgid "Sun"
 msgstr "周日"
 
-#: src/pages/LabsEnvironment.tsx:1204
+#: src/pages/LabsEnvironment.tsx:1217
 msgid "Support ID"
 msgstr "支持 ID"
 
-#: src/pages/LabsEnvironment.tsx:629
+#: src/pages/LabsEnvironment.tsx:642
 msgid "Supported"
 msgstr "支持充足"
 
@@ -7985,11 +7985,11 @@ msgstr "目标完赛时间"
 #~ msgid "Telemetry trust boundary"
 #~ msgstr "遥测信任边界"
 
-#: src/pages/LabsEnvironment.tsx:768
+#: src/pages/LabsEnvironment.tsx:781
 msgid "Temperature (°C)"
 msgstr "温度（°C）"
 
-#: src/pages/LabsEnvironment.tsx:81
+#: src/pages/LabsEnvironment.tsx:86
 msgid "Temperature and humidity are not both present on enough of the same activities."
 msgstr "同时包含温度和湿度的活动数量不足。"
 
@@ -7997,7 +7997,7 @@ msgstr "同时包含温度和湿度的活动数量不足。"
 #~ msgid "Temperature and humidity were not provided by your synced activities."
 #~ msgstr "已同步的活动未提供温度和湿度数据。"
 
-#: src/pages/LabsEnvironment.tsx:79
+#: src/pages/LabsEnvironment.tsx:84
 msgid "Temperature is missing from too many otherwise eligible activities."
 msgstr "其他条件合格的活动中，温度缺失过多。"
 
@@ -8016,7 +8016,7 @@ msgstr "临时训练安排"
 msgid "Temporary context can stay active for at most 90 days."
 msgstr "这类临时信息最长可生效 90 天。"
 
-#: src/pages/LabsEnvironment.tsx:258
+#: src/pages/LabsEnvironment.tsx:263
 msgid "Temporary service issue; retry queued"
 msgstr "临时服务问题，已排队重试"
 
@@ -8040,7 +8040,7 @@ msgstr "这一天已归入已完成记录，无法再修改。"
 msgid "That is a complete state, not missing data. Praxys keeps the reason unknown and does not reduce your standing or invent an explanation."
 msgstr "没有填写也是完整状态，并不代表数据缺失。Praxys 会保留“原因未知”，不会因此作出负面判断或自行补充解释。"
 
-#: src/pages/LabsEnvironment.tsx:940
+#: src/pages/LabsEnvironment.tsx:953
 msgid "The accepted Praxys evidence review found controlled support for heat-related cardiovascular drift, but no field study validating a causal or predictive personal Stull wet-bulb response curve. V1 is therefore descriptive and Stryd-only."
 msgstr "已接受的 Praxys 证据评审支持热环境相关的心血管漂移，但尚无实地研究验证具有因果或预测能力的个人 Stull 湿球温度响应曲线。因此 V1 仅作描述，并且只支持 Stryd。"
 
@@ -8056,23 +8056,23 @@ msgstr "无法刷新智能体决策与结果汇总。"
 msgid "The alert summary could not be refreshed."
 msgstr "无法刷新警报摘要。"
 
-#: src/pages/LabsEnvironment.tsx:1195
+#: src/pages/LabsEnvironment.tsx:1208
 msgid "The analysis did not finish"
 msgstr "分析未完成"
 
-#: src/pages/LabsEnvironment.tsx:94
+#: src/pages/LabsEnvironment.tsx:99
 msgid "The analysis did not finish successfully."
 msgstr "分析未能成功完成。"
 
-#: src/pages/LabsEnvironment.tsx:93
+#: src/pages/LabsEnvironment.tsx:98
 msgid "The analysis worker could not complete the model after repeated infrastructure attempts."
 msgstr "多次基础设施尝试后，分析任务仍未能完成模型计算。"
 
-#: src/pages/LabsEnvironment.tsx:83
+#: src/pages/LabsEnvironment.tsx:88
 msgid "The available Critical Power does not match the eligible Stryd power regime."
 msgstr "当前临界功率与符合条件的 Stryd 功率数据体系不匹配。"
 
-#: src/pages/LabsEnvironment.tsx:68
+#: src/pages/LabsEnvironment.tsx:73
 msgid "The available history could not be analyzed as one complete snapshot."
 msgstr "现有历史数据无法作为一个完整快照进行分析。"
 
@@ -8088,27 +8088,27 @@ msgstr "运维队列可用，但无法刷新整体下发健康状态。"
 msgid "The canonical Praxys plan is preserved. Existing target workouts stay in place until you resume or leave."
 msgstr "Praxys 计划会完整保留。恢复下发或退出托管前，目标平台上的现有训练保持不变。"
 
-#: src/pages/LabsEnvironment.tsx:1180
+#: src/pages/LabsEnvironment.tsx:1193
 msgid "The chronological holdout and sensitivity checks passed, but this personal historical association is still not a clinical claim or future-condition forecast."
 msgstr "时间顺序留出检验和敏感性检查已通过，但这一私人历史关联仍不构成临床结论，也不能预测未来环境下的表现。"
 
-#: src/pages/LabsEnvironment.tsx:92
+#: src/pages/LabsEnvironment.tsx:97
 msgid "The chronological prediction check could not be evaluated, so Praxys withholds the fitted curve."
 msgstr "无法评估按时间顺序进行的预测检查，因此 Praxys 不显示拟合曲线。"
 
-#: src/pages/LabsEnvironment.tsx:1005
+#: src/pages/LabsEnvironment.tsx:1018
 msgid "The consent text changed. Review and confirm the current version."
 msgstr "同意说明已更新。请阅读并确认当前版本。"
 
-#: src/pages/LabsEnvironment.tsx:84
+#: src/pages/LabsEnvironment.tsx:89
 msgid "The continuous sample coverage is too sparse for a stable comparison."
 msgstr "连续采样覆盖过于稀疏，无法进行稳定比较。"
 
-#: src/pages/LabsEnvironment.tsx:308
+#: src/pages/LabsEnvironment.tsx:313
 msgid "The cooldown prevents accidental repeat analysis."
 msgstr "冷却期可避免意外重复分析。"
 
-#: src/pages/LabsEnvironment.tsx:86
+#: src/pages/LabsEnvironment.tsx:91
 msgid "The eligible history crosses incompatible power-device or algorithm regimes."
 msgstr "符合条件的历史数据跨越了不兼容的功率设备或算法阶段。"
 
@@ -8124,7 +8124,7 @@ msgstr "结束日期必须晚于开始日期。"
 #~ msgid "The environmental ramps, effective minutes, stage thresholds, and 7–28 day decay window are Praxys operational estimates. Evidence coverage is not biological certainty. Stop and begin cooling for heat-illness symptoms; seek urgent medical help for confusion, collapse, or altered mental status."
 #~ msgstr "环境权重坡度、加权分钟、阶段阈值和 7–28 天衰减窗口均为 Praxys 的操作性估算。证据覆盖度不代表生理适应的确定性。如出现热病症状，请停止训练并开始降温；如出现意识混乱、虚脱或精神状态改变，应立即寻求紧急医疗救助。"
 
-#: src/pages/LabsEnvironment.tsx:89
+#: src/pages/LabsEnvironment.tsx:94
 msgid "The estimated direction changes too much when activities are resampled."
 msgstr "重新抽样活动后，估算方向变化过大。"
 
@@ -8136,7 +8136,7 @@ msgstr "无法刷新反馈汇总。"
 msgid "The incident aggregate could not be refreshed."
 msgstr "无法刷新事件聚合数据。"
 
-#: src/pages/LabsEnvironment.tsx:269
+#: src/pages/LabsEnvironment.tsx:274
 msgid "The isolated worker is building the aggregate response from your eligible activity data."
 msgstr "独立分析任务正在基于符合条件的活动数据生成汇总结果。"
 
@@ -8167,7 +8167,7 @@ msgstr "最新 HRV 读数过旧，不能用于当日恢复分类。请同步设�
 #~ msgid "The latest HRV reading is too old for a same-day recovery classification. Sync your device to refresh it.\" \"最近一次 HRV 读数过旧，无法用于当日恢复分类。请同步设备以刷新数据。"
 #~ msgstr ""
 
-#: src/pages/LabsEnvironment.tsx:1300
+#: src/pages/LabsEnvironment.tsx:1313
 msgid "The line is a historical model inside supported ranges only. A blank range means comparable stable workload did not pass the display floor; Praxys does not estimate or connect through it. The shaded band shows aggregate uncertainty where the curve is supported. It does not identify a causal personal coefficient and never extrapolates beyond your observed domain. Wind, solar load, clothing, hydration, fatigue, and other unmeasured conditions can still differ between runs."
 msgstr "曲线仅显示在支持充足的历史区间。空白区间表示可比稳定负荷未达到显示门槛；Praxys 不会在其中估算，也不会跨越连接。阴影带表示曲线支持区间内的汇总不确定性。它不是个人因果系数，也不会外推到观测范围之外。不同活动之间的风、太阳辐射、衣着、补水、疲劳及其他未测量条件仍可能不同。"
 
@@ -8208,8 +8208,8 @@ msgstr "已恢复上一项训练"
 msgid "The public status feed has no unresolved incidents."
 msgstr "公共状态源中没有未解决事件。"
 
-#: src/pages/LabsEnvironment.tsx:382
-#: src/pages/LabsEnvironment.tsx:1002
+#: src/pages/LabsEnvironment.tsx:387
+#: src/pages/LabsEnvironment.tsx:1015
 msgid "The quick check found a data requirement that needs attention."
 msgstr "快速检查发现一项需要处理的数据要求。"
 
@@ -8226,19 +8226,19 @@ msgstr "滚动的 14 天窗口会下发到 {0}。"
 msgid "The rolling exposure threshold is still met, but it does not establish a retention plateau; response-specific adaptations may already be declining."
 msgstr "滚动暴露阈值仍然满足，但这并不代表存在保留平台期；不同适应反应可能已经开始减弱。"
 
-#: src/pages/LabsEnvironment.tsx:320
+#: src/pages/LabsEnvironment.tsx:325
 msgid "The rolling limit protects the shared analysis capacity from repeated requests."
 msgstr "滚动上限可防止重复请求占用共享分析容量。"
 
-#: src/pages/LabsEnvironment.tsx:995
+#: src/pages/LabsEnvironment.tsx:1008
 msgid "The rolling recompute limit has been reached. Try again after {availableAt}."
 msgstr "已达到滚动重新计算上限，请在 {availableAt} 后重试。"
 
-#: src/pages/LabsEnvironment.tsx:996
+#: src/pages/LabsEnvironment.tsx:1009
 msgid "The rolling recompute limit has been reached. Try again later."
 msgstr "已达到滚动重新计算上限，请稍后重试。"
 
-#: src/pages/LabsEnvironment.tsx:76
+#: src/pages/LabsEnvironment.tsx:81
 msgid "The same comparable-power range is not represented across enough environmental conditions."
 msgstr "同一可比功率范围未覆盖足够多的环境条件。"
 
@@ -8266,15 +8266,15 @@ msgstr "数据服务更新完成后，每周历史图表将自动显示。"
 msgid "Theme"
 msgstr "主题"
 
-#: src/pages/LabsEnvironment.tsx:71
+#: src/pages/LabsEnvironment.tsx:76
 msgid "There are not enough eligible Stryd activities yet."
 msgstr "符合条件的 Stryd 活动数量暂时不足。"
 
-#: src/pages/LabsEnvironment.tsx:72
+#: src/pages/LabsEnvironment.tsx:77
 msgid "There are not enough stable, comparable segments yet."
 msgstr "稳定且可比的分段数量暂时不足。"
 
-#: src/pages/LabsEnvironment.tsx:74
+#: src/pages/LabsEnvironment.tsx:79
 msgid "There is not enough chronological history to evaluate whether the relationship holds later."
 msgstr "按时间顺序的数据不足，无法评估该关系在后续活动中是否仍然成立。"
 
@@ -8290,7 +8290,7 @@ msgstr "此操作无法撤销。如果这是最后一个管理员账号，将无
 msgid "This change used confirmed private context. The private detail is not copied into the plan record."
 msgstr "这次调整使用了已确认的计划个性化信息，具体内容不会写入计划记录。"
 
-#: src/pages/LabsEnvironment.tsx:799
+#: src/pages/LabsEnvironment.tsx:812
 msgid "This combination is outside Praxys’s conservative Stull method domain."
 msgstr "此温湿度组合超出 Praxys 采用的保守 Stull 方法范围。"
 
@@ -8319,11 +8319,11 @@ msgstr "这类信息会进入安全流程，暂停常规训练优化。Praxys �
 msgid "This evaluates past training only; it does not assess today's weather or conditions."
 msgstr "这仅评估过往训练，不评估今天的天气或环境条件。"
 
-#: src/pages/LabsEnvironment.tsx:822
+#: src/pages/LabsEnvironment.tsx:835
 msgid "This falls in an unsupported historical range, so it is not marked on the curve."
 msgstr "该值落在证据不足的历史范围内，因此不会标记在曲线上。"
 
-#: src/pages/LabsEnvironment.tsx:87
+#: src/pages/LabsEnvironment.tsx:92
 msgid "This first experiment currently supports continuous Stryd power only."
 msgstr "首个实验目前仅支持连续 Stryd 功率。"
 
@@ -8343,11 +8343,11 @@ msgstr "此护栏采用个体化 HRV 指导，且不会加载活动强度。具�
 msgid "This insight changed. Refresh the page before sending feedback."
 msgstr "这条解读已更新。请先刷新页面，再提交反馈。"
 
-#: src/pages/LabsEnvironment.tsx:899
+#: src/pages/LabsEnvironment.tsx:912
 msgid "This is a retrospective historical association. It does not forecast a future run, prove that heat caused a heart-rate change, prescribe pace, measure adaptation or hydration, or assess heat safety."
 msgstr "这是一项回顾性的历史关联分析。它不会预测未来跑步、证明热环境导致心率变化、建议配速、衡量热适应或补水状态，也不评估高温安全。"
 
-#: src/pages/LabsEnvironment.tsx:817
+#: src/pages/LabsEnvironment.tsx:830
 msgid "This is above your displayed historical range, so the curve does not extrapolate to it."
 msgstr "该值高于已显示的历史范围，因此曲线不会外推到此处。"
 
@@ -8355,7 +8355,7 @@ msgstr "该值高于已显示的历史范围，因此曲线不会外推到此处
 msgid "This is an inference from training evidence in similar conditions, not a direct physiological measurement."
 msgstr "这是基于相似环境下训练证据的推断，并非直接的生理测量。"
 
-#: src/pages/LabsEnvironment.tsx:812
+#: src/pages/LabsEnvironment.tsx:825
 msgid "This is below your displayed historical range, so the curve does not extrapolate to it."
 msgstr "该值低于已显示的历史范围，因此曲线不会外推到此处。"
 
@@ -8363,7 +8363,7 @@ msgstr "该值低于已显示的历史范围，因此曲线不会外推到此处
 msgid "This is not medical clearance or a personal heat-tolerance assessment."
 msgstr "这不构成医疗许可，也不是个人耐热能力评估。"
 
-#: src/pages/LabsEnvironment.tsx:831
+#: src/pages/LabsEnvironment.tsx:844
 msgid "This is Stull’s psychrometric estimate from air temperature and relative humidity. It is not apparent temperature, natural wet bulb, outdoor WBGT, body temperature, or a heat-safety assessment."
 msgstr "这是根据气温和相对湿度计算的 Stull 干湿球湿球温度估算值。它不是体感温度、自然湿球温度、室外 WBGT、体温或高温安全评估。"
 
@@ -8396,7 +8396,7 @@ msgstr "这项权限与托管下发相互独立。启用前请确认具体边界
 msgid "This queue item no longer exists. Refresh the queue."
 msgstr "这个队列项已不存在。请刷新队列。"
 
-#: src/pages/LabsEnvironment.tsx:401
+#: src/pages/LabsEnvironment.tsx:406
 msgid "This quick check only covers definite prerequisites. The full analysis can still return insufficient support, an unstable association, or no conclusion."
 msgstr "快速检查只覆盖明确的前置条件。完整分析仍可能返回支持不足、关联不稳定或无法得出结论。"
 
@@ -8404,11 +8404,11 @@ msgstr "快速检查只覆盖明确的前置条件。完整分析仍可能返回
 msgid "This removes the Praxys workout from the canonical plan. Any external workout stays untouched."
 msgstr "这会从 Praxys 主计划中删除该训练。外部训练不会受到影响。"
 
-#: src/pages/LabsEnvironment.tsx:978
+#: src/pages/LabsEnvironment.tsx:991
 msgid "This result did not pass the experiment’s release guardrails."
 msgstr "此结果未通过实验的发布门槛。"
 
-#: src/pages/LabsEnvironment.tsx:70
+#: src/pages/LabsEnvironment.tsx:75
 msgid "This result uses an earlier experiment model and needs to be run again."
 msgstr "该结果使用了旧版实验模型，需要重新运行。"
 
@@ -8423,7 +8423,7 @@ msgstr "该结果使用了旧版实验模型，需要重新运行。"
 msgid "This section is unavailable. Other management workflows remain available."
 msgstr "此部分暂不可用，其他管理流程仍可使用。"
 
-#: src/pages/LabsEnvironment.tsx:807
+#: src/pages/LabsEnvironment.tsx:820
 msgid "This sits inside your displayed historical range and is marked on the curve."
 msgstr "该值位于已显示的历史范围内，并已标记在曲线上。"
 
@@ -8723,7 +8723,7 @@ msgstr "无法连接状态服务"
 #: src/pages/admin/AdminFeedback.tsx:466
 #: src/pages/admin/AdminFeedback.tsx:493
 #: src/pages/admin/AdminOps.tsx:191
-#: src/pages/LabsEnvironment.tsx:160
+#: src/pages/LabsEnvironment.tsx:165
 msgid "Unavailable"
 msgstr "不可用"
 
@@ -8957,7 +8957,7 @@ msgstr "VO2max、CP、LTHR、训练状态"
 msgid "Volume"
 msgstr "里程"
 
-#: src/pages/LabsEnvironment.tsx:1129
+#: src/pages/LabsEnvironment.tsx:1142
 msgid "Voluntary experiments that help you inspect your own training history without turning early research into advice."
 msgstr "自愿参与的实验，帮助理解个人训练历史，同时不把早期研究包装成建议。"
 
@@ -9091,11 +9091,11 @@ msgstr "欢迎回来。"
 #~ msgid "Wet-bulb estimate unavailable"
 #~ msgstr "无法估算湿球温度"
 
-#: src/pages/LabsEnvironment.tsx:504
+#: src/pages/LabsEnvironment.tsx:517
 msgid "wet-bulb proxy"
 msgstr "湿球温度代理值"
 
-#: src/pages/LabsEnvironment.tsx:760
+#: src/pages/LabsEnvironment.tsx:773
 msgid "Wet-bulb proxy calculator"
 msgstr "湿球温度代理值计算器"
 
@@ -9123,7 +9123,7 @@ msgstr "遇到了什么问题，或希望我们做些什么？"
 msgid "What happened?"
 msgstr "这次训练怎么了？"
 
-#: src/pages/LabsEnvironment.tsx:897
+#: src/pages/LabsEnvironment.tsx:910
 msgid "What this can—and cannot—tell you"
 msgstr "它能说明什么，又不能说明什么"
 
@@ -9147,7 +9147,7 @@ msgstr "训练目标是什么？（可选）"
 msgid "Why this is conservative"
 msgstr "为什么这是保守调整"
 
-#: src/pages/LabsEnvironment.tsx:935
+#: src/pages/LabsEnvironment.tsx:948
 msgid "Why this remains experimental"
 msgstr "为什么它仍属于实验"
 
@@ -9155,7 +9155,7 @@ msgstr "为什么它仍属于实验"
 msgid "Will sync:"
 msgstr "将同步以下内容："
 
-#: src/pages/LabsEnvironment.tsx:1226
+#: src/pages/LabsEnvironment.tsx:1239
 msgid "Withdraw"
 msgstr "退出"
 
@@ -9163,27 +9163,27 @@ msgstr "退出"
 msgid "Withdraw AI permission"
 msgstr "撤回 AI 权限"
 
-#: src/pages/LabsEnvironment.tsx:1382
+#: src/pages/LabsEnvironment.tsx:1395
 msgid "Withdraw and delete"
 msgstr "退出并删除"
 
-#: src/pages/LabsEnvironment.tsx:1347
+#: src/pages/LabsEnvironment.tsx:1360
 msgid "Withdraw and delete result"
 msgstr "退出并删除结果"
 
-#: src/pages/LabsEnvironment.tsx:889
+#: src/pages/LabsEnvironment.tsx:902
 msgid "Withdraw anytime"
 msgstr "可随时退出"
 
-#: src/pages/LabsEnvironment.tsx:1365
+#: src/pages/LabsEnvironment.tsx:1378
 msgid "Withdraw from this experiment?"
 msgstr "退出此实验？"
 
-#: src/pages/LabsEnvironment.tsx:1321
+#: src/pages/LabsEnvironment.tsx:1334
 msgid "Withdrawal deletes the experiment consent and aggregate result. Rejoining later requires new consent and a new computation."
 msgstr "退出后将删除实验同意记录和汇总结果。今后重新加入时，需要再次同意并重新计算。"
 
-#: src/pages/LabsEnvironment.tsx:891
+#: src/pages/LabsEnvironment.tsx:904
 msgid "Withdrawal immediately deletes experiment consent and the derived result. Your ordinary account activities remain unchanged."
 msgstr "退出后会立即删除实验同意记录和派生结果，账号中的普通活动保持不变。"
 
@@ -9255,7 +9255,7 @@ msgstr "你"
 msgid "You can attach up to 3 images."
 msgstr "最多可添加 3 张图片。"
 
-#: src/pages/LabsEnvironment.tsx:275
+#: src/pages/LabsEnvironment.tsx:280
 msgid "You can leave this page and return later. No action is needed while the analysis runs."
 msgstr "可离开此页面，稍后再回来。分析运行期间无需任何操作。"
 
@@ -9263,7 +9263,7 @@ msgstr "可离开此页面，稍后再回来。分析运行期间无需任何操
 msgid "You can withdraw before any later request. Withdrawal cannot recall a request the provider already processed. Deleting the item removes local provider-use receipts and dependent private explanations."
 msgstr "你可以在后续请求前撤回。撤回无法收回 AI 服务已处理的请求。删除该项会移除本地 AI 使用记录和关联的私密说明。"
 
-#: src/pages/LabsEnvironment.tsx:1319
+#: src/pages/LabsEnvironment.tsx:1332
 msgid "You control this experiment"
 msgstr "此实验由你掌控"
 
@@ -9285,11 +9285,11 @@ msgstr "you@example.com"
 msgid "Your account is active. You can now sign in."
 msgstr "账号已激活，现在可以登录了。"
 
-#: src/pages/LabsEnvironment.tsx:676
+#: src/pages/LabsEnvironment.tsx:689
 msgid "Your comparable power range"
 msgstr "个人可比功率范围"
 
-#: src/pages/LabsEnvironment.tsx:581
+#: src/pages/LabsEnvironment.tsx:594
 msgid "Your comparable range"
 msgstr "个人可比范围"
 
@@ -9301,7 +9301,7 @@ msgstr "正在下载数据导出文件。"
 #~ msgid "Your descriptive stability checks passed, but the chronological test did not show better future-run prediction. Read the curve only as a pattern in eligible past runs."
 #~ msgstr "描述性稳定性检查已通过，但按时间顺序的测试未显示对未来跑步有更好的预测能力。请仅将曲线理解为符合条件的历史跑步模式。"
 
-#: src/pages/LabsEnvironment.tsx:73
+#: src/pages/LabsEnvironment.tsx:78
 msgid "Your eligible runs do not cover enough different temperature-and-humidity conditions."
 msgstr "符合条件的跑步尚未覆盖足够多样的温湿度条件。"
 
@@ -9318,11 +9318,11 @@ msgstr "计划仍由外部工具管理。"
 msgid "Your Garmin account has multi-factor authentication enabled. Enter the verification code Garmin sent you to finish connecting."
 msgstr "你的 Garmin 账号已启用多重验证。输入 Garmin 发送的验证码，完成连接。"
 
-#: src/pages/LabsEnvironment.tsx:1241
+#: src/pages/LabsEnvironment.tsx:1254
 msgid "Your historical environmental-response curve"
 msgstr "你的历史环境响应曲线"
 
-#: src/pages/LabsEnvironment.tsx:95
+#: src/pages/LabsEnvironment.tsx:100
 msgid "Your history includes enough broad sample coverage, but the full analysis must confirm that power, heart rate, and Critical Power use one compatible Stryd regime."
 msgstr "历史数据具备足够的总体采样覆盖，但仍需完整分析确认功率、心率和临界功率来自兼容的 Stryd 数据体系。"
 
@@ -9334,11 +9334,11 @@ msgstr "Praxys 账号信息"
 msgid "Your name"
 msgstr "姓名"
 
-#: src/pages/LabsEnvironment.tsx:1240
+#: src/pages/LabsEnvironment.tsx:1253
 msgid "Your partial historical environmental-response curve"
 msgstr "你的部分历史环境响应曲线"
 
-#: src/pages/LabsEnvironment.tsx:1303
+#: src/pages/LabsEnvironment.tsx:1316
 msgid "Your personal comparable-power range controls where the curve can be displayed. The fitted model still uses every otherwise eligible stable segment from 65–95% CP, so the display range does not discard broader model data."
 msgstr "个人可比功率范围只决定曲线可显示的区间。拟合模型仍会使用 65–95% CP 内所有其他条件均符合要求的稳定区段，因此显示范围不会丢弃更广范围的模型数据。"
 
@@ -9356,19 +9356,19 @@ msgstr "Praxys 邀请码：{0}\n"
 "\n"
 "注册链接：{1}"
 
-#: src/pages/LabsEnvironment.tsx:271
+#: src/pages/LabsEnvironment.tsx:276
 msgid "Your request is stored durably and will run separately from the app."
 msgstr "请求已安全保存，并会与应用分开运行。"
 
-#: src/pages/LabsEnvironment.tsx:879
+#: src/pages/LabsEnvironment.tsx:892
 msgid "Your result is not pooled with other users and is not donated to cohort research."
 msgstr "你的结果不会与其他用户合并，也不会捐赠给群体研究。"
 
-#: src/pages/LabsEnvironment.tsx:1193
+#: src/pages/LabsEnvironment.tsx:1206
 msgid "Your result needs recomputing"
 msgstr "结果需要重新计算"
 
-#: src/pages/LabsEnvironment.tsx:69
+#: src/pages/LabsEnvironment.tsx:74
 msgid "Your source data changed while this result was being computed."
 msgstr "计算过程中源数据发生了变化。"
 

--- a/web/src/pages/LabsEnvironment.tsx
+++ b/web/src/pages/LabsEnvironment.tsx
@@ -46,6 +46,11 @@ import { useApi, apiFetch, extractErrorMessage } from '@/hooks/useApi';
 import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '@/hooks/useTheme';
 import { getChartColors } from '@/lib/chart-theme';
+import {
+  getMarkerLabelPosition,
+  getWetBulbChartDomain,
+  getWetBulbPointDomain,
+} from '@/lib/labs-environment-chart';
 import { cn } from '@/lib/utils';
 import type {
   LabsEnvironmentCurvePoint,
@@ -447,6 +452,8 @@ function ResultChart({
       bandBase: point.relative_lower_bpm,
       bandSize: point.relative_upper_bpm - point.relative_lower_bpm,
     }));
+  const chartDomain =
+    getWetBulbChartDomain(supportBins) ?? getWetBulbPointDomain(points);
   const markerVisible =
     calculatorWetBulb != null &&
     (
@@ -458,8 +465,14 @@ function ResultChart({
             calculatorWetBulb <= bin.upper_wet_bulb_c
           ),
         )
-        : points.some((point) => point.wet_bulb_c === calculatorWetBulb)
+        : chartDomain != null &&
+          calculatorWetBulb >= chartDomain[0] &&
+          calculatorWetBulb <= chartDomain[1]
     );
+  const markerLabelPosition =
+    calculatorWetBulb != null && chartDomain != null
+      ? getMarkerLabelPosition(calculatorWetBulb, chartDomain)
+      : 'insideTopRight';
 
   return (
     <div
@@ -473,7 +486,7 @@ function ResultChart({
           <XAxis
             dataKey="wet_bulb_c"
             type="number"
-            domain={['dataMin', 'dataMax']}
+            domain={chartDomain ?? ['dataMin', 'dataMax']}
             tick={{ fill: colors.tick, fontSize: 12 }}
             tickFormatter={(value) => `${Number(value).toFixed(1)}°`}
             label={{
@@ -538,7 +551,7 @@ function ResultChart({
                 value: i18n._(msg`Calculator`),
                 fill: colors.threshold,
                 fontSize: 11,
-                position: 'insideTopRight',
+                position: markerLabelPosition,
               }}
             />
           )}

--- a/web/tests/labs-environment.test.mjs
+++ b/web/tests/labs-environment.test.mjs
@@ -52,6 +52,26 @@ test('web Labs covers consent, result, calculator, and withdrawal states', async
   assert.match(app, /Reload Labs/);
 });
 
+test('Labs chart keeps calculator markers inside the displayed bin domain', async () => {
+  const {
+    getMarkerLabelPosition,
+    getWetBulbChartDomain,
+    getWetBulbPointDomain,
+  } = await import('../src/lib/labs-environment-chart.ts');
+  const domain = getWetBulbChartDomain([
+    { lower_wet_bulb_c: 5.7, upper_wet_bulb_c: 9.9 },
+    { lower_wet_bulb_c: 22.7, upper_wet_bulb_c: 26.9 },
+  ]);
+
+  assert.deepEqual(domain, [5.7, 26.9]);
+  assert.deepEqual(
+    getWetBulbPointDomain([{ wet_bulb_c: 7.8 }, { wet_bulb_c: 24.8 }]),
+    [7.8, 24.8],
+  );
+  assert.equal(getMarkerLabelPosition(25.8, domain), 'insideTopRight');
+  assert.equal(getMarkerLabelPosition(8.0, domain), 'insideTopLeft');
+});
+
 test('a timed-out Labs preflight aborts once and leaves its query in error', async () => {
   const originalWindow = globalThis.window;
   const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

Fix the intermittent Labs wet-bulb calculator marker by using the displayed support-bin boundaries, rather than curve-point midpoints, as the chart's numeric domain. Keep the calculator label inside the plot near either edge and preserve continuous marker behavior for legacy point-only results.

## Validation

- `cd web && npm run build`
- `python scripts/check_ui_quality.py --base origin/main --head HEAD --skip-evidence`
- Rendered 25.8 °C and 6.9 °C repeated calculations against a representative 5.7–26.9 °C result
- Full preflight completed 2,221 backend tests on the first run before requesting generated catalog references. The clean rerun reached six unrelated date-boundary failures in plan tests; the same failures reproduce on `origin/main` while local time is one day ahead of UTC.

## UI quality

- Impeccable: `harden web/src/pages/LabsEnvironment.tsx`
- Visual review: web desktop 1440×900 and mobile 390×844, light theme, English and Simplified Chinese
- States checked: available result, repeated calculations, lower supported edge, upper supported edge beyond the last curve midpoint
- Accessibility: existing labeled inputs and chart accessible name preserved; marker and translated label remain visible without mobile clipping
- Design system impact: none - bounded chart-domain and label-position fix using existing chart tokens
- Miniapp parity: not applicable - the miniapp calculator does not claim or render a chart marker
- Exceptions: none