### PR TITLE
Extract Stryd transport into shared client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Garmin/Stryd/Oura APIs → sync/*.py → db/sync_writer.py → SQLite (trainsigh
 
 | Directory | Owns | Key Files |
 |-----------|------|-----------|
-| `sync/` | Platform fetch + parse | `garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`, `csv_utils.py` |
+| `sync/` | Platform fetch + parse (`stryd_sync.py` uses the external `stryd-client` transport) | `garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`, `csv_utils.py` |
 | `analysis/` | Metric computation | `metrics.py` (pure functions), `data_loader.py` (loads from DB), `science.py` (theory YAML loader), `evidence_registry.py` (versioned evidence/SDR validation), `config.py` (`UserConfig`), `zones.py`, `thresholds.py`, `training_base.py` |
 | `analysis/providers/` | Pluggable data sources | `base.py` (ABCs), `garmin.py`, `stryd.py`, `oura.py`, `ai.py`, `models.py` |
 | `db/` | SQLite layer | `models.py` (SQLAlchemy), `session.py`, `crypto.py` (Fernet credential encryption), `sync_writer.py` (upserts), `sync_scheduler.py` |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Garmin, Stryd, Oura, COROS, and WeChat are trademarks of their respective owners
 ### Third-party data sources
 
 - **Garmin Connect** — synced via the unofficial [`garminconnect`](https://github.com/cyberjunky/python-garminconnect) Python library. There is no official Garmin partnership; the integration depends on Garmin's consumer web endpoints continuing to work. Garmin's [Terms of Use](https://www.garmin.com/en-US/legal/general-terms-of-use/) restrict automated access — use at your own risk.
-- **Stryd** — synced via the same email/password endpoints the Stryd web app uses. There is no official partner API for individual users. Same risk class as Garmin.
+- **Stryd** — synced through the reusable, unofficial [`stryd-client`](https://github.com/praxys-run/python-stryd-client) library, which uses the same email/password endpoints as the Stryd web app. There is no official partner API for individual users. Same risk class as Garmin.
 - **Oura Ring** — synced via the [official Oura API v2](https://cloud.ouraring.com/v2/docs) using a Personal Access Token. This is a supported integration path.
 - **COROS** — synced via the unofficial Training Hub web API (activities, HRV, resting HR, VO2max) and the reverse-engineered mobile API (sleep data). There is no official COROS partnership. Same risk class as Garmin.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -122,13 +122,17 @@ If `KEY_VAULT_URL` is set, the `CredentialVault` initializes an Azure `Cryptogra
 
 ### Plan Delivery Boundary
 
-`api/plan_delivery/` separates provider-neutral orchestration from Stryd API
-details. The service authenticates before starting a durable attempt, scopes
-credentials and ledger rows to the authenticated Praxys user, and records a
-fingerprint of the exact provider payload (including CP-derived workout
-blocks), plus a normalized content fingerprint that excludes volatile provider
-identifiers. The canonical Praxys plan version remains separate so
-reconciliation can distinguish a Praxys edit from a target edit.
+`api/plan_delivery/` separates provider-neutral orchestration from Stryd
+details. Raw authentication and PowerCenter HTTP operations live in the
+external [`stryd-client`](https://github.com/praxys-run/python-stryd-client)
+package; `sync/stryd_sync.py` retains Praxys-specific parsing, workout
+translation, and fingerprints. The service authenticates before starting a
+durable attempt, scopes credentials and ledger rows to the authenticated
+Praxys user, and records a fingerprint of the exact provider payload
+(including CP-derived workout blocks), plus a normalized content fingerprint
+that excludes volatile provider identifiers. The canonical Praxys plan version
+remains separate so reconciliation can distinguish a Praxys edit from a target
+edit.
 
 Successful creates persist the authenticated provider account ID. A later
 delete is refused if the user has reconnected a different provider account.
@@ -514,11 +518,15 @@ Database layer:
 
 ### sync/
 
-Each sync script (`garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`) is self-contained:
+Each sync adapter (`garmin_sync.py`, `stryd_sync.py`, `oura_sync.py`):
 - Authenticates with the platform API
 - Fetches new data since last sync (or from `--from-date`)
 - Normalizes to the model schema
 - Writes to the database via `db/sync_writer.py`
+
+Stryd's undocumented endpoint transport is isolated in the external
+`stryd-client` package. Praxys owns only normalization, persistence, and
+training/workout semantics around the raw responses.
 
 `sync_all.py` orchestrates all three with error isolation per source.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,10 @@
 # minor-version bump can rename either. Re-validate with
 # scripts/garmin_diagnose.py before loosening this bound.
 garminconnect>=0.3.9,<0.4.0
+# Unofficial Stryd PowerCenter transport extracted from Praxys. The release
+# artifact is hash-pinned because the upstream API is undocumented and this
+# dependency owns the compatibility boundary.
+stryd-client @ https://github.com/praxys-run/python-stryd-client/releases/download/v0.1.1/stryd_client-0.1.1-py3-none-any.whl#sha256=634ad3022ef89b1e974de2f1378479f4bbc8ad501d0e6eb611e917cf27812f52
 requests>=2.34.2
 python-dotenv>=1.2.2
 pandas>=3.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ garminconnect>=0.3.9,<0.4.0
 # Unofficial Stryd PowerCenter transport extracted from Praxys. The release
 # artifact is hash-pinned because the upstream API is undocumented and this
 # dependency owns the compatibility boundary.
-stryd-client @ https://github.com/praxys-run/python-stryd-client/releases/download/v0.1.1/stryd_client-0.1.1-py3-none-any.whl#sha256=634ad3022ef89b1e974de2f1378479f4bbc8ad501d0e6eb611e917cf27812f52
+stryd-client @ https://github.com/praxys-run/python-stryd-client/releases/download/v0.2.0/stryd_client-0.2.0-py3-none-any.whl#sha256=d5ecc8c14beafe1cf2df6e5021b0bee71094b15cf14dfc039f0652c8c9c030e4
 requests>=2.34.2
 python-dotenv>=1.2.2
 pandas>=3.0.5

--- a/sync/stryd_sync.py
+++ b/sync/stryd_sync.py
@@ -1,7 +1,7 @@
-"""Stryd API integration — fetch/parse layer for the sync API route.
+"""Stryd fetch/parse layer for the sync API route.
 
 Provides login, activity fetch, training plan fetch, lap split computation,
-and workout upload/delete via the Stryd calendar and activity APIs.
+and workout translation around the reusable ``stryd-client`` transport.
 """
 import hashlib
 import json
@@ -13,6 +13,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any, Mapping
 
 import requests
+from stryd_client import StrydClient, StrydClientError
 
 from api.plan_workout_structure import (
     StructuredWorkoutRepeatGroupV1,
@@ -25,20 +26,25 @@ from api.plan_workout_structure import (
 logger = logging.getLogger(__name__)
 
 
+def _authenticated_client(
+    user_id: str | None,
+    token: str,
+    *,
+    timeout: float,
+) -> StrydClient:
+    """Create a token-backed client using this module's injectable transport."""
+    return StrydClient.from_token(
+        token=token,
+        user_id=user_id,
+        timeout=timeout,
+        http=requests,
+    )
+
+
 def _workout_type_from_name(name: str) -> str:
     """Extract workout type from Stryd plan name like 'Day 46 - Steady Aerobic'."""
     m = re.match(r"Day\s+\d+\s*-\s*(.+)", name)
     return m.group(1).strip().lower() if m else name.lower()
-
-
-# --- API-based fetch ---
-
-STRYD_LOGIN_URL = "https://www.stryd.com/b/email/signin"
-STRYD_CALENDAR_API = "https://api.stryd.com/b/api/v1/users/{user_id}/calendar"
-STRYD_ACTIVITY_API = "https://api.stryd.com/b/api/v1/activities/{activity_id}"
-STRYD_WORKOUT_API = "https://api.stryd.com/b/api/v1/users/{user_id}/workouts"
-STRYD_ESTIMATE_API = "https://api.stryd.com/b/api/v1/users/workouts/estimate"
-STRYD_USER_API = "https://api.stryd.com/b/api/v1/users/{user_id}"
 
 
 def _normalize_stryd_content_value(value):
@@ -92,19 +98,14 @@ def stryd_delivery_payload_fingerprint(payload: dict) -> str:
 def _login_api(email: str, password: str) -> tuple[str, str]:
     """Login via Stryd API. Returns (user_id, token)."""
     logger.debug("  Logging in via Stryd API...")
-    resp = requests.post(
-        STRYD_LOGIN_URL,
-        json={"email": email, "password": password},
+    session = StrydClient(
+        email=email,
+        password=password,
         timeout=15,
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    user_id = data.get("id", "")
-    token = data.get("token", "")
-    if not token:
-        raise RuntimeError("Login succeeded but no token in response")
-    logger.debug(f"  Login successful (user_id={user_id})")
-    return user_id, token
+        http=requests,
+    ).authenticate()
+    logger.debug(f"  Login successful (user_id={session.user_id})")
+    return session.user_id, session.token
 
 
 def fetch_current_cp(user_id: str, token: str) -> float | None:
@@ -115,15 +116,12 @@ def fetch_current_cp(user_id: str, token: str) -> float | None:
     shown on Stryd's Power Center. Per-activity ftp is a snapshot at activity
     time and may lag behind the profile value.
     """
-    url = STRYD_USER_API.format(user_id=user_id)
     try:
-        resp = requests.get(
-            url,
-            headers={"Authorization": f"Bearer {token}"},
+        data = _authenticated_client(
+            user_id,
+            token,
             timeout=15,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        ).get_profile()
         training_info = data.get("training_info") or {}
         cp = training_info.get("critical_power")
         if cp is not None:
@@ -132,7 +130,13 @@ def fetch_current_cp(user_id: str, token: str) -> float | None:
             return cp
         logger.debug("  No CP found in user profile training_info")
         return None
-    except Exception as e:
+    except (
+        requests.RequestException,
+        StrydClientError,
+        OverflowError,
+        TypeError,
+        ValueError,
+    ) as e:
         logger.debug(f"  Failed to fetch current CP: {e}")
         return None
 
@@ -151,14 +155,11 @@ def fetch_activity_splits(
     already fetched to compute lap averages; this function preserves them
     instead of discarding after averaging.
     """
-    url = STRYD_ACTIVITY_API.format(activity_id=activity_id)
-    resp = requests.get(
-        url,
-        headers={"Authorization": f"Bearer {token}"},
+    data = _authenticated_client(
+        user_id=None,
+        token=token,
         timeout=30,
-    )
-    resp.raise_for_status()
-    data = resp.json()
+    ).get_activity(activity_id)
 
     power_list = data.get("total_power_list", [])
     hr_list = data.get("heart_rate_list", [])
@@ -300,15 +301,14 @@ def fetch_activities_api(
     from_ts = int(start_dt.timestamp())
     to_ts = int(end_dt.timestamp())
 
-    url = STRYD_CALENDAR_API.format(user_id=user_id)
-    resp = requests.get(
-        url,
-        params={"from": from_ts, "to": to_ts, "include_deleted": "false"},
-        headers={"Authorization": f"Bearer {token}"},
+    data = _authenticated_client(
+        user_id,
+        token,
         timeout=30,
+    ).get_calendar(
+        from_timestamp=from_ts,
+        to_timestamp=to_ts,
     )
-    resp.raise_for_status()
-    data = resp.json()
 
     activities = data.get("activities", [])
     logger.debug(f"  API returned {len(activities)} activities")
@@ -654,15 +654,14 @@ def fetch_training_plan_api(
     from_ts = int(datetime.combine(start, datetime.min.time()).timestamp())
     to_ts = int(datetime.combine(end, datetime.max.time()).timestamp())
 
-    url = STRYD_CALENDAR_API.format(user_id=user_id)
-    resp = requests.get(
-        url,
-        params={"from": from_ts, "to": to_ts, "include_deleted": "false"},
-        headers={"Authorization": f"Bearer {token}"},
+    data = _authenticated_client(
+        user_id,
+        token,
         timeout=30,
+    ).get_calendar(
+        from_timestamp=from_ts,
+        to_timestamp=to_ts,
     )
-    resp.raise_for_status()
-    data = resp.json()
 
     workouts = data.get("workouts") or []
     logger.debug(f"  Plan API returned {len(workouts)} planned workouts")
@@ -831,14 +830,11 @@ def fetch_activity_detail_api(
     Returns the full activity object with populated *_list fields.
     Raises requests.HTTPError on API failure.
     """
-    url = STRYD_ACTIVITY_API.format(activity_id=activity_id)
-    resp = requests.get(
-        url,
-        headers={"Authorization": f"Bearer {token}"},
+    return _authenticated_client(
+        user_id=None,
+        token=token,
         timeout=30,
-    )
-    resp.raise_for_status()
-    return resp.json()
+    ).get_activity(activity_id)
 
 
 def compute_lap_splits(activity: dict, activity_id: str) -> list[dict]:
@@ -1404,7 +1400,6 @@ def create_workout_api(
     dt = datetime.strptime(workout_date, "%Y-%m-%d")
     timestamp = int(dt.replace(tzinfo=timezone.utc).timestamp())
 
-    url = STRYD_WORKOUT_API.format(user_id=user_id)
     payload = {
         "type": workout_type,
         "desc": description,
@@ -1419,18 +1414,14 @@ def create_workout_api(
         "tags": None,
     }
 
-    resp = requests.post(
-        url,
-        params={"timestamp": timestamp},
-        json=payload,
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
+    return _authenticated_client(
+        user_id,
+        token,
         timeout=30,
+    ).create_workout(
+        timestamp=timestamp,
+        payload=payload,
     )
-    resp.raise_for_status()
-    return resp.json()
 
 
 def delete_workout_api(user_id: str, token: str, workout_id: str) -> bool:
@@ -1438,11 +1429,9 @@ def delete_workout_api(user_id: str, token: str, workout_id: str) -> bool:
 
     Returns True if successfully deleted.
     """
-    url = f"{STRYD_WORKOUT_API.format(user_id=user_id)}/{workout_id}"
-    resp = requests.delete(
-        url,
-        headers={"Authorization": f"Bearer {token}"},
+    _authenticated_client(
+        user_id,
+        token,
         timeout=30,
-    )
-    resp.raise_for_status()
+    ).delete_workout(workout_id)
     return True

--- a/tests/test_stryd_sync.py
+++ b/tests/test_stryd_sync.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 from sync.stryd_sync import (
+    _login_api,
     _workout_type_from_name,
     fetch_activities_api,
     fetch_training_plan_api,
@@ -17,6 +18,23 @@ def test_workout_type_from_name():
     assert _workout_type_from_name("Day 48 - Long") == "long"
     assert _workout_type_from_name("Day 47 - Recovery") == "recovery"
     assert _workout_type_from_name("Custom Name") == "custom name"
+
+
+@patch("sync.stryd_sync.StrydClient")
+def test_login_delegates_to_shared_stryd_client(mock_client):
+    session = MagicMock(user_id="stryd-user", token="stryd-token")
+    mock_client.return_value.authenticate.return_value = session
+
+    assert _login_api("runner@example.test", "secret") == (
+        "stryd-user",
+        "stryd-token",
+    )
+    mock_client.assert_called_once_with(
+        email="runner@example.test",
+        password="secret",
+        timeout=15,
+        http=requests,
+    )
 
 
 def test_delivery_content_fingerprint_ignores_provider_uuids():


### PR DESCRIPTION
## Summary

- adopt the public [`praxys-run/python-stryd-client`](https://github.com/praxys-run/python-stryd-client) transport package
- remove Stryd endpoint URLs and direct HTTP operations from Praxys while preserving its parsing, workout translation, fingerprints, and delivery semantics
- pin the completed 0.2.0 PowerCenter coverage release wheel by SHA-256 and document the new ownership boundary

## Validation

- `python -m pytest -q tests/test_stryd_sync.py tests/test_stryd_upload.py tests/test_stryd_activity_samples.py tests/test_compute_lap_splits.py tests/test_plan_delivery_adapter.py tests/test_stryd_push_status_endpoints.py`
- 118 passed
- published hash-pinned release artifact installed successfully and `pip check` passed

## Upstream

- package: https://github.com/praxys-run/python-stryd-client
- release: https://github.com/praxys-run/python-stryd-client/releases/tag/v0.2.0
- PyPI follow-up: https://github.com/praxys-run/python-stryd-client/issues/1
