### PR TITLE
Standardize frontend builds on Node 24 LTS

### DIFF
--- a/.github/workflows/ci-premerge.yml
+++ b/.github/workflows/ci-premerge.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/package-lock.json
 
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Check changed UI files and PR evidence
         if: github.event_name == 'pull_request'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/deploy-frontend-appservice.yml
+++ b/.github/workflows/deploy-frontend-appservice.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/package-lock.json
 
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/miniapp-build.yml
+++ b/.github/workflows/miniapp-build.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: miniapp/package-lock.json
       - name: Install

--- a/.github/workflows/miniapp-publish.yml
+++ b/.github/workflows/miniapp-publish.yml
@@ -84,7 +84,7 @@ jobs:
       - if: steps.gate.outputs.publish == 'true'
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: miniapp/package-lock.json
 

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -97,8 +97,10 @@ and synthetic sandbox preparation. The cloud config's literal
 `actions/setup-python`; local profiles continue to require the project
 virtualenv unless `PRAXYS_MCP_PYTHON` is explicitly set.
 
-The setup workflow also owns the cloud agent's Node 22 dependency bootstrap.
-It uses `npm install` because the current Lingui package metadata is not strict
+The setup workflow also owns the cloud agent's Node 24 LTS dependency
+bootstrap. Application web and mini-program build workflows use the same Node
+major so CI validation and production artifacts share a supported baseline. It
+uses `npm install` because the current Lingui package metadata is not strict
 `npm ci` compatible, then restores and verifies `web/package-lock.json` before
 the agent starts. This requires no secret or repository variable; change the
 workflow and this runbook together if the install strategy changes.

--- a/miniapp/package-lock.json
+++ b/miniapp/package-lock.json
@@ -8,15 +8,15 @@
       "name": "praxys-miniapp",
       "version": "0.2.0",
       "devDependencies": {
-        "miniprogram-api-typings": "^5.2.3",
+        "miniprogram-api-typings": "^5.2.2",
         "typescript": "^5.6.3",
         "yaml": "^2.9.0"
       }
     },
     "node_modules/miniprogram-api-typings": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/miniprogram-api-typings/-/miniprogram-api-typings-5.2.3.tgz",
-      "integrity": "sha512-KVcNSfR2VmRtz35rxkjLxE92HlsBnbT6NsKyTcDX3ebbTKAsAiTOFO1mRM82Xbe848dnEYqNGzaD48LMEvGytw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/miniprogram-api-typings/-/miniprogram-api-typings-5.2.2.tgz",
+      "integrity": "sha1-wD4BytVFrqLRLs8P/eN4XrhugGY=",
       "dev": true,
       "license": "MIT"
     },

--- a/miniapp/package.json
+++ b/miniapp/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
-    "miniprogram-api-typings": "^5.2.3",
+    "miniprogram-api-typings": "^5.2.2",
     "typescript": "^5.6.3",
     "yaml": "^2.9.0"
   }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,7 +23,7 @@
         "@tanstack/react-query": "^5.101.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^1.30.0",
+        "lucide-react": "^1.28.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-is": "^19.2.8",
@@ -31,11 +31,11 @@
         "react-router-dom": "^7.18.2",
         "recharts": "^3.10.1",
         "remark-gfm": "^4.0.1",
-        "shadcn": "^4.16.2",
+        "shadcn": "^4.16.1",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
-        "web-vitals": "^6.1.0"
+        "web-vitals": "^6.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -43,17 +43,17 @@
         "@lingui/format-po": "^6.6.0",
         "@lingui/swc-plugin": "^6.6.0",
         "@lingui/vite-plugin": "^6.6.0",
-        "@types/node": "^26.2.0",
+        "@types/node": "^26.1.2",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react-swc": "^4.3.3",
-        "eslint": "^10.8.1",
+        "eslint": "^10.8.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.9.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.66.0",
-        "vite": "^8.2.1",
+        "vite": "^8.2.0",
         "vite-plugin-pwa": "^1.3.0"
       }
     },
@@ -4558,9 +4558,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha1-2nlwjx+cYpT0zeyPRVowMrAogIo=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -6475,9 +6475,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha1-5tGZB6PwkKU6AiJhujTF/20EkIs=",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -8936,9 +8936,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.30.0.tgz",
-      "integrity": "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha1-2VVTavsN9JCk6X+vBozrjGstr78=",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -11481,9 +11481,9 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.16.2.tgz",
-      "integrity": "sha512-M1AvZKFWcCzWRDoyApIqJMSLIpY8Ev4uBGuiPLSFmiTbixXhPmzotSTvLzFmBrfoIxG9aIg2dZOETblEaXGUnQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.16.1.tgz",
+      "integrity": "sha1-LD9S8bj4NhvtB+KlnrHQcbkmFz8=",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -12704,16 +12704,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
-      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha1-kC/NPcAxL1U8hbbLxGJdysotjfg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.25",
-        "rolldown": "~1.2.1",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -13086,9 +13086,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.1.0.tgz",
-      "integrity": "sha512-ZNoJ/MbU6aaR2WjKrFVUvy5WQx+G96YvXQFSsmKTz3A/0VlAFywjUcxl00hc/S6wef2stfgQ4yWYIJCWCNudkA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.1.tgz",
+      "integrity": "sha1-d03l+6VhFUMTvMCdElmQ8Eb90XQ=",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
     "@tanstack/react-query": "^5.101.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.30.0",
+    "lucide-react": "^1.28.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-is": "^19.2.8",
@@ -36,11 +36,11 @@
     "react-router-dom": "^7.18.2",
     "recharts": "^3.10.1",
     "remark-gfm": "^4.0.1",
-    "shadcn": "^4.16.2",
+    "shadcn": "^4.16.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",
-    "web-vitals": "^6.1.0"
+    "web-vitals": "^6.0.1"
   },
   "overrides": {
     "serialize-javascript": "^7.0.5"
@@ -51,17 +51,17 @@
     "@lingui/format-po": "^6.6.0",
     "@lingui/swc-plugin": "^6.6.0",
     "@lingui/vite-plugin": "^6.6.0",
-    "@types/node": "^26.2.0",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react-swc": "^4.3.3",
-    "eslint": "^10.8.1",
+    "eslint": "^10.8.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.9.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.66.0",
-    "vite": "^8.2.1",
+    "vite": "^8.2.0",
     "vite-plugin-pwa": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Summary

- standardize web, mini-program, deployment, i18n, and cloud-agent builds on Node 24 LTS
- align frontend dependency versions with the shared compatibility baseline used by local and CI installs
- update the operations runbook with the supported build-toolchain baseline

## Validation

- `cd web && npm ci --no-audit --no-fund && npm run build`
- `cd miniapp && npm ci --no-audit --no-fund && npm run typecheck`
- downloaded all backend, MCP, and frontend-server Python requirement artifacts
- parsed the changed workflow YAML files
- `python scripts/validate_ops_runbooks.py`
- `python scripts/check_ui_quality.py --base origin/main --head HEAD --skip-evidence`
