### PR TITLE
Fix science approval event resolution

### DIFF
--- a/.github/workflows/science-approval-ledger.yml
+++ b/.github/workflows/science-approval-ledger.yml
@@ -39,21 +39,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_PATH: ${{ github.event_path }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         shell: bash
         run: |
           set -euo pipefail
           case "$EVENT_NAME" in
             issue_comment)
-              if jq -e '.issue.pull_request != null' "$EVENT_PATH" >/dev/null; then
-                pr_numbers="$(jq -c '[.issue.number]' "$EVENT_PATH")"
+              if jq -e '.issue.pull_request != null' "$GITHUB_EVENT_PATH" >/dev/null; then
+                pr_numbers="$(jq -c '[.issue.number]' "$GITHUB_EVENT_PATH")"
               else
                 pr_numbers='[]'
               fi
               ;;
             pull_request_target)
-              pr_numbers="$(jq -c '[.pull_request.number]' "$EVENT_PATH")"
+              pr_numbers="$(jq -c '[.pull_request.number]' "$GITHUB_EVENT_PATH")"
               ;;
             workflow_dispatch)
               if [[ -n "$INPUT_PR_NUMBER" && "$INPUT_PR_NUMBER" != "0" ]]; then

--- a/tests/test_science_approval_workflow.py
+++ b/tests/test_science_approval_workflow.py
@@ -680,6 +680,8 @@ def test_workflow_uses_trusted_code_and_rechecks_the_exact_pr_head() -> None:
 
     assert "issue_comment:" in workflow
     assert "pull_request_target:" in workflow
+    assert '"$GITHUB_EVENT_PATH"' in workflow
+    assert "github.event_path" not in workflow
     assert "head.repo.full_name == $repository" in workflow
     assert 'any(.labels[]; .name == "science")' in workflow
     assert "compare/${default_sha}...${head_sha}" in workflow


### PR DESCRIPTION
## Summary

Use the runner-provided `GITHUB_EVENT_PATH` when resolving `issue_comment` and `pull_request_target` payloads. The original workflow referenced a nonexistent expression and received an empty path, so #702 approval materialization stopped in discovery.

## Validation

- `actionlint .github/workflows/science-approval-ledger.yml`
- `pytest tests/test_science_approval_workflow.py -q`

No science content, approval digest, or runtime state changes.