### PR TITLE
Integrate WeChat DevTools skills for WSL2

### DIFF
--- a/.claude/skills/wechat-devtools/SKILL.md
+++ b/.claude/skills/wechat-devtools/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: wechat-devtools
+description: >-
+  Use for Praxys WeChat miniapp compilation, simulator automation, screenshots,
+  diagnostics, preview, and upload through Windows Nightly DevTools from WSL2.
+---
+
+# WeChat DevTools
+
+The canonical cross-agent integration is
+`.github/skills/wechat-devtools/SKILL.md`. Read it in full and follow it. It
+bridges WSL2 to the Windows Nightly installation while leaving Tencent's
+installed `wechatide-skill` as the authoritative tool specification.

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,5 @@
 *.css text eol=lf
 *.sh text eol=lf
 *.js text eol=lf
+scripts/wechatide text eol=lf
 .github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,10 @@ state coverage, and the PR evidence required by CI.
   semantics when useful, never as a substitute for rendered review. If no
   browser tool is available, keep the PR draft and say that rendered
   verification is incomplete.
+- For local miniapp work on Windows + WSL2, invoke the repository
+  `wechat-devtools` skill. It bridges to the separately installed Nightly
+  WeChat DevTools for compilation, simulator automation, screenshots, and
+  console/network inspection. Tencent's installed skill remains authoritative.
 - Follow `.github/instructions/ui-quality.instructions.md` for the complete
   path-specific flow. Classify design-system discoveries as fixed locally,
   updated in the design source of truth, or linked to a filed follow-up, and

--- a/.github/skills/wechat-devtools/SKILL.md
+++ b/.github/skills/wechat-devtools/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: wechat-devtools
+description: >-
+  Use for Praxys WeChat miniapp compilation, simulator automation, screenshots,
+  console/network diagnostics, preview, and upload. Bridges a WSL2 agent to the
+  Windows Nightly WeChat DevTools and delegates tool semantics to Tencent's
+  installed wechatide-skill.
+user-invocable: true
+argument-hint: "[miniapp task]"
+---
+
+# WeChat DevTools
+
+Use this skill whenever a miniapp task needs rendered verification, simulator
+interaction, runtime diagnostics, preview, or upload. It complements the
+repository `ui-quality` skill; it does not replace the required product,
+accessibility, state, parity, or PR-evidence review.
+
+## Load the authoritative upstream skill
+
+Tencent ships the canonical skill inside the installed Nightly DevTools. Do not
+copy or edit that directory in this repository.
+
+```bash
+skill_root="$(scripts/wechatide --print-skill-root)"
+```
+
+Read `${skill_root}/SKILL.md`, then read only the scene and references it routes
+the current task to. Tool names and parameters come from the installed skill,
+especially `${skill_root}/wechatide-tools/references/tools.yaml`; never invent
+them.
+
+All upstream commands written as `wechatide ...` must be executed as:
+
+```bash
+scripts/wechatide ...
+```
+
+The wrapper selects the separately installed `*-nightly` build and invokes the
+Windows CLI. WeChat DevTools rejects WSL UNC project roots, so when a command
+receives the repository `miniapp/` path the wrapper first synchronizes it to a
+generated Windows-side mirror, then passes that local Windows path. The WSL
+repository remains the only source of truth; never edit the mirror.
+
+Set `WECHATIDE_INSTALL_ROOT` to an explicit WSL path only when Nightly is
+installed outside the normal Tencent directory. Set
+`WECHATIDE_PROJECT_MIRROR` only when the generated mirror needs a different
+Windows-mounted location.
+
+## Praxys project
+
+The miniapp project root is:
+
+```text
+<repository root>/miniapp
+```
+
+Before opening it, confirm `miniapp/project.config.json` exists and has a valid
+non-tourist `appid`, as required by the upstream skill. Pass the absolute WSL
+path; the wrapper synchronizes and converts it. To prepare or inspect the
+mirror explicitly:
+
+```bash
+scripts/wechatide --sync-project
+scripts/wechatide --print-project-root
+```
+
+Use the stable client name `Copilot` for authorization:
+
+```bash
+scripts/wechatide -c Copilot check_wechatide_status --skill-version <version>
+```
+
+Read `<version>` from the installed upstream `SKILL.md`; do not hardcode it.
+Complete the upstream status, login, token, approval, and asynchronous-task
+gates before invoking business tools. Never store a CLI access token in the
+repository or print it in logs.
+
+## Verification boundary
+
+For miniapp UI changes, use the simulator tools to open the affected page,
+exercise the interaction, capture synthetic-data screenshots, and inspect
+console/network output. A simulator refresh alone is not compilation proof;
+follow the upstream compiler scene and still run `cd miniapp && npm run
+typecheck`.
+
+Preview, upload, cloud writes, destructive project operations, login, and
+authorization remain user-gated exactly as documented by the upstream skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ For **production operations** (deploy, config & secrets, monitoring & alerts, ad
 
 ## Claude Code Automations
 
-Automations live in `.claude/` and are committed so every contributor using Claude Code sees the same behavior. See `.claude/settings.json` for post-edit hooks (run pytest on Python changes; run ESLint on web TS changes; run the shared Impeccable detector on UI edits plus a stop-time deep pass), `.claude/agents/` for subagents (`science-reviewer`, `metric-addition-reviewer`, `api-contract-reviewer` — all read-only), and `.claude/skills/` for dev-workflow skills. The `ui-quality` skill points to the canonical vendored Impeccable copy in `.github/skills/impeccable/` so Claude and Copilot follow the same design policy.
+Automations live in `.claude/` and are committed so every contributor using Claude Code sees the same behavior. See `.claude/settings.json` for post-edit hooks (run pytest on Python changes; run ESLint on web TS changes; run the shared Impeccable detector on UI edits plus a stop-time deep pass), `.claude/agents/` for subagents (`science-reviewer`, `metric-addition-reviewer`, `api-contract-reviewer` — all read-only), and `.claude/skills/` for dev-workflow skills. The `ui-quality` skill points to the canonical vendored Impeccable copy in `.github/skills/impeccable/` so Claude and Copilot follow the same design policy. The `wechat-devtools` skill uses `scripts/wechatide` to bridge WSL2 to a separately installed Windows Nightly WeChat DevTools and reads Tencent's installed skill as the authoritative simulator/compiler/debugger contract.
 
 ## AI Skills
 

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -284,6 +284,10 @@ The repo ships committed Claude Code automations in `.claude/`. Full inventory i
   - `api-contract-reviewer` — cross-reads Python response shapes against TS interfaces.
 - **Dev skills**:
   - `ui-quality` — mandatory cross-agent UI workflow; delegates to the canonical Impeccable copy under `.github/skills/`.
+  - `wechat-devtools` — bridges WSL2 agents to the separately installed Windows
+    Nightly WeChat DevTools. It loads Tencent's installed `wechatide-skill`
+    rather than vendoring a stale copy, and provides simulator, compile,
+    screenshot, console/network, preview, and upload workflows.
   - `seed-and-preview` — resets the local DB to sample data and boots API + Vite. User-invocable only (has side effects). See `.claude/skills/seed-and-preview/SKILL.md`.
 
 If a hook is getting in your way, edit `.claude/settings.json`. If a reviewer agent misses a pattern, extend its prompt in `.claude/agents/<name>.md` — they are just markdown with YAML frontmatter.

--- a/docs/dev/ui-quality-harness.md
+++ b/docs/dev/ui-quality-harness.md
@@ -49,16 +49,26 @@ the rendered files trigger it.
 7. Classify design-system impact: fix a local defect now; update a clear missing
    reusable rule/token/component in the source of truth; or file a linked
    `Design system gap` issue for a broad decision or out-of-scope migration.
-8. Run the real feature with sample data. Inspect desktop and mobile together
-   with Chrome DevTools MCP or built-in cloud-agent Playwright, exercise the
-   interaction by keyboard, and review console output. Praxys MCP may provide
-   synthetic data semantics but does not replace rendered review. Fix findings
-   in one batch, then do at most one confirmation pass.
+8. Run the real feature with sample data. Inspect web desktop and mobile
+   together with Chrome DevTools MCP or built-in cloud-agent Playwright. For a
+   local miniapp change on Windows + WSL2, invoke `wechat-devtools` and inspect
+   the affected page in the WeChat simulator, including screenshots and
+   console/network output. Praxys MCP may provide synthetic data semantics but
+   does not replace rendered review. Fix findings in one batch, then do at most
+   one confirmation pass.
 9. Run targeted tests, builds/typechecks, and the local gate. Complete the PR
    evidence before marking the PR ready.
 
 If browser automation is unavailable, the contributor must not claim rendered
 verification. An agent keeps the PR draft and records the limitation.
+
+The repository does not vendor Tencent's DevTools skill. The
+`wechat-devtools` wrapper reads the authoritative copy from a separately
+installed Nightly build and uses `scripts/wechatide` to cross the WSL2/Windows
+process boundary. Because DevTools rejects WSL UNC project roots, the wrapper
+synchronizes `miniapp/` to a generated Windows-side mirror before project
+operations; the WSL repository remains authoritative. Stable WeChat DevTools
+remains separate and is not selected by default.
 
 ## Brand floor
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -34,6 +34,26 @@ This is deliberately separate from the athlete-facing `/science` plugin skill.
 research literature or change Evidence Reviews, SDRs, formulas, or product
 behavior.
 
+## Developer WeChat DevTools
+
+`wechat-devtools` is the repository-owned integration at
+`.github/skills/wechat-devtools/SKILL.md`, with a thin Claude Code entry point
+at `.claude/skills/wechat-devtools/SKILL.md`. It is used for miniapp
+compilation, simulator automation, screenshots, console/network diagnostics,
+preview, and upload.
+
+The repository intentionally does not copy Tencent's skill. On Windows + WSL2,
+`scripts/wechatide` finds the separately installed `*-nightly` WeChat DevTools,
+invokes its Windows CLI, and synchronizes `miniapp/` to a generated local
+Windows mirror because DevTools rejects WSL UNC project roots. The WSL
+repository remains the only source of truth. Agents load the authoritative
+`wechatide-skill` from that installation, so DevTools upgrades update the tool
+contract without a stale vendored copy. Stable DevTools remains separate.
+
+The first `Copilot` connection requires authorization in Nightly DevTools.
+Login, CLI access tokens, previews/uploads, cloud writes, and destructive
+operations remain subject to Tencent's interactive approval gates.
+
 ## Athlete-facing plugin requirements
 
 - [Claude Code](https://claude.com/claude-code) or [GitHub Copilot CLI](https://githubnext.com/projects/copilot-cli/)

--- a/scripts/wechatide
+++ b/scripts/wechatide
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+powershell_script="${repo_root}/scripts/wechatide.ps1"
+
+if [[ -z "${WSL_DISTRO_NAME:-}" ]] && ! grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null; then
+  echo "scripts/wechatide currently supports WSL2 calling Windows WeChat DevTools." >&2
+  exit 1
+fi
+
+resolve_install_root() {
+  if [[ -n "${WECHATIDE_INSTALL_ROOT:-}" ]]; then
+    if [[ ! -d "${WECHATIDE_INSTALL_ROOT}" ]]; then
+      echo "WECHATIDE_INSTALL_ROOT is not a directory: ${WECHATIDE_INSTALL_ROOT}" >&2
+      exit 1
+    fi
+    printf '%s\n' "${WECHATIDE_INSTALL_ROOT}"
+    return
+  fi
+
+  local candidates=()
+  local candidate
+  shopt -s nullglob
+  for candidate in /mnt/?/"Program Files (x86)"/Tencent/*-nightly; do
+    [[ -f "${candidate}/wechatide.cmd" ]] && candidates+=("${candidate}")
+  done
+  shopt -u nullglob
+
+  if (( ${#candidates[@]} == 0 )); then
+    echo "Nightly WeChat DevTools was not found. Set WECHATIDE_INSTALL_ROOT to its WSL path." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${candidates[0]}"
+}
+
+install_root="$(resolve_install_root)"
+skill_root="${install_root}/resources/app.asar.unpacked/wechatide-skill"
+miniapp_source="${repo_root}/miniapp"
+windows_drive_mount="${install_root%%/Program Files*}"
+miniapp_mirror="${WECHATIDE_PROJECT_MIRROR:-${windows_drive_mount}/Praxys/wechatide/praxys-miniapp}"
+
+sync_miniapp() {
+  if ! command -v rsync >/dev/null 2>&1; then
+    echo "rsync is required to synchronize the miniapp into Windows." >&2
+    exit 1
+  fi
+
+  if [[ "${miniapp_mirror}" != /mnt/?/* || "${miniapp_mirror}" == "${miniapp_source}" ]]; then
+    echo "WECHATIDE_PROJECT_MIRROR must be a dedicated directory on a mounted Windows drive." >&2
+    exit 1
+  fi
+
+  mkdir -p "${miniapp_mirror}"
+  mirror_marker="${miniapp_mirror}/.praxys-wechatide-mirror"
+  if [[ ! -f "${mirror_marker}" ]] &&
+    find "${miniapp_mirror}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    echo "Refusing to synchronize into a non-empty unmarked directory: ${miniapp_mirror}" >&2
+    exit 1
+  fi
+  touch "${mirror_marker}"
+
+  rsync -a --delete \
+    --exclude .praxys-wechatide-mirror \
+    --exclude node_modules/ \
+    --exclude miniprogram_npm/ \
+    --exclude project.private.config.json \
+    --exclude '*.log' \
+    "${miniapp_source}/" "${miniapp_mirror}/"
+}
+
+if [[ "${1:-}" == "--print-skill-root" ]]; then
+  if [[ ! -f "${skill_root}/SKILL.md" ]]; then
+    echo "The installed WeChat DevTools does not contain wechatide-skill: ${skill_root}" >&2
+    exit 1
+  fi
+  printf '%s\n' "${skill_root}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--sync-project" ]]; then
+  sync_miniapp
+  printf '%s\n' "${miniapp_mirror}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--print-project-root" ]]; then
+  printf '%s\n' "${miniapp_mirror}"
+  exit 0
+fi
+
+if [[ ! -f "${powershell_script}" ]]; then
+  echo "Missing PowerShell bridge: ${powershell_script}" >&2
+  exit 1
+fi
+
+powershell_exe="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+if [[ ! -x "${powershell_exe}" ]]; then
+  echo "Windows PowerShell is unavailable; WSL interop must be enabled." >&2
+  exit 1
+fi
+
+converted_args=()
+for arg in "$@"; do
+  if [[ "${arg}" == "${miniapp_source}" || "${arg}" == "${miniapp_source}/"* ]]; then
+    sync_miniapp
+    relative_path="${arg#"${miniapp_source}"}"
+    converted_args+=("$(wslpath -w "${miniapp_mirror}${relative_path}")")
+  elif [[ "${arg}" == /* && -e "${arg}" ]]; then
+    converted_args+=("$(wslpath -w "${arg}")")
+  else
+    converted_args+=("${arg}")
+  fi
+done
+
+exec "${powershell_exe}" \
+  -NoProfile \
+  -ExecutionPolicy Bypass \
+  -File "$(wslpath -w "${powershell_script}")" \
+  -InstallRoot "$(wslpath -w "${install_root}")" \
+  "${converted_args[@]}"

--- a/scripts/wechatide.ps1
+++ b/scripts/wechatide.ps1
@@ -1,0 +1,23 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $InstallRoot,
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $WechatIdeArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$command = Join-Path $installRoot "wechatide.cmd"
+if (-not (Test-Path -LiteralPath $command -PathType Leaf)) {
+    throw "wechatide.cmd was not found at $command"
+}
+
+Push-Location $env:SystemRoot
+try {
+    & $command @WechatIdeArgs
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

- add a repository `wechat-devtools` skill that delegates to Tencent's installed Nightly skill
- bridge WSL2 agents to the Windows `wechatide` CLI and safely mirror `miniapp/` onto a local Windows path
- document the simulator, diagnostics, preview, upload, and UI-quality workflow

## Validation

- `bash -n scripts/wechatide`
- verified skill discovery and authenticated `check_wechatide_status` against Nightly 0.3.9
- opened the mirrored Praxys miniapp and captured a simulator screenshot
- verified synchronization refuses a non-empty unmarked mirror directory
- `git diff --check`
