### PR TITLE
Accept shared routing and road 10K policies

### DIFF
--- a/data/science/REGISTRY.md
+++ b/data/science/REGISTRY.md
@@ -16,7 +16,9 @@ Evidence reviews record what the literature supports. Science Decision Records (
 | [evidence-heat-decay-v1](evidence/heat-decay/evidence-heat-decay-v1.yaml) — Heat adaptation decay and re-induction | 1 | heat-decay | 2026-07-25 |
 | [evidence-outdoor-5k-plan-generation-policy-v1](evidence/outdoor-5k-plan-generation-policy/evidence-outdoor-5k-plan-generation-policy-v1.yaml) — Adult recreational outdoor 5 km plan generation | 1 | outdoor-5k-plan-generation-policy | 2026-08-13 |
 | [evidence-personal-environment-response-v1](evidence/personal-environment-response/evidence-personal-environment-response-v1.yaml) — Personal retrospective environmental and heart-rate associations | 1 | personal-environment-response | 2026-08-08 |
+| [evidence-plan-generation-eligibility-safety-v1](evidence/plan-generation-eligibility-safety/evidence-plan-generation-eligibility-safety-v1.yaml) — Cross-cutting plan-generation eligibility and safety | 1 | plan-generation-eligibility-safety | 2026-08-14 |
 | [evidence-preplan-baseline-policy-v1](evidence/preplan-baseline-policy/evidence-preplan-baseline-policy-v1.yaml) — History-first pre-plan baseline evidence for 5 km road performance | 1 | preplan-baseline-policy | 2026-08-10 |
+| [evidence-road-10k-plan-generation-policy-v1](evidence/road-10k-plan-generation-policy/evidence-road-10k-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road 10 km performance planning | 1 | road-10k-plan-generation-policy | 2026-08-14 |
 
 ### Science decisions
 
@@ -25,7 +27,9 @@ Evidence reviews record what the literature supports. Science Decision Records (
 | [sdr-environmental-performance-v4](decisions/sdr-environmental-performance-v4.yaml) — Center comparable-power support on each athlete's observed training workload | 4 | environmental-performance-context-v4 | 2026-08-10 |
 | [sdr-heat-adaptation-v1](decisions/sdr-heat-adaptation-v1.yaml) — Interpret recent heat exposure as qualitative adaptation evidence | 1 | heat-adaptation-v8 | 2026-07-26 |
 | [sdr-outdoor-5k-plan-generation-policy-v1](decisions/sdr-outdoor-5k-plan-generation-policy-v1.yaml) — Use a history-anchored 28-day outdoor 5 km plan block | 1 | outdoor-5k-plan-generation-policy-v1 | 2026-08-13 |
+| [sdr-plan-generation-eligibility-safety-v1](decisions/sdr-plan-generation-eligibility-safety-v1.yaml) — Match plan generation by capability, history, and non-medical safety state | 1 | plan-generation-eligibility-safety-v1 | 2026-08-14 |
 | [sdr-preplan-baseline-policy-v1](decisions/sdr-preplan-baseline-policy-v1.yaml) — Use qualified 5 km history before offering an opt-in same-protocol baseline | 1 | preplan-baseline-policy-v1 | 2026-08-10 |
+| [sdr-road-10k-plan-generation-policy-v1](decisions/sdr-road-10k-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road 10 km performance policy | 1 | road-10k-plan-generation-policy-v1 | 2026-08-14 |
 
 ## Pending
 
@@ -35,9 +39,7 @@ Evidence reviews record what the literature supports. Science Decision Records (
 |---|---:|---|---|
 | [evidence-adaptive-training-load-v1](evidence/adaptive-training-load/evidence-adaptive-training-load-v1.yaml) — Adaptive endurance-training load decisions | 1 | adaptive-training-load | 2026-08-08 |
 | [evidence-individual-goal-feasibility-v1](evidence/individual-goal-feasibility/evidence-individual-goal-feasibility-v1.yaml) — Individual goal feasibility and prediction limits | 1 | individual-goal-feasibility | 2026-08-08 |
-| [evidence-plan-generation-eligibility-safety-v1](evidence/plan-generation-eligibility-safety/evidence-plan-generation-eligibility-safety-v1.yaml) — Cross-cutting plan-generation eligibility and safety | 1 | plan-generation-eligibility-safety | 2026-08-14 |
 | [evidence-plan-outcome-interpretation-v1](evidence/plan-outcome-interpretation/evidence-plan-outcome-interpretation-v1.yaml) — Training-plan outcome interpretation | 1 | plan-outcome-interpretation | 2026-08-08 |
-| [evidence-road-10k-plan-generation-policy-v1](evidence/road-10k-plan-generation-policy/evidence-road-10k-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road 10 km performance planning | 1 | road-10k-plan-generation-policy | 2026-08-14 |
 | [evidence-running-field-tests-v1](evidence/running-field-tests/evidence-running-field-tests-v1.yaml) — Running field tests for plan baselines and outcomes | 1 | running-field-tests | 2026-08-08 |
 | [evidence-short-interruption-detraining-v1](evidence/short-interruption-detraining/evidence-short-interruption-detraining-v1.yaml) — Short training interruption and detraining | 1 | short-interruption-detraining | 2026-08-08 |
 
@@ -46,8 +48,6 @@ Evidence reviews record what the literature supports. Science Decision Records (
 | Record | Version | Topic/model | Reviewed/decided |
 |---|---:|---|---|
 | [sdr-adaptive-plan-feasibility-and-adjustment-v1](decisions/sdr-adaptive-plan-feasibility-and-adjustment-v1.yaml) — Bound adaptive-plan feasibility, adjustment, and outcome interpretation | 1 | adaptive-plan-policy-v1 | 2026-08-08 |
-| [sdr-plan-generation-eligibility-safety-v1](decisions/sdr-plan-generation-eligibility-safety-v1.yaml) — Match plan generation by capability, history, and non-medical safety state | 1 | plan-generation-eligibility-safety-v1 | 2026-08-14 |
-| [sdr-road-10k-plan-generation-policy-v1](decisions/sdr-road-10k-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road 10 km performance policy | 1 | road-10k-plan-generation-policy-v1 | 2026-08-14 |
 
 ## Superseded
 

--- a/data/science/decisions/sdr-plan-generation-eligibility-safety-v1.yaml
+++ b/data/science/decisions/sdr-plan-generation-eligibility-safety-v1.yaml
@@ -2,11 +2,12 @@ schema_version: 1
 id: sdr-plan-generation-eligibility-safety-v1
 version: 1
 title: "Match plan generation by capability, history, and non-medical safety state"
-status: draft
+status: accepted
 decision_date: 2026-08-14
 owners:
   - team:praxys
-human_reviewers: []
+human_reviewers:
+  - github:dddtc2005
 model_version: plan-generation-eligibility-safety-v1
 evidence_review_ids:
   - evidence-plan-generation-eligibility-safety-v1
@@ -21,22 +22,22 @@ evidence_claim_ids:
   - eligibility.current-symptoms-support-stop-not-clearance
   - eligibility.evidence-quality-no-personal-probability
 accepted_interpretation: >
-  If accepted, every Praxys training-plan flow would separate goal capture from
+  Praxys accepts that every training-plan flow must separate goal capture from
   plan generation. A user may record a supported discipline, distance, surface,
   completion or performance intent, and optional target date even when no
-  accepted generator policy currently matches. A shared deterministic router
-  would then evaluate current goal-relevant capability, history depth, recent
-  consistency, event context, time-bounded training patterns, evidence
-  directness, adult scope, non-medical safety state, and athlete-stated
-  constraints before selecting an independently accepted sport-, distance-,
-  intent-, and context-specific policy. Beginner, currently capable, returning,
-  sparse-history, high-load, race-dense, and other states would describe the
-  current evidence window rather than label the person as recreational,
-  serious, professional, or elite. Imported events and profile fields would
-  remain source-labelled candidates until their product purpose is disclosed
-  and the athlete confirms or corrects them. Adult eligibility or another
-  truly policy-critical field may block the dependent plan path; missing
-  optional age, sex, or other modifiers would instead remain unknown and
+  accepted generator policy currently matches. Once separately implemented and
+  activated, a shared deterministic router will evaluate current goal-relevant
+  capability, history depth, recent consistency, event context, time-bounded
+  training patterns, evidence directness, adult scope, non-medical safety state,
+  and athlete-stated constraints before selecting an independently accepted
+  sport-, distance-, intent-, and context-specific policy. Beginner, currently
+  capable, returning, sparse-history, high-load, race-dense, and other states
+  must describe the current evidence window rather than label the person as
+  recreational, serious, professional, or elite. Imported events and profile
+  fields must remain source-labelled candidates until their product purpose is
+  disclosed and the athlete confirms or corrects them. Adult eligibility or
+  another truly policy-critical field may block the dependent plan path;
+  missing optional age, sex, or other modifiers must instead remain unknown and
   disable only the dependent adjustment or metric. Unknown sex may never
   silently become male. A no-event goal may route to rolling training and a
   separately accepted, explicitly chosen completion activity or performance
@@ -51,8 +52,9 @@ accepted_interpretation: >
   prohibited. Optional AI may explain or structure reviewable inputs but
   cannot invent identity, event, profile, capability, history, or safety
   context; broaden eligibility; weaken validation; approve; adopt; mutate; or
-  deliver a plan. This draft authorizes no product behavior until explicit
-  human science acceptance and a separately reviewed implementation.
+  deliver a plan. This accepted decision authorizes the shared routing boundary
+  but no product behavior until the migration gates pass and a separately
+  reviewed implementation is activated.
 rejected_alternatives:
   - alternative: "Hide or reject a goal because no accepted generator policy currently matches"
     rationale: >
@@ -140,9 +142,10 @@ model_parameters:
       managed_provider_delivery_requires_separate_explicit_consent: true
     classification: guardrail
     rationale: >
-      A draft cross-cutting policy cannot activate generation. Separate
-      proposal, adoption, and delivery authority preserves athlete control and
-      prevents this shared classifier from becoming a planner.
+      Acceptance establishes the cross-cutting routing boundary but does not
+      activate generation. Separate proposal, adoption, and delivery authority
+      preserves athlete control and prevents this shared classifier from
+      becoming a planner.
     applies_to: plan-generation-eligibility-safety-v1
   - name: goal_intent_and_policy_separation
     value:
@@ -176,17 +179,17 @@ model_parameters:
     applies_to: goal capture, capability discovery, and every training-plan entry
   - name: existing_policy_alignment_gate
     value:
-      accepted_records_requiring_successor_alignment:
+      accepted_records_requiring_successor_alignment_before_activation:
         - sdr-preplan-baseline-policy-v1
         - sdr-outdoor-5k-plan-generation-policy-v1
-      draft_records_requiring_alignment_before_acceptance:
+      draft_records_requiring_alignment_before_activation:
         - sdr-adaptive-plan-feasibility-and-adjustment-v1
       alignment_topics:
         - goal_recording_independent_from_policy_availability
         - dynamic_patterns_instead_of_static_runner_identity
         - event_context_and_no_event_routing
         - profile_provenance_and_field_level_missingness
-      accepted_records_remain_unchanged_in_this_draft: true
+      accepted_records_remain_unchanged_in_this_decision: true
       shared_router_activation_before_successor_acceptance: false
     classification: guardrail
     rationale: >
@@ -788,7 +791,7 @@ validation_plan:
   - Audit provider imports for purpose disclosure, minimum fields, confirmation, conflict handling, deletion, and no silent overwrite.
   - Verify missing optional age or sex disables only the dependent modifier or metric and never selects a hidden male default.
   - Verify every enabled capability also references an accepted distance-specific SDR and cannot inherit another policy's numeric values.
-  - Require draft successor coverage for accepted baseline and outdoor 5 km records before shared-router activation; do not edit or supersede accepted history without human approval.
+  - Require accepted successor coverage for baseline and outdoor 5 km records before shared-router activation; draft successors may be prepared but cannot satisfy the activation gate, and accepted history must not be edited or superseded without human approval.
   - Audit every UI, API, plugin, and MCP response for personal probabilities, hidden policy relaxation, invented context, or diagnosis-shaped wording.
   - Pre-register safety exits, adverse reports, acceptance, edits, rejection, burden, and subgroup stop criteria before any suggestion-first pilot.
   - Require a successor decision before promoting sparse-history or masters status to a separate policy family or adding autonomous permissions.
@@ -797,7 +800,7 @@ falsification_conditions:
   - The shared router activates while accepted baseline or outdoor 5 km records still rely on unaligned static identity or goal-flow assumptions.
   - A goal-distance match alone enables generation despite a population, capability, history, evidence, or safety mismatch.
   - A beginner enters an already-capable policy without a separately accepted family.
-  - A goal-distance-novel runner enters an already-capable policy despite the draft conservative routing guardrail.
+  - A goal-distance-novel runner enters an already-capable policy despite the accepted conservative routing guardrail.
   - A static recreational, serious, professional, elite, or beginner identity determines routing after current data changes.
   - A dynamic pattern lacks an evaluation window, version, provenance, or correction path.
   - An empty or unavailable event calendar is treated as proof that no race or maximal effort exists.
@@ -844,10 +847,10 @@ affected_surfaces:
 supersedes: []
 superseded_by:
 decision_notes:
-  - "This is a decision proposal for issue #685, not an accepted policy or implementation authorization."
-  - Human review should focus on goal-versus-policy separation, dynamic pattern semantics, event-calendar completeness, provider-profile confirmation, field-level missingness, first-completion routing, masters modifiers, and symptom-stop semantics.
+  - "Human acceptance for issue #685 records the shared routing boundary, not implementation authorization."
+  - Human review accepted goal-versus-policy separation, dynamic pattern semantics, event-calendar completeness, provider-profile confirmation, field-level missingness, first-completion routing, masters modifiers, and symptom-stop semantics.
   - Accepted pre-plan baseline and outdoor 5 km records remain unchanged; separately reviewed successor records are required before shared-router activation.
-  - No numeric recent-history, weekly-frequency, intensity, quality-session, long-run, progression, taper, horizon, event-priority, or reassessment value is selected by this draft.
-  - "Impact map: draft Evidence Review -> draft SDR -> future goal and shared pure routing model -> capability registry -> dynamic pattern, event, profile, and evidence snapshots -> API contract -> web types and UI -> miniapp parity -> plugin/MCP parity -> ScienceNote and localization -> tests -> offline shadow validation -> suggestion-first pilot."
+  - No numeric recent-history, weekly-frequency, intensity, quality-session, long-run, progression, taper, horizon, event-priority, or reassessment value is selected by this shared decision.
+  - "Impact map: accepted Evidence Review -> accepted inactive SDR -> future goal and shared pure routing model -> capability registry -> dynamic pattern, event, profile, and evidence snapshots -> API contract -> web types and UI -> miniapp parity -> plugin/MCP parity -> ScienceNote and localization -> tests -> offline shadow validation -> suggestion-first pilot."
   - Accepted 5 km records remain unchanged and continue to govern only their current implementation.
-  - Explicit human acceptance and a separate implementation review are required before this model version can become active.
+  - Human acceptance is recorded; migration gates and a separate implementation review remain required before this model version can become active.

--- a/data/science/decisions/sdr-road-10k-plan-generation-policy-v1.yaml
+++ b/data/science/decisions/sdr-road-10k-plan-generation-policy-v1.yaml
@@ -2,11 +2,12 @@ schema_version: 1
 id: sdr-road-10k-plan-generation-policy-v1
 version: 1
 title: "History-anchored adult outdoor road 10 km performance policy"
-status: draft
+status: accepted
 decision_date: 2026-08-14
 owners:
   - team:praxys
-human_reviewers: []
+human_reviewers:
+  - github:dddtc2005
 model_version: road-10k-plan-generation-policy-v1
 evidence_review_ids:
   - evidence-plan-generation-eligibility-safety-v1
@@ -37,16 +38,17 @@ model_parameters:
         sdr_id: sdr-plan-generation-eligibility-safety-v1
         required_status_before_activation: accepted
       distance_policy_required_status_before_activation: accepted
-      human_science_review_required: true
+      human_science_acceptance_recorded: true
+      implementation_review_required_before_activation: true
       capability_registry_entry_default_enabled: false
       generator_api_web_and_miniapp_activation_in_this_record: false
     evidence_claim_ids:
       - eligibility.evidence-quality-no-personal-probability
     rationale: >
-      The shared eligibility proposal and this distance-specific decision are
-      both draft. No generator, route, registry availability, web control, or
-      miniapp control may activate before coordinated human acceptance and
-      implementation review.
+      The shared eligibility and distance-specific boundaries are accepted,
+      but acceptance alone does not activate a generator, route, registry
+      capability, web control, or miniapp control. Exact execution-window and
+      workout-template decisions plus implementation review remain required.
   - name: road_10k_goal_tuple
     classification: guardrail
     value:
@@ -894,8 +896,8 @@ privacy_implications:
 validation_plan:
   - >
     Registry validation must prove exact Evidence Review and claim links,
-    globally unique IDs, draft lifecycle validity, parameter classifications,
-    conditional accepted wording, and inactive behavior.
+    globally unique IDs, accepted lifecycle metadata, parameter
+    classifications, bounded accepted wording, and inactive behavior.
   - >
     Unit tests must cover the exact performance intent, adult history-rich pattern,
     direct-baseline hierarchy, 56-day freshness guardrail, eight-week history
@@ -1000,25 +1002,25 @@ affected_surfaces:
 supersedes: []
 superseded_by:
 accepted_interpretation: >
-  If accepted by identified human science reviewers, this SDR would authorize
-  only the bounded, inactive-by-default outdoor road 10 km performance policy
-  for an adult, currently capable, history-rich dynamic training pattern. The
-  goal may have no race date or target time; planning would be rolling, and an
-  optional benchmark would require explicit athlete scheduling. Confirmed
-  races would consume quality and load, with race-dense conflicts resolved
-  before a full proposal. This SDR would not activate a generator, choose the
+  Praxys accepts only the bounded, inactive-by-default outdoor road 10 km
+  performance policy for an adult, currently capable, history-rich dynamic
+  training pattern. The goal may have no race date or target time; planning is
+  rolling, and an optional benchmark requires explicit athlete scheduling.
+  Confirmed races consume quality and load, with race-dense conflicts resolved
+  before a full proposal. This SDR does not activate a generator, choose the
   exact execution-window length, accept workout templates, validate personal
   probabilities, authorize first-completion or clinical planning, label the
   person recreational or professional, or generalize to another distance or
   surface.
 decision_notes:
   - >
-    This is a stacked decision proposal for issue #686 and depends on the draft
-    shared eligibility and safety policy from issue #685.
+    Human acceptance for issue #686 records this distance-specific boundary
+    and its dependency on the accepted shared eligibility and safety policy
+    from issue #685.
   - >
-    The preferred recommendation is the narrow generation option. If reviewers
-    do not accept the required guardrails, the product recommendation falls
-    back to readiness-only rather than copying the outdoor 5 km generator.
+    The accepted recommendation is the narrow generation option. Any future
+    challenge to the required guardrails falls back to readiness-only rather
+    than copying the outdoor 5 km generator.
   - >
     The main unresolved scientific gaps are exact 10 km workout templates,
     direct long-run prescription, execution-window length, reassessment
@@ -1030,9 +1032,10 @@ decision_notes:
     pilot decision thresholds are product guardrails, not published biology or
     inherited 5 km defaults. No 42-day eligibility horizon remains.
   - >
-    No runtime behavior changes while this record is draft. If accepted and
-    implemented later, rollout must remain default-off, suggestion-only, and
-    reversible without substituting the 5 km policy.
+    Acceptance does not change runtime behavior. If implemented later, rollout
+    must remain default-off, suggestion-only, and reversible without
+    substituting the 5 km policy.
   - >
-    Human science approval is required before lifecycle transition,
-    implementation activation, pilot authorization, or user-facing claims.
+    Human science acceptance is recorded. Implementation activation, pilot
+    authorization, and user-facing claims still require their documented
+    reviews and validation.

--- a/data/science/evidence/plan-generation-eligibility-safety/evidence-plan-generation-eligibility-safety-v1.yaml
+++ b/data/science/evidence/plan-generation-eligibility-safety/evidence-plan-generation-eligibility-safety-v1.yaml
@@ -11,12 +11,13 @@ research_question: >
   exact planning choices remain Praxys guardrails rather than published
   prescriptions?
 topic: plan-generation-eligibility-safety
-status: draft
+status: accepted
 authors:
   - agent:github-copilot
-human_reviewers: []
+human_reviewers:
+  - github:dddtc2005
 created_on: 2026-08-14
-reviewed_on:
+reviewed_on: 2026-08-14
 intended_product_purpose: >
   Define a shared evidence boundary and product-routing contract for every
   training plan. Keep goal selection independent from plan availability, route

--- a/data/science/evidence/road-10k-plan-generation-policy/evidence-road-10k-plan-generation-policy-v1.yaml
+++ b/data/science/evidence/road-10k-plan-generation-policy/evidence-road-10k-plan-generation-policy-v1.yaml
@@ -9,12 +9,13 @@ research_question: >
   performance policy with an optional race date, confirmed event context, and
   an optional athlete-chosen benchmark when no race exists?
 topic: road-10k-plan-generation-policy
-status: draft
+status: accepted
 authors:
   - agent:github-copilot
-human_reviewers: []
+human_reviewers:
+  - github:dddtc2005
 created_on: 2026-08-14
-reviewed_on:
+reviewed_on: 2026-08-14
 intended_product_purpose: >
   Define the distance-specific evidence boundary for one dynamically matched
   road 10 km performance pattern without copying the accepted outdoor 5 km

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -302,7 +302,7 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     assert decision.human_reviewers == ["github:dddtc2005"]
 
 
-def test_plan_generation_eligibility_proposal_stays_inactive_and_cross_cutting() -> None:
+def test_plan_generation_eligibility_policy_is_accepted_but_inactive_and_cross_cutting() -> None:
     registry = load_science_registry()
     review = registry.evidence_reviews[
         "evidence-plan-generation-eligibility-safety-v1"
@@ -311,9 +311,9 @@ def test_plan_generation_eligibility_proposal_stays_inactive_and_cross_cutting()
         "sdr-plan-generation-eligibility-safety-v1"
     ]
 
-    assert review.status == "draft"
-    assert review.human_reviewers == []
-    assert review.reviewed_on is None
+    assert review.status == "accepted"
+    assert review.human_reviewers == ["github:dddtc2005"]
+    assert review.reviewed_on == date(2026, 8, 14)
     assert review.method.review_type.value == "rigorous"
     assert len(review.citations) >= 17
     assert {
@@ -331,8 +331,8 @@ def test_plan_generation_eligibility_proposal_stays_inactive_and_cross_cutting()
     } <= {note.split(";", 1)[0] for note in review.review_notes}
     _assert_exact_verification_notes(review)
 
-    assert decision.status == "draft"
-    assert decision.human_reviewers == []
+    assert decision.status == "accepted"
+    assert decision.human_reviewers == ["github:dddtc2005"]
     assert decision.evidence_review_ids == [review.id]
     assert {claim.id for claim in review.claims} == set(
         decision.evidence_claim_ids
@@ -361,12 +361,17 @@ def test_plan_generation_eligibility_proposal_stays_inactive_and_cross_cutting()
         "goal_recorded_plan_policy_unavailable"
     )
     alignment = parameters["existing_policy_alignment_gate"].value
-    assert alignment["accepted_records_requiring_successor_alignment"] == [
+    assert alignment[
+        "accepted_records_requiring_successor_alignment_before_activation"
+    ] == [
         "sdr-preplan-baseline-policy-v1",
         "sdr-outdoor-5k-plan-generation-policy-v1",
     ]
+    assert alignment["draft_records_requiring_alignment_before_activation"] == [
+        "sdr-adaptive-plan-feasibility-and-adjustment-v1",
+    ]
     assert alignment[
-        "accepted_records_remain_unchanged_in_this_draft"
+        "accepted_records_remain_unchanged_in_this_decision"
     ] is True
     assert alignment[
         "shared_router_activation_before_successor_acceptance"
@@ -500,12 +505,12 @@ def test_plan_generation_eligibility_proposal_stays_inactive_and_cross_cutting()
         "athlete_reported_safety_stop"
     ].value["stop_reasons"]
     assert any(
-        "not an accepted policy" in note
+        "Human acceptance for issue #685" in note
         for note in decision.decision_notes
     )
 
 
-def test_road_10k_policy_proposal_is_distance_specific_and_inactive() -> None:
+def test_road_10k_policy_is_accepted_distance_specific_and_inactive() -> None:
     registry = load_science_registry()
     review = registry.evidence_reviews[
         "evidence-road-10k-plan-generation-policy-v1"
@@ -514,9 +519,9 @@ def test_road_10k_policy_proposal_is_distance_specific_and_inactive() -> None:
         "sdr-road-10k-plan-generation-policy-v1"
     ]
 
-    assert review.status == "draft"
-    assert review.human_reviewers == []
-    assert review.reviewed_on is None
+    assert review.status == "accepted"
+    assert review.human_reviewers == ["github:dddtc2005"]
+    assert review.reviewed_on == date(2026, 8, 14)
     assert review.method.review_type.value == "rigorous"
     assert len(review.citations) >= 19
     assert {
@@ -539,8 +544,8 @@ def test_road_10k_policy_proposal_is_distance_specific_and_inactive() -> None:
     } <= {note.split(";", 1)[0] for note in review.review_notes}
     _assert_exact_verification_notes(review)
 
-    assert decision.status == "draft"
-    assert decision.human_reviewers == []
+    assert decision.status == "accepted"
+    assert decision.human_reviewers == ["github:dddtc2005"]
     assert decision.evidence_review_ids == [
         "evidence-plan-generation-eligibility-safety-v1",
         review.id,
@@ -561,6 +566,14 @@ def test_road_10k_policy_proposal_is_distance_specific_and_inactive() -> None:
     assert activation["distance_policy_required_status_before_activation"] == (
         "accepted"
     )
+    assert activation["human_science_acceptance_recorded"] is True
+    assert activation[
+        "implementation_review_required_before_activation"
+    ] is True
+    assert activation["capability_registry_entry_default_enabled"] is False
+    assert activation[
+        "generator_api_web_and_miniapp_activation_in_this_record"
+    ] is False
     assert parameters["road_10k_goal_tuple"].value["goal_kind"] == (
         "distance_10k"
     )
@@ -791,7 +804,7 @@ def test_road_10k_policy_proposal_is_distance_specific_and_inactive() -> None:
         "published"
     )
     assert any(
-        "stacked decision proposal for issue #686" in note
+        "Human acceptance for issue #686" in note
         for note in decision.decision_notes
     )
 


### PR DESCRIPTION
# Science lifecycle change

## Summary

- Record maintainer `github:dddtc2005` as the human reviewer for the shared plan-routing and road 10K Evidence Reviews and SDRs.
- Move all four records from `draft` to `accepted` after the explicit 2026-08-14 decision following #696 and #698.
- Keep accepted science separate from runtime activation and preserve every unresolved implementation boundary.

## Accepted boundary

- Goal recording remains separate from current plan-policy availability.
- Routing uses current capability, orthogonal history depth, dynamic training-context patterns, confirmed event context, evidence directness, adult scope, non-medical safety state, constraints, and field-level provenance/missingness.
- The accepted road 10K policy remains limited to adult outdoor-road performance intent with current 10K capability, stable recent history, within-recent load, and direct or supporting evidence.
- The documented 56-day baseline, eight-week history, 3-6 running days, 75% low-intensity floor, two-session quality ceiling, history caps, and taper values remain explicit pilot guardrails rather than biological laws.

## Still inactive and unresolved

- `active_behavior` remains `false`; capability registration remains default-disabled.
- No generator, API, web, miniapp, plugin, or MCP behavior is enabled.
- Exact committed execution-window length remains `not_accepted`.
- Exact 10K workout templates require a separate versioned guardrail review.
- First-10K completion, sparse-history, other surfaces, and clinical routes remain separate policies.
- Accepted preplan/5K successor alignment and adaptive-plan alignment remain required before shared-router activation.

## Evidence and review

- No claims, citations, effect estimates, or source-verification levels changed.
- `science-reviewer` found no blocking issues; two stale draft-wording inconsistencies were corrected.
- Accepted records identify `github:dddtc2005` and review date `2026-08-14`.

## Validation

- `python scripts/generate_science_registry_index.py`
- `python -m pytest tests/test_evidence_registry.py tests/test_science.py -q` (68 passed)
- `git diff --check`

## UI quality

- Not applicable: no user-visible or runtime behavior changed.

Follow-up to #696 and #698.