### PR TITLE
Speed up Training plan loading and harden backend deploy cutover

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -11,7 +11,6 @@ on:
       - 'db/**'
       - 'config/agent-loop-policies.json'
       - 'data/science/**'
-      - 'tests/**'
       - 'requirements.txt'
       - 'scripts/appinsights_boundary.sh'
       - 'scripts/provision_labs_worker_db.py'
@@ -70,6 +69,7 @@ jobs:
             VERSION="$(date -u +%Y.%m.%d).${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}"
           fi
           echo "${VERSION}" > api/_build_version.txt
+          echo "PRAXYS_EXPECTED_API_VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "Build version: ${VERSION}"
 
       - name: Wait for compatible frontend deployment
@@ -373,3 +373,61 @@ jobs:
         with:
           app-name: trainsight-app
           resource-group-name: rg-trainsight
+
+      - name: Verify deployed backend cutover
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_url="https://api.praxys.run/api/version"
+          ready_url="https://api.praxys.run/api/health/ready"
+
+          deployment_ready() {
+            local version_payload ready_payload live_version ready_status
+            version_payload="$(
+              curl --fail --silent --show-error --max-time 8 \
+                --header "Cache-Control: no-cache" \
+                "${version_url}" 2>/dev/null || true
+            )"
+            ready_payload="$(
+              curl --fail --silent --show-error --max-time 8 \
+                --header "Cache-Control: no-cache" \
+                "${ready_url}" 2>/dev/null || true
+            )"
+            live_version="$(
+              jq -r '.version // empty' <<< "${version_payload}" \
+                2>/dev/null || true
+            )"
+            ready_status="$(
+              jq -r '.status // empty' <<< "${ready_payload}" \
+                2>/dev/null || true
+            )"
+            echo "Live version=${live_version:-unavailable} readiness=${ready_status:-unavailable}"
+            [[ "${live_version}" == "${PRAXYS_EXPECTED_API_VERSION}" &&
+               "${ready_status}" == "ready" ]]
+          }
+
+          for attempt in {1..6}; do
+            if deployment_ready; then
+              exit 0
+            fi
+            echo "Waiting for deployed backend cutover (${attempt}/6)."
+            sleep 10
+          done
+
+          echo "OneDeploy did not activate the expected build; restarting App Service once."
+          az webapp restart \
+            --name trainsight-app \
+            --resource-group rg-trainsight \
+            --only-show-errors
+
+          for attempt in {1..30}; do
+            if deployment_ready; then
+              exit 0
+            fi
+            echo "Waiting for backend after restart (${attempt}/30)."
+            sleep 5
+          done
+
+          echo "Expected backend build did not become ready after restart." >&2
+          exit 1

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -8,7 +8,7 @@
 
 | Surface | Workflow | Triggers | Target |
 |---|---|---|---|
-| Backend (API) | `deploy-backend.yml` | push to `main` touching backend code/tests, observability config/scripts, or the workflow; or `api-*` tag | App Service `trainsight-app` |
+| Backend (API) | `deploy-backend.yml` | push to `main` touching backend runtime code, observability config/scripts, dependencies, or the workflow; or `api-*` tag | App Service `trainsight-app` |
 | Labs analysis worker | `deploy-labs-worker.yml` | push to `main` touching worker/backend analysis code, its Dockerfile/requirements, Bicep, tests, or the workflow; manual dispatch | Service Bus + Container Apps Job; Azure deploy is gated by `PRAXYS_LABS_WORKER_DEPLOY_ENABLED=true` |
 | Frontend (SPA) | `deploy-frontend-appservice.yml` | push to `main` touching the SPA/static server, observability config/scripts, or the workflow; or `web-*` tag | App Service `praxys-frontend`; optionally Tencent Lighthouse |
 | Mini program | `miniapp-publish.yml` | `miniapp-YYYY.MM.MICRO` release tag (robot 1); `main` pushes auto-publish a dev build (robot 5) | WeChat (`miniprogram-ci`) |
@@ -33,10 +33,18 @@ Automatic on merge to `main` (for the paths above). The workflow:
 5. Waits for the App Service SCM deployment endpoint to remain healthy across
    three probes after the configuration recycle, then runs
    `azure/webapps-deploy`.
+6. Verifies that `/api/version` reports the stamped build and database
+   readiness is green. If OneDeploy has not activated the new process after
+   the initial activation probes, the workflow performs one App Service
+   restart and verifies again before reporting success.
 
 The settle gate is load-bearing: App Service management writes recycle the SCM
 container, and starting ZipDeploy during that recycle aborts the deployment
 with `Deployment has been stopped due to SCM container restart`.
+
+Test-only changes do not deploy the backend. Pull requests already run the
+backend suite in the required pre-merge workflow; recycling production when no
+runtime artifact changed adds outage risk without changing the service.
 
 Force a deploy without a code change: re-run the latest `deploy-backend.yml` run
 (`gh run rerun <id>`), or push an `api-YYYY.MM.MICRO` tag for a versioned release.

--- a/tests/test_appinsights_boundary.py
+++ b/tests/test_appinsights_boundary.py
@@ -66,6 +66,13 @@ def test_backend_workflow_enforces_server_only_ingestion() -> None:
     assert "stable_probes >= 3" in workflow
     assert "timeout-minutes: 8" in workflow
     assert "timeout 20s az webapp" in workflow
+    assert "      - 'tests/**'" not in workflow
+    assert "PRAXYS_EXPECTED_API_VERSION" in workflow
+    assert "Verify deployed backend cutover" in workflow
+    assert "OneDeploy did not activate the expected build" in workflow
+    assert "az webapp restart" in workflow
+    assert 'live_version}" == "${PRAXYS_EXPECTED_API_VERSION}' in workflow
+    assert 'ready_status}" == "ready"' in workflow
     assert "group: deploy-backend-production" in workflow
     assert "cancel-in-progress: false" in workflow
     assert "Monitoring Metrics Publisher" in script

--- a/tests/test_training_analysis_page_split.py
+++ b/tests/test_training_analysis_page_split.py
@@ -41,6 +41,27 @@ def test_web_separates_plan_management_from_analysis() -> None:
     assert "{ to: '/analysis'" in sidebar
 
 
+def test_web_training_prioritizes_one_plan_request() -> None:
+    """Training preloads one maximum window and defers secondary plan reads."""
+    prefetch = _source("web/src/lib/dashboard-prefetch.ts")
+    plan = _source("web/src/lib/plan.ts")
+    upcoming = _source("web/src/components/UpcomingPlanCard.tsx")
+    context = _source("web/src/components/PersonalContextPanel.tsx")
+    plan_start = _source("web/src/components/Outdoor5KPlanStart.tsx")
+
+    assert "MAX_MANAGED_PLAN_WINDOW_DAYS = 28" in plan
+    assert "pathname === '/training'" in prefetch
+    assert "planWindowUrl(MAX_MANAGED_PLAN_WINDOW_DAYS)" in prefetch
+    assert "planWindowUrl(\n      MAX_MANAGED_PLAN_WINDOW_DAYS," in upcoming
+    assert "workouts: planData.workouts.filter" in upcoming
+    assert "window: { start: windowStart, end: windowEnd }" in upcoming
+    assert (
+        "enabled: composerOpen && form.mode === 'execution_explanation'"
+        in context
+    )
+    assert "enabled: performance5kGoal" in plan_start
+
+
 def test_miniapp_uses_analysis_and_me_as_primary_tabs() -> None:
     """The five-tab miniapp exposes observed training and secondary tools."""
     training = _source("miniapp/pages/training/index.wxml")

--- a/web/src/components/Outdoor5KPlanStart.tsx
+++ b/web/src/components/Outdoor5KPlanStart.tsx
@@ -142,19 +142,33 @@ export default function Outdoor5KPlanStart() {
   const { t } = useLingui();
   const { locale } = useLocale();
   const { isDemo } = useAuth();
-  const { config, planDeliveryOptions, updateSettings } = useSettings();
+  const {
+    config,
+    error: settingsError,
+    loading: settingsLoading,
+    planDeliveryOptions,
+    refetch: refetchSettings,
+    updateSettings,
+  } = useSettings();
   const navigate = useNavigate();
+  const performance5kGoal = config?.goal.goal_kind === 'performance_5k';
   const {
     data: goal,
     loading: goalLoading,
     error: goalError,
     refetch: refetchGoal,
-  } = useApi<GoalResponse>('/api/goal', { timeoutMs: 12_000 });
+  } = useApi<GoalResponse>(
+    '/api/goal',
+    { timeoutMs: 12_000, enabled: performance5kGoal },
+  );
   const {
     data: currentProposal,
     error: currentProposalError,
     refetch: refetchProposal,
-  } = useApi<AdaptivePlanProposal>('/api/plan/proposals/current', { timeoutMs: 12_000 });
+  } = useApi<AdaptivePlanProposal>(
+    '/api/plan/proposals/current',
+    { timeoutMs: 12_000, enabled: performance5kGoal },
+  );
 
   const [availableDays, setAvailableDays] = useState<Outdoor5KWeekday[]>([]);
   const [dayLimits, setDayLimits] = useState<DayLimits>({});
@@ -410,21 +424,23 @@ export default function Outdoor5KPlanStart() {
     }
   };
 
-  if (goalLoading) return <PlanStartSkeleton />;
+  if (settingsLoading) return <PlanStartSkeleton />;
 
-  if (goalError) {
+  if (settingsError) {
     return (
       <Alert id="outdoor-5k-plan" variant="destructive">
         <AlertTitle><Trans>Could not load plan-start context</Trans></AlertTitle>
         <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
-          <span>{goalError}</span>
-          <Button variant="outline" size="sm" onClick={() => void refetchGoal()}><Trans>Retry</Trans></Button>
+          <span>{settingsError}</span>
+          <Button variant="outline" size="sm" onClick={refetchSettings}><Trans>Retry</Trans></Button>
         </AlertDescription>
       </Alert>
     );
   }
 
-  if (goal?.goal_kind !== 'performance_5k') {
+  if (!config) return <PlanStartSkeleton />;
+
+  if (!performance5kGoal) {
     return (
       <Card id="outdoor-5k-plan">
         <CardHeader>
@@ -439,6 +455,20 @@ export default function Outdoor5KPlanStart() {
       </Card>
     );
   }
+
+  if (goalError) {
+    return (
+      <Alert id="outdoor-5k-plan" variant="destructive">
+        <AlertTitle><Trans>Could not load plan-start context</Trans></AlertTitle>
+        <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+          <span>{goalError}</span>
+          <Button variant="outline" size="sm" onClick={() => void refetchGoal()}><Trans>Retry</Trans></Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (goalLoading || !goal) return <PlanStartSkeleton />;
 
   const baseline = goal.baseline;
   const result = readiness?.result;

--- a/web/src/components/PersonalContextPanel.tsx
+++ b/web/src/components/PersonalContextPanel.tsx
@@ -190,16 +190,21 @@ export default function PersonalContextPanel() {
     error,
     refetch,
   } = useApi<PersonalContextListResponse>(listUrl);
-  const recentPlanUrl = useMemo(() => contextPlanUrl(), []);
-  const {
-    data: recentPlan,
-    loading: recentPlanLoading,
-  } = useApi<PlanResponse>(recentPlanUrl);
   const [composerOpen, setComposerOpen] = useState(false);
   const [form, setForm] = useState<PersonalContextDraftForm>(
     () => createPersonalContextDraft('temporary_constraint'),
   );
   const [editingItem, setEditingItem] = useState<PersonalContextItem | null>(null);
+  const recentPlanUrl = useMemo(() => contextPlanUrl(), []);
+  const {
+    data: recentPlan,
+    loading: recentPlanLoading,
+  } = useApi<PlanResponse>(
+    recentPlanUrl,
+    {
+      enabled: composerOpen && form.mode === 'execution_explanation',
+    },
+  );
   const [preview, setPreview] = useState<PersonalContextPreviewResponse | null>(null);
   const [previewRequest, setPreviewRequest] =
     useState<PersonalContextDraftRequest | null>(null);

--- a/web/src/components/UpcomingPlanCard.tsx
+++ b/web/src/components/UpcomingPlanCard.tsx
@@ -45,6 +45,7 @@ import {
   useApi,
 } from '@/hooks/useApi';
 import {
+  MAX_MANAGED_PLAN_WINDOW_DAYS,
   athletePlanWindow,
   athletePlanDateDistance,
   isPraxysOwned,
@@ -72,7 +73,7 @@ import type {
 const WINDOW_OPTIONS = [
   { id: '1wk', days: 7 },
   { id: '2wk', days: 14 },
-  { id: '4wk', days: 28 },
+  { id: '4wk', days: MAX_MANAGED_PLAN_WINDOW_DAYS },
 ] as const;
 type WindowId = typeof WINDOW_OPTIONS[number]['id'];
 const WINDOW_STORAGE_KEY = 'praxys.plan_window';
@@ -1003,12 +1004,35 @@ export default function UpcomingPlanCard() {
   const windowStart = shiftAthletePlanDate(localDay, windowOffsetDays);
   const planUrl = useMemo(
     () => planWindowUrl(
-      windowDays,
+      MAX_MANAGED_PLAN_WINDOW_DAYS,
       new Date(`${windowStart}T12:00:00`),
     ),
-    [windowDays, windowStart],
+    [windowStart],
   );
-  const { data, loading, error, refetch } = useApi<PlanResponse>(planUrl);
+  const {
+    data: planData,
+    loading,
+    error,
+    refetch,
+  } = useApi<PlanResponse>(planUrl);
+  const data = useMemo<PlanResponse | null>(() => {
+    if (!planData) return null;
+    const windowEnd = shiftAthletePlanDate(windowStart, windowDays - 1);
+    const inWindow = (date: string) => (
+      date >= windowStart && date <= windowEnd
+    );
+    return {
+      ...planData,
+      workouts: planData.workouts.filter((workout) => inWindow(workout.date)),
+      window: { start: windowStart, end: windowEnd },
+      adjustments: planData.adjustments?.filter(
+        (adjustment) => (
+          adjustment.workout_date == null
+          || inWindow(adjustment.workout_date)
+        ),
+      ),
+    };
+  }, [planData, windowDays, windowStart]);
   const [workingKey, setWorkingKey] = useState<string | null>(null);
   const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
   const [reviewWorkout, setReviewWorkout] = useState<PlannedWorkout | null>(null);

--- a/web/src/lib/dashboard-prefetch.ts
+++ b/web/src/lib/dashboard-prefetch.ts
@@ -1,9 +1,17 @@
+import {
+  MAX_MANAGED_PLAN_WINDOW_DAYS,
+  planWindowUrl,
+} from './plan.ts';
+
 export function initialDashboardUrl(
   pathname: string,
   hasToken: boolean,
-): '/api/today' | '/api/training' | null {
+): string | null {
   if (!hasToken) return null;
   if (pathname === '/' || pathname === '/today') return '/api/today';
+  if (pathname === '/training') {
+    return planWindowUrl(MAX_MANAGED_PLAN_WINDOW_DAYS);
+  }
   if (pathname === '/analysis') return '/api/training';
   return null;
 }

--- a/web/src/lib/plan.ts
+++ b/web/src/lib/plan.ts
@@ -1,6 +1,7 @@
 import type { PlanManagementConfig, PlannedWorkout } from '@/types/api';
 
 export const MANAGED_PLAN_WINDOW_DAYS = 14;
+export const MAX_MANAGED_PLAN_WINDOW_DAYS = 28;
 
 function utcIsoDate(value: Date): string {
   const year = value.getUTCFullYear();

--- a/web/src/locales/en/messages.po
+++ b/web/src/locales/en/messages.po
@@ -26,7 +26,7 @@ msgstr "· last {0} weeks"
 msgid "(Garmin rate limits apply)"
 msgstr "(Garmin rate limits apply)"
 
-#: src/components/PersonalContextPanel.tsx:1055
+#: src/components/PersonalContextPanel.tsx:1060
 msgid "(optional)"
 msgstr "(optional)"
 
@@ -46,7 +46,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, one {# recommendation} other {# recommendations}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:1477
+#: src/components/UpcomingPlanCard.tsx:1501
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, one {# workout} other {# workouts}}"
 
@@ -242,7 +242,7 @@ msgstr "{abbrev} is <0>{dirLabel}</0>. Add more activities for a race-time predi
 msgid "{completed} of {0} steps complete"
 msgstr "{completed} of {0} steps complete"
 
-#: src/components/UpcomingPlanCard.tsx:1470
+#: src/components/UpcomingPlanCard.tsx:1494
 msgid "{conflictCount, plural, one {# needs review} other {# need review}}"
 msgstr "{conflictCount, plural, one {# needs review} other {# need review}}"
 
@@ -250,7 +250,7 @@ msgstr "{conflictCount, plural, one {# needs review} other {# need review}}"
 #~ msgid "{conflictCount} need review"
 #~ msgstr "{conflictCount} need review"
 
-#: src/components/Outdoor5KPlanStart.tsx:552
+#: src/components/Outdoor5KPlanStart.tsx:582
 msgid "{dayLabel} time limit (minutes)"
 msgstr "{dayLabel} time limit (minutes)"
 
@@ -300,7 +300,7 @@ msgstr "{minutes} effective min"
 msgid "{observationCount}-observation Trend"
 msgstr "{observationCount}-observation Trend"
 
-#: src/components/UpcomingPlanCard.tsx:787
+#: src/components/UpcomingPlanCard.tsx:788
 msgid "{target} version"
 msgstr "{target} version"
 
@@ -385,7 +385,7 @@ msgstr "1 day ago"
 msgid "1 month"
 msgstr "1 month"
 
-#: src/components/UpcomingPlanCard.tsx:173
+#: src/components/UpcomingPlanCard.tsx:174
 msgid "1 wk"
 msgstr "1 wk"
 
@@ -420,7 +420,7 @@ msgstr "14-day managed window"
 msgid "1Y"
 msgstr "1Y"
 
-#: src/components/UpcomingPlanCard.tsx:174
+#: src/components/UpcomingPlanCard.tsx:175
 msgid "2 wk"
 msgstr "2 wk"
 
@@ -440,7 +440,7 @@ msgstr "3 months"
 msgid "3M"
 msgstr "3M"
 
-#: src/components/UpcomingPlanCard.tsx:175
+#: src/components/UpcomingPlanCard.tsx:176
 msgid "4 wk"
 msgstr "4 wk"
 
@@ -556,7 +556,7 @@ msgstr "A single activity has too much influence on the result."
 msgid "A Stryd-aligned Critical Power value is required for this experiment."
 msgstr "A Stryd-aligned Critical Power value is required for this experiment."
 
-#: src/components/Outdoor5KPlanStart.tsx:340
+#: src/components/Outdoor5KPlanStart.tsx:354
 msgid "A successor proposal is ready. The earlier proposal is preserved as superseded."
 msgstr "A successor proposal is ready. The earlier proposal is preserved as superseded."
 
@@ -635,8 +635,8 @@ msgid "Activate managed plan"
 msgstr "Activate managed plan"
 
 #: src/components/ManagedPlanSettingsCard.tsx:487
-#: src/components/PersonalContextPanel.tsx:797
-#: src/components/PersonalContextPanel.tsx:1330
+#: src/components/PersonalContextPanel.tsx:802
+#: src/components/PersonalContextPanel.tsx:1335
 #: src/pages/admin/AdminFeedback.tsx:351
 #: src/pages/admin/AdminOps.tsx:1584
 #: src/pages/Science.tsx:405
@@ -666,8 +666,8 @@ msgstr "Active Incidents"
 msgid "Active incidents: {0}"
 msgstr "Active incidents: {0}"
 
-#: src/components/PersonalContextPanel.tsx:1164
-#: src/components/PersonalContextPanel.tsx:1345
+#: src/components/PersonalContextPanel.tsx:1169
+#: src/components/PersonalContextPanel.tsx:1350
 msgid "Active until"
 msgstr "Active until"
 
@@ -753,7 +753,7 @@ msgstr "Add a step or repeat group to begin."
 msgid "Add at least one step to this repeat."
 msgstr "Add at least one step to this repeat."
 
-#: src/components/PersonalContextPanel.tsx:729
+#: src/components/PersonalContextPanel.tsx:734
 msgid "Add availability"
 msgstr "Add availability"
 
@@ -777,11 +777,11 @@ msgstr "Add screenshot"
 #~ msgid "Add step"
 #~ msgstr "Add step"
 
-#: src/components/UpcomingPlanCard.tsx:1643
+#: src/components/UpcomingPlanCard.tsx:1667
 msgid "Add the first workout"
 msgstr "Add the first workout"
 
-#: src/components/UpcomingPlanCard.tsx:1490
+#: src/components/UpcomingPlanCard.tsx:1514
 #: src/components/WorkoutPlanEditor.tsx:642
 #: src/components/WorkoutPlanEditor.tsx:931
 msgid "Add workout"
@@ -810,11 +810,11 @@ msgstr "Admin console"
 msgid "Admin sections"
 msgstr "Admin sections"
 
-#: src/components/Outdoor5KPlanStart.tsx:705
+#: src/components/Outdoor5KPlanStart.tsx:735
 msgid "Adopt exact proposal"
 msgstr "Adopt exact proposal"
 
-#: src/components/UpcomingPlanCard.tsx:260
+#: src/components/UpcomingPlanCard.tsx:261
 msgid "Adopt in Settings"
 msgstr "Adopt in Settings"
 
@@ -822,7 +822,7 @@ msgstr "Adopt in Settings"
 msgid "Adopt Praxys as your planner before enabling automatic changes. Coaching remains suggestion-only."
 msgstr "Adopt Praxys as your planner before enabling automatic changes. Coaching remains suggestion-only."
 
-#: src/components/Outdoor5KPlanStart.tsx:705
+#: src/components/Outdoor5KPlanStart.tsx:735
 msgid "Adopting…"
 msgstr "Adopting…"
 
@@ -834,15 +834,15 @@ msgstr "Adopting…"
 msgid "Aerobic"
 msgstr "Aerobic"
 
-#: src/components/PersonalContextPanel.tsx:269
+#: src/components/PersonalContextPanel.tsx:274
 msgid "Affected dates"
 msgstr "Affected dates"
 
-#: src/components/PersonalContextPanel.tsx:270
+#: src/components/PersonalContextPanel.tsx:275
 msgid "Affected weekdays"
 msgstr "Affected weekdays"
 
-#: src/components/PersonalContextPanel.tsx:1075
+#: src/components/PersonalContextPanel.tsx:1080
 msgid "Affected weekdays (optional)"
 msgstr "Affected weekdays (optional)"
 
@@ -874,35 +874,35 @@ msgstr "agent-ready candidates"
 msgid "Aggregate storage"
 msgstr "Aggregate storage"
 
-#: src/components/PersonalContextPanel.tsx:813
+#: src/components/PersonalContextPanel.tsx:818
 msgid "AI allowed"
 msgstr "AI allowed"
 
-#: src/components/PersonalContextPanel.tsx:1520
+#: src/components/PersonalContextPanel.tsx:1525
 msgid "AI option"
 msgstr "AI option"
 
-#: src/components/PersonalContextPanel.tsx:1640
+#: src/components/PersonalContextPanel.tsx:1645
 msgid "AI output can be wrong. It cannot diagnose, provide treatment, clear you to train, or override Praxys safety, science, and approval boundaries."
 msgstr "AI output can be wrong. It cannot diagnose, provide treatment, clear you to train, or override Praxys safety, science, and approval boundaries."
 
-#: src/components/PersonalContextPanel.tsx:1351
+#: src/components/PersonalContextPanel.tsx:1356
 msgid "AI processing"
 msgstr "AI processing"
 
-#: src/components/PersonalContextPanel.tsx:633
+#: src/components/PersonalContextPanel.tsx:638
 msgid "AI processing enabled for this item only."
 msgstr "AI processing enabled for this item only."
 
-#: src/components/PersonalContextPanel.tsx:1573
+#: src/components/PersonalContextPanel.tsx:1578
 msgid "AI processing for one item"
 msgstr "AI processing for one item"
 
-#: src/components/PersonalContextPanel.tsx:634
+#: src/components/PersonalContextPanel.tsx:639
 msgid "AI processing withdrawn. No new provider requests are allowed."
 msgstr "AI processing withdrawn. No new provider requests are allowed."
 
-#: src/components/PersonalContextPanel.tsx:1582
+#: src/components/PersonalContextPanel.tsx:1587
 msgid "AI service: Microsoft Azure"
 msgstr "AI service: Microsoft Azure"
 
@@ -947,7 +947,7 @@ msgstr "All systems operational"
 msgid "All Systems Operational"
 msgstr "All Systems Operational"
 
-#: src/components/PersonalContextPanel.tsx:1695
+#: src/components/PersonalContextPanel.tsx:1700
 msgid "Allow for this item"
 msgstr "Allow for this item"
 
@@ -955,7 +955,7 @@ msgstr "Allow for this item"
 msgid "Allow structured plan context?"
 msgstr "Allow structured plan context?"
 
-#: src/components/PersonalContextPanel.tsx:1357
+#: src/components/PersonalContextPanel.tsx:1362
 msgid "Allowed for this item"
 msgstr "Allowed for this item"
 
@@ -968,11 +968,11 @@ msgstr "Allowed for this item"
 msgid "Already have an invitation code?"
 msgstr "Already have an invitation code?"
 
-#: src/components/PersonalContextPanel.tsx:1628
+#: src/components/PersonalContextPanel.tsx:1633
 msgid "Also send my optional note"
 msgstr "Also send my optional note"
 
-#: src/components/UpcomingPlanCard.tsx:1563
+#: src/components/UpcomingPlanCard.tsx:1587
 msgid "An earlier automatic change was superseded"
 msgstr "An earlier automatic change was superseded"
 
@@ -980,7 +980,7 @@ msgstr "An earlier automatic change was superseded"
 #~ msgid "An empty structured workout cannot be sent."
 #~ msgstr "An empty structured workout cannot be sent."
 
-#: src/components/UpcomingPlanCard.tsx:1514
+#: src/components/UpcomingPlanCard.tsx:1538
 msgid "An external planner overlaps the Praxys plan. Use one planner at a time to avoid duplicate or conflicting sessions."
 msgstr "An external planner overlaps the Praxys plan. Use one planner at a time to avoid duplicate or conflicting sessions."
 
@@ -1034,7 +1034,7 @@ msgstr "API"
 msgid "Applied"
 msgstr "Applied"
 
-#: src/components/UpcomingPlanCard.tsx:851
+#: src/components/UpcomingPlanCard.tsx:852
 msgid "Applying…"
 msgstr "Applying…"
 
@@ -1132,9 +1132,9 @@ msgstr "Automatic recovery guardrail"
 msgid "Automatic retries exhausted"
 msgstr "Automatic retries exhausted"
 
-#: src/components/PersonalContextPanel.tsx:223
-#: src/components/PersonalContextPanel.tsx:224
-#: src/components/PersonalContextPanel.tsx:225
+#: src/components/PersonalContextPanel.tsx:228
+#: src/components/PersonalContextPanel.tsx:229
+#: src/components/PersonalContextPanel.tsx:230
 msgid "Availability"
 msgstr "Availability"
 
@@ -1147,7 +1147,7 @@ msgstr "Availability rate"
 msgid "Available"
 msgstr "Available"
 
-#: src/components/PersonalContextPanel.tsx:272
+#: src/components/PersonalContextPanel.tsx:277
 msgid "Available equipment"
 msgstr "Available equipment"
 
@@ -1155,15 +1155,15 @@ msgstr "Available equipment"
 msgid "Available experiments"
 msgstr "Available experiments"
 
-#: src/components/PersonalContextPanel.tsx:381
+#: src/components/PersonalContextPanel.tsx:386
 msgid "Available minutes must be a whole number from 1 to 1440."
 msgstr "Available minutes must be a whole number from 1 to 1440."
 
-#: src/components/Outdoor5KPlanStart.tsx:522
+#: src/components/Outdoor5KPlanStart.tsx:552
 msgid "Available run days"
 msgstr "Available run days"
 
-#: src/components/PersonalContextPanel.tsx:273
+#: src/components/PersonalContextPanel.tsx:278
 msgid "Available terrain"
 msgstr "Available terrain"
 
@@ -1179,7 +1179,7 @@ msgstr "Avg Power"
 msgid "Avg Work {intensityLabel}"
 msgstr "Avg Work {intensityLabel}"
 
-#: src/components/PersonalContextPanel.tsx:1136
+#: src/components/PersonalContextPanel.tsx:1141
 msgid "Avoid names, diagnoses, precise locations, and other private details. Notes are deleted after 30 days even when the structured context remains."
 msgstr "Avoid names, diagnoses, precise locations, and other private details. Notes are deleted after 30 days even when the structured context remains."
 
@@ -1220,7 +1220,7 @@ msgstr "Azure Monitor returned an incomplete result, so this section was not ref
 #~ msgid "Azure-backed summary"
 #~ msgstr "Azure-backed summary"
 
-#: src/components/PersonalContextPanel.tsx:1262
+#: src/components/PersonalContextPanel.tsx:1267
 msgid "Back"
 msgstr "Back"
 
@@ -1282,12 +1282,12 @@ msgstr "Baseline"
 msgid "Baseline evidence is currently sufficient."
 msgstr "Baseline evidence is currently sufficient."
 
-#: src/components/Outdoor5KPlanStart.tsx:463
+#: src/components/Outdoor5KPlanStart.tsx:493
 msgid "Baseline needs review"
 msgstr "Baseline needs review"
 
 #: src/components/Outdoor5KPlanStart.tsx:105
-#: src/components/Outdoor5KPlanStart.tsx:463
+#: src/components/Outdoor5KPlanStart.tsx:493
 msgid "Baseline ready"
 msgstr "Baseline ready"
 
@@ -1315,7 +1315,7 @@ msgstr "Below caution band"
 #~ msgid "Below threshold"
 #~ msgstr "Below threshold"
 
-#: src/components/PersonalContextPanel.tsx:256
+#: src/components/PersonalContextPanel.tsx:261
 msgid "Bike"
 msgstr "Bike"
 
@@ -1336,7 +1336,7 @@ msgstr "Bootstrap interval"
 msgid "Both thresholds must be met. The bars describe model evidence, not a biological adaptation percentage."
 msgstr "Both thresholds must be met. The bars describe model evidence, not a biological adaptation percentage."
 
-#: src/components/UpcomingPlanCard.tsx:1438
+#: src/components/UpcomingPlanCard.tsx:1462
 msgid "Browse plan dates"
 msgstr "Browse plan dates"
 
@@ -1413,8 +1413,8 @@ msgstr "Calculator"
 #: src/components/ManagedPlanSettingsCard.tsx:1210
 #: src/components/ManagedPlanSettingsCard.tsx:1435
 #: src/components/ManagedPlanSettingsCard.tsx:1454
-#: src/components/PersonalContextPanel.tsx:1475
-#: src/components/UpcomingPlanCard.tsx:843
+#: src/components/PersonalContextPanel.tsx:1480
+#: src/components/UpcomingPlanCard.tsx:844
 #: src/components/WorkoutPlanEditor.tsx:917
 #: src/pages/admin/AdminOps.tsx:1215
 #: src/pages/admin/AdminUsers.tsx:1043
@@ -1450,7 +1450,7 @@ msgstr "Canonical workout remains safe"
 msgid "CAPTCHA required"
 msgstr "CAPTCHA required"
 
-#: src/components/PersonalContextPanel.tsx:226
+#: src/components/PersonalContextPanel.tsx:231
 msgid "Caregiving"
 msgstr "Caregiving"
 
@@ -1468,9 +1468,9 @@ msgstr "Carry your training signal outdoors. Scan to open Praxys in WeChat."
 msgid "cases"
 msgstr "cases"
 
-#: src/components/PersonalContextPanel.tsx:301
-#: src/components/PersonalContextPanel.tsx:971
-#: src/components/PersonalContextPanel.tsx:1158
+#: src/components/PersonalContextPanel.tsx:306
+#: src/components/PersonalContextPanel.tsx:976
+#: src/components/PersonalContextPanel.tsx:1163
 msgid "Category"
 msgstr "Category"
 
@@ -1516,7 +1516,7 @@ msgstr "Changed later"
 msgid "Changed what I'll do"
 msgstr "Changed what I'll do"
 
-#: src/components/Outdoor5KPlanStart.tsx:610
+#: src/components/Outdoor5KPlanStart.tsx:640
 msgid "Check readiness"
 msgstr "Check readiness"
 
@@ -1540,7 +1540,7 @@ msgstr "Checking delivery compatibility…"
 #~ msgid "Checking provider compatibility…"
 #~ msgstr "Checking provider compatibility…"
 
-#: src/components/Outdoor5KPlanStart.tsx:610
+#: src/components/Outdoor5KPlanStart.tsx:640
 msgid "Checking readiness…"
 msgstr "Checking readiness…"
 
@@ -1558,7 +1558,7 @@ msgstr "China"
 msgid "Chinese"
 msgstr "Chinese"
 
-#: src/components/PersonalContextPanel.tsx:983
+#: src/components/PersonalContextPanel.tsx:988
 msgid "Choose a category"
 msgstr "Choose a category"
 
@@ -1574,7 +1574,7 @@ msgstr "Choose a category"
 msgid "Choose a race target, track continuous progress, or use the 5K baseline pilot."
 msgstr "Choose a race target, track continuous progress, or use the 5K baseline pilot."
 
-#: src/components/PersonalContextPanel.tsx:914
+#: src/components/PersonalContextPanel.tsx:919
 msgid "Choose a recent workout"
 msgstr "Choose a recent workout"
 
@@ -1586,7 +1586,7 @@ msgstr "Choose how much historical data to pull"
 msgid "Choose one"
 msgstr "Choose one"
 
-#: src/components/PersonalContextPanel.tsx:360
+#: src/components/PersonalContextPanel.tsx:365
 msgid "Choose one category to continue."
 msgstr "Choose one category to continue."
 
@@ -1594,11 +1594,11 @@ msgstr "Choose one category to continue."
 msgid "Choose primary source"
 msgstr "Choose primary source"
 
-#: src/components/Outdoor5KPlanStart.tsx:195
+#: src/components/Outdoor5KPlanStart.tsx:209
 msgid "Choose the days you are available to run."
 msgstr "Choose the days you are available to run."
 
-#: src/components/PersonalContextPanel.tsx:365
+#: src/components/PersonalContextPanel.tsx:370
 msgid "Choose the workout that changed."
 msgstr "Choose the workout that changed."
 
@@ -1611,11 +1611,11 @@ msgstr "Choose training base"
 msgid "Choose voluntary experiments that help you inspect your own training history without turning early research into advice."
 msgstr "Choose voluntary experiments that help you inspect your own training history without turning early research into advice."
 
-#: src/components/PersonalContextPanel.tsx:370
+#: src/components/PersonalContextPanel.tsx:375
 msgid "Choose when this constraint starts and ends."
 msgstr "Choose when this constraint starts and ends."
 
-#: src/components/PersonalContextPanel.tsx:366
+#: src/components/PersonalContextPanel.tsx:371
 msgid "Choose whether it was missed or modified."
 msgstr "Choose whether it was missed or modified."
 
@@ -1727,7 +1727,7 @@ msgstr "Compatibility preview is unavailable. Check your connection and try agai
 msgid "Complete these steps to unlock your training insights"
 msgstr "Complete these steps to unlock your training insights"
 
-#: src/components/Outdoor5KPlanStart.tsx:634
+#: src/components/Outdoor5KPlanStart.tsx:664
 msgid "complete weeks; latest run"
 msgstr "complete weeks; latest run"
 
@@ -1779,7 +1779,7 @@ msgstr "Confirm that you are 18 or older to join this experiment."
 msgid "Confirm the boundary before Praxys writes to {targetLabel}."
 msgstr "Confirm the boundary before Praxys writes to {targetLabel}."
 
-#: src/components/Outdoor5KPlanStart.tsx:193
+#: src/components/Outdoor5KPlanStart.tsx:207
 msgid "Confirm the supported athlete and goal scope first."
 msgstr "Confirm the supported athlete and goal scope first."
 
@@ -1796,7 +1796,7 @@ msgstr "Confirmed what I planned"
 msgid "Conflict <0>{0}</0>"
 msgstr "Conflict <0>{0}</0>"
 
-#: src/components/UpcomingPlanCard.tsx:374
+#: src/components/UpcomingPlanCard.tsx:375
 msgid "Conflict retained"
 msgstr "Conflict retained"
 
@@ -1875,11 +1875,11 @@ msgstr "Connection funnel"
 msgid "Consent text version"
 msgstr "Consent text version"
 
-#: src/components/PersonalContextPanel.tsx:573
+#: src/components/PersonalContextPanel.tsx:578
 msgid "Context and dependent private traces deleted."
 msgstr "Context and dependent private traces deleted."
 
-#: src/components/PersonalContextPanel.tsx:545
+#: src/components/PersonalContextPanel.tsx:550
 msgid "Context excluded from future assessments."
 msgstr "Context excluded from future assessments."
 
@@ -1887,7 +1887,7 @@ msgstr "Context excluded from future assessments."
 msgid "Context type"
 msgstr "Context type"
 
-#: src/components/PersonalContextPanel.tsx:1405
+#: src/components/PersonalContextPanel.tsx:1410
 msgid "Context use"
 msgstr "Context use"
 
@@ -1963,15 +1963,15 @@ msgstr "Cooldown"
 msgid "Copy code"
 msgstr "Copy code"
 
-#: src/components/UpcomingPlanCard.tsx:836
+#: src/components/UpcomingPlanCard.tsx:837
 msgid "copy the target workout into Praxys; future management follows that version."
 msgstr "copy the target workout into Praxys; future management follows that version."
 
-#: src/components/PersonalContextPanel.tsx:1507
+#: src/components/PersonalContextPanel.tsx:1512
 msgid "Correct"
 msgstr "Correct"
 
-#: src/components/PersonalContextPanel.tsx:863
+#: src/components/PersonalContextPanel.tsx:868
 msgid "Correct private context"
 msgstr "Correct private context"
 
@@ -1979,17 +1979,17 @@ msgstr "Correct private context"
 #~ msgid "Cosmetic — changes names and colors without affecting calculations"
 #~ msgstr "Cosmetic — changes names and colors without affecting calculations"
 
-#: src/components/UpcomingPlanCard.tsx:1264
+#: src/components/UpcomingPlanCard.tsx:1288
 msgid "Could not add this workout"
 msgstr "Could not add this workout"
 
-#: src/components/Outdoor5KPlanStart.tsx:398
-#: src/components/Outdoor5KPlanStart.tsx:407
+#: src/components/Outdoor5KPlanStart.tsx:412
+#: src/components/Outdoor5KPlanStart.tsx:421
 msgid "Could not adopt the proposal."
 msgstr "Could not adopt the proposal."
 
-#: src/components/Outdoor5KPlanStart.tsx:270
-#: src/components/Outdoor5KPlanStart.tsx:275
+#: src/components/Outdoor5KPlanStart.tsx:284
+#: src/components/Outdoor5KPlanStart.tsx:289
 msgid "Could not assess this plan start."
 msgstr "Could not assess this plan start."
 
@@ -2007,25 +2007,25 @@ msgstr "Could not change the execution target"
 msgid "Could not convert this legacy workout."
 msgstr "Could not convert this legacy workout."
 
-#: src/components/UpcomingPlanCard.tsx:1308
+#: src/components/UpcomingPlanCard.tsx:1332
 msgid "Could not convert this workout to rest"
 msgstr "Could not convert this workout to rest"
 
-#: src/components/Outdoor5KPlanStart.tsx:298
-#: src/components/Outdoor5KPlanStart.tsx:309
+#: src/components/Outdoor5KPlanStart.tsx:312
+#: src/components/Outdoor5KPlanStart.tsx:323
 msgid "Could not create the proposal."
 msgstr "Could not create the proposal."
 
-#: src/components/PersonalContextPanel.tsx:569
-#: src/components/PersonalContextPanel.tsx:578
+#: src/components/PersonalContextPanel.tsx:574
+#: src/components/PersonalContextPanel.tsx:583
 msgid "Could not delete this private context."
 msgstr "Could not delete this private context."
 
-#: src/components/UpcomingPlanCard.tsx:1337
+#: src/components/UpcomingPlanCard.tsx:1361
 msgid "Could not delete this workout"
 msgstr "Could not delete this workout"
 
-#: src/components/PersonalContextPanel.tsx:627
+#: src/components/PersonalContextPanel.tsx:632
 msgid "Could not enable AI processing."
 msgstr "Could not enable AI processing."
 
@@ -2033,8 +2033,8 @@ msgstr "Could not enable AI processing."
 msgid "Could not enable managed delivery"
 msgstr "Could not enable managed delivery"
 
-#: src/components/PersonalContextPanel.tsx:654
-#: src/components/PersonalContextPanel.tsx:673
+#: src/components/PersonalContextPanel.tsx:659
+#: src/components/PersonalContextPanel.tsx:678
 msgid "Could not export private context."
 msgstr "Could not export private context."
 
@@ -2046,7 +2046,8 @@ msgstr "Could not leave managed mode"
 msgid "Could not load automatic change history."
 msgstr "Could not load automatic change history."
 
-#: src/components/Outdoor5KPlanStart.tsx:418
+#: src/components/Outdoor5KPlanStart.tsx:432
+#: src/components/Outdoor5KPlanStart.tsx:462
 msgid "Could not load plan-start context"
 msgstr "Could not load plan-start context"
 
@@ -2054,8 +2055,8 @@ msgstr "Could not load plan-start context"
 msgid "Could not load the managed-window preview."
 msgstr "Could not load the managed-window preview."
 
-#: src/components/PersonalContextPanel.tsx:509
-#: src/components/PersonalContextPanel.tsx:516
+#: src/components/PersonalContextPanel.tsx:514
+#: src/components/PersonalContextPanel.tsx:521
 msgid "Could not load this private context."
 msgstr "Could not load this private context."
 
@@ -2063,17 +2064,17 @@ msgstr "Could not load this private context."
 msgid "Could not pause delivery"
 msgstr "Could not pause delivery"
 
-#: src/components/Outdoor5KPlanStart.tsx:653
+#: src/components/Outdoor5KPlanStart.tsx:683
 msgid "Could not refresh proposal state"
 msgstr "Could not refresh proposal state"
 
-#: src/components/Outdoor5KPlanStart.tsx:336
-#: src/components/Outdoor5KPlanStart.tsx:347
+#: src/components/Outdoor5KPlanStart.tsx:350
+#: src/components/Outdoor5KPlanStart.tsx:361
 msgid "Could not regenerate the proposal."
 msgstr "Could not regenerate the proposal."
 
-#: src/components/Outdoor5KPlanStart.tsx:369
-#: src/components/Outdoor5KPlanStart.tsx:375
+#: src/components/Outdoor5KPlanStart.tsx:383
+#: src/components/Outdoor5KPlanStart.tsx:389
 msgid "Could not reject the proposal."
 msgstr "Could not reject the proposal."
 
@@ -2082,30 +2083,30 @@ msgstr "Could not reject the proposal."
 msgid "Could not remove future delivered workouts"
 msgstr "Could not remove future delivered workouts"
 
-#: src/components/UpcomingPlanCard.tsx:1119
-#: src/components/UpcomingPlanCard.tsx:1130
+#: src/components/UpcomingPlanCard.tsx:1143
+#: src/components/UpcomingPlanCard.tsx:1154
 msgid "Could not resolve this workout"
 msgstr "Could not resolve this workout"
 
 #: src/components/ManagedPlanSettingsCard.tsx:459
 #: src/components/ManagedPlanSettingsCard.tsx:477
-#: src/components/UpcomingPlanCard.tsx:1148
-#: src/components/UpcomingPlanCard.tsx:1158
+#: src/components/UpcomingPlanCard.tsx:1172
+#: src/components/UpcomingPlanCard.tsx:1182
 msgid "Could not restore the previous workout"
 msgstr "Could not restore the previous workout"
 
-#: src/components/PersonalContextPanel.tsx:404
-#: src/components/PersonalContextPanel.tsx:411
+#: src/components/PersonalContextPanel.tsx:409
+#: src/components/PersonalContextPanel.tsx:416
 msgid "Could not review this private context."
 msgstr "Could not review this private context."
 
-#: src/components/PersonalContextPanel.tsx:455
-#: src/components/PersonalContextPanel.tsx:490
+#: src/components/PersonalContextPanel.tsx:460
+#: src/components/PersonalContextPanel.tsx:495
 msgid "Could not save this correction."
 msgstr "Could not save this correction."
 
-#: src/components/PersonalContextPanel.tsx:473
-#: src/components/PersonalContextPanel.tsx:491
+#: src/components/PersonalContextPanel.tsx:478
+#: src/components/PersonalContextPanel.tsx:496
 msgid "Could not save this private context."
 msgstr "Could not save this private context."
 
@@ -2113,12 +2114,12 @@ msgstr "Could not save this private context."
 msgid "Could not save your email. Please email us instead."
 msgstr "Could not save your email. Please email us instead."
 
-#: src/components/PersonalContextPanel.tsx:543
-#: src/components/PersonalContextPanel.tsx:550
+#: src/components/PersonalContextPanel.tsx:548
+#: src/components/PersonalContextPanel.tsx:555
 msgid "Could not stop using this context."
 msgstr "Could not stop using this context."
 
-#: src/components/PersonalContextPanel.tsx:640
+#: src/components/PersonalContextPanel.tsx:645
 msgid "Could not update AI processing."
 msgstr "Could not update AI processing."
 
@@ -2130,12 +2131,12 @@ msgstr "Could not update automatic plan changes"
 #~ msgid "Could not update experimental Garmin delivery"
 #~ msgstr "Could not update experimental Garmin delivery"
 
-#: src/components/UpcomingPlanCard.tsx:1204
-#: src/components/UpcomingPlanCard.tsx:1251
+#: src/components/UpcomingPlanCard.tsx:1228
+#: src/components/UpcomingPlanCard.tsx:1275
 msgid "Could not update this workout"
 msgstr "Could not update this workout"
 
-#: src/components/PersonalContextPanel.tsx:628
+#: src/components/PersonalContextPanel.tsx:633
 msgid "Could not withdraw AI processing."
 msgstr "Could not withdraw AI processing."
 
@@ -2225,7 +2226,7 @@ msgstr "Create an account"
 msgid "Create and manage dismissible banners shown to all users."
 msgstr "Create and manage dismissible banners shown to all users."
 
-#: src/components/Outdoor5KPlanStart.tsx:614
+#: src/components/Outdoor5KPlanStart.tsx:644
 msgid "Create proposal"
 msgstr "Create proposal"
 
@@ -2249,7 +2250,7 @@ msgstr "Created"
 msgid "Creating account…"
 msgstr "Creating account…"
 
-#: src/components/Outdoor5KPlanStart.tsx:614
+#: src/components/Outdoor5KPlanStart.tsx:644
 msgid "Creating proposal…"
 msgstr "Creating proposal…"
 
@@ -2284,7 +2285,7 @@ msgstr "Critical Power"
 msgid "Critical: {0}. Major: {1}. Minor: {2}."
 msgstr "Critical: {0}. Major: {1}. Minor: {2}."
 
-#: src/components/UpcomingPlanCard.tsx:571
+#: src/components/UpcomingPlanCard.tsx:572
 #: src/components/WorkoutPlanEditor.tsx:450
 msgid "Cross-training"
 msgstr "Cross-training"
@@ -2340,7 +2341,7 @@ msgid "Current evidence"
 msgstr "Current evidence"
 
 #: src/components/ManagedPlanSettingsCard.tsx:993
-#: src/components/UpcomingPlanCard.tsx:1579
+#: src/components/UpcomingPlanCard.tsx:1603
 msgid "Current HRV crossed your personal caution band."
 msgstr "Current HRV crossed your personal caution band."
 
@@ -2362,7 +2363,7 @@ msgstr "Custom wording"
 msgid "Custom workout purpose"
 msgstr "Custom workout purpose"
 
-#: src/components/UpcomingPlanCard.tsx:566
+#: src/components/UpcomingPlanCard.tsx:567
 #: src/components/WorkoutPlanEditor.tsx:445
 #: src/pages/Setup.tsx:165
 msgid "Cycling"
@@ -2494,7 +2495,7 @@ msgstr "Degraded performance"
 msgid "Degraded Performance"
 msgstr "Degraded Performance"
 
-#: src/components/PersonalContextPanel.tsx:1538
+#: src/components/PersonalContextPanel.tsx:1543
 #: src/components/WorkoutPlanEditor.tsx:880
 #: src/components/WorkoutStructureEditor.tsx:1785
 msgid "Delete"
@@ -2512,16 +2513,16 @@ msgstr "Delete my account"
 msgid "Delete my account?"
 msgstr "Delete my account?"
 
-#: src/components/PersonalContextPanel.tsx:1492
+#: src/components/PersonalContextPanel.tsx:1497
 #: src/pages/Settings.tsx:1647
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: src/components/PersonalContextPanel.tsx:1553
+#: src/components/PersonalContextPanel.tsx:1558
 msgid "Delete retained history"
 msgstr "Delete retained history"
 
-#: src/components/PersonalContextPanel.tsx:1454
+#: src/components/PersonalContextPanel.tsx:1459
 msgid "Delete this context permanently?"
 msgstr "Delete this context permanently?"
 
@@ -2544,12 +2545,12 @@ msgid "Delete workout"
 msgstr "Delete workout"
 
 #. placeholder {0}: formatDate(currentDetailItem.narrative_purge_at)
-#: src/components/PersonalContextPanel.tsx:1394
+#: src/components/PersonalContextPanel.tsx:1399
 msgid "Deletes {0}"
 msgstr "Deletes {0}"
 
-#: src/components/PersonalContextPanel.tsx:800
-#: src/components/PersonalContextPanel.tsx:1333
+#: src/components/PersonalContextPanel.tsx:805
+#: src/components/PersonalContextPanel.tsx:1338
 msgid "Deleting"
 msgstr "Deleting"
 
@@ -2562,7 +2563,7 @@ msgstr "Deleting..."
 msgid "Deleting…"
 msgstr "Deleting…"
 
-#: src/components/UpcomingPlanCard.tsx:515
+#: src/components/UpcomingPlanCard.tsx:516
 msgid "Deliver now"
 msgstr "Deliver now"
 
@@ -2570,9 +2571,9 @@ msgstr "Deliver now"
 msgid "Delivery enabled"
 msgstr "Delivery enabled"
 
-#: src/components/UpcomingPlanCard.tsx:447
-#: src/components/UpcomingPlanCard.tsx:1090
-#: src/components/UpcomingPlanCard.tsx:1097
+#: src/components/UpcomingPlanCard.tsx:448
+#: src/components/UpcomingPlanCard.tsx:1114
+#: src/components/UpcomingPlanCard.tsx:1121
 #: src/pages/admin/AdminOps.tsx:444
 msgid "Delivery failed"
 msgstr "Delivery failed"
@@ -2593,7 +2594,7 @@ msgstr "Delivery outcomes"
 msgid "Delivery preview"
 msgstr "Delivery preview"
 
-#: src/components/Outdoor5KPlanStart.tsx:731
+#: src/components/Outdoor5KPlanStart.tsx:761
 msgid "Delivery remains disabled. Review the existing 14-day managed-delivery preview and explicitly consent only if you want Praxys to deliver this canonical plan."
 msgstr "Delivery remains disabled. Review the existing 14-day managed-delivery preview and explicitly consent only if you want Praxys to deliver this canonical plan."
 
@@ -2725,8 +2726,8 @@ msgstr "Disable delivery from any other planner first. Two planners can create o
 msgid "Disabled. Click to open"
 msgstr "Disabled. Click to open"
 
-#: src/components/PersonalContextPanel.tsx:235
-#: src/components/PersonalContextPanel.tsx:239
+#: src/components/PersonalContextPanel.tsx:240
+#: src/components/PersonalContextPanel.tsx:244
 msgid "Disclosure choice"
 msgstr "Disclosure choice"
 
@@ -2841,7 +2842,7 @@ msgstr "Drop intensity by one zone"
 msgid "Drop to easy run (keep power in recovery zone)"
 msgstr "Drop to easy run (keep power in recovery zone)"
 
-#: src/components/UpcomingPlanCard.tsx:704
+#: src/components/UpcomingPlanCard.tsx:705
 #: src/components/WorkoutStructureEditor.tsx:1779
 msgid "Duplicate"
 msgstr "Duplicate"
@@ -2949,7 +2950,7 @@ msgstr "Each value is a non-overlapping seven-day bucket ending on the shown dat
 #~ msgid "Each value is a non-overlapping seven-day bucket ending on the shown date. Zero-activity weeks remain in the series and average; the trend compares the older and newer halves. This is a Praxys operational summary, not a readiness score."
 #~ msgstr "Each value is a non-overlapping seven-day bucket ending on the shown date. Zero-activity weeks remain in the series and average; the trend compares the older and newer halves. This is a Praxys operational summary, not a readiness score."
 
-#: src/components/UpcomingPlanCard.tsx:576
+#: src/components/UpcomingPlanCard.tsx:577
 #: src/components/WorkoutPlanEditor.tsx:432
 msgid "Easy"
 msgstr "Easy"
@@ -2963,7 +2964,7 @@ msgstr "EASY"
 msgid "Easy Run"
 msgstr "Easy Run"
 
-#: src/components/UpcomingPlanCard.tsx:691
+#: src/components/UpcomingPlanCard.tsx:692
 #: src/pages/Settings.tsx:1391
 #: src/pages/Setup.tsx:844
 msgid "Edit"
@@ -3018,7 +3019,7 @@ msgstr "Eligible"
 msgid "Eligible activities"
 msgstr "Eligible activities"
 
-#: src/components/PersonalContextPanel.tsx:257
+#: src/components/PersonalContextPanel.tsx:262
 msgid "Elliptical"
 msgstr "Elliptical"
 
@@ -3080,11 +3081,11 @@ msgstr "Enabled. Click to close"
 msgid "Enabling…"
 msgstr "Enabling…"
 
-#: src/components/PersonalContextPanel.tsx:828
+#: src/components/PersonalContextPanel.tsx:833
 msgid "Encrypted at rest · excluded from analytics and model training"
 msgstr "Encrypted at rest · excluded from analytics and model training"
 
-#: src/components/PersonalContextPanel.tsx:1035
+#: src/components/PersonalContextPanel.tsx:1040
 msgid "Ends"
 msgstr "Ends"
 
@@ -3108,7 +3109,7 @@ msgstr "Enter a complete value in this unit."
 msgid "Enter numeric temperature and humidity values."
 msgstr "Enter numeric temperature and humidity values."
 
-#: src/components/Outdoor5KPlanStart.tsx:199
+#: src/components/Outdoor5KPlanStart.tsx:213
 msgid "Enter one whole-minute limit for every selected day."
 msgstr "Enter one whole-minute limit for every selected day."
 
@@ -3120,8 +3121,8 @@ msgstr "Enter pace as minutes:seconds per kilometre."
 msgid "Enter pace as minutes:seconds per mile."
 msgstr "Enter pace as minutes:seconds per mile."
 
-#: src/components/PersonalContextPanel.tsx:233
-#: src/components/PersonalContextPanel.tsx:234
+#: src/components/PersonalContextPanel.tsx:238
+#: src/components/PersonalContextPanel.tsx:239
 msgid "Environment"
 msgstr "Environment"
 
@@ -3130,11 +3131,11 @@ msgstr "Environment"
 msgid "Environmental response"
 msgstr "Environmental response"
 
-#: src/components/PersonalContextPanel.tsx:234
+#: src/components/PersonalContextPanel.tsx:239
 msgid "Equipment access"
 msgstr "Equipment access"
 
-#: src/components/PersonalContextPanel.tsx:1088
+#: src/components/PersonalContextPanel.tsx:1093
 msgid "Equipment still available (optional)"
 msgstr "Equipment still available (optional)"
 
@@ -3241,16 +3242,16 @@ msgstr "Execution target changed. Delivery remains paused."
 #~ msgid "Experimental Garmin delivery"
 #~ msgstr "Experimental Garmin delivery"
 
-#: src/components/PersonalContextPanel.tsx:798
-#: src/components/PersonalContextPanel.tsx:1331
+#: src/components/PersonalContextPanel.tsx:803
+#: src/components/PersonalContextPanel.tsx:1336
 msgid "Expired"
 msgstr "Expired"
 
-#: src/components/Outdoor5KPlanStart.tsx:699
+#: src/components/Outdoor5KPlanStart.tsx:729
 msgid "Expires:"
 msgstr "Expires:"
 
-#: src/components/PersonalContextPanel.tsx:721
+#: src/components/PersonalContextPanel.tsx:726
 msgid "Explain a workout"
 msgstr "Explain a workout"
 
@@ -3258,7 +3259,7 @@ msgstr "Explain a workout"
 msgid "Explore whether modeled heart rate varied with temperature and humidity at comparable recorded Stryd power in your eligible past runs."
 msgstr "Explore whether modeled heart rate varied with temperature and humidity at comparable recorded Stryd power in your eligible past runs."
 
-#: src/components/PersonalContextPanel.tsx:841
+#: src/components/PersonalContextPanel.tsx:846
 msgid "Export context"
 msgstr "Export context"
 
@@ -3276,11 +3277,11 @@ msgstr "Export my data"
 #~ msgstr "Extended rest period. Fitness declining."
 
 #: src/components/ManagedPlanSettingsCard.tsx:496
-#: src/components/UpcomingPlanCard.tsx:363
+#: src/components/UpcomingPlanCard.tsx:364
 msgid "External"
 msgstr "External"
 
-#: src/components/UpcomingPlanCard.tsx:235
+#: src/components/UpcomingPlanCard.tsx:236
 msgid "External plan mode"
 msgstr "External plan mode"
 
@@ -3374,7 +3375,7 @@ msgstr "Failed to load settings"
 #~ msgid "Failed to load training data"
 #~ msgstr "Failed to load training data"
 
-#: src/components/UpcomingPlanCard.tsx:1367
+#: src/components/UpcomingPlanCard.tsx:1391
 msgid "Failed to load training plan"
 msgstr "Failed to load training plan"
 
@@ -3424,7 +3425,7 @@ msgstr "falling"
 msgid "Falling"
 msgstr "Falling"
 
-#: src/components/PersonalContextPanel.tsx:228
+#: src/components/PersonalContextPanel.tsx:233
 msgid "Fatigue"
 msgstr "Fatigue"
 
@@ -3507,7 +3508,7 @@ msgstr "Fix the marked structured step before saving."
 msgid "flat"
 msgstr "flat"
 
-#: src/components/PersonalContextPanel.tsx:265
+#: src/components/PersonalContextPanel.tsx:270
 #: src/pages/Goal.tsx:54
 msgid "Flat"
 msgstr "Flat"
@@ -3570,7 +3571,7 @@ msgstr "Fourteen-day activity record"
 #~ msgid "Freshened up — good window for racing or testing."
 #~ msgstr "Freshened up — good window for racing or testing."
 
-#: src/components/PersonalContextPanel.tsx:247
+#: src/components/PersonalContextPanel.tsx:252
 msgid "Fri"
 msgstr "Fri"
 
@@ -3667,7 +3668,7 @@ msgstr "Generate a token at cloud.ouraring.com/personal-access-tokens."
 msgid "Generating…"
 msgstr "Generating…"
 
-#: src/components/Outdoor5KPlanStart.tsx:677
+#: src/components/Outdoor5KPlanStart.tsx:707
 msgid "Generator"
 msgstr "Generator"
 
@@ -3725,7 +3726,7 @@ msgstr "Goal type"
 #~ msgid "Good balance of fitness and recovery. Ready for quality work."
 #~ msgstr "Good balance of fitness and recovery. Ready for quality work."
 
-#: src/components/PersonalContextPanel.tsx:255
+#: src/components/PersonalContextPanel.tsx:260
 msgid "Gym"
 msgstr "Gym"
 
@@ -3867,18 +3868,18 @@ msgstr "High coverage"
 msgid "High variability"
 msgstr "High variability"
 
-#: src/components/UpcomingPlanCard.tsx:568
+#: src/components/UpcomingPlanCard.tsx:569
 #: src/components/WorkoutPlanEditor.tsx:447
 #: src/pages/Setup.tsx:167
 msgid "Hiking"
 msgstr "Hiking"
 
-#: src/components/UpcomingPlanCard.tsx:582
+#: src/components/UpcomingPlanCard.tsx:583
 #: src/components/WorkoutPlanEditor.tsx:438
 msgid "Hill repeats"
 msgstr "Hill repeats"
 
-#: src/components/PersonalContextPanel.tsx:266
+#: src/components/PersonalContextPanel.tsx:271
 msgid "Hilly"
 msgstr "Hilly"
 
@@ -3910,7 +3911,7 @@ msgstr "History candidates"
 msgid "History first: you already have usable current 5K evidence."
 msgstr "History first: you already have usable current 5K evidence."
 
-#: src/components/Outdoor5KPlanStart.tsx:632
+#: src/components/Outdoor5KPlanStart.tsx:662
 msgid "History used:"
 msgstr "History used:"
 
@@ -4062,15 +4063,15 @@ msgstr "Humidity (%)"
 msgid "I agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
 msgstr "I agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
 
-#: src/components/Outdoor5KPlanStart.tsx:480
+#: src/components/Outdoor5KPlanStart.tsx:510
 msgid "I am 18 or older."
 msgstr "I am 18 or older."
 
-#: src/components/Outdoor5KPlanStart.tsx:481
+#: src/components/Outdoor5KPlanStart.tsx:511
 msgid "I am self-coached for recreational road running."
 msgstr "I am self-coached for recreational road running."
 
-#: src/components/Outdoor5KPlanStart.tsx:482
+#: src/components/Outdoor5KPlanStart.tsx:512
 msgid "I can currently complete 5 km."
 msgstr "I can currently complete 5 km."
 
@@ -4092,7 +4093,7 @@ msgstr "I'm not training today"
 msgid "Identified"
 msgstr "Identified"
 
-#: src/components/PersonalContextPanel.tsx:230
+#: src/components/PersonalContextPanel.tsx:235
 msgid "Illness"
 msgstr "Illness"
 
@@ -4109,7 +4110,7 @@ msgstr "Illness"
 msgid "In progress <0>{0}</0>"
 msgstr "In progress <0>{0}</0>"
 
-#: src/components/UpcomingPlanCard.tsx:403
+#: src/components/UpcomingPlanCard.tsx:404
 msgid "In sync"
 msgstr "In sync"
 
@@ -4164,11 +4165,11 @@ msgstr "Insert after"
 msgid "Insert before"
 msgstr "Insert before"
 
-#: src/components/UpcomingPlanCard.tsx:1591
+#: src/components/UpcomingPlanCard.tsx:1615
 msgid "Inspect context"
 msgstr "Inspect context"
 
-#: src/components/PersonalContextPanel.tsx:1313
+#: src/components/PersonalContextPanel.tsx:1318
 msgid "Inspect what is stored, where it was used, and who may process it."
 msgstr "Inspect what is stored, where it was used, and who may process it."
 
@@ -4214,7 +4215,7 @@ msgstr "Intentional all-out complete 5K"
 msgid "International"
 msgstr "International"
 
-#: src/components/PersonalContextPanel.tsx:1602
+#: src/components/PersonalContextPanel.tsx:1607
 msgid "Interpret one missed or modified workout without diagnosing a cause."
 msgstr "Interpret one missed or modified workout without diagnosing a cause."
 
@@ -4222,11 +4223,11 @@ msgstr "Interpret one missed or modified workout without diagnosing a cause."
 msgid "Interpret one workout without guessing a cause"
 msgstr "Interpret one workout without guessing a cause"
 
-#: src/components/PersonalContextPanel.tsx:1154
+#: src/components/PersonalContextPanel.tsx:1159
 msgid "Interpret this workout without guessing a cause"
 msgstr "Interpret this workout without guessing a cause"
 
-#: src/components/UpcomingPlanCard.tsx:581
+#: src/components/UpcomingPlanCard.tsx:582
 #: src/components/WorkoutPlanEditor.tsx:437
 msgid "Intervals"
 msgstr "Intervals"
@@ -4287,7 +4288,7 @@ msgstr "Issue"
 msgid "Issue created"
 msgstr "Issue created"
 
-#: src/components/PersonalContextPanel.tsx:1458
+#: src/components/PersonalContextPanel.tsx:1463
 msgid "It stays in your private history until its purge date, but cannot influence a new assessment."
 msgstr "It stays in your private history until its purge date, but cannot influence a new assessment."
 
@@ -4350,11 +4351,11 @@ msgstr "Keep participating"
 msgid "Keep suggestion-only"
 msgstr "Keep suggestion-only"
 
-#: src/components/PersonalContextPanel.tsx:362
+#: src/components/PersonalContextPanel.tsx:367
 msgid "Keep the optional note to 280 characters or fewer."
 msgstr "Keep the optional note to 280 characters or fewer."
 
-#: src/components/UpcomingPlanCard.tsx:830
+#: src/components/UpcomingPlanCard.tsx:831
 msgid "keep the Praxys workout canonical and replace or recreate the target version."
 msgstr "keep the Praxys workout canonical and replace or recreate the target version."
 
@@ -4495,7 +4496,7 @@ msgstr "Leaving…"
 msgid "Legacy flat summary"
 msgstr "Legacy flat summary"
 
-#: src/components/PersonalContextPanel.tsx:223
+#: src/components/PersonalContextPanel.tsx:228
 msgid "Less time"
 msgstr "Less time"
 
@@ -4503,8 +4504,8 @@ msgstr "Less time"
 msgid "Let Praxys manage this plan?"
 msgstr "Let Praxys manage this plan?"
 
-#: src/components/PersonalContextPanel.tsx:226
-#: src/components/PersonalContextPanel.tsx:227
+#: src/components/PersonalContextPanel.tsx:231
+#: src/components/PersonalContextPanel.tsx:232
 msgid "Life constraint"
 msgstr "Life constraint"
 
@@ -4570,7 +4571,7 @@ msgstr "Link URL (optional)"
 msgid "Link your training devices and services"
 msgstr "Link your training devices and services"
 
-#: src/components/PersonalContextPanel.tsx:892
+#: src/components/PersonalContextPanel.tsx:897
 msgid "Linked workout"
 msgstr "Linked workout"
 
@@ -4629,11 +4630,11 @@ msgstr "Load compliance"
 msgid "Loading components…"
 msgstr "Loading components…"
 
-#: src/components/PersonalContextPanel.tsx:744
+#: src/components/PersonalContextPanel.tsx:749
 msgid "Loading private context"
 msgstr "Loading private context"
 
-#: src/components/PersonalContextPanel.tsx:913
+#: src/components/PersonalContextPanel.tsx:918
 msgid "Loading recent workouts…"
 msgstr "Loading recent workouts…"
 
@@ -4658,7 +4659,7 @@ msgstr "Log out"
 #~ msgid "Login"
 #~ msgstr "Login"
 
-#: src/components/UpcomingPlanCard.tsx:578
+#: src/components/UpcomingPlanCard.tsx:579
 #: src/components/WorkoutPlanEditor.tsx:434
 msgid "Long run"
 msgstr "Long run"
@@ -4751,7 +4752,7 @@ msgstr "Major service outage"
 msgid "Make today a full recovery day and reassess the hard session tomorrow"
 msgstr "Make today a full recovery day and reassess the hard session tomorrow"
 
-#: src/components/UpcomingPlanCard.tsx:260
+#: src/components/UpcomingPlanCard.tsx:261
 msgid "Manage in Settings"
 msgstr "Manage in Settings"
 
@@ -4771,15 +4772,15 @@ msgstr "Manage seats, roles, invitations, and waitlist onboarding."
 msgid "Managed athletes"
 msgstr "Managed athletes"
 
-#: src/components/UpcomingPlanCard.tsx:233
+#: src/components/UpcomingPlanCard.tsx:234
 msgid "Managed by Praxys"
 msgstr "Managed by Praxys"
 
-#: src/components/UpcomingPlanCard.tsx:1663
+#: src/components/UpcomingPlanCard.tsx:1687
 msgid "Managed delivery is active, but this window contains no Praxys-owned workouts. External workouts remain untouched."
 msgstr "Managed delivery is active, but this window contains no Praxys-owned workouts. External workouts remain untouched."
 
-#: src/components/UpcomingPlanCard.tsx:234
+#: src/components/UpcomingPlanCard.tsx:235
 msgid "Managed delivery paused"
 msgstr "Managed delivery paused"
 
@@ -4872,11 +4873,11 @@ msgstr "MAU"
 msgid "Max HR"
 msgstr "Max HR"
 
-#: src/components/PersonalContextPanel.tsx:1053
+#: src/components/PersonalContextPanel.tsx:1058
 msgid "Maximum minutes available per affected day"
 msgstr "Maximum minutes available per affected day"
 
-#: src/components/PersonalContextPanel.tsx:271
+#: src/components/PersonalContextPanel.tsx:276
 msgid "Maximum training minutes per day"
 msgstr "Maximum training minutes per day"
 
@@ -4909,7 +4910,7 @@ msgstr "MFA"
 msgid "MFA required"
 msgstr "MFA required"
 
-#: src/components/PersonalContextPanel.tsx:1418
+#: src/components/PersonalContextPanel.tsx:1423
 msgid "Microsoft Azure AI"
 msgstr "Microsoft Azure AI"
 
@@ -4918,8 +4919,8 @@ msgstr "Microsoft Azure AI"
 #~ msgstr "mild fatigue"
 
 #: src/components/ManagedPlanSettingsCard.tsx:628
-#: src/components/UpcomingPlanCard.tsx:773
-#: src/components/UpcomingPlanCard.tsx:795
+#: src/components/UpcomingPlanCard.tsx:774
+#: src/components/UpcomingPlanCard.tsx:796
 #: src/components/WorkoutStructureEditor.tsx:1498
 msgid "min"
 msgstr "min"
@@ -4955,8 +4956,8 @@ msgstr "mirrors {0}"
 msgid "Mismatch"
 msgstr "Mismatch"
 
-#: src/components/PersonalContextPanel.tsx:281
-#: src/components/PersonalContextPanel.tsx:945
+#: src/components/PersonalContextPanel.tsx:286
+#: src/components/PersonalContextPanel.tsx:950
 msgid "Missed"
 msgstr "Missed"
 
@@ -4976,7 +4977,7 @@ msgstr "Missing evidence"
 msgid "Mixed providers"
 msgstr "Mixed providers"
 
-#: src/components/UpcomingPlanCard.tsx:570
+#: src/components/UpcomingPlanCard.tsx:571
 #: src/components/WorkoutPlanEditor.tsx:449
 msgid "Mobility"
 msgstr "Mobility"
@@ -5013,8 +5014,8 @@ msgstr "Moderate coverage"
 #~ msgid "Moderate evidence"
 #~ msgstr "Moderate evidence"
 
-#: src/components/PersonalContextPanel.tsx:282
-#: src/components/PersonalContextPanel.tsx:946
+#: src/components/PersonalContextPanel.tsx:287
+#: src/components/PersonalContextPanel.tsx:951
 msgid "Modified"
 msgstr "Modified"
 
@@ -5023,7 +5024,7 @@ msgstr "Modified"
 msgid "MODIFY"
 msgstr "MODIFY"
 
-#: src/components/PersonalContextPanel.tsx:243
+#: src/components/PersonalContextPanel.tsx:248
 msgid "Mon"
 msgstr "Mon"
 
@@ -5067,7 +5068,7 @@ msgstr "More historical HRV observations are needed before Praxys can form a per
 #~ msgid "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
 #~ msgstr "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
 
-#: src/components/PersonalContextPanel.tsx:229
+#: src/components/PersonalContextPanel.tsx:234
 msgid "Motivation"
 msgstr "Motivation"
 
@@ -5092,7 +5093,7 @@ msgstr "Move up"
 msgid "Multiple platforms provide <0>{0}</0> data. Which should be the primary source?"
 msgstr "Multiple platforms provide <0>{0}</0> data. Which should be the primary source?"
 
-#: src/components/Outdoor5KPlanStart.tsx:483
+#: src/components/Outdoor5KPlanStart.tsx:513
 msgid "My goal is an outdoor road 5K."
 msgstr "My goal is an outdoor road 5K."
 
@@ -5241,7 +5242,7 @@ msgstr "Newly triaged work will appear here when admin action is needed."
 msgid "Next"
 msgstr "Next"
 
-#: src/components/UpcomingPlanCard.tsx:1459
+#: src/components/UpcomingPlanCard.tsx:1483
 msgid "Next plan window"
 msgstr "Next plan window"
 
@@ -5289,7 +5290,7 @@ msgstr "No admin configuration found"
 msgid "No announcements yet"
 msgstr "No announcements yet"
 
-#: src/components/PersonalContextPanel.tsx:1437
+#: src/components/PersonalContextPanel.tsx:1442
 msgid "No assessment or plan change has used this context yet."
 msgstr "No assessment or plan change has used this context yet."
 
@@ -5346,7 +5347,7 @@ msgstr "no data"
 msgid "No decision"
 msgstr "No decision"
 
-#: src/components/UpcomingPlanCard.tsx:1091
+#: src/components/UpcomingPlanCard.tsx:1115
 msgid "No delivery result was returned for this workout"
 msgstr "No delivery result was returned for this workout"
 
@@ -5358,11 +5359,11 @@ msgstr "No evidence"
 msgid "No executable steps yet."
 msgstr "No executable steps yet."
 
-#: src/components/PersonalContextPanel.tsx:810
+#: src/components/PersonalContextPanel.tsx:815
 msgid "no expiry"
 msgstr "no expiry"
 
-#: src/components/PersonalContextPanel.tsx:310
+#: src/components/PersonalContextPanel.tsx:315
 msgid "No expiry"
 msgstr "No expiry"
 
@@ -5428,12 +5429,12 @@ msgstr "No planned load this week"
 msgid "No Praxys workouts are scheduled in this window. Future Praxys-created workouts will enter the rolling window automatically."
 msgstr "No Praxys workouts are scheduled in this window. Future Praxys-created workouts will enter the rolling window automatically."
 
-#: src/components/Outdoor5KPlanStart.tsx:585
-#: src/components/Outdoor5KPlanStart.tsx:587
+#: src/components/Outdoor5KPlanStart.tsx:615
+#: src/components/Outdoor5KPlanStart.tsx:617
 msgid "No preference"
 msgstr "No preference"
 
-#: src/components/PersonalContextPanel.tsx:764
+#: src/components/PersonalContextPanel.tsx:769
 msgid "No private context saved"
 msgstr "No private context saved"
 
@@ -5462,7 +5463,7 @@ msgstr "No prompt"
 #~ msgid "No recent activity reached the model's {0}-minute inclusion threshold."
 #~ msgstr "No recent activity reached the model's {0}-minute inclusion threshold."
 
-#: src/components/PersonalContextPanel.tsx:932
+#: src/components/PersonalContextPanel.tsx:937
 msgid "No recent Praxys workout is available to link."
 msgstr "No recent Praxys workout is available to link."
 
@@ -5474,7 +5475,7 @@ msgstr "No recent Praxys workout is available to link."
 #~ msgid "No reliable heat history yet"
 #~ msgstr "No reliable heat history yet"
 
-#: src/components/Outdoor5KPlanStart.tsx:517
+#: src/components/Outdoor5KPlanStart.tsx:547
 msgid "No safety stop"
 msgstr "No safety stop"
 
@@ -5561,7 +5562,7 @@ msgstr "No weekly distance history yet"
 msgid "No Workout"
 msgstr "No Workout"
 
-#: src/components/UpcomingPlanCard.tsx:808
+#: src/components/UpcomingPlanCard.tsx:809
 msgid "No workout is present on {target}."
 msgstr "No workout is present on {target}."
 
@@ -5586,11 +5587,11 @@ msgstr "No Workout Scheduled"
 msgid "No workout scheduled."
 msgstr "No workout scheduled."
 
-#: src/components/UpcomingPlanCard.tsx:1627
+#: src/components/UpcomingPlanCard.tsx:1651
 msgid "No workouts scheduled in this window."
 msgstr "No workouts scheduled in this window."
 
-#: src/components/PersonalContextPanel.tsx:252
+#: src/components/PersonalContextPanel.tsx:257
 msgid "None"
 msgstr "None"
 
@@ -5710,7 +5711,7 @@ msgstr "Note"
 msgid "Note (optional)"
 msgstr "Note (optional)"
 
-#: src/components/PersonalContextPanel.tsx:1177
+#: src/components/PersonalContextPanel.tsx:1182
 msgid "Note deleted"
 msgstr "Note deleted"
 
@@ -5718,7 +5719,7 @@ msgstr "Note deleted"
 msgid "Note on Garmin native power"
 msgstr "Note on Garmin native power"
 
-#: src/components/PersonalContextPanel.tsx:870
+#: src/components/PersonalContextPanel.tsx:875
 msgid "Nothing is stored until you confirm this exact purpose and expiry."
 msgstr "Nothing is stored until you confirm this exact purpose and expiry."
 
@@ -5773,11 +5774,11 @@ msgid "of"
 msgstr "of"
 
 #: src/components/ManagedPlanSettingsCard.tsx:893
-#: src/components/PersonalContextPanel.tsx:1358
+#: src/components/PersonalContextPanel.tsx:1363
 msgid "Off"
 msgstr "Off"
 
-#: src/components/PersonalContextPanel.tsx:1631
+#: src/components/PersonalContextPanel.tsx:1636
 msgid "Off by default. The note may contain more private detail than the structured fields."
 msgstr "Off by default. The note may contain more private detail than the structured fields."
 
@@ -5817,7 +5818,7 @@ msgstr "Only PNG, JPG, or WebP images are supported."
 msgid "Only supported and eligible platforms can receive workouts."
 msgstr "Only supported and eligible platforms can receive workouts."
 
-#: src/components/PersonalContextPanel.tsx:1584
+#: src/components/PersonalContextPanel.tsx:1589
 msgid "Only the fields below are sent to Microsoft Azure AI. Microsoft states that inputs and outputs are not available to OpenAI or used to train foundation models without permission; Praxys does not grant that permission. Flagged content may be reviewed for abuse monitoring under Azure terms. Praxys does not log raw requests or responses."
 msgstr "Only the fields below are sent to Microsoft Azure AI. Microsoft states that inputs and outputs are not available to OpenAI or used to train foundation models without permission; Praxys does not grant that permission. Flagged content may be reviewed for abuse monitoring under Azure terms. Praxys does not log raw requests or responses."
 
@@ -5950,7 +5951,7 @@ msgstr "Optional coaching cue"
 msgid "Optional comment"
 msgstr "Optional comment"
 
-#: src/components/PersonalContextPanel.tsx:871
+#: src/components/PersonalContextPanel.tsx:876
 msgid "Optional context helps Praxys avoid guessing. Share only what changes the plan."
 msgstr "Optional context helps Praxys avoid guessing. Share only what changes the plan."
 
@@ -5974,8 +5975,8 @@ msgstr "Optional session-level notes"
 msgid "Options"
 msgstr "Options"
 
-#: src/components/PersonalContextPanel.tsx:235
-#: src/components/UpcomingPlanCard.tsx:573
+#: src/components/PersonalContextPanel.tsx:240
+#: src/components/UpcomingPlanCard.tsx:574
 #: src/components/WorkoutPlanEditor.tsx:452
 #: src/components/WorkoutStructureEditor.tsx:328
 #: src/pages/admin/AdminFeedback.tsx:124
@@ -5999,7 +6000,7 @@ msgstr "Outage"
 msgid "Outdoor road 5K plan"
 msgstr "Outdoor road 5K plan"
 
-#: src/components/Outdoor5KPlanStart.tsx:431
+#: src/components/Outdoor5KPlanStart.tsx:447
 msgid "Outdoor road 5K plans"
 msgstr "Outdoor road 5K plans"
 
@@ -6059,7 +6060,7 @@ msgstr "Pace maximum (min/km)"
 msgid "Pace minimum (min/km)"
 msgstr "Pace minimum (min/km)"
 
-#: src/components/PersonalContextPanel.tsx:231
+#: src/components/PersonalContextPanel.tsx:236
 msgid "Pain or injury"
 msgstr "Pain or injury"
 
@@ -6117,7 +6118,7 @@ msgid "Pause delivery to change the target."
 msgstr "Pause delivery to change the target."
 
 #: src/components/ManagedPlanSettingsCard.tsx:493
-#: src/components/UpcomingPlanCard.tsx:391
+#: src/components/UpcomingPlanCard.tsx:392
 #: src/pages/admin/AdminOps.tsx:968
 msgid "Paused"
 msgstr "Paused"
@@ -6139,11 +6140,11 @@ msgstr "Peer metrics"
 msgid "Pending <0>{0}</0>"
 msgstr "Pending <0>{0}</0>"
 
-#: src/components/Outdoor5KPlanStart.tsx:569
+#: src/components/Outdoor5KPlanStart.tsx:599
 msgid "Per-day limits are unsupported"
 msgstr "Per-day limits are unsupported"
 
-#: src/components/Outdoor5KPlanStart.tsx:198
+#: src/components/Outdoor5KPlanStart.tsx:212
 msgid "Per-day limits are unsupported by this policy. Use one shared limit for all selected days."
 msgstr "Per-day limits are unsupported by this policy. Use one shared limit for all selected days."
 
@@ -6184,19 +6185,19 @@ msgstr "Plan"
 msgid "Plan activity"
 msgstr "Plan activity"
 
-#: src/components/PersonalContextPanel.tsx:1340
+#: src/components/PersonalContextPanel.tsx:1345
 msgid "Plan adjustment"
 msgstr "Plan adjustment"
 
-#: src/components/Outdoor5KPlanStart.tsx:729
+#: src/components/Outdoor5KPlanStart.tsx:759
 msgid "Plan adopted"
 msgstr "Plan adopted"
 
-#: src/components/Outdoor5KPlanStart.tsx:403
+#: src/components/Outdoor5KPlanStart.tsx:417
 msgid "Plan adopted. Delivery remains disabled until you explicitly enable it."
 msgstr "Plan adopted. Delivery remains disabled until you explicitly enable it."
 
-#: src/components/PersonalContextPanel.tsx:702
+#: src/components/PersonalContextPanel.tsx:707
 msgid "Plan context"
 msgstr "Plan context"
 
@@ -6204,11 +6205,11 @@ msgstr "Plan context"
 msgid "Plan management"
 msgstr "Plan management"
 
-#: src/components/Outdoor5KPlanStart.tsx:455
+#: src/components/Outdoor5KPlanStart.tsx:485
 msgid "Plan preview"
 msgstr "Plan preview"
 
-#: src/components/Outdoor5KPlanStart.tsx:666
+#: src/components/Outdoor5KPlanStart.tsx:696
 msgid "Plan proposal"
 msgstr "Plan proposal"
 
@@ -6216,11 +6217,11 @@ msgstr "Plan proposal"
 #~ msgid "Plan sync target"
 #~ msgstr "Plan sync target"
 
-#: src/components/UpcomingPlanCard.tsx:180
+#: src/components/UpcomingPlanCard.tsx:181
 msgid "Plan window"
 msgstr "Plan window"
 
-#: src/components/Outdoor5KPlanStart.tsx:750
+#: src/components/Outdoor5KPlanStart.tsx:780
 msgid "Plan-start action did not complete"
 msgstr "Plan-start action did not complete"
 
@@ -6269,7 +6270,7 @@ msgstr "Please check your email format and try again."
 msgid "Please verify your email before signing in. Check your inbox for the link."
 msgstr "Please verify your email before signing in. Check your inbox for the link."
 
-#: src/components/Outdoor5KPlanStart.tsx:676
+#: src/components/Outdoor5KPlanStart.tsx:706
 msgid "Policy"
 msgstr "Policy"
 
@@ -6283,7 +6284,7 @@ msgstr "Policy {0} · decision {1}"
 msgid "Policy-gated auto-merge"
 msgstr "Policy-gated auto-merge"
 
-#: src/components/PersonalContextPanel.tsx:258
+#: src/components/PersonalContextPanel.tsx:263
 msgid "Pool"
 msgstr "Pool"
 
@@ -6386,11 +6387,11 @@ msgstr "Power-source match"
 msgid "Praxys adapts individualized HRV-guided training and ln(RMSSD) trend monitoring into operational reference bands. The exact reference-band and caution-band cutoffs are product guardrails, not thresholds validated by the cited studies. CV above {cvThreshold}% is also a coaching caution flag, not a diagnosis. Sleep, readiness, RHR, and TSB remain separate informational context."
 msgstr "Praxys adapts individualized HRV-guided training and ln(RMSSD) trend monitoring into operational reference bands. The exact reference-band and caution-band cutoffs are product guardrails, not thresholds validated by the cited studies. CV above {cvThreshold}% is also a coaching caution flag, not a diagnosis. Sleep, readiness, RHR, and TSB remain separate informational context."
 
-#: src/components/PersonalContextPanel.tsx:1462
+#: src/components/PersonalContextPanel.tsx:1467
 msgid "Praxys also removes dependent private reasoning and use receipts. Accepted workout changes remain without the private reason."
 msgstr "Praxys also removes dependent private reasoning and use receipts. Accepted workout changes remain without the private reason."
 
-#: src/components/UpcomingPlanCard.tsx:758
+#: src/components/UpcomingPlanCard.tsx:759
 msgid "Praxys and {target} have different versions. Choose which one becomes canonical."
 msgstr "Praxys and {target} have different versions. Choose which one becomes canonical."
 
@@ -6426,7 +6427,7 @@ msgstr "Praxys Coach plugin"
 msgid "Praxys could not determine your time zone. Check your device settings and try again."
 msgstr "Praxys could not determine your time zone. Check your device settings and try again."
 
-#: src/components/UpcomingPlanCard.tsx:756
+#: src/components/UpcomingPlanCard.tsx:757
 msgid "Praxys could not finish delivery. Retrying keeps the Praxys version canonical."
 msgstr "Praxys could not finish delivery. Retrying keeps the Praxys version canonical."
 
@@ -6482,7 +6483,7 @@ msgstr "Praxys is experiencing degraded performance."
 msgid "Praxys is in private alpha."
 msgstr "Praxys is in private alpha."
 
-#: src/components/UpcomingPlanCard.tsx:251
+#: src/components/UpcomingPlanCard.tsx:252
 msgid "Praxys is read-only and leaves every target workout untouched."
 msgstr "Praxys is read-only and leaves every target workout untouched."
 
@@ -6498,7 +6499,7 @@ msgstr "Praxys keeps the canonical workout. This preview explains what the selec
 msgid "Praxys Labs"
 msgstr "Praxys Labs"
 
-#: src/components/UpcomingPlanCard.tsx:1557
+#: src/components/UpcomingPlanCard.tsx:1581
 msgid "Praxys made a conservative plan change"
 msgstr "Praxys made a conservative plan change"
 
@@ -6512,12 +6513,12 @@ msgstr "Praxys on mobile"
 msgid "Praxys on your phone"
 msgstr "Praxys on your phone"
 
-#: src/components/UpcomingPlanCard.tsx:381
+#: src/components/UpcomingPlanCard.tsx:382
 msgid "Praxys only"
 msgstr "Praxys only"
 
-#: src/components/UpcomingPlanCard.tsx:1648
-#: src/components/UpcomingPlanCard.tsx:1728
+#: src/components/UpcomingPlanCard.tsx:1672
+#: src/components/UpcomingPlanCard.tsx:1752
 msgid "Praxys only changes workouts it created or you explicitly adopt. Manual workouts and workouts from another coach stay untouched."
 msgstr "Praxys only changes workouts it created or you explicitly adopt. Manual workouts and workouts from another coach stay untouched."
 
@@ -6541,7 +6542,7 @@ msgstr "Praxys stopped before consent or long-running analysis. Sync or collect 
 msgid "Praxys stores curve points, uncertainty, counts, gates, versions, and timestamps—not routes, activity dates, raw samples, or per-activity research rows."
 msgstr "Praxys stores curve points, uncertainty, counts, gates, versions, and timestamps—not routes, activity dates, raw samples, or per-activity research rows."
 
-#: src/components/UpcomingPlanCard.tsx:767
+#: src/components/UpcomingPlanCard.tsx:768
 msgid "Praxys version"
 msgstr "Praxys version"
 
@@ -6553,7 +6554,7 @@ msgstr "Praxys will analyze eligible past runs to see whether modeled heart rate
 msgid "Praxys will immediately delete your Labs consent and derived aggregate result. Your underlying account activities are not deleted."
 msgstr "Praxys will immediately delete your Labs consent and derived aggregate result. Your underlying account activities are not deleted."
 
-#: src/components/PersonalContextPanel.tsx:996
+#: src/components/PersonalContextPanel.tsx:1001
 msgid "Praxys will preserve the reason as unknown. This never counts against you."
 msgstr "Praxys will preserve the reason as unknown. This never counts against you."
 
@@ -6579,7 +6580,7 @@ msgstr "Predicted using Riegel's formula (T₂ = T₁ × (D₂/D₁)^1.06), trea
 msgid "Predicted using Stryd race power model (5K at 103.8% CP, marathon at 89.9% CP)."
 msgstr "Predicted using Stryd race power model (5K at 103.8% CP, marathon at 89.9% CP)."
 
-#: src/components/PersonalContextPanel.tsx:238
+#: src/components/PersonalContextPanel.tsx:243
 msgid "Prefer not to say"
 msgstr "Prefer not to say"
 
@@ -6587,7 +6588,7 @@ msgstr "Prefer not to say"
 msgid "Prefer to wait?"
 msgstr "Prefer to wait?"
 
-#: src/components/Outdoor5KPlanStart.tsx:580
+#: src/components/Outdoor5KPlanStart.tsx:610
 msgid "Preferred longest-run day"
 msgstr "Preferred longest-run day"
 
@@ -6604,7 +6605,7 @@ msgstr "Previewing"
 msgid "Previous"
 msgstr "Previous"
 
-#: src/components/UpcomingPlanCard.tsx:1446
+#: src/components/UpcomingPlanCard.tsx:1470
 msgid "Previous plan window"
 msgstr "Previous plan window"
 
@@ -6633,7 +6634,7 @@ msgstr "Prior heat adaptation evidence may be declining."
 msgid "Priority is excluded from readiness evaluation."
 msgstr "Priority is excluded from readiness evaluation."
 
-#: src/components/PersonalContextPanel.tsx:1660
+#: src/components/PersonalContextPanel.tsx:1665
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -6641,28 +6642,28 @@ msgstr "Privacy Policy"
 msgid "Private alpha · Invitation only"
 msgstr "Private alpha · Invitation only"
 
-#: src/components/PersonalContextPanel.tsx:1310
+#: src/components/PersonalContextPanel.tsx:1315
 msgid "Private context"
 msgstr "Private context"
 
-#: src/components/PersonalContextPanel.tsx:753
+#: src/components/PersonalContextPanel.tsx:758
 msgid "Private context could not be loaded."
 msgstr "Private context could not be loaded."
 
-#: src/components/PersonalContextPanel.tsx:669
+#: src/components/PersonalContextPanel.tsx:674
 msgid "Private context export downloaded."
 msgstr "Private context export downloaded."
 
-#: src/components/PersonalContextPanel.tsx:483
+#: src/components/PersonalContextPanel.tsx:488
 msgid "Private context saved. AI processing remains off."
 msgstr "Private context saved. AI processing remains off."
 
-#: src/components/PersonalContextPanel.tsx:1212
-#: src/components/PersonalContextPanel.tsx:1388
+#: src/components/PersonalContextPanel.tsx:1217
+#: src/components/PersonalContextPanel.tsx:1393
 msgid "Private note"
 msgstr "Private note"
 
-#: src/components/PersonalContextPanel.tsx:1117
+#: src/components/PersonalContextPanel.tsx:1122
 msgid "Private note (optional)"
 msgstr "Private note (optional)"
 
@@ -6675,7 +6676,7 @@ msgstr "Proceed but monitor heart-rate drift during the session"
 msgid "Processing"
 msgstr "Processing"
 
-#: src/components/PersonalContextPanel.tsx:1184
+#: src/components/PersonalContextPanel.tsx:1189
 msgid "Processing method"
 msgstr "Processing method"
 
@@ -6714,15 +6715,15 @@ msgstr "Promote to Admin"
 msgid "Prompt-semantic slice:"
 msgstr "Prompt-semantic slice:"
 
-#: src/components/Outdoor5KPlanStart.tsx:302
+#: src/components/Outdoor5KPlanStart.tsx:316
 msgid "Proposal created. It has not changed your canonical plan."
 msgstr "Proposal created. It has not changed your canonical plan."
 
-#: src/components/Outdoor5KPlanStart.tsx:371
+#: src/components/Outdoor5KPlanStart.tsx:385
 msgid "Proposal rejected. Your canonical plan was not changed."
 msgstr "Proposal rejected. Your canonical plan was not changed."
 
-#: src/components/Outdoor5KPlanStart.tsx:719
+#: src/components/Outdoor5KPlanStart.tsx:749
 msgid "Proposal state needs a fresh preview"
 msgstr "Proposal state needs a fresh preview"
 
@@ -6774,9 +6775,9 @@ msgstr "Publish service updates on the <0>public status page</0>."
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "Pull your latest activities, power data, and recovery metrics"
 
-#: src/components/PersonalContextPanel.tsx:1150
-#: src/components/PersonalContextPanel.tsx:1337
-#: src/components/PersonalContextPanel.tsx:1597
+#: src/components/PersonalContextPanel.tsx:1155
+#: src/components/PersonalContextPanel.tsx:1342
+#: src/components/PersonalContextPanel.tsx:1602
 #: src/pages/McpAuthorization.tsx:220
 msgid "Purpose"
 msgstr "Purpose"
@@ -6839,8 +6840,8 @@ msgstr "Qualifying days: {0} of {thresholdDays}"
 msgid "Qualifying exposure has resumed after a longer gap, but current evidence is still limited."
 msgstr "Qualifying exposure has resumed after a longer gap, but current evidence is still limited."
 
-#: src/components/UpcomingPlanCard.tsx:501
-#: src/components/UpcomingPlanCard.tsx:521
+#: src/components/UpcomingPlanCard.tsx:502
+#: src/components/UpcomingPlanCard.tsx:522
 #: src/pages/LabsEnvironment.tsx:151
 #: src/pages/LabsEnvironment.tsx:162
 msgid "Queued"
@@ -6962,7 +6963,7 @@ msgstr "Read-only accounts that mirror your dashboard data."
 msgid "Readiness"
 msgstr "Readiness"
 
-#: src/components/Outdoor5KPlanStart.tsx:625
+#: src/components/Outdoor5KPlanStart.tsx:655
 msgid "Readiness result"
 msgstr "Readiness result"
 
@@ -7165,7 +7166,7 @@ msgstr "Reconcile and replay"
 msgid "Reconciliation completed without replaying a workout."
 msgstr "Reconciliation completed without replaying a workout."
 
-#: src/components/UpcomingPlanCard.tsx:242
+#: src/components/UpcomingPlanCard.tsx:243
 msgid "Reconnect {target} to continue delivery. The Praxys plan remains canonical."
 msgstr "Reconnect {target} to continue delivery. The Praxys plan remains canonical."
 
@@ -7210,7 +7211,7 @@ msgstr "Recoverable: {0}. Retry exhausted: {1}. Stuck in progress: {2}."
 
 #: src/components/RecoveryPanel.tsx:57
 #: src/components/RecoveryPanel.tsx:58
-#: src/components/UpcomingPlanCard.tsx:577
+#: src/components/UpcomingPlanCard.tsx:578
 #: src/components/WorkoutPlanEditor.tsx:433
 #: src/components/WorkoutStructureEditor.tsx:325
 #: src/lib/display-labels.ts:42
@@ -7295,7 +7296,7 @@ msgstr "Recovery was inadequate or fatigue stayed unresolved"
 msgid "Recovery was skipped because delivery eligibility changed. Review the refreshed queue."
 msgstr "Recovery was skipped because delivery eligibility changed. Review the refreshed queue."
 
-#: src/components/PersonalContextPanel.tsx:232
+#: src/components/PersonalContextPanel.tsx:237
 msgid "Red-flag symptoms"
 msgstr "Red-flag symptoms"
 
@@ -7310,7 +7311,7 @@ msgid "Reduce Intensity"
 msgstr "Reduce Intensity"
 
 #. placeholder {0}: detail.linked_revision_ids.length
-#: src/components/PersonalContextPanel.tsx:1428
+#: src/components/PersonalContextPanel.tsx:1433
 msgid "Referenced by {0} plan change record(s)."
 msgstr "Referenced by {0} plan change record(s)."
 
@@ -7336,16 +7337,16 @@ msgstr "Refresh failed"
 msgid "Refresh failed. Showing the last successful snapshot."
 msgstr "Refresh failed. Showing the last successful snapshot."
 
-#: src/components/Outdoor5KPlanStart.tsx:754
+#: src/components/Outdoor5KPlanStart.tsx:784
 msgid "Refresh proposal"
 msgstr "Refresh proposal"
 
-#: src/components/UpcomingPlanCard.tsx:1324
+#: src/components/UpcomingPlanCard.tsx:1348
 msgid "Refresh the plan before deleting this workout."
 msgstr "Refresh the plan before deleting this workout."
 
-#: src/components/UpcomingPlanCard.tsx:1220
-#: src/components/UpcomingPlanCard.tsx:1280
+#: src/components/UpcomingPlanCard.tsx:1244
+#: src/components/UpcomingPlanCard.tsx:1304
 msgid "Refresh the plan before editing this workout."
 msgstr "Refresh the plan before editing this workout."
 
@@ -7357,11 +7358,11 @@ msgstr "Refresh the provider calendar first, then replay only if the prior write
 msgid "Refresh the provider calendar, re-check ownership, and allow one fenced retry for this item."
 msgstr "Refresh the provider calendar, re-check ownership, and allow one fenced retry for this item."
 
-#: src/components/Outdoor5KPlanStart.tsx:709
+#: src/components/Outdoor5KPlanStart.tsx:739
 msgid "Regenerate successor"
 msgstr "Regenerate successor"
 
-#: src/components/Outdoor5KPlanStart.tsx:709
+#: src/components/Outdoor5KPlanStart.tsx:739
 msgid "Regenerating…"
 msgstr "Regenerating…"
 
@@ -7406,7 +7407,7 @@ msgstr "Registration settings unavailable"
 msgid "Reject"
 msgstr "Reject"
 
-#: src/components/Outdoor5KPlanStart.tsx:712
+#: src/components/Outdoor5KPlanStart.tsx:742
 msgid "Reject or defer"
 msgstr "Reject or defer"
 
@@ -7415,7 +7416,7 @@ msgstr "Reject or defer"
 msgid "Rejected"
 msgstr "Rejected"
 
-#: src/components/Outdoor5KPlanStart.tsx:712
+#: src/components/Outdoor5KPlanStart.tsx:742
 msgid "Rejecting…"
 msgstr "Rejecting…"
 
@@ -7566,7 +7567,7 @@ msgstr "Resend verification email"
 msgid "Resolve"
 msgstr "Resolve"
 
-#: src/components/UpcomingPlanCard.tsx:748
+#: src/components/UpcomingPlanCard.tsx:749
 msgid "Resolve workout conflict"
 msgstr "Resolve workout conflict"
 
@@ -7579,9 +7580,9 @@ msgid "Resolved"
 msgstr "Resolved"
 
 #: src/components/ManagedPlanSettingsCard.tsx:983
-#: src/components/UpcomingPlanCard.tsx:572
-#: src/components/UpcomingPlanCard.tsx:584
-#: src/components/UpcomingPlanCard.tsx:1576
+#: src/components/UpcomingPlanCard.tsx:573
+#: src/components/UpcomingPlanCard.tsx:585
+#: src/components/UpcomingPlanCard.tsx:1600
 #: src/components/WorkoutPlanEditor.tsx:440
 #: src/components/WorkoutPlanEditor.tsx:451
 #: src/components/WorkoutStructureEditor.tsx:326
@@ -7614,16 +7615,16 @@ msgstr "Resting heart rate is elevated above your baseline. This can be a cautio
 msgid "Resting HR"
 msgstr "Resting HR"
 
-#: src/components/UpcomingPlanCard.tsx:863
+#: src/components/UpcomingPlanCard.tsx:864
 msgid "Restore Praxys"
 msgstr "Restore Praxys"
 
-#: src/components/UpcomingPlanCard.tsx:829
+#: src/components/UpcomingPlanCard.tsx:830
 msgid "Restore Praxys:"
 msgstr "Restore Praxys:"
 
 #: src/components/ManagedPlanSettingsCard.tsx:1006
-#: src/components/UpcomingPlanCard.tsx:1606
+#: src/components/UpcomingPlanCard.tsx:1630
 msgid "Restore workout"
 msgstr "Restore workout"
 
@@ -7632,8 +7633,8 @@ msgid "Restored"
 msgstr "Restored"
 
 #: src/components/ManagedPlanSettingsCard.tsx:1005
-#: src/components/UpcomingPlanCard.tsx:860
-#: src/components/UpcomingPlanCard.tsx:1605
+#: src/components/UpcomingPlanCard.tsx:861
+#: src/components/UpcomingPlanCard.tsx:1629
 msgid "Restoring…"
 msgstr "Restoring…"
 
@@ -7655,11 +7656,12 @@ msgstr "Retrieval is never qualification; only a full activity with explicit dis
 
 #: src/components/ManagedPlanSettingsCard.tsx:608
 #: src/components/ManagedPlanSettingsCard.tsx:1026
-#: src/components/Outdoor5KPlanStart.tsx:421
-#: src/components/Outdoor5KPlanStart.tsx:656
-#: src/components/PersonalContextPanel.tsx:755
-#: src/components/UpcomingPlanCard.tsx:341
-#: src/components/UpcomingPlanCard.tsx:1371
+#: src/components/Outdoor5KPlanStart.tsx:435
+#: src/components/Outdoor5KPlanStart.tsx:465
+#: src/components/Outdoor5KPlanStart.tsx:686
+#: src/components/PersonalContextPanel.tsx:760
+#: src/components/UpcomingPlanCard.tsx:342
+#: src/components/UpcomingPlanCard.tsx:1395
 #: src/pages/admin/AdminFeedback.tsx:582
 #: src/pages/admin/AdminRouteState.tsx:36
 #: src/pages/admin/AdminUsers.tsx:544
@@ -7686,8 +7688,8 @@ msgstr "Retry before joining. The full analysis has not started."
 msgid "Retry cleanup"
 msgstr "Retry cleanup"
 
-#: src/components/UpcomingPlanCard.tsx:461
-#: src/components/UpcomingPlanCard.tsx:862
+#: src/components/UpcomingPlanCard.tsx:462
+#: src/components/UpcomingPlanCard.tsx:863
 msgid "Retry delivery"
 msgstr "Retry delivery"
 
@@ -7699,7 +7701,7 @@ msgstr "Retry delivery"
 msgid "Retry queue"
 msgstr "Retry queue"
 
-#: src/components/UpcomingPlanCard.tsx:747
+#: src/components/UpcomingPlanCard.tsx:748
 msgid "Retry this delivery?"
 msgstr "Retry this delivery?"
 
@@ -7719,7 +7721,7 @@ msgstr "Retry to load submitted reports and GitHub sync state."
 msgid "Retry to load the public status incidents feed."
 msgstr "Retry to load the public status incidents feed."
 
-#: src/components/UpcomingPlanCard.tsx:336
+#: src/components/UpcomingPlanCard.tsx:337
 msgid "Retry workout action"
 msgstr "Retry workout action"
 
@@ -7731,7 +7733,7 @@ msgstr "Retrying"
 msgid "Return to the plugin to finish the one-time exchange. You can close this tab."
 msgstr "Return to the plugin to finish the one-time exchange. You can close this tab."
 
-#: src/components/PersonalContextPanel.tsx:1519
+#: src/components/PersonalContextPanel.tsx:1524
 msgid "Review AI access"
 msgstr "Review AI access"
 
@@ -7751,15 +7753,15 @@ msgstr "Review and turn on"
 msgid "Review baseline"
 msgstr "Review baseline"
 
-#: src/components/PersonalContextPanel.tsx:861
+#: src/components/PersonalContextPanel.tsx:866
 msgid "Review before saving"
 msgstr "Review before saving"
 
-#: src/components/UpcomingPlanCard.tsx:425
-#: src/components/UpcomingPlanCard.tsx:439
-#: src/components/UpcomingPlanCard.tsx:469
-#: src/components/UpcomingPlanCard.tsx:483
-#: src/components/UpcomingPlanCard.tsx:1529
+#: src/components/UpcomingPlanCard.tsx:426
+#: src/components/UpcomingPlanCard.tsx:440
+#: src/components/UpcomingPlanCard.tsx:470
+#: src/components/UpcomingPlanCard.tsx:484
+#: src/components/UpcomingPlanCard.tsx:1553
 msgid "Review conflict"
 msgstr "Review conflict"
 
@@ -7775,7 +7777,7 @@ msgstr "Review delivery queue"
 msgid "Review first issue"
 msgstr "Review first issue"
 
-#: src/components/Outdoor5KPlanStart.tsx:437
+#: src/components/Outdoor5KPlanStart.tsx:453
 msgid "Review goal"
 msgstr "Review goal"
 
@@ -7795,7 +7797,7 @@ msgstr "Review optional test"
 msgid "Review plan outcomes"
 msgstr "Review plan outcomes"
 
-#: src/components/PersonalContextPanel.tsx:1286
+#: src/components/PersonalContextPanel.tsx:1291
 msgid "Review purpose and expiry"
 msgstr "Review purpose and expiry"
 
@@ -7809,7 +7811,7 @@ msgstr "Review reports, manage screenshots, and sync linked GitHub issues."
 msgid "Review required"
 msgstr "Review required"
 
-#: src/components/Outdoor5KPlanStart.tsx:241
+#: src/components/Outdoor5KPlanStart.tsx:255
 msgid "Review the constraints and try again."
 msgstr "Review the constraints and try again."
 
@@ -7821,7 +7823,7 @@ msgstr "Review the current goal"
 msgid "Review the exact purpose and access below. The plugin cannot approve this request, read private notes, grant AI consent, or save context on its own."
 msgstr "Review the exact purpose and access below. The plugin cannot approve this request, read private notes, grant AI consent, or save context on its own."
 
-#: src/components/UpcomingPlanCard.tsx:1185
+#: src/components/UpcomingPlanCard.tsx:1209
 #: src/components/WorkoutPlanEditor.tsx:544
 msgid "Review the highlighted step fields. Every typed target and termination must be complete."
 msgstr "Review the highlighted step fields. Every typed target and termination must be complete."
@@ -7863,11 +7865,11 @@ msgstr "rising"
 msgid "Rising"
 msgstr "Rising"
 
-#: src/components/PersonalContextPanel.tsx:261
+#: src/components/PersonalContextPanel.tsx:266
 msgid "Road"
 msgstr "Road"
 
-#: src/components/UpcomingPlanCard.tsx:564
+#: src/components/UpcomingPlanCard.tsx:565
 #: src/components/WorkoutPlanEditor.tsx:443
 msgid "Road running"
 msgstr "Road running"
@@ -7892,15 +7894,15 @@ msgstr "RPE · 0–10"
 msgid "Rule based"
 msgstr "Rule based"
 
-#: src/components/PersonalContextPanel.tsx:1417
+#: src/components/PersonalContextPanel.tsx:1422
 msgid "Rules"
 msgstr "Rules"
 
-#: src/components/PersonalContextPanel.tsx:814
+#: src/components/PersonalContextPanel.tsx:819
 msgid "rules only"
 msgstr "rules only"
 
-#: src/components/PersonalContextPanel.tsx:1186
+#: src/components/PersonalContextPanel.tsx:1191
 msgid "Rules only · nothing sent to AI"
 msgstr "Rules only · nothing sent to AI"
 
@@ -7936,9 +7938,9 @@ msgstr "Running"
 msgid "Runs"
 msgstr "Runs"
 
-#: src/components/PersonalContextPanel.tsx:230
-#: src/components/PersonalContextPanel.tsx:231
-#: src/components/PersonalContextPanel.tsx:232
+#: src/components/PersonalContextPanel.tsx:235
+#: src/components/PersonalContextPanel.tsx:236
+#: src/components/PersonalContextPanel.tsx:237
 msgid "Safety"
 msgstr "Safety"
 
@@ -7946,11 +7948,11 @@ msgstr "Safety"
 msgid "Safety policy"
 msgstr "Safety policy"
 
-#: src/components/Outdoor5KPlanStart.tsx:503
+#: src/components/Outdoor5KPlanStart.tsx:533
 msgid "Safety stop"
 msgstr "Safety stop"
 
-#: src/components/Outdoor5KPlanStart.tsx:517
+#: src/components/Outdoor5KPlanStart.tsx:547
 msgid "Safety stop applies"
 msgstr "Safety stop applies"
 
@@ -7976,7 +7978,7 @@ msgstr "Safety stop applies"
 #~ msgid "Samples incomplete · {coverage}% coverage"
 #~ msgstr "Samples incomplete · {coverage}% coverage"
 
-#: src/components/PersonalContextPanel.tsx:248
+#: src/components/PersonalContextPanel.tsx:253
 msgid "Sat"
 msgstr "Sat"
 
@@ -7989,7 +7991,7 @@ msgstr "Sat"
 msgid "Save"
 msgstr "Save"
 
-#: src/components/PersonalContextPanel.tsx:1273
+#: src/components/PersonalContextPanel.tsx:1278
 msgid "Save correction"
 msgstr "Save correction"
 
@@ -8001,7 +8003,7 @@ msgstr "Save goal"
 #~ msgid "Save Goal"
 #~ msgstr "Save Goal"
 
-#: src/components/PersonalContextPanel.tsx:1274
+#: src/components/PersonalContextPanel.tsx:1279
 msgid "Save private context"
 msgstr "Save private context"
 
@@ -8017,11 +8019,11 @@ msgstr "Save workout"
 msgid "Saved"
 msgstr "Saved"
 
-#: src/components/PersonalContextPanel.tsx:482
+#: src/components/PersonalContextPanel.tsx:487
 msgid "Saved without guessing a reason. The cause remains unknown."
 msgstr "Saved without guessing a reason. The cause remains unknown."
 
-#: src/components/PersonalContextPanel.tsx:1234
+#: src/components/PersonalContextPanel.tsx:1239
 msgid "Saving confirms this one purpose. It does not authorize a new purpose, AI processing, analytics, or model training."
 msgstr "Saving confirms this one purpose. It does not authorize a new purpose, AI processing, analytics, or model training."
 
@@ -8047,7 +8049,7 @@ msgstr "Saving will reschedule this workout."
 msgid "Saving…"
 msgstr "Saving…"
 
-#: src/components/PersonalContextPanel.tsx:225
+#: src/components/PersonalContextPanel.tsx:230
 msgid "Schedule conflict"
 msgstr "Schedule conflict"
 
@@ -8071,7 +8073,7 @@ msgstr "Scheduling writes through the canonical workout, revision, and delivery 
 msgid "Science"
 msgstr "Science"
 
-#: src/components/Outdoor5KPlanStart.tsx:678
+#: src/components/Outdoor5KPlanStart.tsx:708
 msgid "Science decision"
 msgstr "Science decision"
 
@@ -8087,7 +8089,7 @@ msgstr "Science models"
 msgid "Scientific models"
 msgstr "Scientific models"
 
-#: src/components/Outdoor5KPlanStart.tsx:470
+#: src/components/Outdoor5KPlanStart.tsx:500
 msgid "Scope and guardrails"
 msgstr "Scope and guardrails"
 
@@ -8132,11 +8134,11 @@ msgstr "Select a day to inspect what entered the estimate."
 msgid "Select a metric to inspect its chart or evidence."
 msgstr "Select a metric to inspect its chart or evidence."
 
-#: src/components/UpcomingPlanCard.tsx:245
+#: src/components/UpcomingPlanCard.tsx:246
 msgid "Select an execution target in Settings to continue delivery."
 msgstr "Select an execution target in Settings to continue delivery."
 
-#: src/components/Outdoor5KPlanStart.tsx:524
+#: src/components/Outdoor5KPlanStart.tsx:554
 msgid "Select availability, then give the same supported session limit for each selected day."
 msgstr "Select availability, then give the same supported session limit for each selected day."
 
@@ -8263,7 +8265,7 @@ msgstr "Set a power threshold so Praxys can identify sustained work without usin
 msgid "Set goal"
 msgstr "Set goal"
 
-#: src/components/Outdoor5KPlanStart.tsx:457
+#: src/components/Outdoor5KPlanStart.tsx:487
 msgid "Set the constraints you can actually keep. Praxys returns a deterministic proposal; it is not yet your plan."
 msgstr "Set the constraints you can actually keep. Praxys returns a deterministic proposal; it is not yet your plan."
 
@@ -8293,11 +8295,11 @@ msgstr "Settings"
 msgid "Setup"
 msgstr "Setup"
 
-#: src/components/PersonalContextPanel.tsx:1128
+#: src/components/PersonalContextPanel.tsx:1133
 msgid "Share only what changes your plan."
 msgstr "Share only what changes your plan."
 
-#: src/components/PersonalContextPanel.tsx:706
+#: src/components/PersonalContextPanel.tsx:711
 msgid "Share only what could change your plan. Praxys keeps it private, never guesses why training changed, and leaves AI off unless you separately allow it."
 msgstr "Share only what could change your plan. Praxys keeps it private, never guesses why training changed, and leaves AI off unless you separately allow it."
 
@@ -8456,7 +8458,7 @@ msgstr "Source"
 msgid "Source stays unchanged"
 msgstr "Source stays unchanged"
 
-#: src/components/UpcomingPlanCard.tsx:648
+#: src/components/UpcomingPlanCard.tsx:649
 msgid "Source-owned"
 msgstr "Source-owned"
 
@@ -8514,11 +8516,11 @@ msgstr "Start, review, and adjust the plan Praxys manages for you."
 msgid "Started"
 msgstr "Started"
 
-#: src/components/PersonalContextPanel.tsx:1021
+#: src/components/PersonalContextPanel.tsx:1026
 msgid "Starts"
 msgstr "Starts"
 
-#: src/components/PersonalContextPanel.tsx:1328
+#: src/components/PersonalContextPanel.tsx:1333
 #: src/pages/admin/AdminFeedback.tsx:390
 #: src/pages/admin/AdminUsers.tsx:734
 #: src/pages/admin/AdminUsers.tsx:873
@@ -8579,12 +8581,12 @@ msgstr "Stop reason"
 msgid "Stop this test"
 msgstr "Stop this test"
 
-#: src/components/PersonalContextPanel.tsx:1491
-#: src/components/PersonalContextPanel.tsx:1529
+#: src/components/PersonalContextPanel.tsx:1496
+#: src/components/PersonalContextPanel.tsx:1534
 msgid "Stop using"
 msgstr "Stop using"
 
-#: src/components/PersonalContextPanel.tsx:1453
+#: src/components/PersonalContextPanel.tsx:1458
 msgid "Stop using this context?"
 msgstr "Stop using this context?"
 
@@ -8592,7 +8594,7 @@ msgstr "Stop using this context?"
 msgid "Stopping or declining preserves your account and the no-test path."
 msgstr "Stopping or declining preserves your account and the no-test path."
 
-#: src/components/PersonalContextPanel.tsx:1170
+#: src/components/PersonalContextPanel.tsx:1175
 msgid "Stored until"
 msgstr "Stored until"
 
@@ -8604,7 +8606,7 @@ msgstr "Strava Client ID"
 msgid "Strava Client Secret"
 msgstr "Strava Client Secret"
 
-#: src/components/UpcomingPlanCard.tsx:569
+#: src/components/UpcomingPlanCard.tsx:570
 #: src/components/WorkoutPlanEditor.tsx:448
 #: src/pages/Setup.tsx:169
 msgid "Strength"
@@ -8626,12 +8628,12 @@ msgstr "Stretch"
 #~ msgid "strongly positive"
 #~ msgstr "strongly positive"
 
-#: src/components/PersonalContextPanel.tsx:1193
-#: src/components/PersonalContextPanel.tsx:1366
+#: src/components/PersonalContextPanel.tsx:1198
+#: src/components/PersonalContextPanel.tsx:1371
 msgid "Structured details"
 msgstr "Structured details"
 
-#: src/components/PersonalContextPanel.tsx:1608
+#: src/components/PersonalContextPanel.tsx:1613
 msgid "Structured fields sent"
 msgstr "Structured fields sent"
 
@@ -8676,11 +8678,11 @@ msgstr "Success"
 msgid "successful"
 msgstr "successful"
 
-#: src/components/PersonalContextPanel.tsx:1601
+#: src/components/PersonalContextPanel.tsx:1606
 msgid "Suggest a bounded adjustment to the current plan."
 msgstr "Suggest a bounded adjustment to the current plan."
 
-#: src/components/PersonalContextPanel.tsx:1153
+#: src/components/PersonalContextPanel.tsx:1158
 #: src/pages/McpAuthorization.tsx:29
 msgid "Suggest adjustments to the current plan"
 msgstr "Suggest adjustments to the current plan"
@@ -8696,7 +8698,7 @@ msgstr "Suggestions"
 msgid "Summary window"
 msgstr "Summary window"
 
-#: src/components/PersonalContextPanel.tsx:249
+#: src/components/PersonalContextPanel.tsx:254
 msgid "Sun"
 msgstr "Sun"
 
@@ -8820,7 +8822,7 @@ msgstr "Sync split or sample power evidence so Praxys can identify sustained wor
 #~ msgid "Sync split-level power so workload can contribute."
 #~ msgstr "Sync split-level power so workload can contribute."
 
-#: src/components/UpcomingPlanCard.tsx:493
+#: src/components/UpcomingPlanCard.tsx:494
 msgid "Sync target to review"
 msgstr "Sync target to review"
 
@@ -8944,7 +8946,7 @@ msgstr "Target type"
 #~ msgid "Telemetry trust boundary"
 #~ msgstr "Telemetry trust boundary"
 
-#: src/components/Outdoor5KPlanStart.tsx:505
+#: src/components/Outdoor5KPlanStart.tsx:535
 msgid "Tell Praxys if a safety stop applies. It will stop this plan path and show policy-bounded alternatives."
 msgstr "Tell Praxys if a safety stop applies. It will stop this plan path and show policy-bounded alternatives."
 
@@ -8964,19 +8966,19 @@ msgstr "Temperature and humidity are not both present on enough of the same acti
 msgid "Temperature is missing from too many otherwise eligible activities."
 msgstr "Temperature is missing from too many otherwise eligible activities."
 
-#: src/components/UpcomingPlanCard.tsx:579
+#: src/components/UpcomingPlanCard.tsx:580
 #: src/components/WorkoutPlanEditor.tsx:435
 #: src/lib/display-labels.ts:44
 #: src/lib/phase-label.ts:14
 msgid "Tempo"
 msgstr "Tempo"
 
-#: src/components/PersonalContextPanel.tsx:806
+#: src/components/PersonalContextPanel.tsx:811
 #: src/pages/McpAuthorization.tsx:48
 msgid "Temporary availability"
 msgstr "Temporary availability"
 
-#: src/components/PersonalContextPanel.tsx:376
+#: src/components/PersonalContextPanel.tsx:381
 msgid "Temporary context can stay active for at most 90 days."
 msgstr "Temporary context can stay active for at most 90 days."
 
@@ -8992,11 +8994,11 @@ msgstr "termination"
 msgid "Termination"
 msgstr "Termination"
 
-#: src/components/Outdoor5KPlanStart.tsx:598
+#: src/components/Outdoor5KPlanStart.tsx:628
 msgid "Terrain and equipment"
 msgstr "Terrain and equipment"
 
-#: src/components/PersonalContextPanel.tsx:1102
+#: src/components/PersonalContextPanel.tsx:1107
 msgid "Terrain still available (optional)"
 msgstr "Terrain still available (optional)"
 
@@ -9004,7 +9006,7 @@ msgstr "Terrain still available (optional)"
 msgid "Test pending"
 msgstr "Test pending"
 
-#: src/components/UpcomingPlanCard.tsx:583
+#: src/components/UpcomingPlanCard.tsx:584
 #: src/components/WorkoutPlanEditor.tsx:439
 msgid "Testing"
 msgstr "Testing"
@@ -9017,11 +9019,11 @@ msgstr "Thanks - that helps us improve Today."
 msgid "Thanks for the feedback!"
 msgstr "Thanks for the feedback!"
 
-#: src/components/UpcomingPlanCard.tsx:1179
+#: src/components/UpcomingPlanCard.tsx:1203
 msgid "That date is now completed history and can no longer be changed."
 msgstr "That date is now completed history and can no longer be changed."
 
-#: src/components/PersonalContextPanel.tsx:767
+#: src/components/PersonalContextPanel.tsx:772
 msgid "That is a complete state, not missing data. Praxys keeps the reason unknown and does not reduce your standing or invent an explanation."
 msgstr "That is a complete state, not missing data. Praxys keeps the reason unknown and does not reduce your standing or invent an explanation."
 
@@ -9029,7 +9031,7 @@ msgstr "That is a complete state, not missing data. Praxys keeps the reason unkn
 msgid "The 42-day rule is a Praxys pilot guardrail, not a physiological cutoff."
 msgstr "The 42-day rule is a Praxys pilot guardrail, not a physiological cutoff."
 
-#: src/components/Outdoor5KPlanStart.tsx:571
+#: src/components/Outdoor5KPlanStart.tsx:601
 msgid "The accepted deterministic policy has one shared maximum-session field. Praxys will not invent a per-day rule or silently reduce your schedule; use one limit for all selected days."
 msgstr "The accepted deterministic policy has one shared maximum-session field. Praxys will not invent a per-day rule or silently reduce your schedule; use one limit for all selected days."
 
@@ -9113,7 +9115,7 @@ msgstr "The cooldown prevents accidental repeat analysis."
 msgid "The current goal is outside this 5K baseline pilot."
 msgstr "The current goal is outside this 5K baseline pilot."
 
-#: src/components/Outdoor5KPlanStart.tsx:628
+#: src/components/Outdoor5KPlanStart.tsx:658
 msgid "The deterministic policy returned no additional explanation."
 msgstr "The deterministic policy returned no additional explanation."
 
@@ -9121,7 +9123,7 @@ msgstr "The deterministic policy returned no additional explanation."
 msgid "The eligible history crosses incompatible power-device or algorithm regimes."
 msgstr "The eligible history crosses incompatible power-device or algorithm regimes."
 
-#: src/components/PersonalContextPanel.tsx:374
+#: src/components/PersonalContextPanel.tsx:379
 msgid "The end date must be after the start date."
 msgstr "The end date must be after the start date."
 
@@ -9210,15 +9212,15 @@ msgstr "The ordered steps and target ranges can be delivered without flattening.
 msgid "The portable workout structure is invalid."
 msgstr "The portable workout structure is invalid."
 
-#: src/components/UpcomingPlanCard.tsx:248
+#: src/components/UpcomingPlanCard.tsx:249
 msgid "The Praxys plan is preserved; no target workouts will change."
 msgstr "The Praxys plan is preserved; no target workouts will change."
 
-#: src/components/UpcomingPlanCard.tsx:754
+#: src/components/UpcomingPlanCard.tsx:755
 msgid "The Praxys workout is missing from {target}. Restoring it keeps the Praxys version canonical."
 msgstr "The Praxys workout is missing from {target}. Restoring it keeps the Praxys version canonical."
 
-#: src/components/UpcomingPlanCard.tsx:1560
+#: src/components/UpcomingPlanCard.tsx:1584
 msgid "The previous workout was restored"
 msgstr "The previous workout was restored"
 
@@ -9268,7 +9270,7 @@ msgid "The readiness decision changed. Review the refreshed decision before reco
 msgstr "The readiness decision changed. Review the refreshed decision before recording a judgment."
 
 #. placeholder {0}: target ?? 'your target'
-#: src/components/UpcomingPlanCard.tsx:239
+#: src/components/UpcomingPlanCard.tsx:240
 msgid "The rolling 14-day window is delivered to {0}."
 msgstr "The rolling 14-day window is delivered to {0}."
 
@@ -9304,7 +9306,7 @@ msgstr "The source workout stays locked. Save this copy as a new Praxys-owned wo
 msgid "The status API did not respond — this itself may indicate an outage."
 msgstr "The status API did not respond — this itself may indicate an outage."
 
-#: src/components/UpcomingPlanCard.tsx:809
+#: src/components/UpcomingPlanCard.tsx:810
 msgid "The target version is unavailable."
 msgstr "The target version is unavailable."
 
@@ -9356,7 +9358,7 @@ msgstr "This appears only when history is missing, stale, or still needs review.
 msgid "This cannot be undone. If this is the last admin account, deletion will be blocked."
 msgstr "This cannot be undone. If this is the last admin account, deletion will be blocked."
 
-#: src/components/UpcomingPlanCard.tsx:1583
+#: src/components/UpcomingPlanCard.tsx:1607
 msgid "This change used confirmed private context. The private detail is not copied into the plan record."
 msgstr "This change used confirmed private context. The private detail is not copied into the plan record."
 
@@ -9372,7 +9374,7 @@ msgstr "This combination is outside Praxys’s conservative Stull method domain.
 msgid "This connects the official Praxys Coach plugin to your account. Personal plan context stays unavailable until you approve a separate, short-lived request."
 msgstr "This connects the official Praxys Coach plugin to your account. Personal plan context stays unavailable until you approve a separate, short-lived request."
 
-#: src/components/PersonalContextPanel.tsx:1575
+#: src/components/PersonalContextPanel.tsx:1580
 msgid "This decision is separate from saving context and applies only to this exact version."
 msgstr "This decision is separate from saving context and applies only to this exact version."
 
@@ -9384,12 +9386,12 @@ msgstr "This delivery cannot be replayed automatically. Review the refreshed que
 msgid "This delivery changed before recovery started. Review the refreshed queue."
 msgstr "This delivery changed before recovery started. Review the refreshed queue."
 
-#: src/components/Outdoor5KPlanStart.tsx:643
+#: src/components/Outdoor5KPlanStart.tsx:673
 msgid "This deterministic result uses the published and pilot guardrails named by the policy response. It is not AI coaching and does not make an injury, readiness, or goal guarantee."
 msgstr "This deterministic result uses the published and pilot guardrails named by the policy response. It is not AI coaching and does not make an injury, readiness, or goal guarantee."
 
-#: src/components/PersonalContextPanel.tsx:1008
-#: src/components/PersonalContextPanel.tsx:1223
+#: src/components/PersonalContextPanel.tsx:1013
+#: src/components/PersonalContextPanel.tsx:1228
 msgid "This enters the safety path and stops ordinary performance optimization. Praxys cannot diagnose, clear you to train, or set a return-to-sport timeline."
 msgstr "This enters the safety path and stops ordinary performance optimization. Praxys cannot diagnose, clear you to train, or set a return-to-sport timeline."
 
@@ -9397,7 +9399,7 @@ msgstr "This enters the safety path and stops ordinary performance optimization.
 msgid "This evaluates past training only; it does not assess today's weather or conditions."
 msgstr "This evaluates past training only; it does not assess today's weather or conditions."
 
-#: src/components/Outdoor5KPlanStart.tsx:402
+#: src/components/Outdoor5KPlanStart.tsx:416
 msgid "This exact proposal was already adopted. Delivery remains disabled until you explicitly enable it."
 msgstr "This exact proposal was already adopted. Delivery remains disabled until you explicitly enable it."
 
@@ -9425,7 +9427,7 @@ msgstr "This guardrail uses individualized HRV guidance and never loads activity
 msgid "This imported or older workout has no portable tree. Edit its summary as-is, or explicitly convert one flat step without guessing semantics."
 msgstr "This imported or older workout has no portable tree. Edit its summary as-is, or explicitly convert one flat step without guessing semantics."
 
-#: src/components/UpcomingPlanCard.tsx:1197
+#: src/components/UpcomingPlanCard.tsx:1221
 msgid "This imported structure cannot be edited safely. Duplicate it into a supported Praxys workout first."
 msgstr "This imported structure cannot be edited safely. Duplicate it into a supported Praxys workout first."
 
@@ -9437,7 +9439,7 @@ msgstr "This insight changed. Refresh the page before sending feedback."
 msgid "This is a maximal-effort test, and the no-test path always stays available."
 msgstr "This is a maximal-effort test, and the no-test path always stays available."
 
-#: src/components/Outdoor5KPlanStart.tsx:472
+#: src/components/Outdoor5KPlanStart.tsx:502
 msgid "This is a pilot for adult, self-coached recreational outdoor-road 5K runners. It does not diagnose, clear, or guarantee a performance outcome."
 msgstr "This is a pilot for adult, self-coached recreational outdoor-road 5K runners. It does not diagnose, clear, or guarantee a performance outcome."
 
@@ -9517,11 +9519,11 @@ msgstr "This pilot is for adult, self-coached recreational runners preparing for
 msgid "This pilot is only for adults who already can complete 5 km."
 msgstr "This pilot is only for adults who already can complete 5 km."
 
-#: src/components/Outdoor5KPlanStart.tsx:433
+#: src/components/Outdoor5KPlanStart.tsx:449
 msgid "This plan-start pilot is available only for the supported outdoor road 5K performance goal."
 msgstr "This plan-start pilot is available only for the supported outdoor road 5K performance goal."
 
-#: src/components/Outdoor5KPlanStart.tsx:600
+#: src/components/Outdoor5KPlanStart.tsx:630
 msgid "This policy supports outdoor road running only. Terrain, treadmill, trail, and equipment preferences are unsupported inputs and are not inferred."
 msgstr "This policy supports outdoor road running only. Terrain, treadmill, trail, and equipment preferences are unsupported inputs and are not inferred."
 
@@ -9530,11 +9532,11 @@ msgstr "This policy supports outdoor road running only. Terrain, treadmill, trai
 #~ msgstr "This portable structure can be represented without flattening."
 
 #. placeholder {0}: proposalStateLabel(activeProposal.state)
-#: src/components/Outdoor5KPlanStart.tsx:721
+#: src/components/Outdoor5KPlanStart.tsx:751
 msgid "This proposal is {0}. It cannot mutate the canonical plan; review readiness and create a new proposal when you are ready."
 msgstr "This proposal is {0}. It cannot mutate the canonical plan; review readiness and create a new proposal when you are ready."
 
-#: src/components/Outdoor5KPlanStart.tsx:668
+#: src/components/Outdoor5KPlanStart.tsx:698
 msgid "This proposal is not yet your plan. It cannot deliver workouts until after explicit adoption and separate delivery consent."
 msgstr "This proposal is not yet your plan. It cannot deliver workouts until after explicit adoption and separate delivery consent."
 
@@ -9595,7 +9597,7 @@ msgstr "This source uses a newer workout structure and cannot be duplicated with
 #~ msgid "This step termination cannot be represented safely."
 #~ msgstr "This step termination cannot be represented safely."
 
-#: src/components/UpcomingPlanCard.tsx:1191
+#: src/components/UpcomingPlanCard.tsx:1215
 msgid "This structure is authoritative. Edit its steps instead of changing its flat summary."
 msgstr "This structure is authoritative. Edit its steps instead of changing its flat summary."
 
@@ -9608,7 +9610,7 @@ msgstr "This structure is authoritative. Edit its steps instead of changing its 
 msgid "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 msgstr "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 
-#: src/components/UpcomingPlanCard.tsx:1171
+#: src/components/UpcomingPlanCard.tsx:1195
 msgid "This workout changed elsewhere. The plan was refreshed; reopen the workout to continue."
 msgstr "This workout changed elsewhere. The plan was refreshed; reopen the workout to continue."
 
@@ -9616,7 +9618,7 @@ msgstr "This workout changed elsewhere. The plan was refreshed; reopen the worko
 #~ msgid "This workout differs on Stryd — click to overwrite with the Praxys version."
 #~ msgstr "This workout differs on Stryd — click to overwrite with the Praxys version."
 
-#: src/components/UpcomingPlanCard.tsx:752
+#: src/components/UpcomingPlanCard.tsx:753
 msgid "This workout stays external unless you explicitly make it canonical in Praxys."
 msgstr "This workout stays external unless you explicitly make it canonical in Praxys."
 
@@ -9628,7 +9630,7 @@ msgstr "This workout uses a newer portable structure that this editor cannot cha
 #~ msgid "This workout was imported from Stryd."
 #~ msgstr "This workout was imported from Stryd."
 
-#: src/components/UpcomingPlanCard.tsx:580
+#: src/components/UpcomingPlanCard.tsx:581
 #: src/components/WorkoutPlanEditor.tsx:436
 #: src/lib/display-labels.ts:45
 #: src/lib/phase-label.ts:15
@@ -9648,7 +9650,7 @@ msgstr "Threshold Pace Trend"
 msgid "Thresholds"
 msgstr "Thresholds"
 
-#: src/components/PersonalContextPanel.tsx:246
+#: src/components/PersonalContextPanel.tsx:251
 msgid "Thu"
 msgstr "Thu"
 
@@ -9695,7 +9697,7 @@ msgstr "To target"
 msgid "Today"
 msgstr "Today"
 
-#: src/components/UpcomingPlanCard.tsx:626
+#: src/components/UpcomingPlanCard.tsx:627
 msgid "TODAY"
 msgstr "TODAY"
 
@@ -9755,8 +9757,8 @@ msgstr "Total users tracked"
 msgid "Totals are deterministic only when every repeated step has the same measurable termination. Praxys does not invent a training-load score here."
 msgstr "Totals are deterministic only when every repeated step has the same measurable termination. Praxys does not invent a training-load score here."
 
-#: src/components/PersonalContextPanel.tsx:254
-#: src/components/PersonalContextPanel.tsx:263
+#: src/components/PersonalContextPanel.tsx:259
+#: src/components/PersonalContextPanel.tsx:268
 msgid "Track"
 msgstr "Track"
 
@@ -9768,11 +9770,11 @@ msgstr "Track trend over time"
 msgid "Tracking"
 msgstr "Tracking"
 
-#: src/components/PersonalContextPanel.tsx:262
+#: src/components/PersonalContextPanel.tsx:267
 msgid "Trail"
 msgstr "Trail"
 
-#: src/components/UpcomingPlanCard.tsx:565
+#: src/components/UpcomingPlanCard.tsx:566
 #: src/components/WorkoutPlanEditor.tsx:444
 msgid "Trail running"
 msgstr "Trail running"
@@ -9810,8 +9812,8 @@ msgstr "Training review"
 msgid "Training Science"
 msgstr "Training Science"
 
-#: src/components/PersonalContextPanel.tsx:228
-#: src/components/PersonalContextPanel.tsx:229
+#: src/components/PersonalContextPanel.tsx:233
+#: src/components/PersonalContextPanel.tsx:234
 msgid "Training state"
 msgstr "Training state"
 
@@ -9823,12 +9825,12 @@ msgstr "Training Zones"
 msgid "Translates training stress into fitness."
 msgstr "Translates training stress into fitness."
 
-#: src/components/PersonalContextPanel.tsx:227
+#: src/components/PersonalContextPanel.tsx:232
 msgid "Travel"
 msgstr "Travel"
 
-#: src/components/PersonalContextPanel.tsx:253
-#: src/components/PersonalContextPanel.tsx:264
+#: src/components/PersonalContextPanel.tsx:258
+#: src/components/PersonalContextPanel.tsx:269
 msgid "Treadmill"
 msgstr "Treadmill"
 
@@ -9853,7 +9855,7 @@ msgstr "Trusted sync and connection outcomes from the backend telemetry boundary
 #~ msgid "Trusted Today signals"
 #~ msgstr "Trusted Today signals"
 
-#: src/components/UpcomingPlanCard.tsx:1629
+#: src/components/UpcomingPlanCard.tsx:1653
 msgid "Try a longer window above."
 msgstr "Try a longer window above."
 
@@ -9873,7 +9875,7 @@ msgstr "TSB"
 msgid "TSB (load balance)"
 msgstr "TSB (load balance)"
 
-#: src/components/PersonalContextPanel.tsx:244
+#: src/components/PersonalContextPanel.tsx:249
 msgid "Tue"
 msgstr "Tue"
 
@@ -9942,11 +9944,11 @@ msgstr "Unable to reach the status service"
 msgid "Unavailable"
 msgstr "Unavailable"
 
-#: src/components/PersonalContextPanel.tsx:224
+#: src/components/PersonalContextPanel.tsx:229
 msgid "Unavailable day"
 msgstr "Unavailable day"
 
-#: src/components/PersonalContextPanel.tsx:1355
+#: src/components/PersonalContextPanel.tsx:1360
 msgid "Unavailable for safety context"
 msgstr "Unavailable for safety context"
 
@@ -10009,7 +10011,7 @@ msgid "Unknown failure"
 msgstr "Unknown failure"
 
 #. placeholder {0}: formatDate(item.expires_at)
-#: src/components/PersonalContextPanel.tsx:809
+#: src/components/PersonalContextPanel.tsx:814
 msgid "until {0}"
 msgstr "until {0}"
 
@@ -10025,7 +10027,7 @@ msgstr "Unverified"
 msgid "Up to date"
 msgstr "Up to date"
 
-#: src/components/UpcomingPlanCard.tsx:1432
+#: src/components/UpcomingPlanCard.tsx:1456
 msgid "Upcoming Plan"
 msgstr "Upcoming Plan"
 
@@ -10081,11 +10083,11 @@ msgstr "Usage aggregates are unavailable."
 #~ msgid "Usage proxy"
 #~ msgstr "Usage proxy"
 
-#: src/components/UpcomingPlanCard.tsx:851
+#: src/components/UpcomingPlanCard.tsx:852
 msgid "Use {target} version"
 msgstr "Use {target} version"
 
-#: src/components/UpcomingPlanCard.tsx:835
+#: src/components/UpcomingPlanCard.tsx:836
 msgid "Use {target}:"
 msgstr "Use {target}:"
 
@@ -10101,7 +10103,7 @@ msgstr "Use confirmed context for plan generation"
 msgid "Use history first, then decide whether the optional pilot test is needed"
 msgstr "Use history first, then decide whether the optional pilot test is needed"
 
-#: src/components/UpcomingPlanCard.tsx:357
+#: src/components/UpcomingPlanCard.tsx:358
 msgid "Use in Praxys"
 msgstr "Use in Praxys"
 
@@ -10118,7 +10120,7 @@ msgstr "Use Praxys on the go with the WeChat Mini Program"
 #~ msgid "Use this"
 #~ msgstr "Use this"
 
-#: src/components/UpcomingPlanCard.tsx:746
+#: src/components/UpcomingPlanCard.tsx:747
 msgid "Use this {target} workout in Praxys?"
 msgstr "Use this {target} workout in Praxys?"
 
@@ -10189,7 +10191,7 @@ msgstr "Verification failed"
 msgid "Verify"
 msgstr "Verify"
 
-#: src/components/UpcomingPlanCard.tsx:413
+#: src/components/UpcomingPlanCard.tsx:414
 msgid "Verifying"
 msgstr "Verifying"
 
@@ -10256,7 +10258,7 @@ msgstr "Waitlist"
 msgid "Waitlist unavailable"
 msgstr "Waitlist unavailable"
 
-#: src/components/UpcomingPlanCard.tsx:567
+#: src/components/UpcomingPlanCard.tsx:568
 #: src/components/WorkoutPlanEditor.tsx:446
 #: src/pages/Setup.tsx:168
 msgid "Walking"
@@ -10301,7 +10303,7 @@ msgstr "We're inviting runners in waves while we tighten the science. Drop your 
 msgid "We've logged it and will take a look."
 msgstr "We've logged it and will take a look."
 
-#: src/components/PersonalContextPanel.tsx:233
+#: src/components/PersonalContextPanel.tsx:238
 msgid "Weather"
 msgstr "Weather"
 
@@ -10325,7 +10327,7 @@ msgstr "WeChat Mini Program"
 msgid "WeChat Mini Program QR code"
 msgstr "WeChat Mini Program QR code"
 
-#: src/components/PersonalContextPanel.tsx:245
+#: src/components/PersonalContextPanel.tsx:250
 msgid "Wed"
 msgstr "Wed"
 
@@ -10386,11 +10388,11 @@ msgstr "wet-bulb proxy"
 msgid "Wet-bulb proxy calculator"
 msgstr "Wet-bulb proxy calculator"
 
-#: src/components/PersonalContextPanel.tsx:866
+#: src/components/PersonalContextPanel.tsx:871
 msgid "What availability changed?"
 msgstr "What availability changed?"
 
-#: src/components/PersonalContextPanel.tsx:865
+#: src/components/PersonalContextPanel.tsx:870
 msgid "What changed with this workout?"
 msgstr "What changed with this workout?"
 
@@ -10406,7 +10408,7 @@ msgstr "What changed with this workout?"
 msgid "What happened, or what would you like to see?"
 msgstr "What happened, or what would you like to see?"
 
-#: src/components/PersonalContextPanel.tsx:941
+#: src/components/PersonalContextPanel.tsx:946
 msgid "What happened?"
 msgstr "What happened?"
 
@@ -10450,7 +10452,7 @@ msgstr "Will sync:"
 msgid "Withdraw"
 msgstr "Withdraw"
 
-#: src/components/PersonalContextPanel.tsx:1684
+#: src/components/PersonalContextPanel.tsx:1689
 msgid "Withdraw AI permission"
 msgstr "Withdraw AI permission"
 
@@ -10478,8 +10480,8 @@ msgstr "Withdrawal deletes the experiment consent and aggregate result. Rejoinin
 msgid "Withdrawal immediately deletes experiment consent and the derived result. Your ordinary account activities remain unchanged."
 msgstr "Withdrawal immediately deletes experiment consent and the derived result. Your ordinary account activities remain unchanged."
 
-#: src/components/PersonalContextPanel.tsx:799
-#: src/components/PersonalContextPanel.tsx:1332
+#: src/components/PersonalContextPanel.tsx:804
+#: src/components/PersonalContextPanel.tsx:1337
 msgid "Withdrawn"
 msgstr "Withdrawn"
 
@@ -10491,7 +10493,7 @@ msgstr "Within reference band"
 msgid "Work"
 msgstr "Work"
 
-#: src/components/UpcomingPlanCard.tsx:324
+#: src/components/UpcomingPlanCard.tsx:325
 msgid "Working…"
 msgstr "Working…"
 
@@ -10500,8 +10502,8 @@ msgid "Workload evidence"
 msgstr "Workload evidence"
 
 #: src/components/ManagedPlanSettingsCard.tsx:979
-#: src/components/PersonalContextPanel.tsx:879
-#: src/components/UpcomingPlanCard.tsx:1574
+#: src/components/PersonalContextPanel.tsx:884
+#: src/components/UpcomingPlanCard.tsx:1598
 msgid "Workout"
 msgstr "Workout"
 
@@ -10509,7 +10511,7 @@ msgstr "Workout"
 msgid "Workout conflict requires athlete input"
 msgstr "Workout conflict requires athlete input"
 
-#: src/components/Outdoor5KPlanStart.tsx:689
+#: src/components/Outdoor5KPlanStart.tsx:719
 msgid "Workout content is view-only in this deterministic policy. Change the bounded inputs above and regenerate to create an immutable successor; Praxys never constructs replacement workouts in this client."
 msgstr "Workout content is view-only in this deterministic policy. Change the bounded inputs above and regenerate to create an immutable successor; Praxys never constructs replacement workouts in this client."
 
@@ -10525,12 +10527,12 @@ msgstr "Workout delivery is not supported."
 #~ msgid "Workout differs on Stryd — re-push to overwrite"
 #~ msgstr "Workout differs on Stryd — re-push to overwrite"
 
-#: src/components/PersonalContextPanel.tsx:805
+#: src/components/PersonalContextPanel.tsx:810
 #: src/pages/McpAuthorization.tsx:51
 msgid "Workout explanation"
 msgstr "Workout explanation"
 
-#: src/components/PersonalContextPanel.tsx:1341
+#: src/components/PersonalContextPanel.tsx:1346
 msgid "Workout interpretation"
 msgstr "Workout interpretation"
 
@@ -10552,7 +10554,7 @@ msgstr "Workout profile"
 msgid "Workout purpose"
 msgstr "Workout purpose"
 
-#: src/components/PersonalContextPanel.tsx:274
+#: src/components/PersonalContextPanel.tsx:279
 msgid "Workout status"
 msgstr "Workout status"
 
@@ -10588,7 +10590,7 @@ msgstr "You can leave this page and return later. No action is needed while the 
 msgid "You can still save this workout in Praxys, but managed delivery cannot preserve it until the marked details are changed."
 msgstr "You can still save this workout in Praxys, but managed delivery cannot preserve it until the marked details are changed."
 
-#: src/components/PersonalContextPanel.tsx:1649
+#: src/components/PersonalContextPanel.tsx:1654
 msgid "You can withdraw before any later request. Withdrawal cannot recall a request the provider already processed. Deleting the item removes local provider-use receipts and dependent private explanations."
 msgstr "You can withdraw before any later request. Withdrawal cannot recall a request the provider already processed. Deleting the item removes local provider-use receipts and dependent private explanations."
 

--- a/web/src/locales/zh/messages.po
+++ b/web/src/locales/zh/messages.po
@@ -26,7 +26,7 @@ msgstr "· 最近 {0} 周"
 msgid "(Garmin rate limits apply)"
 msgstr "（受 Garmin 访问频率限制）"
 
-#: src/components/PersonalContextPanel.tsx:1055
+#: src/components/PersonalContextPanel.tsx:1060
 msgid "(optional)"
 msgstr "（可选）"
 
@@ -46,7 +46,7 @@ msgid "{0, plural, one {# recommendation} other {# recommendations}}"
 msgstr "{0, plural, other {# 条建议}}"
 
 #. placeholder {0}: data.workouts.length
-#: src/components/UpcomingPlanCard.tsx:1477
+#: src/components/UpcomingPlanCard.tsx:1501
 msgid "{0, plural, one {# workout} other {# workouts}}"
 msgstr "{0, plural, other {# 次训练}}"
 
@@ -242,7 +242,7 @@ msgstr "{abbrev} <0>{dirLabel}</0>。再同步一些活动后即可生成比赛�
 msgid "{completed} of {0} steps complete"
 msgstr "已完成 {completed} / {0} 步"
 
-#: src/components/UpcomingPlanCard.tsx:1470
+#: src/components/UpcomingPlanCard.tsx:1494
 msgid "{conflictCount, plural, one {# needs review} other {# need review}}"
 msgstr "{conflictCount, plural, other {# 个待处理}}"
 
@@ -250,7 +250,7 @@ msgstr "{conflictCount, plural, other {# 个待处理}}"
 #~ msgid "{conflictCount} need review"
 #~ msgstr "{conflictCount} 个待处理"
 
-#: src/components/Outdoor5KPlanStart.tsx:552
+#: src/components/Outdoor5KPlanStart.tsx:582
 msgid "{dayLabel} time limit (minutes)"
 msgstr "{dayLabel} 时间上限（分钟）"
 
@@ -300,7 +300,7 @@ msgstr "等效热暴露 {minutes} 分钟"
 msgid "{observationCount}-observation Trend"
 msgstr "{observationCount}次观测趋势"
 
-#: src/components/UpcomingPlanCard.tsx:787
+#: src/components/UpcomingPlanCard.tsx:788
 msgid "{target} version"
 msgstr "{target} 版本"
 
@@ -385,7 +385,7 @@ msgstr "1 天前"
 msgid "1 month"
 msgstr "1 个月"
 
-#: src/components/UpcomingPlanCard.tsx:173
+#: src/components/UpcomingPlanCard.tsx:174
 msgid "1 wk"
 msgstr "1 周"
 
@@ -420,7 +420,7 @@ msgstr "14 天托管窗口"
 msgid "1Y"
 msgstr "1年"
 
-#: src/components/UpcomingPlanCard.tsx:174
+#: src/components/UpcomingPlanCard.tsx:175
 msgid "2 wk"
 msgstr "2 周"
 
@@ -440,7 +440,7 @@ msgstr "3 个月"
 msgid "3M"
 msgstr "3月"
 
-#: src/components/UpcomingPlanCard.tsx:175
+#: src/components/UpcomingPlanCard.tsx:176
 msgid "4 wk"
 msgstr "4 周"
 
@@ -555,7 +555,7 @@ msgstr "单次活动对结果的影响过大。"
 msgid "A Stryd-aligned Critical Power value is required for this experiment."
 msgstr "此实验需要与 Stryd 数据一致的临界功率值。"
 
-#: src/components/Outdoor5KPlanStart.tsx:340
+#: src/components/Outdoor5KPlanStart.tsx:354
 msgid "A successor proposal is ready. The earlier proposal is preserved as superseded."
 msgstr "后继提案已就绪。此前的提案会保留为已取代。"
 
@@ -634,8 +634,8 @@ msgid "Activate managed plan"
 msgstr "启用托管计划"
 
 #: src/components/ManagedPlanSettingsCard.tsx:487
-#: src/components/PersonalContextPanel.tsx:797
-#: src/components/PersonalContextPanel.tsx:1330
+#: src/components/PersonalContextPanel.tsx:802
+#: src/components/PersonalContextPanel.tsx:1335
 #: src/pages/admin/AdminFeedback.tsx:351
 #: src/pages/admin/AdminOps.tsx:1584
 #: src/pages/Science.tsx:405
@@ -665,8 +665,8 @@ msgstr "当前故障"
 msgid "Active incidents: {0}"
 msgstr "活跃事件：{0}"
 
-#: src/components/PersonalContextPanel.tsx:1164
-#: src/components/PersonalContextPanel.tsx:1345
+#: src/components/PersonalContextPanel.tsx:1169
+#: src/components/PersonalContextPanel.tsx:1350
 msgid "Active until"
 msgstr "生效至"
 
@@ -752,7 +752,7 @@ msgstr "添加一个步骤或重复组即可开始。"
 msgid "Add at least one step to this repeat."
 msgstr "请为此重复组至少添加一个步骤。"
 
-#: src/components/PersonalContextPanel.tsx:729
+#: src/components/PersonalContextPanel.tsx:734
 msgid "Add availability"
 msgstr "调整可训练时间"
 
@@ -776,11 +776,11 @@ msgstr "添加截图"
 #~ msgid "Add step"
 #~ msgstr "添加步骤"
 
-#: src/components/UpcomingPlanCard.tsx:1643
+#: src/components/UpcomingPlanCard.tsx:1667
 msgid "Add the first workout"
 msgstr "添加首项训练"
 
-#: src/components/UpcomingPlanCard.tsx:1490
+#: src/components/UpcomingPlanCard.tsx:1514
 #: src/components/WorkoutPlanEditor.tsx:642
 #: src/components/WorkoutPlanEditor.tsx:931
 msgid "Add workout"
@@ -809,11 +809,11 @@ msgstr "管理后台"
 msgid "Admin sections"
 msgstr "管理模块"
 
-#: src/components/Outdoor5KPlanStart.tsx:705
+#: src/components/Outdoor5KPlanStart.tsx:735
 msgid "Adopt exact proposal"
 msgstr "采纳此精确提案"
 
-#: src/components/UpcomingPlanCard.tsx:260
+#: src/components/UpcomingPlanCard.tsx:261
 msgid "Adopt in Settings"
 msgstr "前往设置启用"
 
@@ -821,7 +821,7 @@ msgstr "前往设置启用"
 msgid "Adopt Praxys as your planner before enabling automatic changes. Coaching remains suggestion-only."
 msgstr "将 Praxys 设为计划方后，才能启用自动调整。目前仍仅提供建议。"
 
-#: src/components/Outdoor5KPlanStart.tsx:705
+#: src/components/Outdoor5KPlanStart.tsx:735
 msgid "Adopting…"
 msgstr "正在采纳…"
 
@@ -833,15 +833,15 @@ msgstr "正在采纳…"
 msgid "Aerobic"
 msgstr "有氧"
 
-#: src/components/PersonalContextPanel.tsx:269
+#: src/components/PersonalContextPanel.tsx:274
 msgid "Affected dates"
 msgstr "受影响日期"
 
-#: src/components/PersonalContextPanel.tsx:270
+#: src/components/PersonalContextPanel.tsx:275
 msgid "Affected weekdays"
 msgstr "受影响的星期几"
 
-#: src/components/PersonalContextPanel.tsx:1075
+#: src/components/PersonalContextPanel.tsx:1080
 msgid "Affected weekdays (optional)"
 msgstr "哪些天受影响（可多选）"
 
@@ -873,35 +873,35 @@ msgstr "agent-ready 候选"
 msgid "Aggregate storage"
 msgstr "仅存储汇总结果"
 
-#: src/components/PersonalContextPanel.tsx:813
+#: src/components/PersonalContextPanel.tsx:818
 msgid "AI allowed"
 msgstr "已允许 AI 处理"
 
-#: src/components/PersonalContextPanel.tsx:1520
+#: src/components/PersonalContextPanel.tsx:1525
 msgid "AI option"
 msgstr "AI 处理选项"
 
-#: src/components/PersonalContextPanel.tsx:1640
+#: src/components/PersonalContextPanel.tsx:1645
 msgid "AI output can be wrong. It cannot diagnose, provide treatment, clear you to train, or override Praxys safety, science, and approval boundaries."
 msgstr "AI 可能出错，不能用于诊断、治疗或判断是否可以训练，也不能绕过 Praxys 的安全、科学和用户确认规则。"
 
-#: src/components/PersonalContextPanel.tsx:1351
+#: src/components/PersonalContextPanel.tsx:1356
 msgid "AI processing"
 msgstr "AI 处理"
 
-#: src/components/PersonalContextPanel.tsx:633
+#: src/components/PersonalContextPanel.tsx:638
 msgid "AI processing enabled for this item only."
 msgstr "已仅为当前版本开启 AI 处理。"
 
-#: src/components/PersonalContextPanel.tsx:1573
+#: src/components/PersonalContextPanel.tsx:1578
 msgid "AI processing for one item"
 msgstr "仅为这条信息开启 AI"
 
-#: src/components/PersonalContextPanel.tsx:634
+#: src/components/PersonalContextPanel.tsx:639
 msgid "AI processing withdrawn. No new provider requests are allowed."
 msgstr "AI 权限已撤回，不会再向 AI 服务发送新的请求。"
 
-#: src/components/PersonalContextPanel.tsx:1582
+#: src/components/PersonalContextPanel.tsx:1587
 msgid "AI service: Microsoft Azure"
 msgstr "AI 服务：Microsoft Azure"
 
@@ -946,7 +946,7 @@ msgstr "系统运行正常"
 msgid "All Systems Operational"
 msgstr "所有系统运行正常"
 
-#: src/components/PersonalContextPanel.tsx:1695
+#: src/components/PersonalContextPanel.tsx:1700
 msgid "Allow for this item"
 msgstr "允许处理当前版本"
 
@@ -954,7 +954,7 @@ msgstr "允许处理当前版本"
 msgid "Allow structured plan context?"
 msgstr "允许访问结构化计划个性化信息？"
 
-#: src/components/PersonalContextPanel.tsx:1357
+#: src/components/PersonalContextPanel.tsx:1362
 msgid "Allowed for this item"
 msgstr "仅当前版本已允许"
 
@@ -967,11 +967,11 @@ msgstr "仅当前版本已允许"
 msgid "Already have an invitation code?"
 msgstr "已有邀请码？"
 
-#: src/components/PersonalContextPanel.tsx:1628
+#: src/components/PersonalContextPanel.tsx:1633
 msgid "Also send my optional note"
 msgstr "同时发送补充说明"
 
-#: src/components/UpcomingPlanCard.tsx:1563
+#: src/components/UpcomingPlanCard.tsx:1587
 msgid "An earlier automatic change was superseded"
 msgstr "此前的自动调整已被后续更改覆盖"
 
@@ -979,7 +979,7 @@ msgstr "此前的自动调整已被后续更改覆盖"
 #~ msgid "An empty structured workout cannot be sent."
 #~ msgstr "无法发送空的结构化训练。"
 
-#: src/components/UpcomingPlanCard.tsx:1514
+#: src/components/UpcomingPlanCard.tsx:1538
 msgid "An external planner overlaps the Praxys plan. Use one planner at a time to avoid duplicate or conflicting sessions."
 msgstr "其他计划源与 Praxys 计划有重叠。建议一次只使用一个计划源，避免重复或冲突训练。"
 
@@ -1033,7 +1033,7 @@ msgstr "API"
 msgid "Applied"
 msgstr "已应用"
 
-#: src/components/UpcomingPlanCard.tsx:851
+#: src/components/UpcomingPlanCard.tsx:852
 msgid "Applying…"
 msgstr "正在应用…"
 
@@ -1131,9 +1131,9 @@ msgstr "恢复状态自动调整"
 msgid "Automatic retries exhausted"
 msgstr "自动重试已耗尽"
 
-#: src/components/PersonalContextPanel.tsx:223
-#: src/components/PersonalContextPanel.tsx:224
-#: src/components/PersonalContextPanel.tsx:225
+#: src/components/PersonalContextPanel.tsx:228
+#: src/components/PersonalContextPanel.tsx:229
+#: src/components/PersonalContextPanel.tsx:230
 msgid "Availability"
 msgstr "可用性"
 
@@ -1146,7 +1146,7 @@ msgstr "可用率"
 msgid "Available"
 msgstr "可用"
 
-#: src/components/PersonalContextPanel.tsx:272
+#: src/components/PersonalContextPanel.tsx:277
 msgid "Available equipment"
 msgstr "可用装备"
 
@@ -1154,15 +1154,15 @@ msgstr "可用装备"
 msgid "Available experiments"
 msgstr "可参与的实验"
 
-#: src/components/PersonalContextPanel.tsx:381
+#: src/components/PersonalContextPanel.tsx:386
 msgid "Available minutes must be a whole number from 1 to 1440."
 msgstr "可训练时长须为 1 到 1440 之间的整数。"
 
-#: src/components/Outdoor5KPlanStart.tsx:522
+#: src/components/Outdoor5KPlanStart.tsx:552
 msgid "Available run days"
 msgstr "可跑步的日期"
 
-#: src/components/PersonalContextPanel.tsx:273
+#: src/components/PersonalContextPanel.tsx:278
 msgid "Available terrain"
 msgstr "可训练地形"
 
@@ -1178,7 +1178,7 @@ msgstr "平均功率"
 msgid "Avg Work {intensityLabel}"
 msgstr "平均工作 {intensityLabel}"
 
-#: src/components/PersonalContextPanel.tsx:1136
+#: src/components/PersonalContextPanel.tsx:1141
 msgid "Avoid names, diagnoses, precise locations, and other private details. Notes are deleted after 30 days even when the structured context remains."
 msgstr "请勿填写姓名、疾病诊断、精确位置等敏感信息。即使其他信息仍在保留期内，补充说明也会在 30 天后删除。"
 
@@ -1219,7 +1219,7 @@ msgstr "Azure Monitor 返回了不完整的结果，因此此部分未刷新。"
 #~ msgid "Azure-backed summary"
 #~ msgstr "Azure 汇总"
 
-#: src/components/PersonalContextPanel.tsx:1262
+#: src/components/PersonalContextPanel.tsx:1267
 msgid "Back"
 msgstr "返回"
 
@@ -1281,12 +1281,12 @@ msgstr "基准"
 msgid "Baseline evidence is currently sufficient."
 msgstr "当前基线证据足够。"
 
-#: src/components/Outdoor5KPlanStart.tsx:463
+#: src/components/Outdoor5KPlanStart.tsx:493
 msgid "Baseline needs review"
 msgstr "基线需要复核"
 
 #: src/components/Outdoor5KPlanStart.tsx:105
-#: src/components/Outdoor5KPlanStart.tsx:463
+#: src/components/Outdoor5KPlanStart.tsx:493
 msgid "Baseline ready"
 msgstr "基线已就绪"
 
@@ -1314,7 +1314,7 @@ msgstr "低于警戒区间"
 #~ msgid "Below threshold"
 #~ msgstr "未达阈值"
 
-#: src/components/PersonalContextPanel.tsx:256
+#: src/components/PersonalContextPanel.tsx:261
 msgid "Bike"
 msgstr "自行车"
 
@@ -1335,7 +1335,7 @@ msgstr "Bootstrap 区间"
 msgid "Both thresholds must be met. The bars describe model evidence, not a biological adaptation percentage."
 msgstr "必须同时达到两个阈值。这些进度条表示模型证据，而不是生理适应百分比。"
 
-#: src/components/UpcomingPlanCard.tsx:1438
+#: src/components/UpcomingPlanCard.tsx:1462
 msgid "Browse plan dates"
 msgstr "浏览训练计划日期"
 
@@ -1412,8 +1412,8 @@ msgstr "计算器"
 #: src/components/ManagedPlanSettingsCard.tsx:1210
 #: src/components/ManagedPlanSettingsCard.tsx:1435
 #: src/components/ManagedPlanSettingsCard.tsx:1454
-#: src/components/PersonalContextPanel.tsx:1475
-#: src/components/UpcomingPlanCard.tsx:843
+#: src/components/PersonalContextPanel.tsx:1480
+#: src/components/UpcomingPlanCard.tsx:844
 #: src/components/WorkoutPlanEditor.tsx:917
 #: src/pages/admin/AdminOps.tsx:1215
 #: src/pages/admin/AdminUsers.tsx:1043
@@ -1449,7 +1449,7 @@ msgstr "Praxys 仍会完整保留训练"
 msgid "CAPTCHA required"
 msgstr "需要 CAPTCHA"
 
-#: src/components/PersonalContextPanel.tsx:226
+#: src/components/PersonalContextPanel.tsx:231
 msgid "Caregiving"
 msgstr "照护安排"
 
@@ -1467,9 +1467,9 @@ msgstr "把训练信号带到户外。扫码即可在微信中打开 Praxys。"
 msgid "cases"
 msgstr "样本"
 
-#: src/components/PersonalContextPanel.tsx:301
-#: src/components/PersonalContextPanel.tsx:971
-#: src/components/PersonalContextPanel.tsx:1158
+#: src/components/PersonalContextPanel.tsx:306
+#: src/components/PersonalContextPanel.tsx:976
+#: src/components/PersonalContextPanel.tsx:1163
 msgid "Category"
 msgstr "类别"
 
@@ -1515,7 +1515,7 @@ msgstr "后续已更改"
 msgid "Changed what I'll do"
 msgstr "调整了今天的训练安排"
 
-#: src/components/Outdoor5KPlanStart.tsx:610
+#: src/components/Outdoor5KPlanStart.tsx:640
 msgid "Check readiness"
 msgstr "检查准备情况"
 
@@ -1539,7 +1539,7 @@ msgstr "正在检查交付兼容性…"
 #~ msgid "Checking provider compatibility…"
 #~ msgstr "正在检查平台兼容性…"
 
-#: src/components/Outdoor5KPlanStart.tsx:610
+#: src/components/Outdoor5KPlanStart.tsx:640
 msgid "Checking readiness…"
 msgstr "正在检查准备情况…"
 
@@ -1557,7 +1557,7 @@ msgstr "中国"
 msgid "Chinese"
 msgstr "中文"
 
-#: src/components/PersonalContextPanel.tsx:983
+#: src/components/PersonalContextPanel.tsx:988
 msgid "Choose a category"
 msgstr "选择原因类型"
 
@@ -1573,7 +1573,7 @@ msgstr "选择原因类型"
 msgid "Choose a race target, track continuous progress, or use the 5K baseline pilot."
 msgstr "选择比赛目标、持续追踪进步，或使用 5 公里基线试点。"
 
-#: src/components/PersonalContextPanel.tsx:914
+#: src/components/PersonalContextPanel.tsx:919
 msgid "Choose a recent workout"
 msgstr "选择近期训练"
 
@@ -1585,7 +1585,7 @@ msgstr "选择要同步多少历史数据"
 msgid "Choose one"
 msgstr "请选择"
 
-#: src/components/PersonalContextPanel.tsx:360
+#: src/components/PersonalContextPanel.tsx:365
 msgid "Choose one category to continue."
 msgstr "请先选择原因类型。"
 
@@ -1593,11 +1593,11 @@ msgstr "请先选择原因类型。"
 msgid "Choose primary source"
 msgstr "选择首选数据来源"
 
-#: src/components/Outdoor5KPlanStart.tsx:195
+#: src/components/Outdoor5KPlanStart.tsx:209
 msgid "Choose the days you are available to run."
 msgstr "请选择可以跑步的日期。"
 
-#: src/components/PersonalContextPanel.tsx:365
+#: src/components/PersonalContextPanel.tsx:370
 msgid "Choose the workout that changed."
 msgstr "请选择要说明的训练。"
 
@@ -1610,11 +1610,11 @@ msgstr "选择训练基准"
 msgid "Choose voluntary experiments that help you inspect your own training history without turning early research into advice."
 msgstr "选择自愿参与的实验，用自己的训练历史探索规律，同时避免把早期研究包装成建议。"
 
-#: src/components/PersonalContextPanel.tsx:370
+#: src/components/PersonalContextPanel.tsx:375
 msgid "Choose when this constraint starts and ends."
 msgstr "请选择这项安排的开始和结束日期。"
 
-#: src/components/PersonalContextPanel.tsx:366
+#: src/components/PersonalContextPanel.tsx:371
 msgid "Choose whether it was missed or modified."
 msgstr "请选择这次训练是未完成还是做了调整。"
 
@@ -1726,7 +1726,7 @@ msgstr "兼容性预览暂不可用。请检查网络后重试。"
 msgid "Complete these steps to unlock your training insights"
 msgstr "完成以下步骤，解锁训练解读"
 
-#: src/components/Outdoor5KPlanStart.tsx:634
+#: src/components/Outdoor5KPlanStart.tsx:664
 msgid "complete weeks; latest run"
 msgstr "个完整周；最近一次跑步"
 
@@ -1778,7 +1778,7 @@ msgstr "确认已满 18 周岁后才能加入此实验。"
 msgid "Confirm the boundary before Praxys writes to {targetLabel}."
 msgstr "确认管理边界后，Praxys 才会写入 {targetLabel}。"
 
-#: src/components/Outdoor5KPlanStart.tsx:193
+#: src/components/Outdoor5KPlanStart.tsx:207
 msgid "Confirm the supported athlete and goal scope first."
 msgstr "请先确认受支持的运动员和目标范围。"
 
@@ -1795,7 +1795,7 @@ msgstr "确认按原计划训练"
 msgid "Conflict <0>{0}</0>"
 msgstr "冲突 <0>{0}</0>"
 
-#: src/components/UpcomingPlanCard.tsx:374
+#: src/components/UpcomingPlanCard.tsx:375
 msgid "Conflict retained"
 msgstr "冲突已保留"
 
@@ -1874,11 +1874,11 @@ msgstr "连接转化漏斗"
 msgid "Consent text version"
 msgstr "同意文本版本"
 
-#: src/components/PersonalContextPanel.tsx:573
+#: src/components/PersonalContextPanel.tsx:578
 msgid "Context and dependent private traces deleted."
 msgstr "这条信息及其关联的私密记录已删除。"
 
-#: src/components/PersonalContextPanel.tsx:545
+#: src/components/PersonalContextPanel.tsx:550
 msgid "Context excluded from future assessments."
 msgstr "这条信息不会再用于后续评估。"
 
@@ -1886,7 +1886,7 @@ msgstr "这条信息不会再用于后续评估。"
 msgid "Context type"
 msgstr "信息类型"
 
-#: src/components/PersonalContextPanel.tsx:1405
+#: src/components/PersonalContextPanel.tsx:1410
 msgid "Context use"
 msgstr "使用记录"
 
@@ -1962,15 +1962,15 @@ msgstr "放松"
 msgid "Copy code"
 msgstr "复制邀请码"
 
-#: src/components/UpcomingPlanCard.tsx:836
+#: src/components/UpcomingPlanCard.tsx:837
 msgid "copy the target workout into Praxys; future management follows that version."
 msgstr "将目标平台上的训练复制到 Praxys，之后以该版本为准。"
 
-#: src/components/PersonalContextPanel.tsx:1507
+#: src/components/PersonalContextPanel.tsx:1512
 msgid "Correct"
 msgstr "更正"
 
-#: src/components/PersonalContextPanel.tsx:863
+#: src/components/PersonalContextPanel.tsx:868
 msgid "Correct private context"
 msgstr "更正计划个性化信息"
 
@@ -1978,17 +1978,17 @@ msgstr "更正计划个性化信息"
 #~ msgid "Cosmetic — changes names and colors without affecting calculations"
 #~ msgstr "仅外观——更改名称与颜色，不影响计算"
 
-#: src/components/UpcomingPlanCard.tsx:1264
+#: src/components/UpcomingPlanCard.tsx:1288
 msgid "Could not add this workout"
 msgstr "无法添加这项训练"
 
-#: src/components/Outdoor5KPlanStart.tsx:398
-#: src/components/Outdoor5KPlanStart.tsx:407
+#: src/components/Outdoor5KPlanStart.tsx:412
+#: src/components/Outdoor5KPlanStart.tsx:421
 msgid "Could not adopt the proposal."
 msgstr "无法采纳该提案。"
 
-#: src/components/Outdoor5KPlanStart.tsx:270
-#: src/components/Outdoor5KPlanStart.tsx:275
+#: src/components/Outdoor5KPlanStart.tsx:284
+#: src/components/Outdoor5KPlanStart.tsx:289
 msgid "Could not assess this plan start."
 msgstr "无法评估此计划起点。"
 
@@ -2006,25 +2006,25 @@ msgstr "无法更换执行平台"
 msgid "Could not convert this legacy workout."
 msgstr "无法转换此旧版训练。"
 
-#: src/components/UpcomingPlanCard.tsx:1308
+#: src/components/UpcomingPlanCard.tsx:1332
 msgid "Could not convert this workout to rest"
 msgstr "无法将这项训练改为休息"
 
-#: src/components/Outdoor5KPlanStart.tsx:298
-#: src/components/Outdoor5KPlanStart.tsx:309
+#: src/components/Outdoor5KPlanStart.tsx:312
+#: src/components/Outdoor5KPlanStart.tsx:323
 msgid "Could not create the proposal."
 msgstr "无法创建提案。"
 
-#: src/components/PersonalContextPanel.tsx:569
-#: src/components/PersonalContextPanel.tsx:578
+#: src/components/PersonalContextPanel.tsx:574
+#: src/components/PersonalContextPanel.tsx:583
 msgid "Could not delete this private context."
 msgstr "无法删除这条计划个性化信息。"
 
-#: src/components/UpcomingPlanCard.tsx:1337
+#: src/components/UpcomingPlanCard.tsx:1361
 msgid "Could not delete this workout"
 msgstr "无法删除这项训练"
 
-#: src/components/PersonalContextPanel.tsx:627
+#: src/components/PersonalContextPanel.tsx:632
 msgid "Could not enable AI processing."
 msgstr "无法启用 AI 处理。"
 
@@ -2032,8 +2032,8 @@ msgstr "无法启用 AI 处理。"
 msgid "Could not enable managed delivery"
 msgstr "无法启用托管下发"
 
-#: src/components/PersonalContextPanel.tsx:654
-#: src/components/PersonalContextPanel.tsx:673
+#: src/components/PersonalContextPanel.tsx:659
+#: src/components/PersonalContextPanel.tsx:678
 msgid "Could not export private context."
 msgstr "无法导出计划个性化信息。"
 
@@ -2045,7 +2045,8 @@ msgstr "无法退出托管模式"
 msgid "Could not load automatic change history."
 msgstr "无法加载自动调整记录。"
 
-#: src/components/Outdoor5KPlanStart.tsx:418
+#: src/components/Outdoor5KPlanStart.tsx:432
+#: src/components/Outdoor5KPlanStart.tsx:462
 msgid "Could not load plan-start context"
 msgstr "无法加载计划起点上下文"
 
@@ -2053,8 +2054,8 @@ msgstr "无法加载计划起点上下文"
 msgid "Could not load the managed-window preview."
 msgstr "无法加载托管窗口预览。"
 
-#: src/components/PersonalContextPanel.tsx:509
-#: src/components/PersonalContextPanel.tsx:516
+#: src/components/PersonalContextPanel.tsx:514
+#: src/components/PersonalContextPanel.tsx:521
 msgid "Could not load this private context."
 msgstr "无法加载这条计划个性化信息。"
 
@@ -2062,17 +2063,17 @@ msgstr "无法加载这条计划个性化信息。"
 msgid "Could not pause delivery"
 msgstr "无法暂停下发"
 
-#: src/components/Outdoor5KPlanStart.tsx:653
+#: src/components/Outdoor5KPlanStart.tsx:683
 msgid "Could not refresh proposal state"
 msgstr "无法刷新提案状态"
 
-#: src/components/Outdoor5KPlanStart.tsx:336
-#: src/components/Outdoor5KPlanStart.tsx:347
+#: src/components/Outdoor5KPlanStart.tsx:350
+#: src/components/Outdoor5KPlanStart.tsx:361
 msgid "Could not regenerate the proposal."
 msgstr "无法重新生成提案。"
 
-#: src/components/Outdoor5KPlanStart.tsx:369
-#: src/components/Outdoor5KPlanStart.tsx:375
+#: src/components/Outdoor5KPlanStart.tsx:383
+#: src/components/Outdoor5KPlanStart.tsx:389
 msgid "Could not reject the proposal."
 msgstr "无法拒绝该提案。"
 
@@ -2081,30 +2082,30 @@ msgstr "无法拒绝该提案。"
 msgid "Could not remove future delivered workouts"
 msgstr "无法移除未来已下发的训练"
 
-#: src/components/UpcomingPlanCard.tsx:1119
-#: src/components/UpcomingPlanCard.tsx:1130
+#: src/components/UpcomingPlanCard.tsx:1143
+#: src/components/UpcomingPlanCard.tsx:1154
 msgid "Could not resolve this workout"
 msgstr "无法处理此训练"
 
 #: src/components/ManagedPlanSettingsCard.tsx:459
 #: src/components/ManagedPlanSettingsCard.tsx:477
-#: src/components/UpcomingPlanCard.tsx:1148
-#: src/components/UpcomingPlanCard.tsx:1158
+#: src/components/UpcomingPlanCard.tsx:1172
+#: src/components/UpcomingPlanCard.tsx:1182
 msgid "Could not restore the previous workout"
 msgstr "无法恢复上一项训练"
 
-#: src/components/PersonalContextPanel.tsx:404
-#: src/components/PersonalContextPanel.tsx:411
+#: src/components/PersonalContextPanel.tsx:409
+#: src/components/PersonalContextPanel.tsx:416
 msgid "Could not review this private context."
 msgstr "无法预览这条计划个性化信息。"
 
-#: src/components/PersonalContextPanel.tsx:455
-#: src/components/PersonalContextPanel.tsx:490
+#: src/components/PersonalContextPanel.tsx:460
+#: src/components/PersonalContextPanel.tsx:495
 msgid "Could not save this correction."
 msgstr "无法保存这条更正。"
 
-#: src/components/PersonalContextPanel.tsx:473
-#: src/components/PersonalContextPanel.tsx:491
+#: src/components/PersonalContextPanel.tsx:478
+#: src/components/PersonalContextPanel.tsx:496
 msgid "Could not save this private context."
 msgstr "无法保存这条计划个性化信息。"
 
@@ -2112,12 +2113,12 @@ msgstr "无法保存这条计划个性化信息。"
 msgid "Could not save your email. Please email us instead."
 msgstr "无法保存邮箱，请直接发邮件联系我们。"
 
-#: src/components/PersonalContextPanel.tsx:543
-#: src/components/PersonalContextPanel.tsx:550
+#: src/components/PersonalContextPanel.tsx:548
+#: src/components/PersonalContextPanel.tsx:555
 msgid "Could not stop using this context."
 msgstr "暂时无法停止使用这条信息。"
 
-#: src/components/PersonalContextPanel.tsx:640
+#: src/components/PersonalContextPanel.tsx:645
 msgid "Could not update AI processing."
 msgstr "无法更新 AI 权限。"
 
@@ -2129,12 +2130,12 @@ msgstr "无法更新自动计划调整设置"
 #~ msgid "Could not update experimental Garmin delivery"
 #~ msgstr "无法更新 Garmin 实验性下发"
 
-#: src/components/UpcomingPlanCard.tsx:1204
-#: src/components/UpcomingPlanCard.tsx:1251
+#: src/components/UpcomingPlanCard.tsx:1228
+#: src/components/UpcomingPlanCard.tsx:1275
 msgid "Could not update this workout"
 msgstr "无法更新这项训练"
 
-#: src/components/PersonalContextPanel.tsx:628
+#: src/components/PersonalContextPanel.tsx:633
 msgid "Could not withdraw AI processing."
 msgstr "无法撤回 AI 处理。"
 
@@ -2224,7 +2225,7 @@ msgstr "创建账号"
 msgid "Create and manage dismissible banners shown to all users."
 msgstr "创建和管理向所有用户显示、可关闭的横幅公告。"
 
-#: src/components/Outdoor5KPlanStart.tsx:614
+#: src/components/Outdoor5KPlanStart.tsx:644
 msgid "Create proposal"
 msgstr "创建提案"
 
@@ -2248,7 +2249,7 @@ msgstr "创建时间"
 msgid "Creating account…"
 msgstr "正在创建账号…"
 
-#: src/components/Outdoor5KPlanStart.tsx:614
+#: src/components/Outdoor5KPlanStart.tsx:644
 msgid "Creating proposal…"
 msgstr "正在创建提案…"
 
@@ -2283,7 +2284,7 @@ msgstr "阈值功率"
 msgid "Critical: {0}. Major: {1}. Minor: {2}."
 msgstr "严重：{0}。重大：{1}。轻微：{2}。"
 
-#: src/components/UpcomingPlanCard.tsx:571
+#: src/components/UpcomingPlanCard.tsx:572
 #: src/components/WorkoutPlanEditor.tsx:450
 msgid "Cross-training"
 msgstr "交叉训练"
@@ -2339,7 +2340,7 @@ msgid "Current evidence"
 msgstr "当前证据"
 
 #: src/components/ManagedPlanSettingsCard.tsx:993
-#: src/components/UpcomingPlanCard.tsx:1579
+#: src/components/UpcomingPlanCard.tsx:1603
 msgid "Current HRV crossed your personal caution band."
 msgstr "当前 HRV 低于个人警戒区间。"
 
@@ -2361,7 +2362,7 @@ msgstr "自定义措辞"
 msgid "Custom workout purpose"
 msgstr "自定义训练目的"
 
-#: src/components/UpcomingPlanCard.tsx:566
+#: src/components/UpcomingPlanCard.tsx:567
 #: src/components/WorkoutPlanEditor.tsx:445
 #: src/pages/Setup.tsx:165
 msgid "Cycling"
@@ -2493,7 +2494,7 @@ msgstr "性能下降"
 msgid "Degraded Performance"
 msgstr "性能降级"
 
-#: src/components/PersonalContextPanel.tsx:1538
+#: src/components/PersonalContextPanel.tsx:1543
 #: src/components/WorkoutPlanEditor.tsx:880
 #: src/components/WorkoutStructureEditor.tsx:1785
 msgid "Delete"
@@ -2511,16 +2512,16 @@ msgstr "删除账号"
 msgid "Delete my account?"
 msgstr "删除账号？"
 
-#: src/components/PersonalContextPanel.tsx:1492
+#: src/components/PersonalContextPanel.tsx:1497
 #: src/pages/Settings.tsx:1647
 msgid "Delete permanently"
 msgstr "永久删除"
 
-#: src/components/PersonalContextPanel.tsx:1553
+#: src/components/PersonalContextPanel.tsx:1558
 msgid "Delete retained history"
 msgstr "删除保留历史记录"
 
-#: src/components/PersonalContextPanel.tsx:1454
+#: src/components/PersonalContextPanel.tsx:1459
 msgid "Delete this context permanently?"
 msgstr "永久删除这条信息？"
 
@@ -2543,12 +2544,12 @@ msgid "Delete workout"
 msgstr "删除训练"
 
 #. placeholder {0}: formatDate(currentDetailItem.narrative_purge_at)
-#: src/components/PersonalContextPanel.tsx:1394
+#: src/components/PersonalContextPanel.tsx:1399
 msgid "Deletes {0}"
 msgstr "将于 {0} 删除"
 
-#: src/components/PersonalContextPanel.tsx:800
-#: src/components/PersonalContextPanel.tsx:1333
+#: src/components/PersonalContextPanel.tsx:805
+#: src/components/PersonalContextPanel.tsx:1338
 msgid "Deleting"
 msgstr "删除中"
 
@@ -2561,7 +2562,7 @@ msgstr "删除中…"
 msgid "Deleting…"
 msgstr "正在删除…"
 
-#: src/components/UpcomingPlanCard.tsx:515
+#: src/components/UpcomingPlanCard.tsx:516
 msgid "Deliver now"
 msgstr "立即下发"
 
@@ -2569,9 +2570,9 @@ msgstr "立即下发"
 msgid "Delivery enabled"
 msgstr "下发已启用"
 
-#: src/components/UpcomingPlanCard.tsx:447
-#: src/components/UpcomingPlanCard.tsx:1090
-#: src/components/UpcomingPlanCard.tsx:1097
+#: src/components/UpcomingPlanCard.tsx:448
+#: src/components/UpcomingPlanCard.tsx:1114
+#: src/components/UpcomingPlanCard.tsx:1121
 #: src/pages/admin/AdminOps.tsx:444
 msgid "Delivery failed"
 msgstr "下发失败"
@@ -2592,7 +2593,7 @@ msgstr "下发结果"
 msgid "Delivery preview"
 msgstr "交付预览"
 
-#: src/components/Outdoor5KPlanStart.tsx:731
+#: src/components/Outdoor5KPlanStart.tsx:761
 msgid "Delivery remains disabled. Review the existing 14-day managed-delivery preview and explicitly consent only if you want Praxys to deliver this canonical plan."
 msgstr "投递仍处于禁用状态。请查看现有的 14 天托管投递预览，并且只有在希望 Praxys 投递此规范计划时才明确同意。"
 
@@ -2724,8 +2725,8 @@ msgstr "请先关闭其他计划工具的下发功能。多个计划工具可能
 msgid "Disabled. Click to open"
 msgstr "已关闭，点击开启"
 
-#: src/components/PersonalContextPanel.tsx:235
-#: src/components/PersonalContextPanel.tsx:239
+#: src/components/PersonalContextPanel.tsx:240
+#: src/components/PersonalContextPanel.tsx:244
 msgid "Disclosure choice"
 msgstr "披露选择"
 
@@ -2848,7 +2849,7 @@ msgstr "改为轻松跑（功率保持在恢复区间）"
 #~ msgid "Drop to easy run (keep power in recovery zone)\" \"改为轻松跑（功率保持在恢复区间）"
 #~ msgstr ""
 
-#: src/components/UpcomingPlanCard.tsx:704
+#: src/components/UpcomingPlanCard.tsx:705
 #: src/components/WorkoutStructureEditor.tsx:1779
 msgid "Duplicate"
 msgstr "复制"
@@ -2956,7 +2957,7 @@ msgstr "每个数值代表截至所示日期的一个互不重叠的 7 天周期
 #~ msgid "Each value is a non-overlapping seven-day bucket ending on the shown date. Zero-activity weeks remain in the series and average; the trend compares the older and newer halves. This is a Praxys operational summary, not a readiness score."
 #~ msgstr "每个数值代表截至所示日期的一个互不重叠的 7 天周期。零活动周仍计入序列和平均值；趋势比较前后两个半段。这是 Praxys 的运营性摘要，并非准备度评分。"
 
-#: src/components/UpcomingPlanCard.tsx:576
+#: src/components/UpcomingPlanCard.tsx:577
 #: src/components/WorkoutPlanEditor.tsx:432
 msgid "Easy"
 msgstr "轻松跑"
@@ -2970,7 +2971,7 @@ msgstr "轻松"
 msgid "Easy Run"
 msgstr "轻松跑"
 
-#: src/components/UpcomingPlanCard.tsx:691
+#: src/components/UpcomingPlanCard.tsx:692
 #: src/pages/Settings.tsx:1391
 #: src/pages/Setup.tsx:844
 msgid "Edit"
@@ -3025,7 +3026,7 @@ msgstr "符合条件"
 msgid "Eligible activities"
 msgstr "符合条件的活动"
 
-#: src/components/PersonalContextPanel.tsx:257
+#: src/components/PersonalContextPanel.tsx:262
 msgid "Elliptical"
 msgstr "椭圆机"
 
@@ -3087,11 +3088,11 @@ msgstr "已开启，点击关闭"
 msgid "Enabling…"
 msgstr "正在启用…"
 
-#: src/components/PersonalContextPanel.tsx:828
+#: src/components/PersonalContextPanel.tsx:833
 msgid "Encrypted at rest · excluded from analytics and model training"
 msgstr "加密保存 · 不用于数据分析或模型训练"
 
-#: src/components/PersonalContextPanel.tsx:1035
+#: src/components/PersonalContextPanel.tsx:1040
 msgid "Ends"
 msgstr "结束日期"
 
@@ -3115,7 +3116,7 @@ msgstr "请使用当前显示的单位输入完整数值。"
 msgid "Enter numeric temperature and humidity values."
 msgstr "请输入有效的温度和湿度数值。"
 
-#: src/components/Outdoor5KPlanStart.tsx:199
+#: src/components/Outdoor5KPlanStart.tsx:213
 msgid "Enter one whole-minute limit for every selected day."
 msgstr "请为每个选定日期输入相同的整分钟上限。"
 
@@ -3127,8 +3128,8 @@ msgstr "以分:秒/公里输入配速。"
 msgid "Enter pace as minutes:seconds per mile."
 msgstr "以分:秒/英里输入配速。"
 
-#: src/components/PersonalContextPanel.tsx:233
-#: src/components/PersonalContextPanel.tsx:234
+#: src/components/PersonalContextPanel.tsx:238
+#: src/components/PersonalContextPanel.tsx:239
 msgid "Environment"
 msgstr "环境"
 
@@ -3137,11 +3138,11 @@ msgstr "环境"
 msgid "Environmental response"
 msgstr "环境响应"
 
-#: src/components/PersonalContextPanel.tsx:234
+#: src/components/PersonalContextPanel.tsx:239
 msgid "Equipment access"
 msgstr "场地或装备受限"
 
-#: src/components/PersonalContextPanel.tsx:1088
+#: src/components/PersonalContextPanel.tsx:1093
 msgid "Equipment still available (optional)"
 msgstr "仍可使用的装备（可多选）"
 
@@ -3248,16 +3249,16 @@ msgstr "执行平台已更换，下发仍保持暂停。"
 #~ msgid "Experimental Garmin delivery"
 #~ msgstr "Garmin 实验性下发"
 
-#: src/components/PersonalContextPanel.tsx:798
-#: src/components/PersonalContextPanel.tsx:1331
+#: src/components/PersonalContextPanel.tsx:803
+#: src/components/PersonalContextPanel.tsx:1336
 msgid "Expired"
 msgstr "已过期"
 
-#: src/components/Outdoor5KPlanStart.tsx:699
+#: src/components/Outdoor5KPlanStart.tsx:729
 msgid "Expires:"
 msgstr "到期时间："
 
-#: src/components/PersonalContextPanel.tsx:721
+#: src/components/PersonalContextPanel.tsx:726
 msgid "Explain a workout"
 msgstr "说明训练情况"
 
@@ -3265,7 +3266,7 @@ msgstr "说明训练情况"
 msgid "Explore whether modeled heart rate varied with temperature and humidity at comparable recorded Stryd power in your eligible past runs."
 msgstr "探索在记录的 Stryd 功率相近时，符合条件的历史跑步中心率模型是否随温度和湿度变化。"
 
-#: src/components/PersonalContextPanel.tsx:841
+#: src/components/PersonalContextPanel.tsx:846
 msgid "Export context"
 msgstr "导出信息"
 
@@ -3283,11 +3284,11 @@ msgstr "导出我的数据"
 #~ msgstr "长时间休息期。体能在下降。"
 
 #: src/components/ManagedPlanSettingsCard.tsx:496
-#: src/components/UpcomingPlanCard.tsx:363
+#: src/components/UpcomingPlanCard.tsx:364
 msgid "External"
 msgstr "外部"
 
-#: src/components/UpcomingPlanCard.tsx:235
+#: src/components/UpcomingPlanCard.tsx:236
 msgid "External plan mode"
 msgstr "外部计划模式"
 
@@ -3381,7 +3382,7 @@ msgstr "加载设置失败"
 #~ msgid "Failed to load training data"
 #~ msgstr "训练数据加载失败"
 
-#: src/components/UpcomingPlanCard.tsx:1367
+#: src/components/UpcomingPlanCard.tsx:1391
 msgid "Failed to load training plan"
 msgstr "训练计划加载失败"
 
@@ -3431,7 +3432,7 @@ msgstr "下降"
 msgid "Falling"
 msgstr "下降"
 
-#: src/components/PersonalContextPanel.tsx:228
+#: src/components/PersonalContextPanel.tsx:233
 msgid "Fatigue"
 msgstr "疲劳"
 
@@ -3514,7 +3515,7 @@ msgstr "请先修正标记的结构化步骤再保存。"
 msgid "flat"
 msgstr "持平"
 
-#: src/components/PersonalContextPanel.tsx:265
+#: src/components/PersonalContextPanel.tsx:270
 #: src/pages/Goal.tsx:54
 msgid "Flat"
 msgstr "持平"
@@ -3577,7 +3578,7 @@ msgstr "14天活动记录"
 #~ msgid "Freshened up — good window for racing or testing."
 #~ msgstr "充分恢复——适合比赛或测试的好时机。"
 
-#: src/components/PersonalContextPanel.tsx:247
+#: src/components/PersonalContextPanel.tsx:252
 msgid "Fri"
 msgstr "周五"
 
@@ -3674,7 +3675,7 @@ msgstr "请前往 cloud.ouraring.com/personal-access-tokens 生成令牌。"
 msgid "Generating…"
 msgstr "正在生成…"
 
-#: src/components/Outdoor5KPlanStart.tsx:677
+#: src/components/Outdoor5KPlanStart.tsx:707
 msgid "Generator"
 msgstr "生成器"
 
@@ -3732,7 +3733,7 @@ msgstr "目标类型"
 #~ msgid "Good balance of fitness and recovery. Ready for quality work."
 #~ msgstr "体能与恢复平衡良好。已准备好进行高质量训练。"
 
-#: src/components/PersonalContextPanel.tsx:255
+#: src/components/PersonalContextPanel.tsx:260
 msgid "Gym"
 msgstr "健身房"
 
@@ -3874,18 +3875,18 @@ msgstr "覆盖度高"
 msgid "High variability"
 msgstr "变异性偏高"
 
-#: src/components/UpcomingPlanCard.tsx:568
+#: src/components/UpcomingPlanCard.tsx:569
 #: src/components/WorkoutPlanEditor.tsx:447
 #: src/pages/Setup.tsx:167
 msgid "Hiking"
 msgstr "徒步"
 
-#: src/components/UpcomingPlanCard.tsx:582
+#: src/components/UpcomingPlanCard.tsx:583
 #: src/components/WorkoutPlanEditor.tsx:438
 msgid "Hill repeats"
 msgstr "爬坡重复"
 
-#: src/components/PersonalContextPanel.tsx:266
+#: src/components/PersonalContextPanel.tsx:271
 msgid "Hilly"
 msgstr "起伏路"
 
@@ -3917,7 +3918,7 @@ msgstr "历史候选活动"
 msgid "History first: you already have usable current 5K evidence."
 msgstr "先看历史：已有可用的当前 5 公里能力证据。"
 
-#: src/components/Outdoor5KPlanStart.tsx:632
+#: src/components/Outdoor5KPlanStart.tsx:662
 msgid "History used:"
 msgstr "已使用的历史："
 
@@ -4105,15 +4106,15 @@ msgstr "湿度（%）"
 msgid "I agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
 msgstr "我同意<0>服务条款</0>和<1>隐私政策</1>。"
 
-#: src/components/Outdoor5KPlanStart.tsx:480
+#: src/components/Outdoor5KPlanStart.tsx:510
 msgid "I am 18 or older."
 msgstr "我已满 18 周岁。"
 
-#: src/components/Outdoor5KPlanStart.tsx:481
+#: src/components/Outdoor5KPlanStart.tsx:511
 msgid "I am self-coached for recreational road running."
 msgstr "我是自主训练的休闲公路跑者。"
 
-#: src/components/Outdoor5KPlanStart.tsx:482
+#: src/components/Outdoor5KPlanStart.tsx:512
 msgid "I can currently complete 5 km."
 msgstr "我目前可以完成 5 公里。"
 
@@ -4135,7 +4136,7 @@ msgstr "今天不训练"
 msgid "Identified"
 msgstr "已定位"
 
-#: src/components/PersonalContextPanel.tsx:230
+#: src/components/PersonalContextPanel.tsx:235
 msgid "Illness"
 msgstr "生病或不适"
 
@@ -4152,7 +4153,7 @@ msgstr "生病或不适"
 msgid "In progress <0>{0}</0>"
 msgstr "进行中 <0>{0}</0>"
 
-#: src/components/UpcomingPlanCard.tsx:403
+#: src/components/UpcomingPlanCard.tsx:404
 msgid "In sync"
 msgstr "一致"
 
@@ -4207,11 +4208,11 @@ msgstr "后插入"
 msgid "Insert before"
 msgstr "前插入"
 
-#: src/components/UpcomingPlanCard.tsx:1591
+#: src/components/UpcomingPlanCard.tsx:1615
 msgid "Inspect context"
 msgstr "查看个性化信息"
 
-#: src/components/PersonalContextPanel.tsx:1313
+#: src/components/PersonalContextPanel.tsx:1318
 msgid "Inspect what is stored, where it was used, and who may process it."
 msgstr "查看保存了哪些内容、曾用于何处，以及哪些服务可能处理这些信息。"
 
@@ -4257,7 +4258,7 @@ msgstr "明确完成的 5 公里全力跑"
 msgid "International"
 msgstr "国际"
 
-#: src/components/PersonalContextPanel.tsx:1602
+#: src/components/PersonalContextPanel.tsx:1607
 msgid "Interpret one missed or modified workout without diagnosing a cause."
 msgstr "在不诊断原因的前提下解读一条错过或修改的训练。"
 
@@ -4265,11 +4266,11 @@ msgstr "在不诊断原因的前提下解读一条错过或修改的训练。"
 msgid "Interpret one workout without guessing a cause"
 msgstr "在不臆测原因的前提下说明一次训练情况"
 
-#: src/components/PersonalContextPanel.tsx:1154
+#: src/components/PersonalContextPanel.tsx:1159
 msgid "Interpret this workout without guessing a cause"
 msgstr "用于理解这次训练，不推测原因"
 
-#: src/components/UpcomingPlanCard.tsx:581
+#: src/components/UpcomingPlanCard.tsx:582
 #: src/components/WorkoutPlanEditor.tsx:437
 msgid "Intervals"
 msgstr "间歇跑"
@@ -4330,7 +4331,7 @@ msgstr "工单"
 msgid "Issue created"
 msgstr "已创建 Issue"
 
-#: src/components/PersonalContextPanel.tsx:1458
+#: src/components/PersonalContextPanel.tsx:1463
 msgid "It stays in your private history until its purge date, but cannot influence a new assessment."
 msgstr "信息会保留到原定删除时间，但不会再用于新的评估。"
 
@@ -4397,11 +4398,11 @@ msgstr "继续参加"
 msgid "Keep suggestion-only"
 msgstr "保持仅建议"
 
-#: src/components/PersonalContextPanel.tsx:362
+#: src/components/PersonalContextPanel.tsx:367
 msgid "Keep the optional note to 280 characters or fewer."
 msgstr "选填备注请控制在 280 个字符以内。"
 
-#: src/components/UpcomingPlanCard.tsx:830
+#: src/components/UpcomingPlanCard.tsx:831
 msgid "keep the Praxys workout canonical and replace or recreate the target version."
 msgstr "继续以 Praxys 训练为准，并替换或重新创建目标平台版本。"
 
@@ -4542,7 +4543,7 @@ msgstr "正在退出…"
 msgid "Legacy flat summary"
 msgstr "旧版扁平摘要"
 
-#: src/components/PersonalContextPanel.tsx:223
+#: src/components/PersonalContextPanel.tsx:228
 msgid "Less time"
 msgstr "训练时间减少"
 
@@ -4550,8 +4551,8 @@ msgstr "训练时间减少"
 msgid "Let Praxys manage this plan?"
 msgstr "让 Praxys 托管此计划？"
 
-#: src/components/PersonalContextPanel.tsx:226
-#: src/components/PersonalContextPanel.tsx:227
+#: src/components/PersonalContextPanel.tsx:231
+#: src/components/PersonalContextPanel.tsx:232
 msgid "Life constraint"
 msgstr "生活限制"
 
@@ -4617,7 +4618,7 @@ msgstr "链接地址（可选）"
 msgid "Link your training devices and services"
 msgstr "连接训练设备和服务"
 
-#: src/components/PersonalContextPanel.tsx:892
+#: src/components/PersonalContextPanel.tsx:897
 msgid "Linked workout"
 msgstr "关联训练"
 
@@ -4676,11 +4677,11 @@ msgstr "计划完成度"
 msgid "Loading components…"
 msgstr "正在加载组件…"
 
-#: src/components/PersonalContextPanel.tsx:744
+#: src/components/PersonalContextPanel.tsx:749
 msgid "Loading private context"
 msgstr "正在加载计划个性化信息"
 
-#: src/components/PersonalContextPanel.tsx:913
+#: src/components/PersonalContextPanel.tsx:918
 msgid "Loading recent workouts…"
 msgstr "正在加载近期训练…"
 
@@ -4705,7 +4706,7 @@ msgstr "退出登录"
 #~ msgid "Login"
 #~ msgstr "登录"
 
-#: src/components/UpcomingPlanCard.tsx:578
+#: src/components/UpcomingPlanCard.tsx:579
 #: src/components/WorkoutPlanEditor.tsx:434
 msgid "Long run"
 msgstr "长距离跑"
@@ -4802,7 +4803,7 @@ msgstr "今天作为恢复日，明天再评估高强度训练"
 #~ msgid "Make today a full recovery day and reassess the hard session tomorrow\" \"今天安排为完整恢复日，明天再评估高强度训练"
 #~ msgstr ""
 
-#: src/components/UpcomingPlanCard.tsx:260
+#: src/components/UpcomingPlanCard.tsx:261
 msgid "Manage in Settings"
 msgstr "前往设置管理"
 
@@ -4822,15 +4823,15 @@ msgstr "管理席位、角色、邀请和候补名单接入。"
 msgid "Managed athletes"
 msgstr "托管运动员"
 
-#: src/components/UpcomingPlanCard.tsx:233
+#: src/components/UpcomingPlanCard.tsx:234
 msgid "Managed by Praxys"
 msgstr "由 Praxys 托管"
 
-#: src/components/UpcomingPlanCard.tsx:1663
+#: src/components/UpcomingPlanCard.tsx:1687
 msgid "Managed delivery is active, but this window contains no Praxys-owned workouts. External workouts remain untouched."
 msgstr "托管下发已启用，但此窗口内没有 Praxys 管理的训练。外部训练保持不变。"
 
-#: src/components/UpcomingPlanCard.tsx:234
+#: src/components/UpcomingPlanCard.tsx:235
 msgid "Managed delivery paused"
 msgstr "托管下发已暂停"
 
@@ -4923,11 +4924,11 @@ msgstr "MAU"
 msgid "Max HR"
 msgstr "最大心率"
 
-#: src/components/PersonalContextPanel.tsx:1053
+#: src/components/PersonalContextPanel.tsx:1058
 msgid "Maximum minutes available per affected day"
 msgstr "这些天每天最多可训练多久（分钟）"
 
-#: src/components/PersonalContextPanel.tsx:271
+#: src/components/PersonalContextPanel.tsx:276
 msgid "Maximum training minutes per day"
 msgstr "每天最多可训练时长（分钟）"
 
@@ -4960,7 +4961,7 @@ msgstr "MFA"
 msgid "MFA required"
 msgstr "需 MFA"
 
-#: src/components/PersonalContextPanel.tsx:1418
+#: src/components/PersonalContextPanel.tsx:1423
 msgid "Microsoft Azure AI"
 msgstr "Microsoft Azure AI 服务"
 
@@ -4969,8 +4970,8 @@ msgstr "Microsoft Azure AI 服务"
 #~ msgstr "轻度疲劳"
 
 #: src/components/ManagedPlanSettingsCard.tsx:628
-#: src/components/UpcomingPlanCard.tsx:773
-#: src/components/UpcomingPlanCard.tsx:795
+#: src/components/UpcomingPlanCard.tsx:774
+#: src/components/UpcomingPlanCard.tsx:796
 #: src/components/WorkoutStructureEditor.tsx:1498
 msgid "min"
 msgstr "分钟"
@@ -5006,8 +5007,8 @@ msgstr "对应 {0}"
 msgid "Mismatch"
 msgstr "不匹配"
 
-#: src/components/PersonalContextPanel.tsx:281
-#: src/components/PersonalContextPanel.tsx:945
+#: src/components/PersonalContextPanel.tsx:286
+#: src/components/PersonalContextPanel.tsx:950
 msgid "Missed"
 msgstr "未完成"
 
@@ -5027,7 +5028,7 @@ msgstr "缺少证据"
 msgid "Mixed providers"
 msgstr "数据来源混合"
 
-#: src/components/UpcomingPlanCard.tsx:570
+#: src/components/UpcomingPlanCard.tsx:571
 #: src/components/WorkoutPlanEditor.tsx:449
 msgid "Mobility"
 msgstr "灵活性训练"
@@ -5064,8 +5065,8 @@ msgstr "覆盖度中等"
 #~ msgid "Moderate evidence"
 #~ msgstr "证据中等"
 
-#: src/components/PersonalContextPanel.tsx:282
-#: src/components/PersonalContextPanel.tsx:946
+#: src/components/PersonalContextPanel.tsx:287
+#: src/components/PersonalContextPanel.tsx:951
 msgid "Modified"
 msgstr "已调整"
 
@@ -5074,7 +5075,7 @@ msgstr "已调整"
 msgid "MODIFY"
 msgstr "调整"
 
-#: src/components/PersonalContextPanel.tsx:243
+#: src/components/PersonalContextPanel.tsx:248
 msgid "Mon"
 msgstr "周一"
 
@@ -5118,7 +5119,7 @@ msgstr "还需要更多历史 HRV 数据，Praxys 才能建立你的个人恢复
 #~ msgid "Most under-target: {0} at {1}% (target {2}%). Add 1-2 sessions in this zone next week."
 #~ msgstr "最欠达标区间：{0} 为 {1}%（目标 {2}%）。下周在此区间增加 1-2 次训练。"
 
-#: src/components/PersonalContextPanel.tsx:229
+#: src/components/PersonalContextPanel.tsx:234
 msgid "Motivation"
 msgstr "训练动力不足"
 
@@ -5143,7 +5144,7 @@ msgstr "上移"
 msgid "Multiple platforms provide <0>{0}</0> data. Which should be the primary source?"
 msgstr "多个平台都提供 <0>{0}</0> 数据。要将哪个设为主要来源？"
 
-#: src/components/Outdoor5KPlanStart.tsx:483
+#: src/components/Outdoor5KPlanStart.tsx:513
 msgid "My goal is an outdoor road 5K."
 msgstr "我的目标是户外公路 5 公里。"
 
@@ -5296,7 +5297,7 @@ msgstr "新分诊且需要管理员处理的工作会显示在这里。"
 msgid "Next"
 msgstr "下一页"
 
-#: src/components/UpcomingPlanCard.tsx:1459
+#: src/components/UpcomingPlanCard.tsx:1483
 msgid "Next plan window"
 msgstr "下一时间段"
 
@@ -5344,7 +5345,7 @@ msgstr "未找到管理配置"
 msgid "No announcements yet"
 msgstr "还没有公告"
 
-#: src/components/PersonalContextPanel.tsx:1437
+#: src/components/PersonalContextPanel.tsx:1442
 msgid "No assessment or plan change has used this context yet."
 msgstr "尚未用于任何评估或计划调整。"
 
@@ -5401,7 +5402,7 @@ msgstr "暂无数据"
 msgid "No decision"
 msgstr "暂无判断"
 
-#: src/components/UpcomingPlanCard.tsx:1091
+#: src/components/UpcomingPlanCard.tsx:1115
 msgid "No delivery result was returned for this workout"
 msgstr "未返回此训练的下发结果"
 
@@ -5413,11 +5414,11 @@ msgstr "暂无记录"
 msgid "No executable steps yet."
 msgstr "还没有可执行步骤。"
 
-#: src/components/PersonalContextPanel.tsx:810
+#: src/components/PersonalContextPanel.tsx:815
 msgid "no expiry"
 msgstr "无到期时间"
 
-#: src/components/PersonalContextPanel.tsx:310
+#: src/components/PersonalContextPanel.tsx:315
 msgid "No expiry"
 msgstr "不过期"
 
@@ -5483,12 +5484,12 @@ msgstr "本周暂无计划负荷"
 msgid "No Praxys workouts are scheduled in this window. Future Praxys-created workouts will enter the rolling window automatically."
 msgstr "此窗口内暂无 Praxys 训练。之后由 Praxys 创建的训练会自动进入滚动窗口。"
 
-#: src/components/Outdoor5KPlanStart.tsx:585
-#: src/components/Outdoor5KPlanStart.tsx:587
+#: src/components/Outdoor5KPlanStart.tsx:615
+#: src/components/Outdoor5KPlanStart.tsx:617
 msgid "No preference"
 msgstr "无偏好"
 
-#: src/components/PersonalContextPanel.tsx:764
+#: src/components/PersonalContextPanel.tsx:769
 msgid "No private context saved"
 msgstr "暂无计划个性化信息"
 
@@ -5517,7 +5518,7 @@ msgstr "未使用提示词"
 #~ msgid "No recent activity reached the model's {0}-minute inclusion threshold."
 #~ msgstr "近期没有活动达到模型设定的 {0} 分钟纳入阈值。"
 
-#: src/components/PersonalContextPanel.tsx:932
+#: src/components/PersonalContextPanel.tsx:937
 msgid "No recent Praxys workout is available to link."
 msgstr "暂无可关联的近期 Praxys 训练。"
 
@@ -5529,7 +5530,7 @@ msgstr "暂无可关联的近期 Praxys 训练。"
 #~ msgid "No reliable heat history yet"
 #~ msgstr "尚无可靠的热适应历史"
 
-#: src/components/Outdoor5KPlanStart.tsx:517
+#: src/components/Outdoor5KPlanStart.tsx:547
 msgid "No safety stop"
 msgstr "没有安全停止条件"
 
@@ -5616,7 +5617,7 @@ msgstr "暂无每周距离历史"
 msgid "No Workout"
 msgstr "无训练安排"
 
-#: src/components/UpcomingPlanCard.tsx:808
+#: src/components/UpcomingPlanCard.tsx:809
 msgid "No workout is present on {target}."
 msgstr "{target} 上没有此训练。"
 
@@ -5653,11 +5654,11 @@ msgstr "今日无训练安排"
 msgid "No workout scheduled."
 msgstr "今日无训练安排。"
 
-#: src/components/UpcomingPlanCard.tsx:1627
+#: src/components/UpcomingPlanCard.tsx:1651
 msgid "No workouts scheduled in this window."
 msgstr "这段时间内暂无训练安排。"
 
-#: src/components/PersonalContextPanel.tsx:252
+#: src/components/PersonalContextPanel.tsx:257
 msgid "None"
 msgstr "无"
 
@@ -5777,7 +5778,7 @@ msgstr "备注"
 msgid "Note (optional)"
 msgstr "备注（可选）"
 
-#: src/components/PersonalContextPanel.tsx:1177
+#: src/components/PersonalContextPanel.tsx:1182
 msgid "Note deleted"
 msgstr "补充说明删除于"
 
@@ -5785,7 +5786,7 @@ msgstr "补充说明删除于"
 msgid "Note on Garmin native power"
 msgstr "关于 Garmin 原生功率的说明"
 
-#: src/components/PersonalContextPanel.tsx:870
+#: src/components/PersonalContextPanel.tsx:875
 msgid "Nothing is stored until you confirm this exact purpose and expiry."
 msgstr "在你确认这个具体用途和到期时间前，不会存储任何内容。"
 
@@ -5840,11 +5841,11 @@ msgid "of"
 msgstr "共"
 
 #: src/components/ManagedPlanSettingsCard.tsx:893
-#: src/components/PersonalContextPanel.tsx:1358
+#: src/components/PersonalContextPanel.tsx:1363
 msgid "Off"
 msgstr "关"
 
-#: src/components/PersonalContextPanel.tsx:1631
+#: src/components/PersonalContextPanel.tsx:1636
 msgid "Off by default. The note may contain more private detail than the structured fields."
 msgstr "默认不发送。补充说明可能包含比上方字段更多的隐私信息。"
 
@@ -5884,7 +5885,7 @@ msgstr "仅支持 PNG、JPG 或 WebP 图片。"
 msgid "Only supported and eligible platforms can receive workouts."
 msgstr "仅受支持且当前可用的平台可以接收训练。"
 
-#: src/components/PersonalContextPanel.tsx:1584
+#: src/components/PersonalContextPanel.tsx:1589
 msgid "Only the fields below are sent to Microsoft Azure AI. Microsoft states that inputs and outputs are not available to OpenAI or used to train foundation models without permission; Praxys does not grant that permission. Flagged content may be reviewed for abuse monitoring under Azure terms. Praxys does not log raw requests or responses."
 msgstr "只有下方列出的信息会发送给 Microsoft Azure AI。Microsoft 声明，输入和输出不会提供给 OpenAI；未经许可，也不会用于训练基础模型。Praxys 不会授予此类许可。根据 Azure 条款，被标记的内容可能接受滥用监测审核。Praxys 不记录原始请求或回复。"
 
@@ -6017,7 +6018,7 @@ msgstr "可选教练提示"
 msgid "Optional comment"
 msgstr "可选备注"
 
-#: src/components/PersonalContextPanel.tsx:871
+#: src/components/PersonalContextPanel.tsx:876
 msgid "Optional context helps Praxys avoid guessing. Share only what changes the plan."
 msgstr "补充这些信息可以避免 Praxys 自行推测。只填写会影响训练计划的内容。"
 
@@ -6041,8 +6042,8 @@ msgstr "可选的整节训练备注"
 msgid "Options"
 msgstr "选项"
 
-#: src/components/PersonalContextPanel.tsx:235
-#: src/components/UpcomingPlanCard.tsx:573
+#: src/components/PersonalContextPanel.tsx:240
+#: src/components/UpcomingPlanCard.tsx:574
 #: src/components/WorkoutPlanEditor.tsx:452
 #: src/components/WorkoutStructureEditor.tsx:328
 #: src/pages/admin/AdminFeedback.tsx:124
@@ -6066,7 +6067,7 @@ msgstr "服务中断"
 msgid "Outdoor road 5K plan"
 msgstr "户外公路 5 公里计划"
 
-#: src/components/Outdoor5KPlanStart.tsx:431
+#: src/components/Outdoor5KPlanStart.tsx:447
 msgid "Outdoor road 5K plans"
 msgstr "户外公路 5 公里计划"
 
@@ -6126,7 +6127,7 @@ msgstr "配速上限（分/公里）"
 msgid "Pace minimum (min/km)"
 msgstr "配速下限（分/公里）"
 
-#: src/components/PersonalContextPanel.tsx:231
+#: src/components/PersonalContextPanel.tsx:236
 msgid "Pain or injury"
 msgstr "疼痛或受伤"
 
@@ -6184,7 +6185,7 @@ msgid "Pause delivery to change the target."
 msgstr "暂停下发后才能更换执行平台。"
 
 #: src/components/ManagedPlanSettingsCard.tsx:493
-#: src/components/UpcomingPlanCard.tsx:391
+#: src/components/UpcomingPlanCard.tsx:392
 #: src/pages/admin/AdminOps.tsx:968
 msgid "Paused"
 msgstr "已暂停"
@@ -6206,11 +6207,11 @@ msgstr "训练指标"
 msgid "Pending <0>{0}</0>"
 msgstr "待处理 <0>{0}</0>"
 
-#: src/components/Outdoor5KPlanStart.tsx:569
+#: src/components/Outdoor5KPlanStart.tsx:599
 msgid "Per-day limits are unsupported"
 msgstr "不支持按日设置上限"
 
-#: src/components/Outdoor5KPlanStart.tsx:198
+#: src/components/Outdoor5KPlanStart.tsx:212
 msgid "Per-day limits are unsupported by this policy. Use one shared limit for all selected days."
 msgstr "此政策不支持按日设置上限。请为所有选定日期使用一个共享上限。"
 
@@ -6251,19 +6252,19 @@ msgstr "计划"
 msgid "Plan activity"
 msgstr "计划活动"
 
-#: src/components/PersonalContextPanel.tsx:1340
+#: src/components/PersonalContextPanel.tsx:1345
 msgid "Plan adjustment"
 msgstr "计划调整"
 
-#: src/components/Outdoor5KPlanStart.tsx:729
+#: src/components/Outdoor5KPlanStart.tsx:759
 msgid "Plan adopted"
 msgstr "计划已采纳"
 
-#: src/components/Outdoor5KPlanStart.tsx:403
+#: src/components/Outdoor5KPlanStart.tsx:417
 msgid "Plan adopted. Delivery remains disabled until you explicitly enable it."
 msgstr "计划已采纳。在你明确启用前，投递仍处于禁用状态。"
 
-#: src/components/PersonalContextPanel.tsx:702
+#: src/components/PersonalContextPanel.tsx:707
 msgid "Plan context"
 msgstr "计划个性化信息"
 
@@ -6271,11 +6272,11 @@ msgstr "计划个性化信息"
 msgid "Plan management"
 msgstr "计划托管"
 
-#: src/components/Outdoor5KPlanStart.tsx:455
+#: src/components/Outdoor5KPlanStart.tsx:485
 msgid "Plan preview"
 msgstr "计划预览"
 
-#: src/components/Outdoor5KPlanStart.tsx:666
+#: src/components/Outdoor5KPlanStart.tsx:696
 msgid "Plan proposal"
 msgstr "计划提案"
 
@@ -6283,11 +6284,11 @@ msgstr "计划提案"
 #~ msgid "Plan sync target"
 #~ msgstr "计划同步目标"
 
-#: src/components/UpcomingPlanCard.tsx:180
+#: src/components/UpcomingPlanCard.tsx:181
 msgid "Plan window"
 msgstr "计划范围"
 
-#: src/components/Outdoor5KPlanStart.tsx:750
+#: src/components/Outdoor5KPlanStart.tsx:780
 msgid "Plan-start action did not complete"
 msgstr "计划起点操作未完成"
 
@@ -6336,7 +6337,7 @@ msgstr "请检查邮箱格式后重试。"
 msgid "Please verify your email before signing in. Check your inbox for the link."
 msgstr "登录前请先验证邮箱。请查看收件箱中的验证链接。"
 
-#: src/components/Outdoor5KPlanStart.tsx:676
+#: src/components/Outdoor5KPlanStart.tsx:706
 msgid "Policy"
 msgstr "政策"
 
@@ -6350,7 +6351,7 @@ msgstr "策略 {0} · 决策 {1}"
 msgid "Policy-gated auto-merge"
 msgstr "策略门禁自动合并"
 
-#: src/components/PersonalContextPanel.tsx:258
+#: src/components/PersonalContextPanel.tsx:263
 msgid "Pool"
 msgstr "泳池"
 
@@ -6461,11 +6462,11 @@ msgstr "功率数据源匹配"
 msgid "Praxys adapts individualized HRV-guided training and ln(RMSSD) trend monitoring into operational reference bands. The exact reference-band and caution-band cutoffs are product guardrails, not thresholds validated by the cited studies. CV above {cvThreshold}% is also a coaching caution flag, not a diagnosis. Sleep, readiness, RHR, and TSB remain separate informational context."
 msgstr "Praxys 将个体化 HRV 引导训练和 ln(RMSSD) 趋势监测转化为可执行的参考区间。具体的参考区间和警戒区间界限是产品保护规则，并非引用研究验证的阈值。CV 高于 {cvThreshold}% 同样只是训练警戒提示，不构成诊断。睡眠、准备度、静息心率和 TSB 均作为独立的信息背景。"
 
-#: src/components/PersonalContextPanel.tsx:1462
+#: src/components/PersonalContextPanel.tsx:1467
 msgid "Praxys also removes dependent private reasoning and use receipts. Accepted workout changes remain without the private reason."
 msgstr "Praxys 还会删除由此产生的私密推理和使用记录。已经接受的训练调整会保留，但不再关联具体原因。"
 
-#: src/components/UpcomingPlanCard.tsx:758
+#: src/components/UpcomingPlanCard.tsx:759
 msgid "Praxys and {target} have different versions. Choose which one becomes canonical."
 msgstr "Praxys 与 {target} 上的版本不同。请选择之后以哪个版本为准。"
 
@@ -6501,7 +6502,7 @@ msgstr "Praxys Coach 插件"
 msgid "Praxys could not determine your time zone. Check your device settings and try again."
 msgstr "Praxys 无法确定所在时区。请检查设备设置后重试。"
 
-#: src/components/UpcomingPlanCard.tsx:756
+#: src/components/UpcomingPlanCard.tsx:757
 msgid "Praxys could not finish delivery. Retrying keeps the Praxys version canonical."
 msgstr "Praxys 未能完成下发。重试后仍以 Praxys 版本为准。"
 
@@ -6557,7 +6558,7 @@ msgstr "Praxys 当前服务性能下降。"
 msgid "Praxys is in private alpha."
 msgstr "Praxys 目前处于私测 alpha 阶段。"
 
-#: src/components/UpcomingPlanCard.tsx:251
+#: src/components/UpcomingPlanCard.tsx:252
 msgid "Praxys is read-only and leaves every target workout untouched."
 msgstr "Praxys 仅会读取计划，不会更改目标平台上的任何训练。"
 
@@ -6573,7 +6574,7 @@ msgstr "Praxys 会保留完整训练。此预览说明所选平台可以接收�
 msgid "Praxys Labs"
 msgstr "Praxys 实验室"
 
-#: src/components/UpcomingPlanCard.tsx:1557
+#: src/components/UpcomingPlanCard.tsx:1581
 msgid "Praxys made a conservative plan change"
 msgstr "Praxys 已保守调整计划"
 
@@ -6587,12 +6588,12 @@ msgstr "手机版 Praxys"
 msgid "Praxys on your phone"
 msgstr "在手机上使用 Praxys"
 
-#: src/components/UpcomingPlanCard.tsx:381
+#: src/components/UpcomingPlanCard.tsx:382
 msgid "Praxys only"
 msgstr "仅 Praxys"
 
-#: src/components/UpcomingPlanCard.tsx:1648
-#: src/components/UpcomingPlanCard.tsx:1728
+#: src/components/UpcomingPlanCard.tsx:1672
+#: src/components/UpcomingPlanCard.tsx:1752
 msgid "Praxys only changes workouts it created or you explicitly adopt. Manual workouts and workouts from another coach stay untouched."
 msgstr "Praxys 只会修改由 Praxys 创建或明确采纳的训练。手动添加及其他教练创建的训练不会受到影响。"
 
@@ -6616,7 +6617,7 @@ msgstr "Praxys 已在记录同意或启动耗时分析前停止。同步或积�
 msgid "Praxys stores curve points, uncertainty, counts, gates, versions, and timestamps—not routes, activity dates, raw samples, or per-activity research rows."
 msgstr "Praxys 仅存储曲线点、不确定性、计数、门槛状态、版本和时间戳，不存储路线、活动日期、原始采样或逐活动研究记录。"
 
-#: src/components/UpcomingPlanCard.tsx:767
+#: src/components/UpcomingPlanCard.tsx:768
 msgid "Praxys version"
 msgstr "Praxys 版本"
 
@@ -6628,7 +6629,7 @@ msgstr "Praxys 将分析符合条件的历史跑步，观察在可比的 Stryd �
 msgid "Praxys will immediately delete your Labs consent and derived aggregate result. Your underlying account activities are not deleted."
 msgstr "Praxys 将立即删除 Labs 同意记录和派生汇总结果，但不会删除账号中的原始活动。"
 
-#: src/components/PersonalContextPanel.tsx:996
+#: src/components/PersonalContextPanel.tsx:1001
 msgid "Praxys will preserve the reason as unknown. This never counts against you."
 msgstr "Praxys 会将原因保留为“未知”，不会因此作出负面判断。"
 
@@ -6654,7 +6655,7 @@ msgstr "按 Riegel 公式预测（T₂ = T₁ × (D₂/D₁)^1.06），将阈值
 msgid "Predicted using Stryd race power model (5K at 103.8% CP, marathon at 89.9% CP)."
 msgstr "按 Stryd 比赛功率模型预测（5K 取 103.8% CP，马拉松取 89.9% CP）。"
 
-#: src/components/PersonalContextPanel.tsx:238
+#: src/components/PersonalContextPanel.tsx:243
 msgid "Prefer not to say"
 msgstr "不想说明"
 
@@ -6662,7 +6663,7 @@ msgstr "不想说明"
 msgid "Prefer to wait?"
 msgstr "想先等等？"
 
-#: src/components/Outdoor5KPlanStart.tsx:580
+#: src/components/Outdoor5KPlanStart.tsx:610
 msgid "Preferred longest-run day"
 msgstr "偏好的最长跑日期"
 
@@ -6679,7 +6680,7 @@ msgstr "预览中"
 msgid "Previous"
 msgstr "上一页"
 
-#: src/components/UpcomingPlanCard.tsx:1446
+#: src/components/UpcomingPlanCard.tsx:1470
 msgid "Previous plan window"
 msgstr "上一时间段"
 
@@ -6708,7 +6709,7 @@ msgstr "先前热适应的证据可能正在减弱。"
 msgid "Priority is excluded from readiness evaluation."
 msgstr "就绪评估不使用优先级。"
 
-#: src/components/PersonalContextPanel.tsx:1660
+#: src/components/PersonalContextPanel.tsx:1665
 msgid "Privacy Policy"
 msgstr "隐私政策"
 
@@ -6716,28 +6717,28 @@ msgstr "隐私政策"
 msgid "Private alpha · Invitation only"
 msgstr "内测中 · 仅限邀请"
 
-#: src/components/PersonalContextPanel.tsx:1310
+#: src/components/PersonalContextPanel.tsx:1315
 msgid "Private context"
 msgstr "计划个性化信息"
 
-#: src/components/PersonalContextPanel.tsx:753
+#: src/components/PersonalContextPanel.tsx:758
 msgid "Private context could not be loaded."
 msgstr "无法加载计划个性化信息。"
 
-#: src/components/PersonalContextPanel.tsx:669
+#: src/components/PersonalContextPanel.tsx:674
 msgid "Private context export downloaded."
 msgstr "计划个性化信息导出文件已下载。"
 
-#: src/components/PersonalContextPanel.tsx:483
+#: src/components/PersonalContextPanel.tsx:488
 msgid "Private context saved. AI processing remains off."
 msgstr "计划个性化信息已保存，AI 处理仍未开启。"
 
-#: src/components/PersonalContextPanel.tsx:1212
-#: src/components/PersonalContextPanel.tsx:1388
+#: src/components/PersonalContextPanel.tsx:1217
+#: src/components/PersonalContextPanel.tsx:1393
 msgid "Private note"
 msgstr "补充说明"
 
-#: src/components/PersonalContextPanel.tsx:1117
+#: src/components/PersonalContextPanel.tsx:1122
 msgid "Private note (optional)"
 msgstr "补充说明（选填）"
 
@@ -6754,7 +6755,7 @@ msgstr "继续训练，但注意观察训练中的心率漂移"
 msgid "Processing"
 msgstr "处理中"
 
-#: src/components/PersonalContextPanel.tsx:1184
+#: src/components/PersonalContextPanel.tsx:1189
 msgid "Processing method"
 msgstr "处理方式"
 
@@ -6793,15 +6794,15 @@ msgstr "设为管理员"
 msgid "Prompt-semantic slice:"
 msgstr "提示词语义样本："
 
-#: src/components/Outdoor5KPlanStart.tsx:302
+#: src/components/Outdoor5KPlanStart.tsx:316
 msgid "Proposal created. It has not changed your canonical plan."
 msgstr "提案已创建。它尚未更改你的规范计划。"
 
-#: src/components/Outdoor5KPlanStart.tsx:371
+#: src/components/Outdoor5KPlanStart.tsx:385
 msgid "Proposal rejected. Your canonical plan was not changed."
 msgstr "提案已拒绝。你的规范计划未被更改。"
 
-#: src/components/Outdoor5KPlanStart.tsx:719
+#: src/components/Outdoor5KPlanStart.tsx:749
 msgid "Proposal state needs a fresh preview"
 msgstr "提案状态需要新的预览"
 
@@ -6853,9 +6854,9 @@ msgstr "在<0>公开状态页</0>发布服务动态。"
 msgid "Pull your latest activities, power data, and recovery metrics"
 msgstr "同步最新活动、功率数据和恢复指标"
 
-#: src/components/PersonalContextPanel.tsx:1150
-#: src/components/PersonalContextPanel.tsx:1337
-#: src/components/PersonalContextPanel.tsx:1597
+#: src/components/PersonalContextPanel.tsx:1155
+#: src/components/PersonalContextPanel.tsx:1342
+#: src/components/PersonalContextPanel.tsx:1602
 #: src/pages/McpAuthorization.tsx:220
 msgid "Purpose"
 msgstr "用途"
@@ -6926,8 +6927,8 @@ msgstr "达标天数：{0}/{thresholdDays}"
 msgid "Qualifying exposure has resumed after a longer gap, but current evidence is still limited."
 msgstr "较长间隔后已恢复达标热暴露，但当前证据仍然有限。"
 
-#: src/components/UpcomingPlanCard.tsx:501
-#: src/components/UpcomingPlanCard.tsx:521
+#: src/components/UpcomingPlanCard.tsx:502
+#: src/components/UpcomingPlanCard.tsx:522
 #: src/pages/LabsEnvironment.tsx:151
 #: src/pages/LabsEnvironment.tsx:162
 msgid "Queued"
@@ -7049,7 +7050,7 @@ msgstr "镜像主页数据的只读账号。"
 msgid "Readiness"
 msgstr "准备度"
 
-#: src/components/Outdoor5KPlanStart.tsx:625
+#: src/components/Outdoor5KPlanStart.tsx:655
 msgid "Readiness result"
 msgstr "准备情况结果"
 
@@ -7252,7 +7253,7 @@ msgstr "对账并重试"
 msgid "Reconciliation completed without replaying a workout."
 msgstr "对账完成，未重试训练下发。"
 
-#: src/components/UpcomingPlanCard.tsx:242
+#: src/components/UpcomingPlanCard.tsx:243
 msgid "Reconnect {target} to continue delivery. The Praxys plan remains canonical."
 msgstr "重新连接 {target} 后可继续下发。仍以 Praxys 计划为准。"
 
@@ -7297,7 +7298,7 @@ msgstr "可恢复：{0}。重试耗尽：{1}。卡在进行中：{2}。"
 
 #: src/components/RecoveryPanel.tsx:57
 #: src/components/RecoveryPanel.tsx:58
-#: src/components/UpcomingPlanCard.tsx:577
+#: src/components/UpcomingPlanCard.tsx:578
 #: src/components/WorkoutPlanEditor.tsx:433
 #: src/components/WorkoutStructureEditor.tsx:325
 #: src/lib/display-labels.ts:42
@@ -7394,7 +7395,7 @@ msgstr "恢复不足或明显疲劳尚未消退"
 msgid "Recovery was skipped because delivery eligibility changed. Review the refreshed queue."
 msgstr "恢复已跳过，因为下发条件已变更。请查看已刷新的队列。"
 
-#: src/components/PersonalContextPanel.tsx:232
+#: src/components/PersonalContextPanel.tsx:237
 msgid "Red-flag symptoms"
 msgstr "需要警惕的症状"
 
@@ -7409,7 +7410,7 @@ msgid "Reduce Intensity"
 msgstr "降低强度"
 
 #. placeholder {0}: detail.linked_revision_ids.length
-#: src/components/PersonalContextPanel.tsx:1428
+#: src/components/PersonalContextPanel.tsx:1433
 msgid "Referenced by {0} plan change record(s)."
 msgstr "被 {0} 条计划调整记录引用。"
 
@@ -7439,16 +7440,16 @@ msgstr "刷新失败，正在显示上次成功的快照。"
 #~ msgid "Refresh failed\" \"刷新失败"
 #~ msgstr ""
 
-#: src/components/Outdoor5KPlanStart.tsx:754
+#: src/components/Outdoor5KPlanStart.tsx:784
 msgid "Refresh proposal"
 msgstr "刷新提案"
 
-#: src/components/UpcomingPlanCard.tsx:1324
+#: src/components/UpcomingPlanCard.tsx:1348
 msgid "Refresh the plan before deleting this workout."
 msgstr "请先刷新计划，再删除这项训练。"
 
-#: src/components/UpcomingPlanCard.tsx:1220
-#: src/components/UpcomingPlanCard.tsx:1280
+#: src/components/UpcomingPlanCard.tsx:1244
+#: src/components/UpcomingPlanCard.tsx:1304
 msgid "Refresh the plan before editing this workout."
 msgstr "请先刷新计划，再编辑这项训练。"
 
@@ -7460,11 +7461,11 @@ msgstr "先刷新数据来源日历；仅在确认上次写入不存在后重试
 msgid "Refresh the provider calendar, re-check ownership, and allow one fenced retry for this item."
 msgstr "刷新数据来源日历，重新核对所有权，然后仅允许此项进行一次受保护的重试。"
 
-#: src/components/Outdoor5KPlanStart.tsx:709
+#: src/components/Outdoor5KPlanStart.tsx:739
 msgid "Regenerate successor"
 msgstr "重新生成后继提案"
 
-#: src/components/Outdoor5KPlanStart.tsx:709
+#: src/components/Outdoor5KPlanStart.tsx:739
 msgid "Regenerating…"
 msgstr "正在重新生成…"
 
@@ -7509,7 +7510,7 @@ msgstr "注册设置暂不可用"
 msgid "Reject"
 msgstr "驳回"
 
-#: src/components/Outdoor5KPlanStart.tsx:712
+#: src/components/Outdoor5KPlanStart.tsx:742
 msgid "Reject or defer"
 msgstr "拒绝或暂缓"
 
@@ -7518,7 +7519,7 @@ msgstr "拒绝或暂缓"
 msgid "Rejected"
 msgstr "已拒绝"
 
-#: src/components/Outdoor5KPlanStart.tsx:712
+#: src/components/Outdoor5KPlanStart.tsx:742
 msgid "Rejecting…"
 msgstr "正在拒绝…"
 
@@ -7669,7 +7670,7 @@ msgstr "重新发送验证邮件"
 msgid "Resolve"
 msgstr "标记为已解决"
 
-#: src/components/UpcomingPlanCard.tsx:748
+#: src/components/UpcomingPlanCard.tsx:749
 msgid "Resolve workout conflict"
 msgstr "处理训练冲突"
 
@@ -7682,9 +7683,9 @@ msgid "Resolved"
 msgstr "已解决"
 
 #: src/components/ManagedPlanSettingsCard.tsx:983
-#: src/components/UpcomingPlanCard.tsx:572
-#: src/components/UpcomingPlanCard.tsx:584
-#: src/components/UpcomingPlanCard.tsx:1576
+#: src/components/UpcomingPlanCard.tsx:573
+#: src/components/UpcomingPlanCard.tsx:585
+#: src/components/UpcomingPlanCard.tsx:1600
 #: src/components/WorkoutPlanEditor.tsx:440
 #: src/components/WorkoutPlanEditor.tsx:451
 #: src/components/WorkoutStructureEditor.tsx:326
@@ -7729,16 +7730,16 @@ msgstr "静息心率高于你的基准。这可能是提醒信号，但不能作
 msgid "Resting HR"
 msgstr "静息心率"
 
-#: src/components/UpcomingPlanCard.tsx:863
+#: src/components/UpcomingPlanCard.tsx:864
 msgid "Restore Praxys"
 msgstr "恢复 Praxys 版本"
 
-#: src/components/UpcomingPlanCard.tsx:829
+#: src/components/UpcomingPlanCard.tsx:830
 msgid "Restore Praxys:"
 msgstr "恢复 Praxys 版本："
 
 #: src/components/ManagedPlanSettingsCard.tsx:1006
-#: src/components/UpcomingPlanCard.tsx:1606
+#: src/components/UpcomingPlanCard.tsx:1630
 msgid "Restore workout"
 msgstr "恢复训练"
 
@@ -7747,8 +7748,8 @@ msgid "Restored"
 msgstr "已恢复"
 
 #: src/components/ManagedPlanSettingsCard.tsx:1005
-#: src/components/UpcomingPlanCard.tsx:860
-#: src/components/UpcomingPlanCard.tsx:1605
+#: src/components/UpcomingPlanCard.tsx:861
+#: src/components/UpcomingPlanCard.tsx:1629
 msgid "Restoring…"
 msgstr "正在恢复…"
 
@@ -7770,11 +7771,12 @@ msgstr "检索到候选活动不代表其已合格；只有完整活动，并明
 
 #: src/components/ManagedPlanSettingsCard.tsx:608
 #: src/components/ManagedPlanSettingsCard.tsx:1026
-#: src/components/Outdoor5KPlanStart.tsx:421
-#: src/components/Outdoor5KPlanStart.tsx:656
-#: src/components/PersonalContextPanel.tsx:755
-#: src/components/UpcomingPlanCard.tsx:341
-#: src/components/UpcomingPlanCard.tsx:1371
+#: src/components/Outdoor5KPlanStart.tsx:435
+#: src/components/Outdoor5KPlanStart.tsx:465
+#: src/components/Outdoor5KPlanStart.tsx:686
+#: src/components/PersonalContextPanel.tsx:760
+#: src/components/UpcomingPlanCard.tsx:342
+#: src/components/UpcomingPlanCard.tsx:1395
 #: src/pages/admin/AdminFeedback.tsx:582
 #: src/pages/admin/AdminRouteState.tsx:36
 #: src/pages/admin/AdminUsers.tsx:544
@@ -7801,8 +7803,8 @@ msgstr "请在参与前重试；完整分析尚未开始。"
 msgid "Retry cleanup"
 msgstr "重试清理"
 
-#: src/components/UpcomingPlanCard.tsx:461
-#: src/components/UpcomingPlanCard.tsx:862
+#: src/components/UpcomingPlanCard.tsx:462
+#: src/components/UpcomingPlanCard.tsx:863
 msgid "Retry delivery"
 msgstr "重试下发"
 
@@ -7814,7 +7816,7 @@ msgstr "重试下发"
 msgid "Retry queue"
 msgstr "重试队列"
 
-#: src/components/UpcomingPlanCard.tsx:747
+#: src/components/UpcomingPlanCard.tsx:748
 msgid "Retry this delivery?"
 msgstr "重试下发此训练？"
 
@@ -7834,7 +7836,7 @@ msgstr "请重试加载已提交报告和 GitHub 同步状态。"
 msgid "Retry to load the public status incidents feed."
 msgstr "重试加载公开状态页的事件列表。"
 
-#: src/components/UpcomingPlanCard.tsx:336
+#: src/components/UpcomingPlanCard.tsx:337
 msgid "Retry workout action"
 msgstr "重试此训练操作"
 
@@ -7846,7 +7848,7 @@ msgstr "正在重试"
 msgid "Return to the plugin to finish the one-time exchange. You can close this tab."
 msgstr "返回插件以完成一次性交换。你可以关闭此页面。"
 
-#: src/components/PersonalContextPanel.tsx:1519
+#: src/components/PersonalContextPanel.tsx:1524
 msgid "Review AI access"
 msgstr "查看 AI 权限"
 
@@ -7866,15 +7868,15 @@ msgstr "查看并启用"
 msgid "Review baseline"
 msgstr "复核基线"
 
-#: src/components/PersonalContextPanel.tsx:861
+#: src/components/PersonalContextPanel.tsx:866
 msgid "Review before saving"
 msgstr "保存前确认"
 
-#: src/components/UpcomingPlanCard.tsx:425
-#: src/components/UpcomingPlanCard.tsx:439
-#: src/components/UpcomingPlanCard.tsx:469
-#: src/components/UpcomingPlanCard.tsx:483
-#: src/components/UpcomingPlanCard.tsx:1529
+#: src/components/UpcomingPlanCard.tsx:426
+#: src/components/UpcomingPlanCard.tsx:440
+#: src/components/UpcomingPlanCard.tsx:470
+#: src/components/UpcomingPlanCard.tsx:484
+#: src/components/UpcomingPlanCard.tsx:1553
 msgid "Review conflict"
 msgstr "处理冲突"
 
@@ -7890,7 +7892,7 @@ msgstr "查看下发队列"
 msgid "Review first issue"
 msgstr "查看第一个问题"
 
-#: src/components/Outdoor5KPlanStart.tsx:437
+#: src/components/Outdoor5KPlanStart.tsx:453
 msgid "Review goal"
 msgstr "复核目标"
 
@@ -7910,7 +7912,7 @@ msgstr "查看可选测试"
 msgid "Review plan outcomes"
 msgstr "回顾计划结果"
 
-#: src/components/PersonalContextPanel.tsx:1286
+#: src/components/PersonalContextPanel.tsx:1291
 msgid "Review purpose and expiry"
 msgstr "确认用途和保留期限"
 
@@ -7924,7 +7926,7 @@ msgstr "审核报告、管理截图，并同步关联的 GitHub issue。"
 msgid "Review required"
 msgstr "需要审核"
 
-#: src/components/Outdoor5KPlanStart.tsx:241
+#: src/components/Outdoor5KPlanStart.tsx:255
 msgid "Review the constraints and try again."
 msgstr "请复核限制条件后重试。"
 
@@ -7936,7 +7938,7 @@ msgstr "回顾当前目标"
 msgid "Review the exact purpose and access below. The plugin cannot approve this request, read private notes, grant AI consent, or save context on its own."
 msgstr "请核对以下具体用途和权限。插件无法批准此请求、读取补充说明、授予 AI 权限或自行保存计划个性化信息。"
 
-#: src/components/UpcomingPlanCard.tsx:1185
+#: src/components/UpcomingPlanCard.tsx:1209
 #: src/components/WorkoutPlanEditor.tsx:544
 msgid "Review the highlighted step fields. Every typed target and termination must be complete."
 msgstr "请检查标出的步骤字段。每个带类型的目标和结束条件都必须完整。"
@@ -7978,11 +7980,11 @@ msgstr "上升"
 msgid "Rising"
 msgstr "上升"
 
-#: src/components/PersonalContextPanel.tsx:261
+#: src/components/PersonalContextPanel.tsx:266
 msgid "Road"
 msgstr "公路"
 
-#: src/components/UpcomingPlanCard.tsx:564
+#: src/components/UpcomingPlanCard.tsx:565
 #: src/components/WorkoutPlanEditor.tsx:443
 msgid "Road running"
 msgstr "公路跑"
@@ -8007,15 +8009,15 @@ msgstr "主观用力程度（RPE）· 0–10"
 msgid "Rule based"
 msgstr "规则判断"
 
-#: src/components/PersonalContextPanel.tsx:1417
+#: src/components/PersonalContextPanel.tsx:1422
 msgid "Rules"
 msgstr "规则"
 
-#: src/components/PersonalContextPanel.tsx:814
+#: src/components/PersonalContextPanel.tsx:819
 msgid "rules only"
 msgstr "仅按规则处理"
 
-#: src/components/PersonalContextPanel.tsx:1186
+#: src/components/PersonalContextPanel.tsx:1191
 msgid "Rules only · nothing sent to AI"
 msgstr "仅按规则处理，不发送给 AI"
 
@@ -8063,9 +8065,9 @@ msgstr "跑步"
 msgid "Runs"
 msgstr "运行次数"
 
-#: src/components/PersonalContextPanel.tsx:230
-#: src/components/PersonalContextPanel.tsx:231
-#: src/components/PersonalContextPanel.tsx:232
+#: src/components/PersonalContextPanel.tsx:235
+#: src/components/PersonalContextPanel.tsx:236
+#: src/components/PersonalContextPanel.tsx:237
 msgid "Safety"
 msgstr "安全"
 
@@ -8073,11 +8075,11 @@ msgstr "安全"
 msgid "Safety policy"
 msgstr "安全策略"
 
-#: src/components/Outdoor5KPlanStart.tsx:503
+#: src/components/Outdoor5KPlanStart.tsx:533
 msgid "Safety stop"
 msgstr "安全停止"
 
-#: src/components/Outdoor5KPlanStart.tsx:517
+#: src/components/Outdoor5KPlanStart.tsx:547
 msgid "Safety stop applies"
 msgstr "存在安全停止条件"
 
@@ -8103,7 +8105,7 @@ msgstr "存在安全停止条件"
 #~ msgid "Samples incomplete · {coverage}% coverage"
 #~ msgstr "样本不完整 · 覆盖率 {coverage}%"
 
-#: src/components/PersonalContextPanel.tsx:248
+#: src/components/PersonalContextPanel.tsx:253
 msgid "Sat"
 msgstr "周六"
 
@@ -8116,7 +8118,7 @@ msgstr "周六"
 msgid "Save"
 msgstr "保存"
 
-#: src/components/PersonalContextPanel.tsx:1273
+#: src/components/PersonalContextPanel.tsx:1278
 msgid "Save correction"
 msgstr "保存更正"
 
@@ -8128,7 +8130,7 @@ msgstr "保存目标"
 #~ msgid "Save Goal"
 #~ msgstr "保存目标"
 
-#: src/components/PersonalContextPanel.tsx:1274
+#: src/components/PersonalContextPanel.tsx:1279
 msgid "Save private context"
 msgstr "保存"
 
@@ -8144,11 +8146,11 @@ msgstr "保存训练"
 msgid "Saved"
 msgstr "已保存"
 
-#: src/components/PersonalContextPanel.tsx:482
+#: src/components/PersonalContextPanel.tsx:487
 msgid "Saved without guessing a reason. The cause remains unknown."
 msgstr "已保存，Praxys 不会推测具体原因。"
 
-#: src/components/PersonalContextPanel.tsx:1234
+#: src/components/PersonalContextPanel.tsx:1239
 msgid "Saving confirms this one purpose. It does not authorize a new purpose, AI processing, analytics, or model training."
 msgstr "保存仅代表同意用于上述用途，不代表同意其他用途、AI 处理、数据分析或模型训练。"
 
@@ -8174,7 +8176,7 @@ msgstr "保存后，这项训练会改期。"
 msgid "Saving…"
 msgstr "保存中…"
 
-#: src/components/PersonalContextPanel.tsx:225
+#: src/components/PersonalContextPanel.tsx:230
 msgid "Schedule conflict"
 msgstr "日程冲突"
 
@@ -8198,7 +8200,7 @@ msgstr "安排测试会通过标准的训练、修订和投递流程写入计划
 msgid "Science"
 msgstr "科学"
 
-#: src/components/Outdoor5KPlanStart.tsx:678
+#: src/components/Outdoor5KPlanStart.tsx:708
 msgid "Science decision"
 msgstr "科学决策"
 
@@ -8214,7 +8216,7 @@ msgstr "科学模型"
 msgid "Scientific models"
 msgstr "科学模型"
 
-#: src/components/Outdoor5KPlanStart.tsx:470
+#: src/components/Outdoor5KPlanStart.tsx:500
 msgid "Scope and guardrails"
 msgstr "范围与护栏"
 
@@ -8259,11 +8261,11 @@ msgstr "选择一天，查看当天哪些训练被纳入估算。"
 msgid "Select a metric to inspect its chart or evidence."
 msgstr "选择一个指标，查看图表或依据。"
 
-#: src/components/UpcomingPlanCard.tsx:245
+#: src/components/UpcomingPlanCard.tsx:246
 msgid "Select an execution target in Settings to continue delivery."
 msgstr "请先在设置中选择执行平台，再继续下发。"
 
-#: src/components/Outdoor5KPlanStart.tsx:524
+#: src/components/Outdoor5KPlanStart.tsx:554
 msgid "Select availability, then give the same supported session limit for each selected day."
 msgstr "选择可用日期，然后为每个选定日期填写相同的受支持单次训练上限。"
 
@@ -8390,7 +8392,7 @@ msgstr "请设置功率阈值，让 Praxys 无需使用被热身和放松稀释�
 msgid "Set goal"
 msgstr "设置目标"
 
-#: src/components/Outdoor5KPlanStart.tsx:457
+#: src/components/Outdoor5KPlanStart.tsx:487
 msgid "Set the constraints you can actually keep. Praxys returns a deterministic proposal; it is not yet your plan."
 msgstr "设置你实际能够遵守的限制条件。Praxys 会返回一个确定性提案；它尚未成为你的计划。"
 
@@ -8420,11 +8422,11 @@ msgstr "设置"
 msgid "Setup"
 msgstr "设置向导"
 
-#: src/components/PersonalContextPanel.tsx:1128
+#: src/components/PersonalContextPanel.tsx:1133
 msgid "Share only what changes your plan."
 msgstr "只填写会影响训练计划的内容。"
 
-#: src/components/PersonalContextPanel.tsx:706
+#: src/components/PersonalContextPanel.tsx:711
 msgid "Share only what could change your plan. Praxys keeps it private, never guesses why training changed, and leaves AI off unless you separately allow it."
 msgstr "只填写会影响训练计划的信息。Praxys 会加密保存，不会自行推测训练变化的原因；只有另行授权后，才会使用 AI 处理。"
 
@@ -8603,7 +8605,7 @@ msgstr "来源"
 msgid "Source stays unchanged"
 msgstr "源训练保持不变"
 
-#: src/components/UpcomingPlanCard.tsx:648
+#: src/components/UpcomingPlanCard.tsx:649
 msgid "Source-owned"
 msgstr "源端所有"
 
@@ -8661,11 +8663,11 @@ msgstr "开始、查看并调整由 Praxys 管理的训练计划。"
 msgid "Started"
 msgstr "开始时间"
 
-#: src/components/PersonalContextPanel.tsx:1021
+#: src/components/PersonalContextPanel.tsx:1026
 msgid "Starts"
 msgstr "开始日期"
 
-#: src/components/PersonalContextPanel.tsx:1328
+#: src/components/PersonalContextPanel.tsx:1333
 #: src/pages/admin/AdminFeedback.tsx:390
 #: src/pages/admin/AdminUsers.tsx:734
 #: src/pages/admin/AdminUsers.tsx:873
@@ -8726,12 +8728,12 @@ msgstr "停止原因"
 msgid "Stop this test"
 msgstr "停止本次测试"
 
-#: src/components/PersonalContextPanel.tsx:1491
-#: src/components/PersonalContextPanel.tsx:1529
+#: src/components/PersonalContextPanel.tsx:1496
+#: src/components/PersonalContextPanel.tsx:1534
 msgid "Stop using"
 msgstr "停止用于计划"
 
-#: src/components/PersonalContextPanel.tsx:1453
+#: src/components/PersonalContextPanel.tsx:1458
 msgid "Stop using this context?"
 msgstr "停止使用这条信息？"
 
@@ -8739,7 +8741,7 @@ msgstr "停止使用这条信息？"
 msgid "Stopping or declining preserves your account and the no-test path."
 msgstr "停止或放弃测试不会影响账号，也可以继续选择不测试。"
 
-#: src/components/PersonalContextPanel.tsx:1170
+#: src/components/PersonalContextPanel.tsx:1175
 msgid "Stored until"
 msgstr "信息保留至"
 
@@ -8751,7 +8753,7 @@ msgstr "Strava 客户端 ID"
 msgid "Strava Client Secret"
 msgstr "Strava 客户端密钥"
 
-#: src/components/UpcomingPlanCard.tsx:569
+#: src/components/UpcomingPlanCard.tsx:570
 #: src/components/WorkoutPlanEditor.tsx:448
 #: src/pages/Setup.tsx:169
 msgid "Strength"
@@ -8773,12 +8775,12 @@ msgstr "挑战目标"
 #~ msgid "strongly positive"
 #~ msgstr "状态极佳"
 
-#: src/components/PersonalContextPanel.tsx:1193
-#: src/components/PersonalContextPanel.tsx:1366
+#: src/components/PersonalContextPanel.tsx:1198
+#: src/components/PersonalContextPanel.tsx:1371
 msgid "Structured details"
 msgstr "已保存的信息"
 
-#: src/components/PersonalContextPanel.tsx:1608
+#: src/components/PersonalContextPanel.tsx:1613
 msgid "Structured fields sent"
 msgstr "将发送的信息"
 
@@ -8823,11 +8825,11 @@ msgstr "成功"
 msgid "successful"
 msgstr "成功率"
 
-#: src/components/PersonalContextPanel.tsx:1601
+#: src/components/PersonalContextPanel.tsx:1606
 msgid "Suggest a bounded adjustment to the current plan."
 msgstr "对当前计划提出一个有限调整建议。"
 
-#: src/components/PersonalContextPanel.tsx:1153
+#: src/components/PersonalContextPanel.tsx:1158
 #: src/pages/McpAuthorization.tsx:29
 msgid "Suggest adjustments to the current plan"
 msgstr "用于建议调整当前计划"
@@ -8843,7 +8845,7 @@ msgstr "建议"
 msgid "Summary window"
 msgstr "汇总时间范围"
 
-#: src/components/PersonalContextPanel.tsx:249
+#: src/components/PersonalContextPanel.tsx:254
 msgid "Sun"
 msgstr "周日"
 
@@ -8971,7 +8973,7 @@ msgstr "同步分段或采样功率数据，帮助 Praxys 识别持续发力的�
 #~ msgid "Sync split-level power so workload can contribute."
 #~ msgstr "同步分段功率数据，训练负荷才能计入。"
 
-#: src/components/UpcomingPlanCard.tsx:493
+#: src/components/UpcomingPlanCard.tsx:494
 msgid "Sync target to review"
 msgstr "同步目标平台后处理"
 
@@ -9095,7 +9097,7 @@ msgstr "目标类型"
 #~ msgid "Telemetry trust boundary"
 #~ msgstr "遥测信任边界"
 
-#: src/components/Outdoor5KPlanStart.tsx:505
+#: src/components/Outdoor5KPlanStart.tsx:535
 msgid "Tell Praxys if a safety stop applies. It will stop this plan path and show policy-bounded alternatives."
 msgstr "如果存在安全停止条件，请告知 Praxys。它将停止此计划路径并显示政策限定的替代方案。"
 
@@ -9115,19 +9117,19 @@ msgstr "同时包含温度和湿度的活动数量不足。"
 msgid "Temperature is missing from too many otherwise eligible activities."
 msgstr "其他条件合格的活动中，温度缺失过多。"
 
-#: src/components/UpcomingPlanCard.tsx:579
+#: src/components/UpcomingPlanCard.tsx:580
 #: src/components/WorkoutPlanEditor.tsx:435
 #: src/lib/display-labels.ts:44
 #: src/lib/phase-label.ts:14
 msgid "Tempo"
 msgstr "节奏跑"
 
-#: src/components/PersonalContextPanel.tsx:806
+#: src/components/PersonalContextPanel.tsx:811
 #: src/pages/McpAuthorization.tsx:48
 msgid "Temporary availability"
 msgstr "临时训练安排"
 
-#: src/components/PersonalContextPanel.tsx:376
+#: src/components/PersonalContextPanel.tsx:381
 msgid "Temporary context can stay active for at most 90 days."
 msgstr "这类临时信息最长可生效 90 天。"
 
@@ -9143,11 +9145,11 @@ msgstr "结束条件"
 msgid "Termination"
 msgstr "结束条件"
 
-#: src/components/Outdoor5KPlanStart.tsx:598
+#: src/components/Outdoor5KPlanStart.tsx:628
 msgid "Terrain and equipment"
 msgstr "地形和装备"
 
-#: src/components/PersonalContextPanel.tsx:1102
+#: src/components/PersonalContextPanel.tsx:1107
 msgid "Terrain still available (optional)"
 msgstr "仍可选择的训练地形（可多选）"
 
@@ -9155,7 +9157,7 @@ msgstr "仍可选择的训练地形（可多选）"
 msgid "Test pending"
 msgstr "测试待完成"
 
-#: src/components/UpcomingPlanCard.tsx:583
+#: src/components/UpcomingPlanCard.tsx:584
 #: src/components/WorkoutPlanEditor.tsx:439
 msgid "Testing"
 msgstr "测试"
@@ -9168,11 +9170,11 @@ msgstr "谢谢，这会帮助我们改进今日建议。"
 msgid "Thanks for the feedback!"
 msgstr "感谢你的反馈！"
 
-#: src/components/UpcomingPlanCard.tsx:1179
+#: src/components/UpcomingPlanCard.tsx:1203
 msgid "That date is now completed history and can no longer be changed."
 msgstr "这一天已归入已完成记录，无法再修改。"
 
-#: src/components/PersonalContextPanel.tsx:767
+#: src/components/PersonalContextPanel.tsx:772
 msgid "That is a complete state, not missing data. Praxys keeps the reason unknown and does not reduce your standing or invent an explanation."
 msgstr "没有填写也是完整状态，并不代表数据缺失。Praxys 会保留“原因未知”，不会因此作出负面判断或自行补充解释。"
 
@@ -9180,7 +9182,7 @@ msgstr "没有填写也是完整状态，并不代表数据缺失。Praxys 会�
 msgid "The 42-day rule is a Praxys pilot guardrail, not a physiological cutoff."
 msgstr "42 天规则是 Praxys 的试点护栏，不是生理学界值。"
 
-#: src/components/Outdoor5KPlanStart.tsx:571
+#: src/components/Outdoor5KPlanStart.tsx:601
 msgid "The accepted deterministic policy has one shared maximum-session field. Praxys will not invent a per-day rule or silently reduce your schedule; use one limit for all selected days."
 msgstr "已接受的确定性政策只有一个共享的单次训练上限字段。Praxys 不会臆造按日规则，也不会悄悄缩减你的安排；请为所有选定日期使用同一个上限。"
 
@@ -9264,7 +9266,7 @@ msgstr "冷却期可避免意外重复分析。"
 msgid "The current goal is outside this 5K baseline pilot."
 msgstr "当前目标不在本次 5 公里基线试点范围内。"
 
-#: src/components/Outdoor5KPlanStart.tsx:628
+#: src/components/Outdoor5KPlanStart.tsx:658
 msgid "The deterministic policy returned no additional explanation."
 msgstr "确定性政策没有返回额外说明。"
 
@@ -9272,7 +9274,7 @@ msgstr "确定性政策没有返回额外说明。"
 msgid "The eligible history crosses incompatible power-device or algorithm regimes."
 msgstr "符合条件的历史数据跨越了不兼容的功率设备或算法阶段。"
 
-#: src/components/PersonalContextPanel.tsx:374
+#: src/components/PersonalContextPanel.tsx:379
 msgid "The end date must be after the start date."
 msgstr "结束日期必须晚于开始日期。"
 
@@ -9368,15 +9370,15 @@ msgstr "这些有序步骤和目标区间可以直接交付，无需简化。"
 msgid "The portable workout structure is invalid."
 msgstr "通用训练结构无效。"
 
-#: src/components/UpcomingPlanCard.tsx:248
+#: src/components/UpcomingPlanCard.tsx:249
 msgid "The Praxys plan is preserved; no target workouts will change."
 msgstr "Praxys 计划会保留，目标平台上的训练不会更改。"
 
-#: src/components/UpcomingPlanCard.tsx:754
+#: src/components/UpcomingPlanCard.tsx:755
 msgid "The Praxys workout is missing from {target}. Restoring it keeps the Praxys version canonical."
 msgstr "{target} 上缺少此 Praxys 训练。恢复后仍以 Praxys 版本为准。"
 
-#: src/components/UpcomingPlanCard.tsx:1560
+#: src/components/UpcomingPlanCard.tsx:1584
 msgid "The previous workout was restored"
 msgstr "已恢复上一项训练"
 
@@ -9426,7 +9428,7 @@ msgid "The readiness decision changed. Review the refreshed decision before reco
 msgstr "就绪判断已更新。请查看刷新后的判断，再记录结论。"
 
 #. placeholder {0}: target ?? 'your target'
-#: src/components/UpcomingPlanCard.tsx:239
+#: src/components/UpcomingPlanCard.tsx:240
 msgid "The rolling 14-day window is delivered to {0}."
 msgstr "滚动的 14 天窗口会下发到 {0}。"
 
@@ -9462,7 +9464,7 @@ msgstr "源训练已锁定。请先将此副本另存为 Praxys 所有的训练�
 msgid "The status API did not respond — this itself may indicate an outage."
 msgstr "状态 API 未响应，这本身可能表示服务中断。"
 
-#: src/components/UpcomingPlanCard.tsx:809
+#: src/components/UpcomingPlanCard.tsx:810
 msgid "The target version is unavailable."
 msgstr "目标平台版本不可用。"
 
@@ -9514,7 +9516,7 @@ msgstr "仅在历史证据缺失、过期或仍待确认时提供。这是一项
 msgid "This cannot be undone. If this is the last admin account, deletion will be blocked."
 msgstr "此操作无法撤销。如果这是最后一个管理员账号，将无法删除。"
 
-#: src/components/UpcomingPlanCard.tsx:1583
+#: src/components/UpcomingPlanCard.tsx:1607
 msgid "This change used confirmed private context. The private detail is not copied into the plan record."
 msgstr "这次调整使用了已确认的计划个性化信息，具体内容不会写入计划记录。"
 
@@ -9530,7 +9532,7 @@ msgstr "此温湿度组合超出 Praxys 采用的保守 Stull 方法范围。"
 msgid "This connects the official Praxys Coach plugin to your account. Personal plan context stays unavailable until you approve a separate, short-lived request."
 msgstr "这会将官方 Praxys Coach 插件连接到你的账号。在你另行批准一项短期请求之前，插件仍无法访问计划个性化信息。"
 
-#: src/components/PersonalContextPanel.tsx:1575
+#: src/components/PersonalContextPanel.tsx:1580
 msgid "This decision is separate from saving context and applies only to this exact version."
 msgstr "AI 权限与保存信息分开确认，且只适用于当前版本。"
 
@@ -9542,12 +9544,12 @@ msgstr "无法自动重试此次下发。请查看已刷新的队列，确认所
 msgid "This delivery changed before recovery started. Review the refreshed queue."
 msgstr "恢复开始前，此次下发状态已变更。请查看已刷新的队列。"
 
-#: src/components/Outdoor5KPlanStart.tsx:643
+#: src/components/Outdoor5KPlanStart.tsx:673
 msgid "This deterministic result uses the published and pilot guardrails named by the policy response. It is not AI coaching and does not make an injury, readiness, or goal guarantee."
 msgstr "此确定性结果使用政策响应中列出的已发表和试点护栏。它不是 AI 指导，也不对受伤、准备情况或目标达成作出保证。"
 
-#: src/components/PersonalContextPanel.tsx:1008
-#: src/components/PersonalContextPanel.tsx:1223
+#: src/components/PersonalContextPanel.tsx:1013
+#: src/components/PersonalContextPanel.tsx:1228
 msgid "This enters the safety path and stops ordinary performance optimization. Praxys cannot diagnose, clear you to train, or set a return-to-sport timeline."
 msgstr "这类信息会进入安全流程，暂停常规训练优化。Praxys 不会进行诊断、判断是否可以训练，也不会设定恢复运动的时间。"
 
@@ -9555,7 +9557,7 @@ msgstr "这类信息会进入安全流程，暂停常规训练优化。Praxys �
 msgid "This evaluates past training only; it does not assess today's weather or conditions."
 msgstr "这仅评估过往训练，不评估今天的天气或环境条件。"
 
-#: src/components/Outdoor5KPlanStart.tsx:402
+#: src/components/Outdoor5KPlanStart.tsx:416
 msgid "This exact proposal was already adopted. Delivery remains disabled until you explicitly enable it."
 msgstr "此精确提案已被采纳。在你明确启用前，投递仍处于禁用状态。"
 
@@ -9583,7 +9585,7 @@ msgstr "此护栏采用个体化 HRV 指导，且不会加载活动强度。具�
 msgid "This imported or older workout has no portable tree. Edit its summary as-is, or explicitly convert one flat step without guessing semantics."
 msgstr "此导入或旧版训练没有便携结构树。可按原样编辑摘要，或显式转换为一个扁平步骤，不会猜测语义。"
 
-#: src/components/UpcomingPlanCard.tsx:1197
+#: src/components/UpcomingPlanCard.tsx:1221
 msgid "This imported structure cannot be edited safely. Duplicate it into a supported Praxys workout first."
 msgstr "无法安全编辑此导入结构。请先复制为受支持的 Praxys 训练。"
 
@@ -9595,7 +9597,7 @@ msgstr "这条解读已更新。请先刷新页面，再提交反馈。"
 msgid "This is a maximal-effort test, and the no-test path always stays available."
 msgstr "这是最大努力测试；始终可以选择不测试。"
 
-#: src/components/Outdoor5KPlanStart.tsx:472
+#: src/components/Outdoor5KPlanStart.tsx:502
 msgid "This is a pilot for adult, self-coached recreational outdoor-road 5K runners. It does not diagnose, clear, or guarantee a performance outcome."
 msgstr "这是面向成年、自主训练休闲户外公路 5 公里跑者的试点。它不进行诊断、不作出健康许可，也不保证表现结果。"
 
@@ -9675,11 +9677,11 @@ msgstr "此试点面向准备户外公路 5 公里的成年、自主训练休闲
 msgid "This pilot is only for adults who already can complete 5 km."
 msgstr "本试点仅适用于已经能够完成 5 公里的成年人。"
 
-#: src/components/Outdoor5KPlanStart.tsx:433
+#: src/components/Outdoor5KPlanStart.tsx:449
 msgid "This plan-start pilot is available only for the supported outdoor road 5K performance goal."
 msgstr "此计划起点试点仅适用于受支持的户外公路 5 公里表现目标。"
 
-#: src/components/Outdoor5KPlanStart.tsx:600
+#: src/components/Outdoor5KPlanStart.tsx:630
 msgid "This policy supports outdoor road running only. Terrain, treadmill, trail, and equipment preferences are unsupported inputs and are not inferred."
 msgstr "此政策仅支持户外公路跑。地形、跑步机、越野和装备偏好均为不受支持的输入，也不会被推断。"
 
@@ -9688,11 +9690,11 @@ msgstr "此政策仅支持户外公路跑。地形、跑步机、越野和装备
 #~ msgstr "此便携结构可以不压扁地表达。"
 
 #. placeholder {0}: proposalStateLabel(activeProposal.state)
-#: src/components/Outdoor5KPlanStart.tsx:721
+#: src/components/Outdoor5KPlanStart.tsx:751
 msgid "This proposal is {0}. It cannot mutate the canonical plan; review readiness and create a new proposal when you are ready."
 msgstr "此提案为 {0}。它无法更改规范计划；准备好后请复核准备情况并创建新提案。"
 
-#: src/components/Outdoor5KPlanStart.tsx:668
+#: src/components/Outdoor5KPlanStart.tsx:698
 msgid "This proposal is not yet your plan. It cannot deliver workouts until after explicit adoption and separate delivery consent."
 msgstr "此提案尚未成为你的计划。在明确采纳并单独同意投递前，它不能投递训练。"
 
@@ -9753,7 +9755,7 @@ msgstr "此来源使用了较新版本的训练结构；为避免丢失细节，
 #~ msgid "This step termination cannot be represented safely."
 #~ msgstr "无法安全表达此步骤结束条件。"
 
-#: src/components/UpcomingPlanCard.tsx:1191
+#: src/components/UpcomingPlanCard.tsx:1215
 msgid "This structure is authoritative. Edit its steps instead of changing its flat summary."
 msgstr "此结构是权威内容。请编辑其步骤，而非更改扁平摘要。"
 
@@ -9766,7 +9768,7 @@ msgstr "此结构是权威内容。请编辑其步骤，而非更改扁平摘要
 msgid "This will permanently delete <0>{0}</0> and all their data (activities, config, connections, plans). This cannot be undone."
 msgstr "这将永久删除 <0>{0}</0> 及其所有数据（活动、配置、连接、计划）。此操作无法撤销。"
 
-#: src/components/UpcomingPlanCard.tsx:1171
+#: src/components/UpcomingPlanCard.tsx:1195
 msgid "This workout changed elsewhere. The plan was refreshed; reopen the workout to continue."
 msgstr "这项训练已在其他位置更新。计划已刷新，请重新打开后继续。"
 
@@ -9774,7 +9776,7 @@ msgstr "这项训练已在其他位置更新。计划已刷新，请重新打开
 #~ msgid "This workout differs on Stryd — click to overwrite with the Praxys version."
 #~ msgstr "Stryd 上这次训练与 Praxys 版本不一致，点击可用 Praxys 版本覆盖。"
 
-#: src/components/UpcomingPlanCard.tsx:752
+#: src/components/UpcomingPlanCard.tsx:753
 msgid "This workout stays external unless you explicitly make it canonical in Praxys."
 msgstr "除非明确采纳到 Praxys，否则此训练会保持为外部训练。"
 
@@ -9786,7 +9788,7 @@ msgstr "此训练使用了当前编辑器尚无法安全修改的较新便携结
 #~ msgid "This workout was imported from Stryd."
 #~ msgstr "此训练由 Stryd 导入。"
 
-#: src/components/UpcomingPlanCard.tsx:580
+#: src/components/UpcomingPlanCard.tsx:581
 #: src/components/WorkoutPlanEditor.tsx:436
 #: src/lib/display-labels.ts:45
 #: src/lib/phase-label.ts:15
@@ -9806,7 +9808,7 @@ msgstr "阈值配速趋势"
 msgid "Thresholds"
 msgstr "阈值"
 
-#: src/components/PersonalContextPanel.tsx:246
+#: src/components/PersonalContextPanel.tsx:251
 msgid "Thu"
 msgstr "周四"
 
@@ -9853,7 +9855,7 @@ msgstr "距目标"
 msgid "Today"
 msgstr "今日"
 
-#: src/components/UpcomingPlanCard.tsx:626
+#: src/components/UpcomingPlanCard.tsx:627
 msgid "TODAY"
 msgstr "今日"
 
@@ -9917,8 +9919,8 @@ msgstr "已记录用户总数"
 msgid "Totals are deterministic only when every repeated step has the same measurable termination. Praxys does not invent a training-load score here."
 msgstr "仅当每个重复步骤具有同一可测结束条件时，总计才是确定的。Praxys 不会在此虚构训练负荷分数。"
 
-#: src/components/PersonalContextPanel.tsx:254
-#: src/components/PersonalContextPanel.tsx:263
+#: src/components/PersonalContextPanel.tsx:259
+#: src/components/PersonalContextPanel.tsx:268
 msgid "Track"
 msgstr "跑道"
 
@@ -9930,11 +9932,11 @@ msgstr "长期观察趋势"
 msgid "Tracking"
 msgstr "跟踪"
 
-#: src/components/PersonalContextPanel.tsx:262
+#: src/components/PersonalContextPanel.tsx:267
 msgid "Trail"
 msgstr "越野"
 
-#: src/components/UpcomingPlanCard.tsx:565
+#: src/components/UpcomingPlanCard.tsx:566
 #: src/components/WorkoutPlanEditor.tsx:444
 msgid "Trail running"
 msgstr "越野跑"
@@ -9972,8 +9974,8 @@ msgstr "训练复盘"
 msgid "Training Science"
 msgstr "训练科学"
 
-#: src/components/PersonalContextPanel.tsx:228
-#: src/components/PersonalContextPanel.tsx:229
+#: src/components/PersonalContextPanel.tsx:233
+#: src/components/PersonalContextPanel.tsx:234
 msgid "Training state"
 msgstr "训练状态"
 
@@ -9985,12 +9987,12 @@ msgstr "训练区间"
 msgid "Translates training stress into fitness."
 msgstr "把训练负荷转化为体能。"
 
-#: src/components/PersonalContextPanel.tsx:227
+#: src/components/PersonalContextPanel.tsx:232
 msgid "Travel"
 msgstr "出行"
 
-#: src/components/PersonalContextPanel.tsx:253
-#: src/components/PersonalContextPanel.tsx:264
+#: src/components/PersonalContextPanel.tsx:258
+#: src/components/PersonalContextPanel.tsx:269
 msgid "Treadmill"
 msgstr "跑步机"
 
@@ -10015,7 +10017,7 @@ msgstr "来自后端可信遥测边界的同步与连接结果。"
 #~ msgid "Trusted Today signals"
 #~ msgstr "受信任的今日信号"
 
-#: src/components/UpcomingPlanCard.tsx:1629
+#: src/components/UpcomingPlanCard.tsx:1653
 msgid "Try a longer window above."
 msgstr "试试上方更长的时间窗口。"
 
@@ -10035,7 +10037,7 @@ msgstr "TSB"
 msgid "TSB (load balance)"
 msgstr "TSB（负荷平衡）"
 
-#: src/components/PersonalContextPanel.tsx:244
+#: src/components/PersonalContextPanel.tsx:249
 msgid "Tue"
 msgstr "周二"
 
@@ -10104,11 +10106,11 @@ msgstr "无法连接状态服务"
 msgid "Unavailable"
 msgstr "不可用"
 
-#: src/components/PersonalContextPanel.tsx:224
+#: src/components/PersonalContextPanel.tsx:229
 msgid "Unavailable day"
 msgstr "某天无法训练"
 
-#: src/components/PersonalContextPanel.tsx:1355
+#: src/components/PersonalContextPanel.tsx:1360
 msgid "Unavailable for safety context"
 msgstr "安全相关信息不支持 AI 处理"
 
@@ -10171,7 +10173,7 @@ msgid "Unknown failure"
 msgstr "未知错误"
 
 #. placeholder {0}: formatDate(item.expires_at)
-#: src/components/PersonalContextPanel.tsx:809
+#: src/components/PersonalContextPanel.tsx:814
 msgid "until {0}"
 msgstr "至 {0}"
 
@@ -10187,7 +10189,7 @@ msgstr "未验证"
 msgid "Up to date"
 msgstr "最新"
 
-#: src/components/UpcomingPlanCard.tsx:1432
+#: src/components/UpcomingPlanCard.tsx:1456
 msgid "Upcoming Plan"
 msgstr "近期计划"
 
@@ -10243,11 +10245,11 @@ msgstr "暂无使用汇总数据。"
 #~ msgid "Usage proxy"
 #~ msgstr "使用代理指标"
 
-#: src/components/UpcomingPlanCard.tsx:851
+#: src/components/UpcomingPlanCard.tsx:852
 msgid "Use {target} version"
 msgstr "采用 {target} 版本"
 
-#: src/components/UpcomingPlanCard.tsx:835
+#: src/components/UpcomingPlanCard.tsx:836
 msgid "Use {target}:"
 msgstr "采用 {target}："
 
@@ -10263,7 +10265,7 @@ msgstr "使用已确认的信息生成计划"
 msgid "Use history first, then decide whether the optional pilot test is needed"
 msgstr "先使用历史基线，再决定是否需要可选试点测试"
 
-#: src/components/UpcomingPlanCard.tsx:357
+#: src/components/UpcomingPlanCard.tsx:358
 msgid "Use in Praxys"
 msgstr "采纳到 Praxys"
 
@@ -10280,7 +10282,7 @@ msgstr "通过微信小程序，随时随地使用 Praxys"
 #~ msgid "Use this"
 #~ msgstr "使用此项"
 
-#: src/components/UpcomingPlanCard.tsx:746
+#: src/components/UpcomingPlanCard.tsx:747
 msgid "Use this {target} workout in Praxys?"
 msgstr "将此 {target} 训练采纳到 Praxys？"
 
@@ -10351,7 +10353,7 @@ msgstr "验证失败"
 msgid "Verify"
 msgstr "验证"
 
-#: src/components/UpcomingPlanCard.tsx:413
+#: src/components/UpcomingPlanCard.tsx:414
 msgid "Verifying"
 msgstr "正在核对"
 
@@ -10418,7 +10420,7 @@ msgstr "候补名单"
 msgid "Waitlist unavailable"
 msgstr "候补名单不可用"
 
-#: src/components/UpcomingPlanCard.tsx:567
+#: src/components/UpcomingPlanCard.tsx:568
 #: src/components/WorkoutPlanEditor.tsx:446
 #: src/pages/Setup.tsx:168
 msgid "Walking"
@@ -10463,7 +10465,7 @@ msgstr "我们正在分批邀请跑者，并持续打磨科学方法。留下邮
 msgid "We've logged it and will take a look."
 msgstr "我们已记录，会尽快查看。"
 
-#: src/components/PersonalContextPanel.tsx:233
+#: src/components/PersonalContextPanel.tsx:238
 msgid "Weather"
 msgstr "天气影响"
 
@@ -10487,7 +10489,7 @@ msgstr "微信小程序"
 msgid "WeChat Mini Program QR code"
 msgstr "微信小程序二维码"
 
-#: src/components/PersonalContextPanel.tsx:245
+#: src/components/PersonalContextPanel.tsx:250
 msgid "Wed"
 msgstr "周三"
 
@@ -10548,11 +10550,11 @@ msgstr "湿球温度代理值"
 msgid "Wet-bulb proxy calculator"
 msgstr "湿球温度代理值计算器"
 
-#: src/components/PersonalContextPanel.tsx:866
+#: src/components/PersonalContextPanel.tsx:871
 msgid "What availability changed?"
 msgstr "哪项可用时间有变？"
 
-#: src/components/PersonalContextPanel.tsx:865
+#: src/components/PersonalContextPanel.tsx:870
 msgid "What changed with this workout?"
 msgstr "这次训练变了什么？"
 
@@ -10568,7 +10570,7 @@ msgstr "这次训练变了什么？"
 msgid "What happened, or what would you like to see?"
 msgstr "遇到了什么问题，或希望我们做些什么？"
 
-#: src/components/PersonalContextPanel.tsx:941
+#: src/components/PersonalContextPanel.tsx:946
 msgid "What happened?"
 msgstr "这次训练怎么了？"
 
@@ -10612,7 +10614,7 @@ msgstr "将同步以下内容："
 msgid "Withdraw"
 msgstr "退出"
 
-#: src/components/PersonalContextPanel.tsx:1684
+#: src/components/PersonalContextPanel.tsx:1689
 msgid "Withdraw AI permission"
 msgstr "撤回 AI 权限"
 
@@ -10640,8 +10642,8 @@ msgstr "退出后将删除实验同意记录和汇总结果。今后重新加入
 msgid "Withdrawal immediately deletes experiment consent and the derived result. Your ordinary account activities remain unchanged."
 msgstr "退出后会立即删除实验同意记录和派生结果，账号中的普通活动保持不变。"
 
-#: src/components/PersonalContextPanel.tsx:799
-#: src/components/PersonalContextPanel.tsx:1332
+#: src/components/PersonalContextPanel.tsx:804
+#: src/components/PersonalContextPanel.tsx:1337
 msgid "Withdrawn"
 msgstr "已撤回"
 
@@ -10653,7 +10655,7 @@ msgstr "处于参考区间内"
 msgid "Work"
 msgstr "训练"
 
-#: src/components/UpcomingPlanCard.tsx:324
+#: src/components/UpcomingPlanCard.tsx:325
 msgid "Working…"
 msgstr "处理中…"
 
@@ -10662,8 +10664,8 @@ msgid "Workload evidence"
 msgstr "负荷证据"
 
 #: src/components/ManagedPlanSettingsCard.tsx:979
-#: src/components/PersonalContextPanel.tsx:879
-#: src/components/UpcomingPlanCard.tsx:1574
+#: src/components/PersonalContextPanel.tsx:884
+#: src/components/UpcomingPlanCard.tsx:1598
 msgid "Workout"
 msgstr "训练"
 
@@ -10671,7 +10673,7 @@ msgstr "训练"
 msgid "Workout conflict requires athlete input"
 msgstr "训练冲突需要运动员介入"
 
-#: src/components/Outdoor5KPlanStart.tsx:689
+#: src/components/Outdoor5KPlanStart.tsx:719
 msgid "Workout content is view-only in this deterministic policy. Change the bounded inputs above and regenerate to create an immutable successor; Praxys never constructs replacement workouts in this client."
 msgstr "在此确定性政策中，训练内容只能查看。请更改上方的受限输入并重新生成，以创建不可变的后继提案；Praxys 不会在此客户端构造替换训练。"
 
@@ -10687,12 +10689,12 @@ msgstr "不支持训练下发。"
 #~ msgid "Workout differs on Stryd — re-push to overwrite"
 #~ msgstr ""
 
-#: src/components/PersonalContextPanel.tsx:805
+#: src/components/PersonalContextPanel.tsx:810
 #: src/pages/McpAuthorization.tsx:51
 msgid "Workout explanation"
 msgstr "训练情况说明"
 
-#: src/components/PersonalContextPanel.tsx:1341
+#: src/components/PersonalContextPanel.tsx:1346
 msgid "Workout interpretation"
 msgstr "训练解读"
 
@@ -10714,7 +10716,7 @@ msgstr "训练概览"
 msgid "Workout purpose"
 msgstr "训练目的"
 
-#: src/components/PersonalContextPanel.tsx:274
+#: src/components/PersonalContextPanel.tsx:279
 msgid "Workout status"
 msgstr "训练完成情况"
 
@@ -10750,7 +10752,7 @@ msgstr "可离开此页面，稍后再回来。分析运行期间无需任何操
 msgid "You can still save this workout in Praxys, but managed delivery cannot preserve it until the marked details are changed."
 msgstr "仍可将此训练保存到 Praxys；但在修改标记的细节前，托管交付无法完整保留这些内容。"
 
-#: src/components/PersonalContextPanel.tsx:1649
+#: src/components/PersonalContextPanel.tsx:1654
 msgid "You can withdraw before any later request. Withdrawal cannot recall a request the provider already processed. Deleting the item removes local provider-use receipts and dependent private explanations."
 msgstr "你可以在后续请求前撤回。撤回无法收回 AI 服务已处理的请求。删除该项会移除本地 AI 使用记录和关联的私密说明。"
 

--- a/web/tests/performance.test.mjs
+++ b/web/tests/performance.test.mjs
@@ -8,7 +8,15 @@ import { initialDashboardUrl } from '../src/lib/dashboard-prefetch.ts';
 test('prefetches the authenticated cold-load dashboard route', () => {
   assert.equal(initialDashboardUrl('/today', true), '/api/today');
   assert.equal(initialDashboardUrl('/analysis', true), '/api/training');
-  assert.equal(initialDashboardUrl('/training', true), null);
+  const trainingUrl = initialDashboardUrl('/training', true);
+  assert.match(
+    trainingUrl,
+    /^\/api\/plan\?start=\d{4}-\d{2}-\d{2}&end=\d{4}-\d{2}-\d{2}$/,
+  );
+  const trainingWindow = new URL(trainingUrl, 'https://www.praxys.run');
+  const start = Date.parse(trainingWindow.searchParams.get('start'));
+  const end = Date.parse(trainingWindow.searchParams.get('end'));
+  assert.equal((end - start) / 86_400_000, 27);
   assert.equal(initialDashboardUrl('/', true), '/api/today');
   assert.equal(initialDashboardUrl('/today', false), null);
   assert.equal(initialDashboardUrl('/settings', true), null);


### PR DESCRIPTION
## Summary

- fetch the maximum 28-day Training plan window once so the 1/2/4-week controls switch locally instead of recomputing `/api/plan`
- defer the historical plan query until the athlete opens the workout-explanation form, and skip 5K goal/proposal reads when the configured goal is outside that pilot
- stop test-only commits from recycling the production backend
- verify the stamped backend version and database readiness after OneDeploy, with one bounded App Service restart when the deployed process does not cut over
- document the updated deployment behavior in the operations handbook

The production incident after #700 showed authenticated plan requests taking 37-40 seconds and SQLAlchemy pool timeouts while an unnecessary backend deployment recycled the service. A manual App Service restart restored readiness and activated the expected build.

## Validation

- `python -m pytest tests/test_training_analysis_page_split.py tests/test_appinsights_boundary.py tests/test_labs_environment.py::test_backend_deploy_supports_manual_cutover -q`
- `cd web && npm run build --silent`
- targeted ESLint for the changed web files and performance test
- extracted `Verify deployed backend cutover` shell block passes `bash -n`
- `python scripts/check_ui_quality.py --base origin/main --head HEAD --skip-evidence`

## UI quality
- Impeccable: `optimize web/src/pages/Training.tsx and web/src/pages/Analysis.tsx`
- Visual review: desktop 1440x900; mobile 390x844
- Primary journey: Training cold load -> 1/2/4-week switch -> Explain a workout; Analysis cold load
- Reviewer handoff: local-only - `test-screenshots/ui-quality/hotfix-training-analysis-performance/`
- States checked: loading, success, deferred workout-history load, 1/2/4-week windows, desktop, mobile
- Accessibility: existing focus and pressed-state semantics preserved; mobile touch targets inspected
- Design system impact: none - existing design system already covers this behavior-only performance fix
- Miniapp parity: not applicable - miniapp uses a fixed 14-day managed-plan window and the API contract is unchanged
- Exceptions: local Vite worktree served fallback fonts because symlinked font paths were denied; the production build bundled font assets successfully and no visual styling changed
