### PR TITLE
Separate science review packets from policy contracts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/science-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/science-change.md
@@ -12,7 +12,10 @@ Do not check any item that was not actually performed.
 - [ ] Each formula, constant, and user-facing claim has provenance or an explicit estimate/guardrail rationale.
 - [ ] Applicability, uncertainty, safety boundaries, and rejected alternatives are documented.
 - [ ] Record lifecycle is versioned/superseded; accepted evidence and decisions were not rewritten.
-- [ ] A human reviewer is named for any accepted SDR or shipped scientific behavior.
+- [ ] Artifact-mode review packets and machine contracts were regenerated and carry matching source/contract digests.
+- [ ] Every code-consumed field appears verbatim in the generated human review packet.
+- [ ] Accepted artifact-mode records include the required digest-bound `evidence_reviewer` or `decision_approver`; active contracts include an `implementation_reviewer`.
+- [ ] Accepted legacy records still identify their human reviewer and review date.
 
 ## Product and implementation
 
@@ -24,6 +27,7 @@ Do not check any item that was not actually performed.
 ## Validation and review
 
 - [ ] Tests cover the changed behavior and the stated validation/falsification plan.
+- [ ] `python scripts/generate_science_artifacts.py --check` passes.
 - [ ] English and Chinese scientific copy have been reviewed for equivalent meaning.
 - [ ] `science-reviewer` ran for `analysis/` or `data/science/` changes and reported its source-verification boundary.
 - [ ] `metric-addition-reviewer` and `api-contract-reviewer` ran when their scopes apply.

--- a/.github/skills/science-research/SKILL.md
+++ b/.github/skills/science-research/SKILL.md
@@ -145,8 +145,21 @@ Follow the existing registry schema and lifecycle:
   every parameter as `published`, `estimate`, or `guardrail`, and document
   rejected alternatives, claim limits, safety/privacy implications, and a
   falsification plan.
-- Only an identified human reviewer can accept an SDR or approve a behavior
-  change. Regenerate `data/science/REGISTRY.md` after valid record changes.
+- New records use `approval_mode: artifact`; draft SDRs declare
+  `artifact_policy.runtime_state: inactive`.
+- Run `python scripts/generate_science_artifacts.py` and hand reviewers the
+  generated Markdown packet, not raw YAML. The packet must include the exact
+  machine JSON contract and the same decision/contract digests.
+- Evidence, decision, and implementation review are separate roles. Only a
+  digest-bound `evidence_reviewer` may accept an artifact-mode Evidence Review;
+  only a `decision_approver` may accept its SDR; only an
+  `implementation_reviewer` may activate its contract.
+- A human reviewer fills each of those roles; generated packets, schema
+  validation, agents, and CI cannot substitute for that judgment.
+- Agents may prepare canonical records, packets, contracts, and lifecycle
+  patches. They may not create human approval artifacts, accept records,
+  activate contracts, or claim approval.
+- Regenerate `data/science/REGISTRY.md` after valid record changes.
 
 ## 5. Map evidence to product behavior
 
@@ -198,6 +211,9 @@ End every run with these artifacts or explicitly state why one does not apply:
 3. Concise product recommendation, alternatives considered, and claim limits.
 4. Unresolved evidence gaps, conflicts, and validation/falsification plan.
 5. Implementation impact map and reviewer checklist.
+6. For artifact-mode work, generated Evidence Review and SDR review packets,
+   the exact inactive machine contract, and any still-missing role-scoped
+   approval artifacts.
 
 Name the mode, verification limits, and the human approval still required in
 the handoff. Do not present a draft as shipped science.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ All training metrics, predictions, and insights must be grounded in exercise sci
 - **Use published values** over guesswork (Stryd race power percentages, Riegel, Banister TRIMP)
 - **Flag estimates** — values without strong research backing noted as estimates in code and UI
 - **Register new theories** — new theory YAML must link an accepted Science Decision Record; unlinked legacy theories are migration-only exceptions
+- **Separate review from runtime artifacts** — new science records use generated human review packets, generated machine contracts, matching digests, and role-scoped approvals; runtime code never derives values from prose
 
 ## Gotchas
 

--- a/analysis/evidence_registry.py
+++ b/analysis/evidence_registry.py
@@ -70,6 +70,20 @@ class RecordStatus(StrEnum):
     RETIRED = "retired"
 
 
+class ApprovalMode(StrEnum):
+    """How human review is recorded for one science record."""
+
+    LEGACY = "legacy"
+    ARTIFACT = "artifact"
+
+
+class ArtifactRuntimeState(StrEnum):
+    """Whether a generated implementation contract may be consumed."""
+
+    INACTIVE = "inactive"
+    ACTIVE = "active"
+
+
 class ReviewType(StrEnum):
     """Depth of the documented literature review."""
 
@@ -251,6 +265,7 @@ class EvidenceReview(RegistryModel):
     research_question: str = Field(min_length=1)
     topic: str = Field(min_length=1)
     status: RecordStatus
+    approval_mode: ApprovalMode = ApprovalMode.LEGACY
     authors: list[Identity] = Field(min_length=1)
     human_reviewers: list[Identity] = Field(default_factory=list)
     created_on: date
@@ -282,7 +297,18 @@ class EvidenceReview(RegistryModel):
             raise ValueError("citation IDs must be unique within a review")
         if self.reviewed_on is not None and self.reviewed_on < self.created_on:
             raise ValueError("reviewed_on must not predate created_on")
-        if self.status in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}:
+        if (
+            self.approval_mode == ApprovalMode.ARTIFACT
+            and self.human_reviewers
+        ):
+            raise ValueError(
+                "artifact-reviewed records use role-scoped approval files, "
+                "not human_reviewers"
+            )
+        if (
+            self.approval_mode == ApprovalMode.LEGACY
+            and self.status in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}
+        ):
             _require_human_review(self.human_reviewers, self.reviewed_on)
         if self.status == RecordStatus.SUPERSEDED and self.superseded_by is None:
             raise ValueError("superseded records require superseded_by")
@@ -334,6 +360,12 @@ class AffectedSurfaces(RegistryModel):
     science_notes: list[str] = Field(default_factory=list)
 
 
+class DecisionArtifactPolicy(RegistryModel):
+    """Generated-artifact and runtime-consumption boundary for one SDR."""
+
+    runtime_state: ArtifactRuntimeState = ArtifactRuntimeState.INACTIVE
+
+
 class ScienceDecisionRecord(RegistryModel):
     """Versioned record of how Praxys interprets accepted evidence."""
 
@@ -342,6 +374,7 @@ class ScienceDecisionRecord(RegistryModel):
     version: int = Field(ge=1)
     title: str = Field(min_length=1)
     status: RecordStatus
+    approval_mode: ApprovalMode = ApprovalMode.LEGACY
     decision_date: date
     owners: list[Identity] = Field(min_length=1)
     human_reviewers: list[Identity] = Field(default_factory=list)
@@ -358,6 +391,7 @@ class ScienceDecisionRecord(RegistryModel):
     validation_plan: list[str] = Field(min_length=1)
     falsification_conditions: list[str] = Field(min_length=1)
     affected_surfaces: AffectedSurfaces
+    artifact_policy: DecisionArtifactPolicy | None = None
     supersedes: list[RecordId] = Field(default_factory=list)
     superseded_by: RecordId | None = None
     decision_notes: list[str] = Field(default_factory=list)
@@ -376,7 +410,32 @@ class ScienceDecisionRecord(RegistryModel):
             raise ValueError("evidence review IDs must be unique")
         if len(self.evidence_claim_ids) != len(set(self.evidence_claim_ids)):
             raise ValueError("evidence claim IDs must be unique")
-        if self.status in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}:
+        if self.approval_mode == ApprovalMode.ARTIFACT:
+            if self.human_reviewers:
+                raise ValueError(
+                    "artifact-reviewed records use role-scoped approval files, "
+                    "not human_reviewers"
+                )
+            if self.artifact_policy is None:
+                raise ValueError(
+                    "artifact-reviewed decisions require artifact_policy"
+                )
+        elif self.artifact_policy is not None:
+            raise ValueError(
+                "legacy-reviewed decisions cannot define artifact_policy"
+            )
+        if (
+            self.artifact_policy is not None
+            and self.artifact_policy.runtime_state == ArtifactRuntimeState.ACTIVE
+            and self.status != RecordStatus.ACCEPTED
+        ):
+            raise ValueError(
+                "active implementation contracts require an accepted decision"
+            )
+        if (
+            self.approval_mode == ApprovalMode.LEGACY
+            and self.status in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}
+        ):
             _require_human_review(self.human_reviewers, self.decision_date)
         if self.status == RecordStatus.SUPERSEDED and self.superseded_by is None:
             raise ValueError("superseded records require superseded_by")
@@ -576,7 +635,7 @@ def _load_science_registry(root: Path) -> ScienceRegistry:
     _validate_supersession(evidence_reviews)
     _validate_supersession(decisions)
 
-    return ScienceRegistry(
+    registry = ScienceRegistry(
         science_dir=root,
         evidence_reviews=evidence_reviews,
         decisions=decisions,
@@ -586,6 +645,10 @@ def _load_science_registry(root: Path) -> ScienceRegistry:
         review_paths=review_paths,
         decision_paths=decision_paths,
     )
+    from analysis.science_artifacts import validate_registry_approvals
+
+    validate_registry_approvals(registry)
+    return registry
 
 
 def _validate_schema_version(raw: dict[str, Any], path: Path) -> None:

--- a/analysis/science_artifacts.py
+++ b/analysis/science_artifacts.py
@@ -864,6 +864,14 @@ def _render_named_lists(sections: dict[str, list[str]]) -> list[str]:
 def _render_effect_estimate(estimate: dict[str, Any]) -> str:
     if estimate.get("estimate") is not None:
         value = str(estimate["estimate"])
+        if (
+            estimate.get("range_low") is not None
+            and estimate.get("range_high") is not None
+        ):
+            value += (
+                f" (range {estimate['range_low']} to "
+                f"{estimate['range_high']})"
+            )
     else:
         value = f"{estimate['range_low']} to {estimate['range_high']}"
     return (

--- a/analysis/science_artifacts.py
+++ b/analysis/science_artifacts.py
@@ -1,0 +1,925 @@
+"""Deterministic human-review and machine-contract science artifacts."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import StrEnum
+from hashlib import sha256
+import json
+from pathlib import Path
+import re
+from typing import Annotated, Any, Literal
+
+from pydantic import AnyHttpUrl, Field, JsonValue, model_validator
+import yaml
+
+from analysis.evidence_registry import (
+    ApprovalMode,
+    ArtifactRuntimeState,
+    ClaimId,
+    EvidenceReview,
+    Identity,
+    ParameterClassification,
+    RecordId,
+    RecordStatus,
+    RegistryModel,
+    ScienceDecisionRecord,
+    ScienceRegistry,
+)
+
+
+_SCIENCE_DIR = Path(__file__).resolve().parents[1] / "data" / "science"
+_REVIEW_PACKET_DIR = Path("generated") / "review-packets"
+_CONTRACT_DIR = Path("generated") / "contracts"
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+Digest = Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")]
+
+
+class ReviewSubjectKind(StrEnum):
+    """Artifact type covered by one human attestation."""
+
+    EVIDENCE_REVIEW = "evidence_review"
+    SCIENCE_DECISION = "science_decision"
+    IMPLEMENTATION_CONTRACT = "implementation_contract"
+
+
+class ReviewRole(StrEnum):
+    """Distinct responsibility carried by one human reviewer."""
+
+    EVIDENCE_REVIEWER = "evidence_reviewer"
+    DECISION_APPROVER = "decision_approver"
+    IMPLEMENTATION_REVIEWER = "implementation_reviewer"
+
+
+class ReviewScope(StrEnum):
+    """Review surfaces that may be attested independently."""
+
+    SEARCH_METHOD = "search_method"
+    EVIDENCE_CLAIMS = "evidence_claims"
+    CITATION_VERIFICATION = "citation_verification"
+    LIMITATIONS_AND_GAPS = "limitations_and_gaps"
+    DECISION_INTERPRETATION = "decision_interpretation"
+    PARAMETERS = "parameters"
+    APPLICABILITY = "applicability"
+    CLAIM_LIMITS = "claim_limits"
+    SAFETY_AND_PRIVACY = "safety_and_privacy"
+    ACTIVATION_BOUNDARY = "activation_boundary"
+    CONTRACT_MAPPING = "contract_mapping"
+    RUNTIME_DIFF = "runtime_diff"
+    VALIDATION = "validation"
+
+
+_ROLE_SUBJECTS = {
+    ReviewRole.EVIDENCE_REVIEWER: ReviewSubjectKind.EVIDENCE_REVIEW,
+    ReviewRole.DECISION_APPROVER: ReviewSubjectKind.SCIENCE_DECISION,
+    ReviewRole.IMPLEMENTATION_REVIEWER:
+        ReviewSubjectKind.IMPLEMENTATION_CONTRACT,
+}
+_REQUIRED_SCOPES = {
+    ReviewRole.EVIDENCE_REVIEWER: {
+        ReviewScope.SEARCH_METHOD,
+        ReviewScope.EVIDENCE_CLAIMS,
+        ReviewScope.CITATION_VERIFICATION,
+        ReviewScope.LIMITATIONS_AND_GAPS,
+    },
+    ReviewRole.DECISION_APPROVER: {
+        ReviewScope.DECISION_INTERPRETATION,
+        ReviewScope.PARAMETERS,
+        ReviewScope.APPLICABILITY,
+        ReviewScope.CLAIM_LIMITS,
+        ReviewScope.SAFETY_AND_PRIVACY,
+        ReviewScope.ACTIVATION_BOUNDARY,
+    },
+    ReviewRole.IMPLEMENTATION_REVIEWER: {
+        ReviewScope.CONTRACT_MAPPING,
+        ReviewScope.RUNTIME_DIFF,
+        ReviewScope.VALIDATION,
+    },
+}
+
+
+class ScienceApproval(RegistryModel):
+    """One role-scoped human attestation bound to an immutable digest."""
+
+    schema_version: Literal[1]
+    subject_kind: ReviewSubjectKind
+    subject_id: RecordId
+    subject_digest: Digest
+    reviewer: Identity
+    role: ReviewRole
+    reviewed_on: date
+    scopes: list[ReviewScope] = Field(min_length=1)
+    source_ref: AnyHttpUrl
+
+    @model_validator(mode="after")
+    def validate_role_and_scope(self) -> "ScienceApproval":
+        """Require the role's exact subject type and complete review scope."""
+        if not self.reviewer.startswith(("github:", "orcid:")):
+            raise ValueError(
+                "science approvals require an identified human reviewer"
+            )
+        if _ROLE_SUBJECTS[self.role] != self.subject_kind:
+            raise ValueError(
+                f"{self.role} cannot approve {self.subject_kind}"
+            )
+        missing = _REQUIRED_SCOPES[self.role] - set(self.scopes)
+        if missing:
+            raise ValueError(
+                f"{self.role} approval is missing scopes: "
+                f"{sorted(scope.value for scope in missing)}"
+            )
+        if len(self.scopes) != len(set(self.scopes)):
+            raise ValueError("approval scopes must be unique")
+        return self
+
+
+class ContractParameter(RegistryModel):
+    """Machine-consumable projection of one reviewed SDR parameter."""
+
+    classification: ParameterClassification
+    value: JsonValue
+    evidence_claim_ids: list[ClaimId] = Field(default_factory=list)
+    applies_to: str | None = None
+
+
+class SciencePolicyContract(RegistryModel):
+    """Generated policy contract consumed by implementation code."""
+
+    schema_version: Literal[1]
+    decision_id: RecordId
+    decision_version: int = Field(ge=1)
+    decision_status: RecordStatus
+    model_version: str = Field(min_length=1)
+    runtime_state: ArtifactRuntimeState
+    source_decision_digest: Digest
+    linked_evidence_digests: dict[str, Digest]
+    evidence_review_ids: list[RecordId] = Field(min_length=1)
+    evidence_claim_ids: list[ClaimId] = Field(min_length=1)
+    affected_models: list[str] = Field(min_length=1)
+    parameters: dict[str, ContractParameter]
+    contract_digest: Digest
+
+    @model_validator(mode="after")
+    def validate_contract_digest(self) -> "SciencePolicyContract":
+        """Reject a contract whose embedded digest does not match its payload."""
+        payload = self.model_dump(
+            mode="json",
+            exclude={"contract_digest"},
+        )
+        expected = digest_payload(payload)
+        if self.contract_digest != expected:
+            raise ValueError("contract_digest does not match contract payload")
+        return self
+
+    @property
+    def parameter_values(self) -> dict[str, JsonValue]:
+        """Return the exact reviewed parameter values for code consumption."""
+        return {
+            name: parameter.value
+            for name, parameter in self.parameters.items()
+        }
+
+
+def digest_payload(payload: Any) -> str:
+    """Return a stable SHA-256 digest for canonical JSON-compatible data."""
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return f"sha256:{sha256(canonical).hexdigest()}"
+
+
+def evidence_review_payload(review: EvidenceReview) -> dict[str, Any]:
+    """Return the complete human-reviewed evidence content without lifecycle."""
+    return review.model_dump(
+        mode="json",
+        exclude={
+            "approval_mode",
+            "human_reviewers",
+            "reviewed_on",
+            "status",
+            "superseded_by",
+        },
+    )
+
+
+def science_decision_payload(
+    decision: ScienceDecisionRecord,
+) -> dict[str, Any]:
+    """Return the complete human-reviewed decision content without lifecycle."""
+    return decision.model_dump(
+        mode="json",
+        exclude={
+            "approval_mode",
+            "human_reviewers",
+            "status",
+            "superseded_by",
+        },
+    )
+
+
+def evidence_review_digest(review: EvidenceReview) -> str:
+    """Return the digest a human evidence review attestation must bind."""
+    return digest_payload(evidence_review_payload(review))
+
+
+def science_decision_digest(decision: ScienceDecisionRecord) -> str:
+    """Return the digest a human decision approval must bind."""
+    return digest_payload(science_decision_payload(decision))
+
+
+def build_policy_contract(
+    registry: ScienceRegistry,
+    decision_id: str,
+) -> SciencePolicyContract:
+    """Compile one artifact-mode SDR into a deterministic machine contract."""
+    decision = registry.decisions[decision_id]
+    if decision.approval_mode != ApprovalMode.ARTIFACT:
+        raise ValueError(
+            f"Decision {decision_id} does not use artifact review mode"
+        )
+    if decision.artifact_policy is None:
+        raise ValueError(f"Decision {decision_id} lacks artifact_policy")
+
+    payload = {
+        "schema_version": 1,
+        "decision_id": decision.id,
+        "decision_version": decision.version,
+        "decision_status": decision.status.value,
+        "model_version": decision.model_version,
+        "runtime_state": decision.artifact_policy.runtime_state.value,
+        "source_decision_digest": science_decision_digest(decision),
+        "linked_evidence_digests": {
+            review_id: evidence_review_digest(
+                registry.evidence_reviews[review_id]
+            )
+            for review_id in decision.evidence_review_ids
+        },
+        "evidence_review_ids": decision.evidence_review_ids,
+        "evidence_claim_ids": decision.evidence_claim_ids,
+        "affected_models": decision.affected_surfaces.models,
+        "parameters": {
+            parameter.name: {
+                "classification": parameter.classification.value,
+                "value": parameter.value,
+                "evidence_claim_ids": parameter.evidence_claim_ids,
+                "applies_to": parameter.applies_to,
+            }
+            for parameter in decision.model_parameters
+        },
+    }
+    return SciencePolicyContract.model_validate({
+        **payload,
+        "contract_digest": digest_payload(payload),
+    })
+
+
+def render_policy_contract_json(contract: SciencePolicyContract) -> str:
+    """Render one contract as stable, pretty JSON."""
+    return json.dumps(
+        contract.model_dump(mode="json"),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def load_science_approvals(
+    science_dir: str | Path,
+) -> list[ScienceApproval]:
+    """Load role-scoped approval artifacts in deterministic path order."""
+    approval_dir = Path(science_dir) / "approvals"
+    if not approval_dir.is_dir():
+        return []
+    approvals: list[ScienceApproval] = []
+    for path in sorted(
+        [*approval_dir.rglob("*.yaml"), *approval_dir.rglob("*.yml")],
+        key=lambda item: item.as_posix(),
+    ):
+        with path.open(encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+        if not isinstance(raw, dict):
+            raise ValueError(f"Science approval must be a mapping: {path}")
+        approvals.append(ScienceApproval.model_validate(raw))
+    return approvals
+
+
+def validate_registry_approvals(registry: ScienceRegistry) -> None:
+    """Validate approval subjects, roles, scopes, and bound digests."""
+    approvals = load_science_approvals(registry.science_dir)
+    seen: set[tuple[str, str, str]] = set()
+    for approval in approvals:
+        key = (
+            approval.subject_kind.value,
+            approval.subject_id,
+            f"{approval.role.value}:{approval.reviewer}",
+        )
+        if key in seen:
+            raise ValueError(
+                "Duplicate science approval for "
+                f"{approval.subject_id}, {approval.role}, {approval.reviewer}"
+            )
+        seen.add(key)
+        expected = _approval_subject_digest(registry, approval)
+        if approval.subject_digest != expected:
+            raise ValueError(
+                f"Science approval for {approval.subject_id} is stale: "
+                f"expected {expected}, got {approval.subject_digest}"
+            )
+
+    for review in registry.evidence_reviews.values():
+        if (
+            review.approval_mode == ApprovalMode.ARTIFACT
+            and review.status in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}
+            and not _has_approval(
+                approvals,
+                ReviewSubjectKind.EVIDENCE_REVIEW,
+                review.id,
+                ReviewRole.EVIDENCE_REVIEWER,
+            )
+        ):
+            raise ValueError(
+                f"Accepted evidence review {review.id} requires an "
+                "evidence_reviewer approval artifact"
+            )
+
+    for decision in registry.decisions.values():
+        if decision.approval_mode != ApprovalMode.ARTIFACT:
+            continue
+        if (
+            decision.status in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}
+            and not _has_approval(
+                approvals,
+                ReviewSubjectKind.SCIENCE_DECISION,
+                decision.id,
+                ReviewRole.DECISION_APPROVER,
+            )
+        ):
+            raise ValueError(
+                f"Accepted science decision {decision.id} requires a "
+                "decision_approver approval artifact"
+            )
+        if (
+            decision.artifact_policy is not None
+            and decision.artifact_policy.runtime_state
+            == ArtifactRuntimeState.ACTIVE
+            and not _has_approval(
+                approvals,
+                ReviewSubjectKind.IMPLEMENTATION_CONTRACT,
+                decision.id,
+                ReviewRole.IMPLEMENTATION_REVIEWER,
+            )
+        ):
+            raise ValueError(
+                f"Active implementation contract {decision.id} requires an "
+                "implementation_reviewer approval artifact"
+            )
+
+
+def _approval_subject_digest(
+    registry: ScienceRegistry,
+    approval: ScienceApproval,
+) -> str:
+    """Resolve the current digest for one approval subject."""
+    if approval.subject_kind == ReviewSubjectKind.EVIDENCE_REVIEW:
+        if approval.subject_id not in registry.evidence_reviews:
+            raise ValueError(
+                f"Approval references unknown evidence review "
+                f"{approval.subject_id}"
+            )
+        review = registry.evidence_reviews[approval.subject_id]
+        if review.approval_mode != ApprovalMode.ARTIFACT:
+            raise ValueError(
+                f"Approval subject {approval.subject_id} uses legacy review mode"
+            )
+        if review.status not in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}:
+            raise ValueError(
+                f"Evidence approval subject {approval.subject_id} is not accepted"
+            )
+        if approval.reviewed_on < review.created_on:
+            raise ValueError(
+                f"Evidence approval for {approval.subject_id} predates the record"
+            )
+        return evidence_review_digest(review)
+
+    if approval.subject_id not in registry.decisions:
+        raise ValueError(
+            f"Approval references unknown science decision {approval.subject_id}"
+        )
+    decision = registry.decisions[approval.subject_id]
+    if decision.approval_mode != ApprovalMode.ARTIFACT:
+        raise ValueError(
+            f"Approval subject {approval.subject_id} uses legacy review mode"
+        )
+    if decision.status not in {RecordStatus.ACCEPTED, RecordStatus.SUPERSEDED}:
+        raise ValueError(
+            f"Decision approval subject {approval.subject_id} is not accepted"
+        )
+    if approval.reviewed_on < decision.decision_date:
+        raise ValueError(
+            f"Science approval for {approval.subject_id} predates the decision"
+        )
+    if approval.subject_kind == ReviewSubjectKind.SCIENCE_DECISION:
+        return science_decision_digest(decision)
+    return build_policy_contract(registry, decision.id).contract_digest
+
+
+def _has_approval(
+    approvals: list[ScienceApproval],
+    subject_kind: ReviewSubjectKind,
+    subject_id: str,
+    role: ReviewRole,
+) -> bool:
+    """Return whether the exact role has approved the exact subject."""
+    return any(
+        approval.subject_kind == subject_kind
+        and approval.subject_id == subject_id
+        and approval.role == role
+        for approval in approvals
+    )
+
+
+def render_evidence_review_packet(
+    registry: ScienceRegistry,
+    review_id: str,
+) -> str:
+    """Render all evidence-review content into a human review packet."""
+    review = registry.evidence_reviews[review_id]
+    digest = evidence_review_digest(review)
+    approvals = load_science_approvals(registry.science_dir)
+    lines = [
+        f"# Evidence review packet: {review.title}",
+        "",
+        "> Generated from the canonical Evidence Review. Review this packet, "
+        "not the raw YAML. Any source change invalidates the digest below.",
+        "",
+        f"- **Record:** `{review.id}`",
+        f"- **Lifecycle:** `{review.status.value}`",
+        f"- **Review mode:** `{review.approval_mode.value}`",
+        f"- **Reviewed content digest:** `{digest}`",
+        f"- **Required role:** `{ReviewRole.EVIDENCE_REVIEWER.value}`",
+        f"- **Approval:** {_approval_label(approvals, review.id, ReviewRole.EVIDENCE_REVIEWER)}",
+        "",
+        "## Approval artifact template",
+        "",
+        "Create this only after a human completes the packet review:",
+        "",
+        "```yaml",
+        _render_approval_template(
+            subject_kind=ReviewSubjectKind.EVIDENCE_REVIEW,
+            subject_id=review.id,
+            subject_digest=digest,
+            role=ReviewRole.EVIDENCE_REVIEWER,
+        ),
+        "```",
+        "",
+        "## Question and product purpose",
+        "",
+        review.research_question,
+        "",
+        review.intended_product_purpose,
+        "",
+        "## Scope",
+        "",
+    ]
+    lines.extend(_render_named_lists({
+        "Population": review.scope.population,
+        "Intervention or exposure": review.scope.intervention_or_exposure,
+        "Comparator": review.scope.comparator,
+        "Outcomes": review.scope.outcomes,
+    }))
+    lines.extend([
+        "## Review method",
+        "",
+        f"- **Type:** `{review.method.review_type.value}`",
+        f"- **Search date:** `{review.method.search_date.isoformat()}`",
+        "",
+        "### Exact searches",
+        "",
+    ])
+    for source in review.method.sources:
+        lines.extend([
+            f"- **{source.name}**",
+            f"  - `{source.search_string}`",
+        ])
+    lines.extend([""])
+    lines.extend(_render_named_lists({
+        "Inclusion criteria": review.method.inclusion_criteria,
+        "Exclusion criteria": review.method.exclusion_criteria,
+        "Method limitations": review.method.method_limitations,
+    }))
+    if review.method.quality_appraisal:
+        lines.extend([
+            "### Quality appraisal",
+            "",
+            review.method.quality_appraisal,
+            "",
+        ])
+
+    lines.extend(["## Claims", ""])
+    for claim in review.claims:
+        lines.extend([
+            f"### `{claim.id}` — {claim.evidence_strength.value}",
+            "",
+            claim.statement,
+            "",
+            f"- **Sources:** {', '.join(f'`{item}`' for item in claim.source_ids)}",
+            f"- **Population:** {'; '.join(claim.applicable_population)}",
+            f"- **Domain:** {'; '.join(claim.domain)}",
+            "- **Limitations:**",
+        ])
+        lines.extend(f"  - {item}" for item in claim.limitations)
+        if claim.effect_estimates:
+            lines.extend(["- **Verified effect estimates:**"])
+            for estimate in claim.effect_estimates:
+                lines.append(
+                    "  - "
+                    + _render_effect_estimate(estimate.model_dump(mode="json"))
+                )
+        lines.extend([""])
+
+    verification = _verification_levels(review)
+    lines.extend([
+        "## Citations and verification level",
+        "",
+        "| ID | Verification | Stable identifier | Citation |",
+        "|---|---|---|---|",
+    ])
+    for citation in review.citations:
+        identifier = (
+            f"DOI `{citation.doi}`"
+            if citation.doi
+            else f"PMID `{citation.pmid}`"
+            if citation.pmid
+            else str(citation.url)
+        )
+        title = citation.title.replace("|", r"\|")
+        lines.append(
+            f"| `{citation.id}` | `{verification.get(citation.id, 'missing')}` "
+            f"| {identifier} | {title} ({citation.year}) |"
+        )
+    lines.extend([""])
+    lines.extend(_render_named_lists({
+        "Known gaps": review.known_gaps,
+        "Conflicting findings": review.conflicting_findings,
+        "Follow-up questions": review.follow_up_questions,
+    }))
+    lines.extend(_render_exact_payload(
+        "Exact reviewed evidence payload",
+        evidence_review_payload(review),
+    ))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_decision_review_packet(
+    registry: ScienceRegistry,
+    decision_id: str,
+) -> str:
+    """Render one decision and its exact machine contract for human approval."""
+    decision = registry.decisions[decision_id]
+    contract = build_policy_contract(registry, decision_id)
+    contract_json = render_policy_contract_json(contract).rstrip()
+    approvals = load_science_approvals(registry.science_dir)
+    lines = [
+        f"# Science decision review packet: {decision.title}",
+        "",
+        "> Generated from the canonical SDR. Every code-consumed field appears "
+        "verbatim in the exact contract section; no prose is parsed into code.",
+        "",
+        f"- **Record:** `{decision.id}`",
+        f"- **Lifecycle:** `{decision.status.value}`",
+        f"- **Model version:** `{decision.model_version}`",
+        f"- **Runtime state:** `{contract.runtime_state.value}`",
+        f"- **Decision digest:** `{contract.source_decision_digest}`",
+        f"- **Contract digest:** `{contract.contract_digest}`",
+        f"- **Required decision role:** `{ReviewRole.DECISION_APPROVER.value}`",
+        "- **Decision approval:** "
+        + _approval_label(
+            approvals,
+            decision.id,
+            ReviewRole.DECISION_APPROVER,
+        ),
+        f"- **Required activation role:** `{ReviewRole.IMPLEMENTATION_REVIEWER.value}`",
+        "- **Implementation approval:** "
+        + _approval_label(
+            approvals,
+            decision.id,
+            ReviewRole.IMPLEMENTATION_REVIEWER,
+        ),
+        "",
+        "## Decision approval artifact template",
+        "",
+        "Create this only after a human approves the decision packet:",
+        "",
+        "```yaml",
+        _render_approval_template(
+            subject_kind=ReviewSubjectKind.SCIENCE_DECISION,
+            subject_id=decision.id,
+            subject_digest=contract.source_decision_digest,
+            role=ReviewRole.DECISION_APPROVER,
+        ),
+        "```",
+        "",
+        "## Implementation approval artifact template",
+        "",
+        "Create this only after code matches the contract and activation is "
+        "separately approved:",
+        "",
+        "```yaml",
+        _render_approval_template(
+            subject_kind=ReviewSubjectKind.IMPLEMENTATION_CONTRACT,
+            subject_id=decision.id,
+            subject_digest=contract.contract_digest,
+            role=ReviewRole.IMPLEMENTATION_REVIEWER,
+        ),
+        "```",
+        "",
+        "## Accepted interpretation",
+        "",
+        decision.accepted_interpretation,
+        "",
+        "## Linked evidence",
+        "",
+    ]
+    for claim_id in decision.evidence_claim_ids:
+        claim = registry.claims[claim_id]
+        review_id = registry.claim_review_ids[claim_id]
+        lines.extend([
+            f"### `{claim.id}` — {claim.evidence_strength.value}",
+            "",
+            claim.statement,
+            "",
+            f"- **Evidence Review:** `{review_id}`",
+            f"- **Sources:** {', '.join(f'`{item}`' for item in claim.source_ids)}",
+            f"- **Limitations:** {'; '.join(claim.limitations)}",
+            "",
+        ])
+
+    lines.extend(["## Reviewed parameters", ""])
+    for parameter in decision.model_parameters:
+        lines.extend([
+            f"### `{parameter.name}` — {parameter.classification.value}",
+            "",
+            f"- **Applies to:** {parameter.applies_to or '_Not specified_'}",
+            "- **Evidence claims:** "
+            + (
+                ", ".join(
+                    f"`{item}`"
+                    for item in parameter.evidence_claim_ids
+                )
+                or "_None; product rationale only_"
+            ),
+            f"- **Rationale:** {parameter.rationale or '_Published value; see linked claims_'}",
+            "- **Exact value:**",
+            "",
+            "```json",
+            json.dumps(
+                parameter.value,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            ),
+            "```",
+            "",
+        ])
+
+    lines.extend(["## Rejected alternatives", ""])
+    for alternative in decision.rejected_alternatives:
+        lines.extend([
+            f"### {alternative.alternative}",
+            "",
+            alternative.rationale,
+            "",
+        ])
+    lines.extend(_render_named_lists({
+        "Applicability": decision.applicability,
+        "User-facing claim limits": decision.user_facing_claim_limits,
+        "Safety implications": decision.safety_implications,
+        "Privacy implications": decision.privacy_implications,
+        "Validation plan": decision.validation_plan,
+        "Falsification conditions": decision.falsification_conditions,
+        "Decision notes": decision.decision_notes,
+    }))
+    lines.extend([
+        "## Exact machine contract",
+        "",
+        "This is the same canonical JSON payload written to the generated "
+        "contract file.",
+        "",
+        "```json",
+        contract_json,
+        "```",
+        "",
+    ])
+    lines.extend(_render_exact_payload(
+        "Exact reviewed decision payload",
+        science_decision_payload(decision),
+    ))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def expected_science_artifacts(
+    registry: ScienceRegistry,
+) -> dict[Path, str]:
+    """Return every generated artifact required by artifact-mode records."""
+    expected: dict[Path, str] = {}
+    for review in sorted(
+        registry.evidence_reviews.values(),
+        key=lambda item: item.id,
+    ):
+        if review.approval_mode != ApprovalMode.ARTIFACT:
+            continue
+        expected[_REVIEW_PACKET_DIR / f"{review.id}.md"] = (
+            render_evidence_review_packet(registry, review.id)
+        )
+    for decision in sorted(
+        registry.decisions.values(),
+        key=lambda item: item.id,
+    ):
+        if decision.approval_mode != ApprovalMode.ARTIFACT:
+            continue
+        contract = build_policy_contract(registry, decision.id)
+        expected[_REVIEW_PACKET_DIR / f"{decision.id}.md"] = (
+            render_decision_review_packet(registry, decision.id)
+        )
+        expected[_CONTRACT_DIR / f"{decision.id}.json"] = (
+            render_policy_contract_json(contract)
+        )
+    return expected
+
+
+def sync_science_artifacts(
+    registry: ScienceRegistry,
+    *,
+    check: bool,
+) -> list[Path]:
+    """Write generated artifacts or return stale paths in check mode."""
+    expected = expected_science_artifacts(registry)
+    science_dir = registry.science_dir
+    existing = {
+        path.relative_to(science_dir)
+        for directory, suffix in (
+            (science_dir / _REVIEW_PACKET_DIR, ".md"),
+            (science_dir / _CONTRACT_DIR, ".json"),
+        )
+        if directory.is_dir()
+        for path in directory.glob(f"*{suffix}")
+    }
+    stale: list[Path] = []
+    for relative, content in expected.items():
+        target = science_dir / relative
+        current = target.read_text(encoding="utf-8") if target.exists() else None
+        if current != content:
+            stale.append(relative)
+            if not check:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(content, encoding="utf-8", newline="\n")
+    for relative in sorted(existing - set(expected)):
+        stale.append(relative)
+        if not check:
+            (science_dir / relative).unlink()
+    return sorted(set(stale), key=lambda path: path.as_posix())
+
+
+def load_policy_contract(
+    decision_id: str,
+    *,
+    science_dir: str | Path | None = None,
+    require_active: bool = False,
+) -> SciencePolicyContract:
+    """Load a generated contract and verify it against its canonical source."""
+    root = Path(science_dir) if science_dir is not None else _SCIENCE_DIR
+    path = root / _CONTRACT_DIR / f"{decision_id}.json"
+    with path.open(encoding="utf-8") as handle:
+        raw = json.load(handle)
+    contract = SciencePolicyContract.model_validate(raw)
+
+    from analysis.evidence_registry import load_science_registry
+
+    registry = load_science_registry(root)
+    expected = build_policy_contract(registry, decision_id)
+    if contract != expected:
+        raise ValueError(
+            f"Generated science contract {decision_id} is stale"
+        )
+    if require_active:
+        if contract.decision_status != RecordStatus.ACCEPTED:
+            raise ValueError(
+                f"Science contract {decision_id} is not accepted"
+            )
+        if contract.runtime_state != ArtifactRuntimeState.ACTIVE:
+            raise ValueError(
+                f"Science contract {decision_id} is not active"
+            )
+    return contract
+
+
+def _approval_label(
+    approvals: list[ScienceApproval],
+    subject_id: str,
+    role: ReviewRole,
+) -> str:
+    matches = [
+        approval
+        for approval in approvals
+        if approval.subject_id == subject_id and approval.role == role
+    ]
+    if not matches:
+        return "_Pending_"
+    return "; ".join(
+        f"`{item.reviewer}` on `{item.reviewed_on.isoformat()}` "
+        f"([source]({item.source_ref}))"
+        for item in matches
+    )
+
+
+def _verification_levels(review: EvidenceReview) -> dict[str, str]:
+    levels: dict[str, str] = {}
+    for note in review.review_notes:
+        if not note.startswith("Verification: "):
+            continue
+        prefix = note.split(";", 1)[0]
+        marker = prefix.removeprefix("Verification: ")
+        citation_id, separator, level = marker.partition(" - ")
+        if separator:
+            levels[citation_id] = level
+    return levels
+
+
+def _render_named_lists(sections: dict[str, list[str]]) -> list[str]:
+    lines: list[str] = []
+    for heading, values in sections.items():
+        lines.extend([f"## {heading}", ""])
+        if values:
+            lines.extend(f"- {value}" for value in values)
+        else:
+            lines.append("_None recorded._")
+        lines.extend([""])
+    return lines
+
+
+def _render_effect_estimate(estimate: dict[str, Any]) -> str:
+    if estimate.get("estimate") is not None:
+        value = str(estimate["estimate"])
+    else:
+        value = f"{estimate['range_low']} to {estimate['range_high']}"
+    return (
+        f"{estimate['metric']}: {value} {estimate['unit']} "
+        f"({estimate['context']})"
+    )
+
+
+def _render_exact_payload(
+    title: str,
+    payload: dict[str, Any],
+) -> list[str]:
+    return [
+        f"<details><summary>{title}</summary>",
+        "",
+        "```json",
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ),
+        "```",
+        "",
+        "</details>",
+        "",
+    ]
+
+
+def _render_approval_template(
+    *,
+    subject_kind: ReviewSubjectKind,
+    subject_id: str,
+    subject_digest: str,
+    role: ReviewRole,
+) -> str:
+    payload = {
+        "schema_version": 1,
+        "subject_kind": subject_kind.value,
+        "subject_id": subject_id,
+        "subject_digest": subject_digest,
+        "reviewer": "github:<reviewer>",
+        "role": role.value,
+        "reviewed_on": "<YYYY-MM-DD>",
+        "scopes": [
+            scope.value
+            for scope in sorted(
+                _REQUIRED_SCOPES[role],
+                key=lambda item: item.value,
+            )
+        ],
+        "source_ref": "<GitHub review URL>",
+    }
+    return yaml.safe_dump(payload, sort_keys=False).rstrip()
+
+
+def is_digest(value: str) -> bool:
+    """Return whether a value uses the canonical digest representation."""
+    return _DIGEST_RE.fullmatch(value) is not None

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -81,6 +81,13 @@ Science changes use two linked, versioned records before implementation:
 - An **Evidence Review** records what the literature supports.
 - A **Science Decision Record (SDR)** records how Praxys applies that evidence.
 
+New records use the artifact review workflow documented in
+[`science-review-artifacts.md`](science-review-artifacts.md). The canonical
+typed record generates a human review packet and a separate machine JSON
+contract with matching digests. Humans approve the generated packet through a
+role-scoped approval artifact; runtime code consumes only the generated
+contract and never derives values from prose.
+
 ### Research before changing science
 
 Use the repository-owned
@@ -110,8 +117,10 @@ honestly; neither level lets schema validation declare a paper true.
 
 1. **Add an Evidence Review** at
    `data/science/evidence/{topic}/evidence-{topic}-v{N}.yaml`:
-   - Identify authors, human reviewers, review dates, purpose, and lifecycle
-     status.
+   - Set `approval_mode: artifact` for new records. Human approval lives in a
+     digest-bound file beneath `data/science/approvals/`, not in the legacy
+     `human_reviewers` list.
+   - Identify authors, purpose, and lifecycle status.
    - Preserve the exact searches, search date, selection rules, scope,
      evidence strength, effect estimates, applicability, limitations,
      conflicting findings, gaps, and follow-up questions.
@@ -120,6 +129,8 @@ honestly; neither level lets schema validation declare a paper true.
 
 2. **Add an SDR** at
    `data/science/decisions/sdr-{decision}-v{N}.yaml`:
+   - Set `approval_mode: artifact` and declare
+     `artifact_policy.runtime_state`. Draft decisions start `inactive`.
    - Link the exact evidence-review and claim IDs used.
    - Record the accepted interpretation, rejected alternatives, claim limits,
      applicability, safety/privacy implications, validation and falsification
@@ -128,8 +139,11 @@ honestly; neither level lets schema validation declare a paper true.
      Published values require a supporting claim; estimates and guardrails
      require an explicit Praxys rationale. This includes `params` plus
      behavior-driving `signal`, `diagnosis`, and `tsb_zones` values.
-   - Only an identified human reviewer may move a record to `accepted`. Agents
-     may prepare `draft` records but cannot accept or ship a science decision.
+   - Only a digest-bound `decision_approver` artifact may move an artifact-mode
+     SDR to `accepted`. A separate `implementation_reviewer` artifact is
+     required before its generated contract becomes active. Agents may prepare
+     draft records and generated artifacts but cannot create human approvals,
+     accept records, or activate contracts.
 
 3. **Create or update the canonical English theory YAML** in
    `data/science/{pillar}/{theory_id}.yaml`:
@@ -151,11 +165,22 @@ honestly; neither level lets schema validation declare a paper true.
    metadata into theory or locale files. Localized YAML should contain only
    translated user-facing prose and identifiers needed by the locale loader.
 
-4. **Regenerate the index**:
+4. **Generate review and implementation artifacts**:
+
+   `python scripts/generate_science_artifacts.py`.
+
+   Review
+   `data/science/generated/review-packets/<record-id>.md`. The exact contract
+   JSON embedded in the packet must match
+   `data/science/generated/contracts/<sdr-id>.json`.
+
+5. **Regenerate the index**:
    `python scripts/generate_science_registry_index.py`.
 
-5. **Validate** with
-   `python -m pytest tests/test_evidence_registry.py tests/test_science.py`.
+6. **Validate** with
+   `python scripts/generate_science_artifacts.py --check` and
+   `python -m pytest tests/test_evidence_registry.py
+   tests/test_science_artifacts.py tests/test_science.py`.
    Then test the theory in Settings or through the `/science` skill.
 
 ### Updating a review without rewriting history

--- a/docs/dev/science-review-artifacts.md
+++ b/docs/dev/science-review-artifacts.md
@@ -1,0 +1,127 @@
+# Science review packets and implementation contracts
+
+Praxys separates what a human approves from what implementation code consumes
+without maintaining two independent sources of truth.
+
+## Model
+
+An artifact-mode Evidence Review or SDR remains the canonical typed source.
+Deterministic generation produces separate projections:
+
+```text
+canonical typed record
+  ├─ review packet Markdown      human review surface
+  └─ policy contract JSON        code consumption surface
+```
+
+Both projections carry stable SHA-256 digests. No generator interprets prose or
+uses an LLM to derive contract values. Every behavior-driving contract field
+comes directly from a typed SDR `model_parameters` entry and appears verbatim
+in the review packet's exact-contract section.
+
+Artifact-mode records declare:
+
+```yaml
+approval_mode: artifact
+```
+
+Artifact-mode SDRs also declare their runtime boundary:
+
+```yaml
+artifact_policy:
+  runtime_state: inactive
+```
+
+`accepted` and `active` are different states. An accepted decision may remain
+inactive until implementation, migration, validation, and rollout gates pass.
+
+## Generated files
+
+Run:
+
+```bash
+python scripts/generate_science_artifacts.py
+```
+
+The command owns:
+
+```text
+data/science/generated/review-packets/<record-id>.md
+data/science/generated/contracts/<sdr-id>.json
+```
+
+Use `--check` in CI or review automation:
+
+```bash
+python scripts/generate_science_artifacts.py --check
+```
+
+Review packets contain the full question, method, claims, verification levels,
+decision interpretation, exact parameters, rationale, applicability, safety
+and privacy boundaries, validation/falsification plans, unresolved content,
+and exact generated JSON contract. Canonical payloads are included in
+collapsible sections so no reviewed field is hidden.
+
+Contracts contain only typed implementation data:
+
+- decision ID, version, lifecycle, and model version;
+- runtime state and source-decision digest;
+- linked Evidence Review digests and claim IDs;
+- affected models;
+- exact parameter values, classifications, claim links, and `applies_to`;
+- a self-validating contract digest.
+
+Runtime code loads contracts through
+`analysis.science_artifacts.load_policy_contract()`. `require_active=True`
+rejects a draft, non-accepted, inactive, stale, or unapproved contract.
+
+## Role-scoped approvals
+
+Artifact-mode records do not use the legacy unscoped `human_reviewers` field.
+Each human attestation is a separate YAML file beneath
+`data/science/approvals/` and binds one reviewer, role, scope, date, source
+reference, and immutable digest:
+
+```yaml
+schema_version: 1
+subject_kind: science_decision
+subject_id: sdr-example-v1
+subject_digest: sha256:...
+reviewer: github:reviewer
+role: decision_approver
+reviewed_on: 2026-08-14
+scopes:
+  - decision_interpretation
+  - parameters
+  - applicability
+  - claim_limits
+  - safety_and_privacy
+  - activation_boundary
+source_ref: https://github.com/org/repo/pull/123#pullrequestreview-456
+```
+
+Roles are intentionally distinct:
+
+| Role | Reviews | Required before |
+|---|---|---|
+| `evidence_reviewer` | Search method, evidence claims, citation verification, limitations and gaps | Artifact-mode Evidence Review acceptance |
+| `decision_approver` | Interpretation, exact parameters, applicability, claim limits, safety/privacy, activation boundary | Artifact-mode SDR acceptance |
+| `implementation_reviewer` | Contract mapping, runtime diff, validation | Contract activation |
+
+Changing reviewed content changes its digest and makes the approval stale.
+Changing an SDR from inactive to active changes both its decision and contract
+digests, requiring renewed decision and implementation review.
+
+## Review workflow
+
+1. Create draft Evidence Review and SDR records with `approval_mode: artifact`.
+2. Generate review packets and contracts.
+3. Review the generated packet, not raw YAML syntax.
+4. Correct the canonical record and regenerate until the packet is stable.
+5. Record role-scoped approval against the displayed digest.
+6. Atomically accept the record and add the approval artifact.
+7. Keep the contract inactive until implementation review and rollout gates
+   are complete.
+
+Legacy records remain supported with `approval_mode: legacy`. New science
+decision work should use artifact mode.

--- a/scripts/generate_science_artifacts.py
+++ b/scripts/generate_science_artifacts.py
@@ -1,0 +1,41 @@
+"""Generate human review packets and machine science contracts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from analysis.evidence_registry import load_science_registry  # noqa: E402
+from analysis.science_artifacts import sync_science_artifacts  # noqa: E402
+
+
+def main() -> int:
+    """Write generated science artifacts or verify checked-in copies."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail instead of writing when generated artifacts are stale",
+    )
+    args = parser.parse_args()
+
+    registry = load_science_registry()
+    stale = sync_science_artifacts(registry, check=args.check)
+    if args.check and stale:
+        print(
+            "Generated science artifacts are stale:\n"
+            + "\n".join(f"- data/science/{path.as_posix()}" for path in stale)
+            + "\nRun python scripts/generate_science_artifacts.py",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_science_artifacts.py
+++ b/tests/test_science_artifacts.py
@@ -1,0 +1,364 @@
+"""Tests for generated science review packets, contracts, and approvals."""
+
+from dataclasses import replace
+from datetime import date
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from analysis.evidence_registry import (
+    ApprovalMode,
+    ArtifactRuntimeState,
+    DecisionArtifactPolicy,
+    EvidenceReview,
+    RecordStatus,
+    ScienceDecisionRecord,
+    ScienceRegistry,
+    load_science_registry,
+)
+from analysis.science_artifacts import (
+    ReviewRole,
+    ReviewScope,
+    ReviewSubjectKind,
+    ScienceApproval,
+    SciencePolicyContract,
+    build_policy_contract,
+    evidence_review_digest,
+    expected_science_artifacts,
+    load_policy_contract,
+    render_policy_contract_json,
+    science_decision_digest,
+    sync_science_artifacts,
+)
+
+
+_EVIDENCE_ID = "evidence-road-10k-plan-generation-policy-v1"
+_SHARED_EVIDENCE_ID = "evidence-plan-generation-eligibility-safety-v1"
+_DECISION_ID = "sdr-road-10k-plan-generation-policy-v1"
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _write_fixture_records(
+    science_dir: Path,
+    *,
+    status: RecordStatus,
+    runtime_state: ArtifactRuntimeState = ArtifactRuntimeState.INACTIVE,
+) -> tuple[EvidenceReview, ScienceDecisionRecord]:
+    current = load_science_registry()
+    shared = current.evidence_reviews[_SHARED_EVIDENCE_ID]
+    review = current.evidence_reviews[_EVIDENCE_ID].model_copy(update={
+        "status": status,
+        "approval_mode": ApprovalMode.ARTIFACT,
+        "human_reviewers": [],
+        "reviewed_on": date(2026, 8, 14)
+        if status == RecordStatus.ACCEPTED
+        else None,
+    })
+    decision = current.decisions[_DECISION_ID].model_copy(update={
+        "status": status,
+        "approval_mode": ApprovalMode.ARTIFACT,
+        "human_reviewers": [],
+        "artifact_policy": DecisionArtifactPolicy(
+            runtime_state=runtime_state,
+        ),
+    })
+    _write_yaml(
+        science_dir / "evidence" / "shared" / f"{shared.id}.yaml",
+        shared.model_dump(mode="json"),
+    )
+    _write_yaml(
+        science_dir / "evidence" / "pilot" / f"{review.id}.yaml",
+        review.model_dump(mode="json"),
+    )
+    _write_yaml(
+        science_dir / "decisions" / f"{decision.id}.yaml",
+        decision.model_dump(mode="json"),
+    )
+    return review, decision
+
+
+def _approval_payload(
+    *,
+    subject_kind: ReviewSubjectKind,
+    subject_id: str,
+    subject_digest: str,
+    role: ReviewRole,
+) -> dict[str, object]:
+    scopes = {
+        ReviewRole.EVIDENCE_REVIEWER: [
+            ReviewScope.SEARCH_METHOD,
+            ReviewScope.EVIDENCE_CLAIMS,
+            ReviewScope.CITATION_VERIFICATION,
+            ReviewScope.LIMITATIONS_AND_GAPS,
+        ],
+        ReviewRole.DECISION_APPROVER: [
+            ReviewScope.DECISION_INTERPRETATION,
+            ReviewScope.PARAMETERS,
+            ReviewScope.APPLICABILITY,
+            ReviewScope.CLAIM_LIMITS,
+            ReviewScope.SAFETY_AND_PRIVACY,
+            ReviewScope.ACTIVATION_BOUNDARY,
+        ],
+        ReviewRole.IMPLEMENTATION_REVIEWER: [
+            ReviewScope.CONTRACT_MAPPING,
+            ReviewScope.RUNTIME_DIFF,
+            ReviewScope.VALIDATION,
+        ],
+    }[role]
+    return {
+        "schema_version": 1,
+        "subject_kind": subject_kind.value,
+        "subject_id": subject_id,
+        "subject_digest": subject_digest,
+        "reviewer": "github:reviewer",
+        "role": role.value,
+        "reviewed_on": "2026-08-14",
+        "scopes": [scope.value for scope in scopes],
+        "source_ref":
+            "https://github.com/praxys-run/praxys/pull/1"
+            "#pullrequestreview-1",
+    }
+
+
+def _write_acceptance_approvals(
+    science_dir: Path,
+    review: EvidenceReview,
+    decision: ScienceDecisionRecord,
+) -> None:
+    _write_yaml(
+        science_dir / "approvals" / "evidence.yaml",
+        _approval_payload(
+            subject_kind=ReviewSubjectKind.EVIDENCE_REVIEW,
+            subject_id=_EVIDENCE_ID,
+            subject_digest=evidence_review_digest(review),
+            role=ReviewRole.EVIDENCE_REVIEWER,
+        ),
+    )
+    _write_yaml(
+        science_dir / "approvals" / "decision.yaml",
+        _approval_payload(
+            subject_kind=ReviewSubjectKind.SCIENCE_DECISION,
+            subject_id=_DECISION_ID,
+            subject_digest=science_decision_digest(decision),
+            role=ReviewRole.DECISION_APPROVER,
+        ),
+    )
+
+
+def test_draft_artifact_records_render_complete_review_and_contract(
+    tmp_path: Path,
+) -> None:
+    science_dir = tmp_path / "science"
+    _write_fixture_records(science_dir, status=RecordStatus.DRAFT)
+    registry = load_science_registry(science_dir)
+
+    expected = expected_science_artifacts(registry)
+    evidence_packet_path = (
+        Path("generated")
+        / "review-packets"
+        / f"{_EVIDENCE_ID}.md"
+    )
+    decision_packet_path = (
+        Path("generated")
+        / "review-packets"
+        / f"{_DECISION_ID}.md"
+    )
+    contract_path = (
+        Path("generated")
+        / "contracts"
+        / f"{_DECISION_ID}.json"
+    )
+    assert set(expected) == {
+        evidence_packet_path,
+        decision_packet_path,
+        contract_path,
+    }
+
+    contract = SciencePolicyContract.model_validate_json(
+        expected[contract_path]
+    )
+    exact_contract_block = (
+        "```json\n"
+        + render_policy_contract_json(contract).rstrip()
+        + "\n```"
+    )
+    assert exact_contract_block in expected[decision_packet_path]
+    assert contract.source_decision_digest in expected[decision_packet_path]
+    assert contract.contract_digest in expected[decision_packet_path]
+    assert "activity_avg_power" in expected[decision_packet_path]
+    assert "Exact reviewed evidence payload" in expected[evidence_packet_path]
+
+    assert sync_science_artifacts(registry, check=False)
+    assert sync_science_artifacts(registry, check=True) == []
+    with pytest.raises(ValueError, match="not accepted"):
+        load_policy_contract(
+            _DECISION_ID,
+            science_dir=science_dir,
+            require_active=True,
+        )
+
+    (science_dir / contract_path).write_text("{}\n", encoding="utf-8")
+    assert sync_science_artifacts(registry, check=True) == [contract_path]
+
+
+def test_review_digests_ignore_lifecycle_but_change_reviewed_content() -> None:
+    current = load_science_registry()
+    review = current.evidence_reviews[_EVIDENCE_ID].model_copy(update={
+        "approval_mode": ApprovalMode.ARTIFACT,
+        "human_reviewers": [],
+    })
+    decision = current.decisions[_DECISION_ID].model_copy(update={
+        "approval_mode": ApprovalMode.ARTIFACT,
+        "human_reviewers": [],
+        "artifact_policy": DecisionArtifactPolicy(),
+    })
+
+    assert evidence_review_digest(review) == evidence_review_digest(
+        review.model_copy(update={
+            "status": RecordStatus.DRAFT,
+            "reviewed_on": None,
+        })
+    )
+    assert science_decision_digest(decision) == science_decision_digest(
+        decision.model_copy(update={"status": RecordStatus.DRAFT})
+    )
+
+    changed_parameters = list(decision.model_parameters)
+    changed_parameters[0] = changed_parameters[0].model_copy(update={
+        "value": {"changed": True},
+    })
+    changed = decision.model_copy(update={
+        "model_parameters": changed_parameters,
+    })
+    assert science_decision_digest(changed) != science_decision_digest(
+        decision
+    )
+
+
+def test_accepted_artifact_records_require_matching_role_approvals(
+    tmp_path: Path,
+) -> None:
+    science_dir = tmp_path / "science"
+    review, decision = _write_fixture_records(
+        science_dir,
+        status=RecordStatus.ACCEPTED,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="requires an evidence_reviewer approval",
+    ):
+        load_science_registry(science_dir)
+
+    _write_acceptance_approvals(science_dir, review, decision)
+    registry = load_science_registry(science_dir)
+    assert registry.evidence_reviews[_EVIDENCE_ID].human_reviewers == []
+    assert registry.decisions[_DECISION_ID].human_reviewers == []
+
+    decision_path = science_dir / "decisions" / f"{_DECISION_ID}.yaml"
+    raw = yaml.safe_load(decision_path.read_text(encoding="utf-8"))
+    raw["accepted_interpretation"] += " Changed after approval."
+    _write_yaml(decision_path, raw)
+    with pytest.raises(ValueError, match="is stale"):
+        load_science_registry(science_dir)
+
+
+def test_active_contract_requires_implementation_approval(
+    tmp_path: Path,
+) -> None:
+    science_dir = tmp_path / "science"
+    review, decision = _write_fixture_records(
+        science_dir,
+        status=RecordStatus.ACCEPTED,
+    )
+    _write_acceptance_approvals(science_dir, review, decision)
+    inactive_registry = load_science_registry(science_dir)
+
+    active_decision = decision.model_copy(update={
+        "artifact_policy": DecisionArtifactPolicy(
+            runtime_state=ArtifactRuntimeState.ACTIVE,
+        ),
+    })
+    active_registry = replace(
+        inactive_registry,
+        decisions={
+            **inactive_registry.decisions,
+            _DECISION_ID: active_decision,
+        },
+    )
+    active_contract = build_policy_contract(active_registry, _DECISION_ID)
+    _write_yaml(
+        science_dir / "decisions" / f"{_DECISION_ID}.yaml",
+        active_decision.model_dump(mode="json"),
+    )
+    _write_yaml(
+        science_dir / "approvals" / "decision.yaml",
+        _approval_payload(
+            subject_kind=ReviewSubjectKind.SCIENCE_DECISION,
+            subject_id=_DECISION_ID,
+            subject_digest=science_decision_digest(active_decision),
+            role=ReviewRole.DECISION_APPROVER,
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="requires an implementation_reviewer approval",
+    ):
+        load_science_registry(science_dir)
+
+    _write_yaml(
+        science_dir / "approvals" / "implementation.yaml",
+        _approval_payload(
+            subject_kind=ReviewSubjectKind.IMPLEMENTATION_CONTRACT,
+            subject_id=_DECISION_ID,
+            subject_digest=active_contract.contract_digest,
+            role=ReviewRole.IMPLEMENTATION_REVIEWER,
+        ),
+    )
+    registry = load_science_registry(science_dir)
+    sync_science_artifacts(registry, check=False)
+    loaded = load_policy_contract(
+        _DECISION_ID,
+        science_dir=science_dir,
+        require_active=True,
+    )
+    assert loaded.runtime_state == ArtifactRuntimeState.ACTIVE
+    assert loaded.parameter_values
+
+
+def test_approval_roles_require_complete_scopes() -> None:
+    payload = _approval_payload(
+        subject_kind=ReviewSubjectKind.SCIENCE_DECISION,
+        subject_id=_DECISION_ID,
+        subject_digest="sha256:" + "0" * 64,
+        role=ReviewRole.DECISION_APPROVER,
+    )
+    payload["scopes"] = [ReviewScope.PARAMETERS.value]
+    with pytest.raises(ValidationError, match="missing scopes"):
+        ScienceApproval.model_validate(payload)
+
+    payload = _approval_payload(
+        subject_kind=ReviewSubjectKind.SCIENCE_DECISION,
+        subject_id=_DECISION_ID,
+        subject_digest="sha256:" + "0" * 64,
+        role=ReviewRole.DECISION_APPROVER,
+    )
+    payload["reviewer"] = "agent:copilot"
+    with pytest.raises(ValidationError, match="identified human reviewer"):
+        ScienceApproval.model_validate(payload)
+
+
+def test_repository_generated_science_artifacts_are_current() -> None:
+    registry = load_science_registry()
+    assert sync_science_artifacts(registry, check=True) == []

--- a/tests/test_science_artifacts.py
+++ b/tests/test_science_artifacts.py
@@ -197,6 +197,7 @@ def test_draft_artifact_records_render_complete_review_and_contract(
     assert contract.contract_digest in expected[decision_packet_path]
     assert "activity_avg_power" in expected[decision_packet_path]
     assert "Exact reviewed evidence payload" in expected[evidence_packet_path]
+    assert "range -0.28 to 0.25" in expected[evidence_packet_path]
 
     assert sync_science_artifacts(registry, check=False)
     assert sync_science_artifacts(registry, check=True) == []


### PR DESCRIPTION
# Science workflow change

## Summary

- Generate human Markdown review packets and machine JSON contracts from one typed canonical Evidence Review/SDR source.
- Embed the exact machine contract in the review packet so no code-consumed field is hidden from the reviewer.
- Bind evidence, decision, and implementation approvals to immutable digests with distinct roles and scopes.
- Keep `accepted` separate from runtime `active`; code loads values from the generated contract rather than deriving them from prose.
- Preserve existing records through `approval_mode: legacy`; new records can opt into `approval_mode: artifact`.

## Artifact workflow

```text
canonical typed record
  ├─ generated/review-packets/<record>.md
  └─ generated/contracts/<sdr>.json
```

- `evidence_reviewer` approves evidence method, claims, verification, and limitations.
- `decision_approver` approves interpretation, exact parameters, applicability, claim limits, safety/privacy, and activation boundary.
- `implementation_reviewer` approves contract mapping, runtime diff, and validation before activation.
- Any reviewed-content change invalidates its approval digest.

## Product and implementation

- [x] Runtime values are never inferred from natural-language rationale.
- [x] Contracts self-validate their digest and are checked against the canonical source.
- [x] Draft/inactive contracts cannot be loaded with `require_active=True`.
- [x] Existing accepted legacy records continue to load unchanged.
- [x] Documentation, the science skill, contributing guide, and PR template describe the new flow.

## Validation and review

- [x] `python scripts/generate_science_artifacts.py --check`
- [x] `python scripts/generate_science_registry_index.py --check`
- [x] `python -m pytest tests/test_science_artifacts.py tests/test_science_research_skill.py tests/test_evidence_registry.py tests/test_science.py -q` (77 passed)
- [x] Submodule-dependent regression selection passed except the existing local cloud-launcher interpreter environment case; required GitHub CI remains authoritative.
- [x] No scientific claim, formula, runtime policy, API, or user-facing behavior changed.

## Pilot

Issue #688 will be opened as a stacked draft PR using artifact mode, with its Evidence Review packet and inactive half-marathon machine contract generated by this branch.

## UI quality

- Not applicable: no rendered UI changed.