### PR TITLE
Make science decision packets actionable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/science-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/science-change.md
@@ -13,6 +13,8 @@ Do not check any item that was not actually performed.
 - [ ] Applicability, uncertainty, safety boundaries, and rejected alternatives are documented.
 - [ ] Record lifecycle is versioned/superseded; accepted evidence and decisions were not rewritten.
 - [ ] Artifact-mode review packets and machine contracts were regenerated and carry matching source/contract digests.
+- [ ] The SDR decision sheet states the reviewer task, proposed approvals, explicit deferrals, approval effects, and non-authorizations.
+- [ ] Every machine-contract parameter group is mapped to at least one decision-sheet item.
 - [ ] Every code-consumed field appears verbatim in the generated human review packet.
 - [ ] Accepted artifact-mode records include the required digest-bound `evidence_reviewer` or `decision_approver`; active contracts include an `implementation_reviewer`.
 - [ ] Accepted legacy records still identify their human reviewer and review date.

--- a/.github/skills/science-research/SKILL.md
+++ b/.github/skills/science-research/SKILL.md
@@ -150,6 +150,12 @@ Follow the existing registry schema and lifecycle:
 - Run `python scripts/generate_science_artifacts.py` and hand reviewers the
   generated Markdown packet, not raw YAML. The packet must include the exact
   machine JSON contract and the same decision/contract digests.
+- Artifact-mode SDRs must define a typed `decision_review` manifest. Start the
+  packet with a short decision sheet that tells the reviewer exactly what to
+  approve, what is explicitly deferred, what approval changes, and what it
+  does not authorize. Map every `model_parameters` group to at least one
+  decision item. Keep the full parameter/evidence/contract material in the
+  audit appendix; never ask a human to infer the decision by skimming it.
 - Evidence, decision, and implementation review are separate roles. Only a
   digest-bound `evidence_reviewer` may accept an artifact-mode Evidence Review;
   only a `decision_approver` may accept its SDR; only an
@@ -212,8 +218,8 @@ End every run with these artifacts or explicitly state why one does not apply:
 4. Unresolved evidence gaps, conflicts, and validation/falsification plan.
 5. Implementation impact map and reviewer checklist.
 6. For artifact-mode work, generated Evidence Review and SDR review packets,
-   the exact inactive machine contract, and any still-missing role-scoped
-   approval artifacts.
+   the action-oriented decision manifest, the exact inactive machine contract,
+   and any still-missing role-scoped approval artifacts.
 
 Name the mode, verification limits, and the human approval still required in
 the handoff. Do not present a draft as shipped science.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ All training metrics, predictions, and insights must be grounded in exercise sci
 - **Use published values** over guesswork (Stryd race power percentages, Riegel, Banister TRIMP)
 - **Flag estimates** — values without strong research backing noted as estimates in code and UI
 - **Register new theories** — new theory YAML must link an accepted Science Decision Record; unlinked legacy theories are migration-only exceptions
-- **Separate review from runtime artifacts** — new science records use generated human review packets, generated machine contracts, matching digests, and role-scoped approvals; runtime code never derives values from prose
+- **Separate review from runtime artifacts** — new science records use action-oriented decision sheets, collapsed audit appendices, generated machine contracts, matching digests, and role-scoped approvals; every contract group maps to a decision item and runtime code never derives values from prose
 
 ## Gotchas
 

--- a/analysis/evidence_registry.py
+++ b/analysis/evidence_registry.py
@@ -61,6 +61,21 @@ class RegistryModel(BaseModel):
     )
 
 
+def _contains_json_literal(value: Any, literal: str) -> bool:
+    """Return whether a nested JSON-compatible value contains one literal."""
+    if isinstance(value, dict):
+        return any(
+            _contains_json_literal(nested, literal)
+            for nested in value.values()
+        )
+    if isinstance(value, list):
+        return any(
+            _contains_json_literal(nested, literal)
+            for nested in value
+        )
+    return value == literal
+
+
 class RecordStatus(StrEnum):
     """Lifecycle state for immutable registry records."""
 
@@ -82,6 +97,13 @@ class ArtifactRuntimeState(StrEnum):
 
     INACTIVE = "inactive"
     ACTIVE = "active"
+
+
+class DecisionReviewDisposition(StrEnum):
+    """How one human-facing decision item is handled by this SDR."""
+
+    APPROVE = "approve"
+    DEFER = "defer"
 
 
 class ReviewType(StrEnum):
@@ -366,6 +388,56 @@ class DecisionArtifactPolicy(RegistryModel):
     runtime_state: ArtifactRuntimeState = ArtifactRuntimeState.INACTIVE
 
 
+class DecisionReviewItem(RegistryModel):
+    """One explicit decision or deferral presented to the human approver."""
+
+    id: str = Field(pattern=r"^[a-z][a-z0-9-]*$")
+    title: str = Field(min_length=1)
+    disposition: DecisionReviewDisposition
+    question: str = Field(min_length=1)
+    proposed_decision: str = Field(min_length=1)
+    approval_effect: list[str] = Field(min_length=1)
+    does_not_authorize: list[str] = Field(min_length=1)
+    parameter_names: list[str] = Field(min_length=1)
+    evidence_claim_ids: list[ClaimId] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_item(self) -> "DecisionReviewItem":
+        """Keep each decision item's contract and evidence mapping unambiguous."""
+        if len(self.parameter_names) != len(set(self.parameter_names)):
+            raise ValueError(
+                "decision review item parameter names must be unique"
+            )
+        if len(self.evidence_claim_ids) != len(set(self.evidence_claim_ids)):
+            raise ValueError(
+                "decision review item evidence claim IDs must be unique"
+            )
+        return self
+
+
+class DecisionReviewManifest(RegistryModel):
+    """Action-oriented human review sheet bound to one science decision."""
+
+    reviewer_task: str = Field(min_length=1)
+    approval_statement: str = Field(min_length=1)
+    items: list[DecisionReviewItem] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_manifest(self) -> "DecisionReviewManifest":
+        """Require unique items and at least one affirmative product decision."""
+        item_ids = [item.id for item in self.items]
+        if len(item_ids) != len(set(item_ids)):
+            raise ValueError("decision review item IDs must be unique")
+        if not any(
+            item.disposition == DecisionReviewDisposition.APPROVE
+            for item in self.items
+        ):
+            raise ValueError(
+                "decision review manifest requires an approve item"
+            )
+        return self
+
+
 class ScienceDecisionRecord(RegistryModel):
     """Versioned record of how Praxys interprets accepted evidence."""
 
@@ -382,6 +454,7 @@ class ScienceDecisionRecord(RegistryModel):
     evidence_review_ids: list[RecordId] = Field(min_length=1)
     evidence_claim_ids: list[ClaimId] = Field(min_length=1)
     accepted_interpretation: str = Field(min_length=1)
+    decision_review: DecisionReviewManifest | None = None
     rejected_alternatives: list[RejectedAlternative] = Field(min_length=1)
     model_parameters: list[ParameterProvenance] = Field(default_factory=list)
     applicability: list[str] = Field(min_length=1)
@@ -420,9 +493,64 @@ class ScienceDecisionRecord(RegistryModel):
                 raise ValueError(
                     "artifact-reviewed decisions require artifact_policy"
                 )
-        elif self.artifact_policy is not None:
+            if self.decision_review is None:
+                raise ValueError(
+                    "artifact-reviewed decisions require decision_review"
+                )
+            reviewed_parameters = {
+                parameter_name
+                for item in self.decision_review.items
+                for parameter_name in item.parameter_names
+            }
+            unknown_parameters = reviewed_parameters - set(parameter_names)
+            if unknown_parameters:
+                raise ValueError(
+                    "decision review references unknown parameters: "
+                    f"{sorted(unknown_parameters)}"
+                )
+            missing_parameters = set(parameter_names) - reviewed_parameters
+            if missing_parameters:
+                raise ValueError(
+                    "decision review does not cover parameters: "
+                    f"{sorted(missing_parameters)}"
+                )
+            deferred_parameters = {
+                parameter_name
+                for item in self.decision_review.items
+                if item.disposition == DecisionReviewDisposition.DEFER
+                for parameter_name in item.parameter_names
+            }
+            unresolved_parameters = {
+                parameter.name
+                for parameter in self.model_parameters
+                if _contains_json_literal(
+                    parameter.value,
+                    "not_accepted",
+                )
+            }
+            hidden_deferrals = unresolved_parameters - deferred_parameters
+            if hidden_deferrals:
+                raise ValueError(
+                    "decision review does not explicitly defer unresolved "
+                    f"parameters: {sorted(hidden_deferrals)}"
+                )
+            reviewed_claims = {
+                claim_id
+                for item in self.decision_review.items
+                for claim_id in item.evidence_claim_ids
+            }
+            unknown_claims = reviewed_claims - set(self.evidence_claim_ids)
+            if unknown_claims:
+                raise ValueError(
+                    "decision review references unlinked evidence claims: "
+                    f"{sorted(unknown_claims)}"
+                )
+        elif (
+            self.artifact_policy is not None
+            or self.decision_review is not None
+        ):
             raise ValueError(
-                "legacy-reviewed decisions cannot define artifact_policy"
+                "legacy-reviewed decisions cannot define artifact review data"
             )
         if (
             self.artifact_policy is not None

--- a/analysis/science_artifacts.py
+++ b/analysis/science_artifacts.py
@@ -664,6 +664,11 @@ def render_decision_review_packet(
                 for boundary in item.does_not_authorize
             )
             lines.extend([
+                "",
+                "<details><summary>Traceability: "
+                f"{len(item.parameter_names)} contract groups, "
+                f"{len(item.evidence_claim_ids)} evidence claims</summary>",
+                "",
                 "- **Contract groups covered:** "
                 + ", ".join(
                     f"`{parameter_name}`"
@@ -677,6 +682,8 @@ def render_decision_review_packet(
                     )
                     or "_None; product or lifecycle boundary only_"
                 ),
+                "",
+                "</details>",
                 "",
             ])
 

--- a/analysis/science_artifacts.py
+++ b/analysis/science_artifacts.py
@@ -17,6 +17,7 @@ from analysis.evidence_registry import (
     ApprovalMode,
     ArtifactRuntimeState,
     ClaimId,
+    DecisionReviewDisposition,
     EvidenceReview,
     Identity,
     ParameterClassification,
@@ -578,16 +579,19 @@ def render_decision_review_packet(
     registry: ScienceRegistry,
     decision_id: str,
 ) -> str:
-    """Render one decision and its exact machine contract for human approval."""
+    """Render an action-oriented decision sheet plus a complete audit appendix."""
     decision = registry.decisions[decision_id]
+    if decision.decision_review is None:
+        raise ValueError(
+            f"Artifact decision {decision_id} has no decision review manifest"
+        )
     contract = build_policy_contract(registry, decision_id)
-    contract_json = render_policy_contract_json(contract).rstrip()
     approvals = load_science_approvals(registry.science_dir)
     lines = [
         f"# Science decision review packet: {decision.title}",
         "",
-        "> Generated from the canonical SDR. Every code-consumed field appears "
-        "verbatim in the exact contract section; no prose is parsed into code.",
+        "> Start with the decision sheet. The audit appendix preserves every "
+        "code-consumed field, but it is not the reviewer's primary task.",
         "",
         f"- **Record:** `{decision.id}`",
         f"- **Lifecycle:** `{decision.status.value}`",
@@ -610,9 +614,84 @@ def render_decision_review_packet(
             ReviewRole.IMPLEMENTATION_REVIEWER,
         ),
         "",
-        "## Decision approval artifact template",
+        "## Your task",
         "",
-        "Create this only after a human approves the decision packet:",
+        decision.decision_review.reviewer_task,
+        "",
+        "Choose one outcome:",
+        "",
+        "1. **Approve the decision sheet as a unit.** This accepts both the "
+        "proposed decisions and the explicit deferrals below.",
+        "2. **Request changes by item ID.** Do this when any proposal, effect, "
+        "or non-authorization is unclear or wrong.",
+        "",
+        "Do not approve merely because the audit appendix looks reasonable or "
+        "because you found no obvious problem while skimming it.",
+        "",
+        "## Decision sheet",
+        "",
+    ]
+    section_headings = {
+        DecisionReviewDisposition.APPROVE:
+            "Proposed decisions to approve",
+        DecisionReviewDisposition.DEFER:
+            "Decisions explicitly deferred",
+    }
+    for disposition, heading in section_headings.items():
+        items = [
+            item
+            for item in decision.decision_review.items
+            if item.disposition == disposition
+        ]
+        if not items:
+            continue
+        lines.extend([f"### {heading}", ""])
+        for item in items:
+            lines.extend([
+                f"#### `{item.id}` — {item.title}",
+                "",
+                f"- **Question:** {item.question}",
+                f"- **Proposed decision:** {item.proposed_decision}",
+                "- **Approval means:**",
+            ])
+            lines.extend(
+                f"  - {effect}"
+                for effect in item.approval_effect
+            )
+            lines.append("- **This does not authorize:**")
+            lines.extend(
+                f"  - {boundary}"
+                for boundary in item.does_not_authorize
+            )
+            lines.extend([
+                "- **Contract groups covered:** "
+                + ", ".join(
+                    f"`{parameter_name}`"
+                    for parameter_name in item.parameter_names
+                ),
+                "- **Evidence claims:** "
+                + (
+                    ", ".join(
+                        f"`{claim_id}`"
+                        for claim_id in item.evidence_claim_ids
+                    )
+                    or "_None; product or lifecycle boundary only_"
+                ),
+                "",
+            ])
+
+    lines.extend([
+        "## Approval statement",
+        "",
+        "A decision approval bound to the displayed digest attests:",
+        "",
+        f"> {decision.decision_review.approval_statement}",
+        "",
+        f"- **Decision approval:** {_approval_label(approvals, decision.id, ReviewRole.DECISION_APPROVER)}",
+        "",
+        "### Decision approval artifact template",
+        "",
+        "Create this only after a human can make the approval statement above:",
         "",
         "```yaml",
         _render_approval_template(
@@ -623,32 +702,22 @@ def render_decision_review_packet(
         ),
         "```",
         "",
-        "## Implementation approval artifact template",
+        "## Audit appendix",
         "",
-        "Create this only after code matches the contract and activation is "
-        "separately approved:",
+        "<details><summary>Evidence, parameters, alternatives, limits, and validation</summary>",
         "",
-        "```yaml",
-        _render_approval_template(
-            subject_kind=ReviewSubjectKind.IMPLEMENTATION_CONTRACT,
-            subject_id=decision.id,
-            subject_digest=contract.contract_digest,
-            role=ReviewRole.IMPLEMENTATION_REVIEWER,
-        ),
-        "```",
-        "",
-        "## Accepted interpretation",
+        "### Accepted interpretation",
         "",
         decision.accepted_interpretation,
         "",
-        "## Linked evidence",
+        "### Linked evidence",
         "",
-    ]
+    ])
     for claim_id in decision.evidence_claim_ids:
         claim = registry.claims[claim_id]
         review_id = registry.claim_review_ids[claim_id]
         lines.extend([
-            f"### `{claim.id}` — {claim.evidence_strength.value}",
+            f"#### `{claim.id}` — {claim.evidence_strength.value}",
             "",
             claim.statement,
             "",
@@ -658,10 +727,10 @@ def render_decision_review_packet(
             "",
         ])
 
-    lines.extend(["## Reviewed parameters", ""])
+    lines.extend(["### Reviewed parameters", ""])
     for parameter in decision.model_parameters:
         lines.extend([
-            f"### `{parameter.name}` — {parameter.classification.value}",
+            f"#### `{parameter.name}` — {parameter.classification.value}",
             "",
             f"- **Applies to:** {parameter.applies_to or '_Not specified_'}",
             "- **Evidence claims:** "
@@ -686,10 +755,10 @@ def render_decision_review_packet(
             "",
         ])
 
-    lines.extend(["## Rejected alternatives", ""])
+    lines.extend(["### Rejected alternatives", ""])
     for alternative in decision.rejected_alternatives:
         lines.extend([
-            f"### {alternative.alternative}",
+            f"#### {alternative.alternative}",
             "",
             alternative.rationale,
             "",
@@ -702,16 +771,31 @@ def render_decision_review_packet(
         "Validation plan": decision.validation_plan,
         "Falsification conditions": decision.falsification_conditions,
         "Decision notes": decision.decision_notes,
-    }))
+    }, heading_level=3))
     lines.extend([
-        "## Exact machine contract",
+        "</details>",
         "",
-        "This is the same canonical JSON payload written to the generated "
-        "contract file.",
+    ])
+    lines.extend(_render_exact_payload(
+        "Exact machine contract — code consumption audit",
+        contract.model_dump(mode="json"),
+    ))
+    lines.extend([
+        "<details><summary>Implementation approval template — not part of decision approval</summary>",
         "",
-        "```json",
-        contract_json,
+        "Create this only after code matches an accepted contract and runtime "
+        "activation is separately approved:",
+        "",
+        "```yaml",
+        _render_approval_template(
+            subject_kind=ReviewSubjectKind.IMPLEMENTATION_CONTRACT,
+            subject_id=decision.id,
+            subject_digest=contract.contract_digest,
+            role=ReviewRole.IMPLEMENTATION_REVIEWER,
+        ),
         "```",
+        "",
+        "</details>",
         "",
     ])
     lines.extend(_render_exact_payload(
@@ -849,10 +933,14 @@ def _verification_levels(review: EvidenceReview) -> dict[str, str]:
     return levels
 
 
-def _render_named_lists(sections: dict[str, list[str]]) -> list[str]:
+def _render_named_lists(
+    sections: dict[str, list[str]],
+    *,
+    heading_level: int = 2,
+) -> list[str]:
     lines: list[str] = []
     for heading, values in sections.items():
-        lines.extend([f"## {heading}", ""])
+        lines.extend([f"{'#' * heading_level} {heading}", ""])
         if values:
             lines.extend(f"- {value}" for value in values)
         else:

--- a/analysis/science_artifacts.py
+++ b/analysis/science_artifacts.py
@@ -647,6 +647,16 @@ def render_decision_review_packet(
             continue
         lines.extend([f"### {heading}", ""])
         for item in items:
+            parameter_label = (
+                "contract group"
+                if len(item.parameter_names) == 1
+                else "contract groups"
+            )
+            claim_label = (
+                "evidence claim"
+                if len(item.evidence_claim_ids) == 1
+                else "evidence claims"
+            )
             lines.extend([
                 f"#### `{item.id}` — {item.title}",
                 "",
@@ -666,8 +676,8 @@ def render_decision_review_packet(
             lines.extend([
                 "",
                 "<details><summary>Traceability: "
-                f"{len(item.parameter_names)} contract groups, "
-                f"{len(item.evidence_claim_ids)} evidence claims</summary>",
+                f"{len(item.parameter_names)} {parameter_label}, "
+                f"{len(item.evidence_claim_ids)} {claim_label}</summary>",
                 "",
                 "- **Contract groups covered:** "
                 + ", ".join(

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -88,6 +88,12 @@ contract with matching digests. Humans approve the generated packet through a
 role-scoped approval artifact; runtime code consumes only the generated
 contract and never derives values from prose.
 
+Artifact-mode SDRs also provide a typed `decision_review` manifest. The
+generated packet begins with its concise decision sheet; every contract
+parameter group must be mapped to an explicit proposed decision or deferral.
+The complete evidence, parameter, and contract material remains a collapsed
+audit appendix rather than the reviewer's primary task.
+
 ### Research before changing science
 
 Use the repository-owned

--- a/docs/dev/science-review-artifacts.md
+++ b/docs/dev/science-review-artifacts.md
@@ -10,7 +10,9 @@ Deterministic generation produces separate projections:
 
 ```text
 canonical typed record
-  ├─ review packet Markdown      human review surface
+  ├─ review packet Markdown
+  │    ├─ decision sheet         primary human review surface
+  │    └─ audit appendix         evidence, parameters, exact contract
   └─ policy contract JSON        code consumption surface
 ```
 
@@ -31,6 +33,38 @@ Artifact-mode SDRs also declare their runtime boundary:
 artifact_policy:
   runtime_state: inactive
 ```
+
+They must also define an action-oriented `decision_review` manifest. Each item
+states the question, proposed decision, effect of approval, what remains
+unauthorized, and the exact contract groups it covers:
+
+```yaml
+decision_review:
+  reviewer_task: >
+    Approve the decision sheet as a unit or request changes by item ID.
+  approval_statement: >
+    I approve the proposed decisions and explicit deferrals as one inactive
+    science decision. I am not approving implementation or activation.
+  items:
+    - id: supported-scope
+      title: Accept the supported population and goal scope
+      disposition: approve
+      question: Should this policy cover the stated training pattern?
+      proposed_decision: Accept the bounded scope.
+      approval_effect:
+        - The mapped routing groups become accepted decision inputs.
+      does_not_authorize:
+        - Any unresolved schedule or dose.
+      parameter_names:
+        - example_goal_tuple
+        - example_supported_pattern
+      evidence_claim_ids:
+        - example.scope-supported
+```
+
+Every `model_parameters` group must appear in at least one decision-review
+item. This makes hidden machine behavior a schema error rather than a reviewer
+discovery problem.
 
 `accepted` and `active` are different states. An accepted decision may remain
 inactive until implementation, migration, validation, and rollout gates pass.
@@ -56,11 +90,17 @@ Use `--check` in CI or review automation:
 python scripts/generate_science_artifacts.py --check
 ```
 
-Review packets contain the full question, method, claims, verification levels,
-decision interpretation, exact parameters, rationale, applicability, safety
-and privacy boundaries, validation/falsification plans, unresolved content,
-and exact generated JSON contract. Canonical payloads are included in
-collapsible sections so no reviewed field is hidden.
+Evidence packets contain the full question, method, claims, verification
+levels, and limitations. Decision packets begin with the reviewer's task and a
+short decision sheet separated into proposed approvals and explicit deferrals.
+The reviewer approves the sheet as a unit or requests changes by item ID.
+Evidence details, exact parameters, alternatives, claim limits, safety/privacy,
+validation/falsification, the machine contract, and canonical payload remain
+available in collapsed audit appendices.
+
+The appendix guarantees completeness; it is not a substitute for a clear
+decision sheet and reviewers must not approve merely because they found no
+obvious issue while skimming it.
 
 Contracts contain only typed implementation data:
 
@@ -105,7 +145,7 @@ Roles are intentionally distinct:
 | Role | Reviews | Required before |
 |---|---|---|
 | `evidence_reviewer` | Search method, evidence claims, citation verification, limitations and gaps | Artifact-mode Evidence Review acceptance |
-| `decision_approver` | Interpretation, exact parameters, applicability, claim limits, safety/privacy, activation boundary | Artifact-mode SDR acceptance |
+| `decision_approver` | Explicit decision sheet, mapped parameters, deferrals, applicability, claim limits, safety/privacy, activation boundary | Artifact-mode SDR acceptance |
 | `implementation_reviewer` | Contract mapping, runtime diff, validation | Contract activation |
 
 Changing reviewed content changes its digest and makes the approval stale.
@@ -116,11 +156,14 @@ digests, requiring renewed decision and implementation review.
 
 1. Create draft Evidence Review and SDR records with `approval_mode: artifact`.
 2. Generate review packets and contracts.
-3. Review the generated packet, not raw YAML syntax.
-4. Correct the canonical record and regenerate until the packet is stable.
-5. Record role-scoped approval against the displayed digest.
-6. Atomically accept the record and add the approval artifact.
-7. Keep the contract inactive until implementation review and rollout gates
+3. For an SDR, review the decision sheet first. Approve it as a unit or request
+   changes by item ID; do not infer a decision from the audit appendix.
+4. Use the audit appendix only to investigate evidence, mappings, and exact
+   machine values.
+5. Correct the canonical record and regenerate until the packet is stable.
+6. Record role-scoped approval against the displayed digest.
+7. Atomically accept the record and add the approval artifact.
+8. Keep the contract inactive until implementation review and rollout gates
    are complete.
 
 Legacy records remain supported with `approval_mode: legacy`. New science

--- a/tests/test_science_artifacts.py
+++ b/tests/test_science_artifacts.py
@@ -13,6 +13,9 @@ from analysis.evidence_registry import (
     ApprovalMode,
     ArtifactRuntimeState,
     DecisionArtifactPolicy,
+    DecisionReviewDisposition,
+    DecisionReviewItem,
+    DecisionReviewManifest,
     EvidenceReview,
     RecordStatus,
     ScienceDecisionRecord,
@@ -40,6 +43,81 @@ _SHARED_EVIDENCE_ID = "evidence-plan-generation-eligibility-safety-v1"
 _DECISION_ID = "sdr-road-10k-plan-generation-policy-v1"
 
 
+def _decision_review_manifest(
+    decision: ScienceDecisionRecord,
+) -> DecisionReviewManifest:
+    def contains_not_accepted(value: object) -> bool:
+        if isinstance(value, dict):
+            return any(
+                contains_not_accepted(nested)
+                for nested in value.values()
+            )
+        if isinstance(value, list):
+            return any(
+                contains_not_accepted(nested)
+                for nested in value
+            )
+        return value == "not_accepted"
+
+    approved_parameters = [
+        parameter.name
+        for parameter in decision.model_parameters
+        if not contains_not_accepted(parameter.value)
+    ]
+    deferred_parameters = [
+        parameter.name
+        for parameter in decision.model_parameters
+        if contains_not_accepted(parameter.value)
+    ]
+    return DecisionReviewManifest(
+        reviewer_task=(
+            "Decide whether the proposed scope and explicit deferrals are "
+            "acceptable. Do not review implementation code in this role."
+        ),
+        approval_statement=(
+            "I approve every proposed decision and explicit deferral in this "
+            "sheet as one inactive science decision. I am not approving "
+            "implementation or runtime activation."
+        ),
+        items=[
+            DecisionReviewItem(
+                id="policy-boundary",
+                title="Accept the policy boundary",
+                disposition=DecisionReviewDisposition.APPROVE,
+                question="Should Praxys accept this bounded policy?",
+                proposed_decision=(
+                    "Accept the stated scope, safety boundary, and claim limits."
+                ),
+                approval_effect=[
+                    "The mapped contract groups become accepted decision inputs.",
+                ],
+                does_not_authorize=[
+                    "Runtime activation or automatic plan adoption.",
+                ],
+                parameter_names=approved_parameters,
+                evidence_claim_ids=[decision.evidence_claim_ids[0]],
+            ),
+            DecisionReviewItem(
+                id="deferred-implementation-details",
+                title="Keep implementation details deferred",
+                disposition=DecisionReviewDisposition.DEFER,
+                question="Should the remaining implementation details stay open?",
+                proposed_decision=(
+                    "Keep the mapped details unresolved until a later decision."
+                ),
+                approval_effect=[
+                    "The mapped groups remain visible but do not activate code.",
+                ],
+                does_not_authorize=[
+                    "Filling deferred values from prose, defaults, or AI.",
+                ],
+                parameter_names=deferred_parameters,
+                evidence_claim_ids=[],
+            ),
+        ],
+    )
+
+
 def _write_yaml(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -64,10 +142,12 @@ def _write_fixture_records(
         if status == RecordStatus.ACCEPTED
         else None,
     })
-    decision = current.decisions[_DECISION_ID].model_copy(update={
+    base_decision = current.decisions[_DECISION_ID]
+    decision = base_decision.model_copy(update={
         "status": status,
         "approval_mode": ApprovalMode.ARTIFACT,
         "human_reviewers": [],
+        "decision_review": _decision_review_manifest(base_decision),
         "artifact_policy": DecisionArtifactPolicy(
             runtime_state=runtime_state,
         ),
@@ -198,6 +278,17 @@ def test_draft_artifact_records_render_complete_review_and_contract(
     assert "activity_avg_power" in expected[decision_packet_path]
     assert "Exact reviewed evidence payload" in expected[evidence_packet_path]
     assert "range -0.28 to 0.25" in expected[evidence_packet_path]
+    packet = expected[decision_packet_path]
+    assert packet.index("## Your task") < packet.index("## Decision sheet")
+    assert packet.index("## Decision sheet") < packet.index(
+        "## Audit appendix"
+    )
+    assert "Approve the decision sheet as a unit" in packet
+    assert "Proposed decisions to approve" in packet
+    assert "Decisions explicitly deferred" in packet
+    assert "Do not approve merely because the audit appendix" in packet
+    assert "I approve every proposed decision" in packet
+    assert "<details><summary>Evidence, parameters" in packet
 
     assert sync_science_artifacts(registry, check=False)
     assert sync_science_artifacts(registry, check=True) == []
@@ -212,15 +303,68 @@ def test_draft_artifact_records_render_complete_review_and_contract(
     assert sync_science_artifacts(registry, check=True) == [contract_path]
 
 
+def test_artifact_decision_review_must_cover_every_contract_group(
+    tmp_path: Path,
+) -> None:
+    science_dir = tmp_path / "science"
+    _, decision = _write_fixture_records(
+        science_dir,
+        status=RecordStatus.DRAFT,
+    )
+    payload = decision.model_dump(mode="json")
+
+    payload_without_review = {
+        **payload,
+        "decision_review": None,
+    }
+    with pytest.raises(
+        ValidationError,
+        match="require decision_review",
+    ):
+        ScienceDecisionRecord.model_validate(payload_without_review)
+
+    missing_payload = json.loads(json.dumps(payload))
+    missing_payload["decision_review"]["items"][0][
+        "parameter_names"
+    ].pop()
+    with pytest.raises(
+        ValidationError,
+        match="does not cover parameters",
+    ):
+        ScienceDecisionRecord.model_validate(missing_payload)
+
+    unknown_payload = json.loads(json.dumps(payload))
+    unknown_payload["decision_review"]["items"][0][
+        "parameter_names"
+    ].append("unknown_contract_group")
+    with pytest.raises(
+        ValidationError,
+        match="references unknown parameters",
+    ):
+        ScienceDecisionRecord.model_validate(unknown_payload)
+
+    hidden_deferral_payload = json.loads(json.dumps(payload))
+    hidden_deferral_payload["decision_review"]["items"][1][
+        "disposition"
+    ] = DecisionReviewDisposition.APPROVE.value
+    with pytest.raises(
+        ValidationError,
+        match="does not explicitly defer unresolved parameters",
+    ):
+        ScienceDecisionRecord.model_validate(hidden_deferral_payload)
+
+
 def test_review_digests_ignore_lifecycle_but_change_reviewed_content() -> None:
     current = load_science_registry()
     review = current.evidence_reviews[_EVIDENCE_ID].model_copy(update={
         "approval_mode": ApprovalMode.ARTIFACT,
         "human_reviewers": [],
     })
-    decision = current.decisions[_DECISION_ID].model_copy(update={
+    base_decision = current.decisions[_DECISION_ID]
+    decision = base_decision.model_copy(update={
         "approval_mode": ApprovalMode.ARTIFACT,
         "human_reviewers": [],
+        "decision_review": _decision_review_manifest(base_decision),
         "artifact_policy": DecisionArtifactPolicy(),
     })
 

--- a/tests/test_science_artifacts.py
+++ b/tests/test_science_artifacts.py
@@ -289,6 +289,7 @@ def test_draft_artifact_records_render_complete_review_and_contract(
     assert "Do not approve merely because the audit appendix" in packet
     assert "I approve every proposed decision" in packet
     assert "<details><summary>Evidence, parameters" in packet
+    assert "<details><summary>Traceability:" in packet
 
     assert sync_science_artifacts(registry, check=False)
     assert sync_science_artifacts(registry, check=True) == []


### PR DESCRIPTION
## Summary

The first artifact-mode review trial exposed a human-review failure: the
decision packet was complete, but the reviewer could not tell what decision
they were being asked to make.

This change makes the decision surface explicit:

- artifact-mode SDRs define a typed `decision_review` manifest;
- each item states the question, proposed decision, approval effect, and what
  it does not authorize;
- items are separated into proposed approvals and explicit deferrals;
- every machine-contract parameter group must map to the decision sheet;
- every group containing `not_accepted` must map to a deferral;
- full evidence, parameters, exact contract, and implementation approval stay
  available in collapsed audit appendices.

Reviewers now approve the decision sheet as a unit or request changes by item
ID. Finding no obvious issue while skimming the appendix is explicitly not an
approval.

## Validation

- [x] Artifact packet and approval tests
- [x] Evidence registry tests
- [x] Science research skill tests
- [x] Generated packet preserves the exact machine contract

## Follow-up

Draft PR #702 will be stacked on this branch and regenerated with a concrete
half-marathon decision sheet. No human approval is inferred from the earlier
review.
