### PR TITLE
Add local-first UI review evidence policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,8 @@
 <!-- Required when web/ or miniapp/ user-visible behavior changes. Delete only when no rendered UI changed. -->
 - Impeccable: <!-- command and target, for example `polish web/src/pages/Today.tsx` -->
 - Visual review: <!-- web: desktop + mobile dimensions; miniapp: WeChat/Skyline device -->
+- Primary journey: <!-- concise reviewer path, for example Goal -> plan preview -> readiness -->
+- Reviewer handoff: <!-- local-only - path/session; PR media - links/summary; CI artifact - run; preview - URL; none - reason -->
 - States checked: <!-- loading, empty, error, success, disabled, long EN/zh, as applicable -->
 - Accessibility: <!-- keyboard, focus, contrast, reduced motion, touch targets -->
 - Design system impact: <!-- none - reason / updated in this PR - changed path / follow-up #123 - gap -->

--- a/.github/PULL_REQUEST_TEMPLATE/science-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/science-change.md
@@ -38,6 +38,8 @@ Do not check any item that was not actually performed.
 <!-- Required when web/ or miniapp/ user-visible behavior changes. Delete only when no rendered UI changed. -->
 - Impeccable: <!-- command and target, for example `polish web/src/pages/Today.tsx` -->
 - Visual review: <!-- web: desktop + mobile dimensions; miniapp: WeChat/Skyline device -->
+- Primary journey: <!-- concise reviewer path, for example Goal -> plan preview -> readiness -->
+- Reviewer handoff: <!-- local-only - path/session; PR media - links/summary; CI artifact - run; preview - URL; none - reason -->
 - States checked: <!-- loading, empty, error, success, disabled, long EN/zh, as applicable -->
 - Accessibility: <!-- keyboard, focus, contrast, reduced motion, touch targets -->
 - Design system impact: <!-- none - reason / updated in this PR - changed path / follow-up #123 - gap -->

--- a/.github/instructions/ui-quality.instructions.md
+++ b/.github/instructions/ui-quality.instructions.md
@@ -35,18 +35,34 @@ as styling after implementation.
    registered tools with raw desktop focus, cursor, keyboard, mouse, or
    coordinate automation. Use keyboard navigation and inspect console errors.
    Fix the batch of findings, then perform at most one confirmation pass.
-8. Run the smallest relevant tests plus `cd web && npm run build`, miniapp
+8. Store detailed captures locally under the gitignored
+   `test-screenshots/ui-quality/<branch-or-pr>/` directory. Use
+   native-resolution screenshots for static or state comparisons, a focused
+   15-45 second video for sequence-dependent interactions, and both only for a
+   material multi-step journey with important edge states. Prefer MP4 for
+   publication; browser-native WebM is acceptable for local review. Never
+   flatten full screens into a downscaled raster storyboard. Use synthetic data
+   and keep credentials, personal training data, raw feedback screenshots, and
+   authenticated network archives out of captures.
+9. Match the handoff to the reviewer. For synchronous local review, share the
+   live URL and local gallery path in the active session and upload nothing.
+   For asynchronous PR review, publish only the minimum useful recording or
+   2-3 stills; keep exhaustive evidence local or in a CI artifact. Create a
+   persistent cloud preview or gallery only when explicitly requested.
+10. Run the smallest relevant tests plus `cd web && npm run build`, miniapp
    `npm run typecheck` when applicable, and:
 
    ```bash
    python scripts/check_ui_quality.py --base origin/main --head HEAD --skip-evidence
    ```
 
-9. Include the exact `## UI quality` block from the PR template, including the
-   mandatory `Design system impact` disposition. Never claim a
-   viewport, state, or accessibility check that was not actually performed. If
-   rendered verification is unavailable, keep the PR draft and record the
-   limitation.
+11. Include the exact `## UI quality` block from the PR template, including the
+    mandatory `Primary journey`, `Reviewer handoff`, and `Design system impact`
+    fields. `Reviewer handoff` must start with `local-only`, `PR media`,
+    `CI artifact`, `preview`, or `none`, followed by a concrete explanation.
+    Never claim a viewport, state, accessibility check, or published artifact
+    that was not actually performed. If rendered verification is unavailable,
+    keep the PR draft and record the limitation.
 
 Brand invariants are binding: green means action, cobalt means reasoning,
 surfaces use warm-paper tokens, numbers use `font-data`, scientific explanations

--- a/.github/skills/ui-quality/SKILL.md
+++ b/.github/skills/ui-quality/SKILL.md
@@ -84,7 +84,43 @@ output. Fix findings in one batch and perform at most one confirmation pass.
 If no browser tool is available, do not claim visual verification. Keep the PR
 draft and record the limitation in the UI evidence.
 
-## 6. Validate and hand off
+## 6. Choose and store reviewer evidence
+
+Store detailed captures locally by default under:
+
+```text
+test-screenshots/ui-quality/<branch-or-pr>/
+```
+
+`test-screenshots/` is gitignored. Keep native-resolution source screenshots,
+recordings, and an optional `index.html` there; never commit them. A local HTML
+gallery must link to the original assets rather than flatten full screens into
+one downscaled raster storyboard.
+
+Choose the smallest medium that explains the change:
+
+| Change | Evidence |
+|---|---|
+| Static styling, copy, chart, or single-state change | Native-resolution screenshots |
+| Responsive behavior or important loading, empty, error, or unsupported states | Screenshots for each materially different viewport/state |
+| Navigation, forms, timing, animation, gestures, or a sequence that stills cannot explain | A focused 15-45 second video; prefer MP4 for publication, while browser-native WebM is acceptable locally |
+| Material multi-step journey with important edge states | Short primary-journey video plus 2-3 edge-state screenshots |
+
+Use synthetic data only. Do not capture credentials, tokens, personal training
+data, raw feedback screenshots, or authenticated network archives. Do not add a
+production dependency only to record evidence; use the available browser or
+platform recorder, and fall back to screenshots when recording is unavailable.
+
+Choose the handoff for the actual reviewer:
+
+- Synchronous local review: keep evidence local, share the live URL and local
+  gallery path in the active session, and keep credentials out of the PR.
+- Asynchronous PR review: publish only the minimum useful recording or 2-3
+  stills. Keep exhaustive state captures local or in a CI artifact.
+- Persistent cloud preview or gallery: create one only when explicitly
+  requested. Blob storage is for static evidence, not an interactive app.
+
+## 7. Validate and hand off
 
 Run the smallest relevant tests, web build, miniapp typecheck when applicable,
 and:
@@ -99,6 +135,8 @@ Complete this exact PR section:
 ## UI quality
 - Impeccable: `polish web/src/...`
 - Visual review: desktop 1440x900; mobile 390x844
+- Primary journey: Goal -> plan preview -> readiness
+- Reviewer handoff: local-only - `test-screenshots/ui-quality/pr-123/index.html`
 - States checked: loading, empty, error, success, long EN/zh
 - Accessibility: keyboard, focus, contrast, reduced motion, touch targets
 - Design system impact: none - existing tokens and components cover this change
@@ -108,4 +146,5 @@ Complete this exact PR section:
 
 Never fill the block with planned work or unverified claims. Impeccable findings
 must be fixed or documented as a narrow, intentional exception approved by a
-maintainer.
+maintainer. Valid reviewer handoff prefixes are `local-only`, `PR media`,
+`CI artifact`, `preview`, and `none`; every value needs a concrete explanation.

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -303,6 +303,8 @@ jobs:
 
             - Impeccable: `audit web/src/locales/zh/messages.po` via the automated context-aware native-copy critic
             - Visual review: desktop and mobile rendered review not applicable - generated locale catalog only; no component or layout files changed
+            - Primary journey: generated Chinese catalog -> synchronized miniapp catalog -> maintainer copy review
+            - Reviewer handoff: none - catalog-only automation has no distinct visual journey; the diff and localized builds are the review surfaces
             - States checked: active catalog coverage, placeholders, protected tokens, terminology, typography, and long Chinese copy
             - Accessibility: no interaction, focus, contrast, motion, or touch-target behavior changed
             - Design system impact: none - the existing localization and typography systems cover catalog-only changes

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -210,9 +210,14 @@ The full flow and maintenance instructions live in
    new or materially reworked flow and `polish` before handoff.
 3. Inspect the real feature with sample data at desktop and mobile sizes, with
    keyboard navigation and relevant states.
-4. Run the web build, miniapp typecheck when applicable, and
+4. Keep detailed screenshots and recordings local under the gitignored
+   `test-screenshots/ui-quality/<branch-or-pr>/` directory. Use screenshots for
+   static/state comparisons, a short video for sequence-dependent interaction,
+   and publish only the minimum media needed for asynchronous PR review.
+5. Run the web build, miniapp typecheck when applicable, and
    `python scripts/check_ui_quality.py --base origin/main --head HEAD --skip-evidence`.
-5. Complete the PR template's `## UI quality` block. If a browser is
+6. Complete the PR template's `## UI quality` block, including the primary
+   journey and reviewer handoff mode. If a browser is
    unavailable, keep the PR draft and state that rendered verification remains
    incomplete.
 

--- a/docs/dev/ui-quality-harness.md
+++ b/docs/dev/ui-quality-harness.md
@@ -56,11 +56,59 @@ the rendered files trigger it.
    console/network output. Praxys MCP may provide synthetic data semantics but
    does not replace rendered review. Fix findings in one batch, then do at most
    one confirmation pass.
-9. Run targeted tests, builds/typechecks, and the local gate. Complete the PR
+9. Choose reviewer evidence using the policy below, keeping detailed captures
+   local by default.
+10. Run targeted tests, builds/typechecks, and the local gate. Complete the PR
    evidence before marking the PR ready.
 
 If browser automation is unavailable, the contributor must not claim rendered
 verification. An agent keeps the PR draft and records the limitation.
+
+## Reviewer evidence and local storage
+
+Detailed review media is local-first. Store native-resolution source files
+under:
+
+```text
+test-screenshots/ui-quality/<branch-or-pr>/
+```
+
+The parent directory is gitignored. A useful local bundle contains clearly
+named screenshots or recordings plus an optional `index.html` that links to the
+original files. Do not flatten desktop screens into a single raster storyboard:
+PR columns and full-page screenshot helpers can silently downscale it until the
+UI copy is unreadable.
+
+Choose the smallest medium that preserves the behavior under review:
+
+| Change | Preferred evidence |
+|---|---|
+| Static styling, copy, chart, or one stable state | Native-resolution screenshots |
+| Responsive differences or loading, empty, error, permission, or unsupported states | Screenshots for each materially different viewport/state |
+| Multi-page navigation, forms, timing, animation, gestures, or progressive state | Focused 15-45 second video; prefer MP4 for publication, while browser-native WebM is acceptable locally |
+| Material multi-step journey plus important edge states | Short primary-journey video and 2-3 edge-state screenshots |
+
+Use synthetic data only. Captures must not contain credentials, access tokens,
+personal training data, raw feedback screenshots, or authenticated HAR/network
+archives. Do not add a product dependency only to record evidence. Use the
+available Chrome/Playwright/WeChat recorder; if recording is unavailable,
+capture the sequence as native-resolution stills.
+
+The review audience determines publication:
+
+- **Synchronous local review:** share the live URL and local gallery path in the
+  active agent session. Keep credentials in that session and upload no media.
+- **Asynchronous PR review:** publish only the minimum useful evidence: one
+  short recording, 2-3 stills, or both for a material journey. Keep the
+  exhaustive state set local or in a CI artifact.
+- **Persistent cloud review:** create an authenticated preview or static
+  gallery only when explicitly requested. Blob storage can host static media
+  but is not an interactive application preview.
+
+The PR remains a concise decision record. `Primary journey` tells reviewers
+what path matters; `Reviewer handoff` says where the evidence lives without
+requiring public media. Valid handoff modes are `local-only`, `PR media`,
+`CI artifact`, `preview`, and `none`, each followed by a concrete explanation.
 
 The repository does not vendor Tencent's DevTools skill. The
 `wechat-devtools` wrapper reads the authoritative copy from a separately
@@ -116,6 +164,8 @@ and requires:
 ## UI quality
 - Impeccable: `polish web/src/...`
 - Visual review: desktop 1440x900; mobile 390x844
+- Primary journey: Goal -> plan preview -> readiness
+- Reviewer handoff: local-only - `test-screenshots/ui-quality/pr-123/index.html`
 - States checked: loading, empty, error, success, long EN/zh
 - Accessibility: keyboard, focus, contrast, reduced motion, touch targets
 - Design system impact: none - existing tokens and components cover this change

--- a/scripts/check_ui_quality.py
+++ b/scripts/check_ui_quality.py
@@ -68,6 +68,8 @@ _DESIGN_GOVERNANCE_FILES = {
 _EVIDENCE_FIELDS = (
     "impeccable",
     "visual review",
+    "primary journey",
+    "reviewer handoff",
     "states checked",
     "accessibility",
     "design system impact",
@@ -101,6 +103,10 @@ _IMPECCABLE_COMMANDS = {
 }
 _PLACEHOLDER_RE = re.compile(
     r"(?:^|\b)(?:todo|tbd|pending|not checked|not run|n/?a)(?:\b|$)",
+    re.IGNORECASE,
+)
+_REVIEWER_HANDOFF_RE = re.compile(
+    r"^(?:local-only|pr media|ci artifact|preview|none)\s*-\s*\S.*$",
     re.IGNORECASE,
 )
 
@@ -286,6 +292,17 @@ def _validate_design_system_impact(
     ]
 
 
+def _validate_reviewer_handoff(value: str) -> list[str]:
+    normalized = re.sub(r"\s+", " ", value.strip())
+    if _REVIEWER_HANDOFF_RE.fullmatch(normalized):
+        return []
+    return [
+        "UI quality field 'reviewer handoff' must use one of: "
+        "'local-only - <path/session>', 'PR media - <links/summary>', "
+        "'CI artifact - <run>', 'preview - <URL>', or 'none - <reason>'."
+    ]
+
+
 def validate_ui_evidence(
     body: str,
     *,
@@ -330,6 +347,10 @@ def validate_ui_evidence(
                 governance_paths,
             )
         )
+
+    handoff_value = values.get("reviewer handoff", "")
+    if not _is_placeholder(handoff_value):
+        errors.extend(_validate_reviewer_handoff(handoff_value))
 
     impeccable_value = values.get("impeccable", "").lower()
     if impeccable_value and not any(

--- a/tests/test_ui_quality_harness.py
+++ b/tests/test_ui_quality_harness.py
@@ -19,6 +19,8 @@ VALID_WEB_EVIDENCE = """\
 ## UI quality
 - Impeccable: `polish web/src/pages/Today.tsx`
 - Visual review: desktop 1440x900; mobile 390x844
+- Primary journey: Today -> recovery verdict -> supporting metrics
+- Reviewer handoff: local-only - test-screenshots/ui-quality/today/index.html reviewed in the maintainer session
 - States checked: loading, empty, error, success, long EN/zh
 - Accessibility: keyboard, focus, contrast, reduced motion, touch targets
 - Design system impact: none - existing tokens and components cover this change
@@ -73,6 +75,33 @@ def test_web_evidence_requires_impeccable_and_two_viewports():
         has_miniapp=False,
     )
     assert "Web UI evidence must include both desktop and mobile review." in errors
+
+
+def test_reviewer_handoff_accepts_bounded_modes_with_detail():
+    current_handoff = (
+        "local-only - test-screenshots/ui-quality/today/index.html "
+        "reviewed in the maintainer session"
+    )
+    for handoff in (
+        "local-only - test-screenshots/ui-quality/pr-123/index.html",
+        "PR media - 25 second journey video and unsupported-state screenshot",
+        "CI artifact - frontend-quality run 123456",
+        "preview - https://preview.example.test/pr-123",
+        "none - copy-only change reviewed live; media adds no reviewer value",
+    ):
+        evidence = VALID_WEB_EVIDENCE.replace(current_handoff, handoff)
+        assert validate_ui_evidence(
+            evidence,
+            has_web=True,
+            has_miniapp=False,
+        ) == []
+
+    errors = validate_ui_evidence(
+        VALID_WEB_EVIDENCE.replace(current_handoff, "uploaded somewhere"),
+        has_web=True,
+        has_miniapp=False,
+    )
+    assert any("reviewer handoff" in error for error in errors)
 
 
 def test_template_placeholders_do_not_count_as_evidence():
@@ -205,7 +234,13 @@ def test_harness_is_wired_into_agents_and_required_ci():
     assert "--allow-unverified-draft" in workflow
     assert "UI Quality Harness (mandatory)" in instructions
     assert "scripts/agent_preflight.py --base origin/main" in instructions
-    assert (ROOT / ".github" / "skills" / "ui-quality" / "SKILL.md").is_file()
+    skill_path = ROOT / ".github" / "skills" / "ui-quality" / "SKILL.md"
+    assert skill_path.is_file()
+    skill = skill_path.read_text(encoding="utf-8")
+    assert "test-screenshots/ui-quality/<branch-or-pr>/" in skill
+    assert "15-45 second video" in skill
+    assert "browser-native WebM is acceptable locally" in skill
+    assert "downscaled raster storyboard" in skill
     assert (
         ROOT / ".github" / "instructions" / "ui-quality.instructions.md"
     ).is_file()


### PR DESCRIPTION
## Summary

- Make detailed UI review captures local-first under the ignored `test-screenshots/ui-quality/<branch-or-pr>/` directory.
- Add an explicit decision matrix for native-resolution screenshots, short journey videos, and combined evidence for material multi-step flows.
- Require UI PRs to name the primary journey and reviewer handoff mode without forcing detailed media into a public PR.
- Keep automated i18n PR evidence compatible with the expanded contract.

Piloted on #684 with a local native-resolution gallery and concise PR handoff.

## Validation

- `/home/feitao/src/tf-personal-pensieve/praxys/.venv/bin/python -m pytest tests/test_ui_quality_harness.py -q`
- `git diff --check`
