### PR TITLE
Add instrument/shadow agent invocation control

### DIFF
--- a/.github/agents/praxys-change-loop.agent.md
+++ b/.github/agents/praxys-change-loop.agent.md
@@ -59,6 +59,20 @@ implementation can skip review.
   with the agent recommendation, alternatives, user impact, and explicit
   deferrals. Do not ask the human to infer a decision from research or a diff.
 
+## Cooperative invocation admission
+
+For every manifest-coordinated role-agent call in this Delivery Loop, use the
+versioned `scripts/agent_invocation_control.py` protocol with the authoritative
+recomputed Work Contract and opaque contract, stable slot, generation, logical,
+attempt, and parent identities. Record finish transitions and recover crashes
+explicitly leaf first; elapsed time never proves a crash.
+
+Only `instrument` and `shadow` are available. Ordinary hypothetical denies do
+not block dispatch; only the explicit kill switch makes
+`launch_authorized=false` for a mediated launch. This cooperative integration
+cannot intercept native or otherwise unmediated invocations and must not claim
+global enforcement. Follow `docs/dev/agent-invocation-control.md`.
+
 ## Required execution order
 
 1. Verify the supplied Work Contract includes the Delivery Loop and record its

--- a/.github/agents/praxys-orchestrator.agent.md
+++ b/.github/agents/praxys-orchestrator.agent.md
@@ -69,6 +69,26 @@ listed order is not an execution order. `outcome_artifacts` are future
 observation obligations: register their observers without pretending the
 post-release outcome already exists.
 
+## Cooperative invocation admission
+
+Before each manifest-coordinated loop or role-agent call, cooperatively submit a
+versioned request to `scripts/agent_invocation_control.py` using the exact
+recomputed Work Contract. Reuse a stable opaque contract and slot identity, use
+a generation-independent slot identity through resumptions, and issue distinct
+generation, logical-invocation, and attempt identities. Carry the active parent
+attempt identity for nested calls and record an explicit finish or leaf-first
+recovery afterward. Initialize the Git-common-dir ledger explicitly before the
+first instrumented run.
+
+The checked-in mode starts at `instrument`; `shadow` is an explicit observation
+step. In either mode, ordinary `would_reject` decisions and missing, corrupt, or
+unsupported state remain non-blocking because enforcement is unavailable. Do not invoke the
+mediated child when `launch_authorized` is false under the explicit kill switch.
+Never request `enforce` or silently alias it to another mode. This is cooperative
+repository mediation only: the repository cannot intercept native agent calls,
+and unmediated activity remains outside coverage. See
+`docs/dev/agent-invocation-control.md`.
+
 ## Environment parity
 
 Before execution, run:

--- a/analysis/agentic_invocation_control.py
+++ b/analysis/agentic_invocation_control.py
@@ -1,0 +1,208 @@
+"""Pure identity and admission policy for agent invocation control."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Mapping
+
+
+SCHEMA_VERSION = 1
+POLICY_VERSION = "agent-invocation-control-v1"
+APPROVED_MODES = ("instrument", "shadow")
+POLICY_REASONS = (
+    "admit",
+    "kill_switch_active",
+    "duplicate_active",
+    "ancestry_cycle",
+    "ancestry_depth_limit",
+    "active_contract_limit",
+    "logical_contract_limit",
+    "retry_fingerprint_limit",
+    "attempt_limit",
+    "no_progress",
+)
+DECISION_REASONS = (
+    "admit",
+    "work_contract_invalid",
+    "kill_switch_active",
+    "duplicate_active",
+    "ancestry_cycle",
+    "ancestry_depth_limit",
+    "active_contract_limit",
+    "logical_contract_limit",
+    "retry_fingerprint_limit",
+    "attempt_limit",
+    "no_progress",
+    "state_missing",
+    "state_corrupt",
+    "state_unsupported",
+)
+MACHINE_REASON_CODES = (
+    "instrument_recorded",
+    "shadow_would_admit",
+    "shadow_would_deny_cycle",
+    "shadow_would_deny_policy_limit",
+    "invalid_request",
+    "invalid_identity",
+    "work_contract_unavailable",
+    "work_contract_mismatch",
+    "policy_unavailable",
+    "recovery_required",
+    "ledger_unavailable",
+    "enforcement_unavailable",
+    "kill_switch_active",
+    "ledger_initialized",
+    "ledger_ready",
+    "identity_created",
+    "finish_recorded",
+    "finish_idempotent",
+    "recovery_recorded",
+    "kill_switch_updated",
+    "status_reported",
+)
+ID_PREFIXES = {
+    "contract": "ctr",
+    "slot": "slt",
+    "generation": "gen",
+    "logical": "log",
+    "attempt": "att",
+    "decision": "dec",
+}
+_IDENTITY_RE = re.compile(r"^[a-z]{3}_[0-9a-f]{32}$")
+_FINGERPRINT_RE = re.compile(r"^fpr_[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class InvocationLimits:
+    """Accepted starting bounds for the candidate policy."""
+
+    maximum_ancestry_depth: int
+    maximum_active_per_contract: int
+    maximum_logical_per_contract: int
+    maximum_attempts_per_logical: int
+    maximum_retries_per_failure_fingerprint: int
+    no_progress_identical_terminals: int
+
+    @classmethod
+    def from_mapping(
+        cls, payload: Mapping[str, object]
+    ) -> "InvocationLimits":
+        """Validate and construct the exact v1 limit set."""
+        expected = {
+            "maximum_ancestry_depth",
+            "maximum_active_per_contract",
+            "maximum_logical_per_contract",
+            "maximum_attempts_per_logical",
+            "maximum_retries_per_failure_fingerprint",
+            "no_progress_identical_terminals",
+        }
+        if set(payload) != expected:
+            raise ValueError("limit keys do not match schema v1")
+        values: dict[str, int] = {}
+        for key in expected:
+            value = payload[key]
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError("limits must be integers")
+            if value < 1:
+                raise ValueError("limits must be positive")
+            values[key] = value
+        return cls(**values)
+
+
+@dataclass(frozen=True)
+class AdmissionFacts:
+    """Privacy-safe facts for one atomic admission decision."""
+
+    kill_switch_active: bool
+    duplicate_active: bool
+    ancestor_slot_ids: tuple[str, ...]
+    proposed_slot_id: str
+    proposed_depth: int
+    active_count: int
+    logical_count: int
+    is_new_logical: bool
+    retry_fingerprint: str | None
+    retries_for_fingerprint: int
+    attempt_count: int
+    recent_terminal_fingerprints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """One stable candidate-policy result."""
+
+    policy_reason: str
+    would_reject: bool
+    launch_authorized: bool
+
+
+def format_identity(kind: str, opaque_hex: str) -> str:
+    """Format a caller-generated, 128-bit opaque identity."""
+    prefix = ID_PREFIXES.get(kind)
+    if prefix is None or re.fullmatch(r"[0-9a-f]{32}", opaque_hex) is None:
+        raise ValueError("invalid opaque identity material")
+    return f"{prefix}_{opaque_hex}"
+
+
+def is_valid_identity(value: object, kind: str) -> bool:
+    """Return whether value is a valid opaque invocation identity."""
+    prefix = ID_PREFIXES.get(kind)
+    return (
+        prefix is not None
+        and isinstance(value, str)
+        and _IDENTITY_RE.fullmatch(value) is not None
+        and value.startswith(f"{prefix}_")
+    )
+
+
+def is_valid_fingerprint(value: object) -> bool:
+    """Return whether value is a versioned opaque fingerprint."""
+    return isinstance(value, str) and _FINGERPRINT_RE.fullmatch(value) is not None
+
+
+def evaluate_admission(
+    facts: AdmissionFacts,
+    limits: InvocationLimits,
+) -> AdmissionDecision:
+    """Evaluate the accepted guards in stable v1 precedence."""
+    reason = "admit"
+    if facts.kill_switch_active:
+        reason = "kill_switch_active"
+    elif facts.duplicate_active:
+        reason = "duplicate_active"
+    elif facts.proposed_slot_id in facts.ancestor_slot_ids:
+        reason = "ancestry_cycle"
+    elif facts.proposed_depth > limits.maximum_ancestry_depth:
+        reason = "ancestry_depth_limit"
+    elif facts.active_count >= limits.maximum_active_per_contract:
+        reason = "active_contract_limit"
+    elif (
+        facts.is_new_logical
+        and facts.logical_count >= limits.maximum_logical_per_contract
+    ):
+        reason = "logical_contract_limit"
+    elif (
+        facts.retry_fingerprint is not None
+        and facts.retries_for_fingerprint
+        >= limits.maximum_retries_per_failure_fingerprint
+    ):
+        reason = "retry_fingerprint_limit"
+    elif facts.attempt_count >= limits.maximum_attempts_per_logical:
+        reason = "attempt_limit"
+    elif (
+        len(facts.recent_terminal_fingerprints)
+        >= limits.no_progress_identical_terminals
+        and len(
+            set(facts.recent_terminal_fingerprints[: limits.no_progress_identical_terminals])
+        )
+        == 1
+    ):
+        reason = "no_progress"
+
+    would_reject = reason != "admit"
+    return AdmissionDecision(
+        policy_reason=reason,
+        would_reject=would_reject,
+        launch_authorized=reason != "kill_switch_active",
+    )

--- a/config/agent-invocation-control.json
+++ b/config/agent-invocation-control.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "policy_version": "agent-invocation-control-v1",
+  "status": "instrument-shadow-only",
+  "default_mode": "instrument",
+  "approved_modes": [
+    "instrument",
+    "shadow"
+  ],
+  "enforcement_approved": false,
+  "ledger_schema_version": 1,
+  "limits": {
+    "maximum_ancestry_depth": 6,
+    "maximum_active_per_contract": 8,
+    "maximum_logical_per_contract": 32,
+    "maximum_attempts_per_logical": 3,
+    "maximum_retries_per_failure_fingerprint": 1,
+    "no_progress_identical_terminals": 2
+  }
+}

--- a/config/copilot-execution-parity.json
+++ b/config/copilot-execution-parity.json
@@ -171,6 +171,15 @@
       ],
       "behavior": "Use the common isolated browser for public sources, record the actual verification level, and block strong conclusions when relevant full text is unavailable.",
       "rationale": "Network availability, publisher access, and paywalls are external to the repository and portable agents do not inherit personal browser sessions."
+    },
+    {
+      "id": "cooperative-invocation-mediation",
+      "environments": [
+        "local",
+        "cloud"
+      ],
+      "behavior": "Use the repository mediator for manifest-coordinated calls in instrument or shadow mode. Only its explicit kill switch rejects a mediated launch; ordinary would-reject and unavailable-state results remain non-blocking.",
+      "rationale": "The repository can cooperatively mediate its own agent manifests but cannot intercept platform-native or otherwise unmediated agent invocations."
     }
   ]
 }

--- a/docs/dev/adr-2026-08-20-agent-invocation-control.md
+++ b/docs/dev/adr-2026-08-20-agent-invocation-control.md
@@ -1,0 +1,191 @@
+# ADR-2026-08-20-agent-invocation-control
+
+- **Status:** Proposed — instrument/shadow scope human-authorized; final implementation-bound ADR approval pending separate review
+- **Decision date:** 2026-08-20
+- **Artifact implementation status:** repository-native Markdown; not schema-backed
+- **Owner role:** Architecture
+
+## Decision record
+
+- **id:** `ADR-2026-08-20-agent-invocation-control`
+- **schema_version:** `1`
+- **decision_type:** `architecture-decision-record`
+- **owner_role:** `Architecture`
+- **question:** Should Praxys add repository-owned mediated agent invocation admission for instrument/shadow evaluation now, and, if so, what architectural boundaries and machine-stable contracts constrain that implementation without broadening the authorized scope?
+- **options:**
+  1. Status quo with no mediated ledger.
+  2. Repository-owned mediated invocation admission with a pure, I/O-free identity/policy core, a thin CLI, and a local SQLite ledger under the Git common directory.
+  3. Flat JSON/file ledger.
+  4. Application database extension or a new service.
+  5. Immediate native interception and enforcement.
+- **recommendation:** Adopt option 2 for instrument/shadow scope only. Preserve the current repository architecture. Defer and do not decide enforcement, native interception, autonomy promotion, policy-bound tuning, operating-model version changes, and final implementation-bound ADR approval.
+- **rationale:** The authorized scope needs local, worktree-safe mediated observation with deterministic contracts, durable lifecycle state, and concurrency-safe recovery, while avoiding a new service, dependency, or application datastore. A pure identity/policy core plus thin CLI and local SQLite ledger provides the smallest architecture change that still supports instrument/shadow evaluation, explicit recovery, and stable machine contracts. The short horizon is shadow-evaluation implementation only; the long-lived horizon is the stable v1 JSON, exit-code, reason-code, identity, and ledger semantics that future review can accept, revise, or supersede.
+- **dependencies:**
+  - Approved policy proposal subject and digest: `policy-change-proposal-agent-invocation-control-v1` at `sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6`.
+  - Digest-bound Work Contract identified below, including classification digest `sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2` and route digest `sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51`.
+  - Independent Decision Review Router outcome `human-review-required` and the recorded human approval below.
+  - Downstream implementation artifacts: evaluation report, implementation impact map, implementation change, and verification evidence. Evaluation and policy artifacts are owned by Meta/Eval and are not modified here.
+- **review_route:** Independent Decision Review Router outcome `human-review-required`; human authorization currently covers instrument/shadow implementation only and does not accept this final implementation-bound ADR.
+- **outcome_plan:** Engineering implements only the accepted instrument/shadow scope. Meta/Eval compares shadow outcomes and mediated coverage without content persistence. Quality produces independent verification evidence. Any deferred decision requires separate independent/human review after implementation and verification evidence.
+- **digest:** `sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6` — digest of `policy-change-proposal-agent-invocation-control-v1`, not a self-hash of this ADR.
+
+## Work Contract binding
+
+- **routing_version:** `praxys-task-routing-v1`
+- **operating_model_version:** `praxys-agentic-operating-model-v1`
+- **primary_object:** `agent-system`
+- **impacts:** `[repository-change, agent-policy-or-autonomy, architecture-boundary]`
+- **risk_triggers:** `[irreversible-or-high-blast-radius-action, out-of-policy-or-out-of-distribution-decision]`
+- **classification_digest:** `sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2`
+- **primary_loop:** `meta-eval`
+- **nested_loop:** `delivery`
+- **lead:** `meta-eval`
+- **contributor:** `architecture`
+- **executor:** `engineering`
+- **verifier:** `quality`
+- **required_artifacts:** `evaluation-report`, `implementation-impact-map`, `implementation-change`, `verification-evidence`, `policy-change-proposal`, `architecture-decision-record`
+- **decision_review:** required
+- **route_digest:** `sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51`
+
+Every mediated admission evaluation must recompute this digest-bound Work Contract. Caller-supplied classification or route is not trusted. In instrument/shadow scope, a mismatch is structured evidence, not a blocker.
+
+## Review and authorization boundary
+
+Independent Decision Review Router outcome: `human-review-required`.
+
+Recorded human approval timestamp: `2026-08-20T23:38:10.880+08:00`
+
+> I approve policy-change-proposal-agent-invocation-control-v1 at sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6 for instrument/shadow implementation only.
+
+This authorization is limited to implementation in instrument/shadow scope. It does not accept this final implementation-bound ADR. Final ADR approval is pending separate independent/human review after implementation and verification evidence.
+
+Explicitly deferred and not decided here:
+
+- enforcement;
+- native interception;
+- autonomy promotion;
+- policy-bound tuning;
+- operating-model version changes; and
+- final implementation-bound ADR approval.
+
+## Context, constraints, affected systems, and reversibility
+
+The decision concerns the `agent-system` object and affects only repository-owned mediated invocation boundaries. The authorized near-term scope is a short shadow-evaluation horizon: implement instrument/shadow observation and hypothetical-admission evaluation without blocking native dispatch. The longer-lived horizon is the stable v1 machine contract surface for JSON I/O, exit semantics, reason-code semantics, identity semantics, and ledger lifecycle semantics.
+
+Affected systems for the authorized scope are bounded implementation targets only: `config` policy, `analysis/agentic_invocation_control.py`, `scripts/agent_invocation_control.py`, focused tests, developer docs, cooperative agent-manifest integration, and Local/Cloud parity/limitation updates. These are implementation boundaries, not authorization for Architecture to edit them. This ADR does not authorize changes to `scripts/route_agentic_task.py` composition, Decision Review behavior, the application database, or `plugins/praxys`.
+
+Reversibility is high. Cooperative integrations can be disabled. The local ledger is disposable observational/control metadata, not product or runtime truth, and has no cross-machine authority.
+
+## Options considered
+
+### 1. Status quo / no mediated ledger
+
+Rejected for the authorized scope. It has the lowest migration cost, but it provides no durable mediated coverage, no local lifecycle record, no deterministic shadow-evaluation output, and no crash-recovery surface for cooperative integrations.
+
+### 2. Repository-owned mediated invocation admission with pure core + thin CLI + local SQLite ledger
+
+Recommended for instrument/shadow scope. It preserves the current repository architecture and keeps the policy/identity decision core pure and I/O-free. The CLI stays thin. The ledger lives under the Git common directory so worktree discovery is safe and local concurrency is coordinated without expanding product/runtime storage. Operational cost stays local and migration cost is reversible.
+
+SQLite is required to run with WAL, foreign keys enabled per connection, and `BEGIN IMMEDIATE` around admission and lifecycle state transitions. The ledger is local observational/control metadata only, not portable truth across clones or machines.
+
+### 3. Flat JSON/file ledger
+
+Rejected. It appears simple but creates higher operational and migration cost for concurrency control, transactional state changes, leaf-first crash recovery, and durable lifecycle bookkeeping. It is materially weaker than SQLite for concurrent local attempts and idempotent recovery.
+
+### 4. Application database extension or new service
+
+Rejected for now. Either choice broadens the architecture boundary, increases privacy and operations scope, and turns a local mediated control into product/runtime infrastructure. That conflicts with the authorized scope and the requirement to avoid a new service, dependency, or application datastore.
+
+### 5. Immediate native interception and enforcement
+
+Deferred and not authorized. Repository tooling and cooperative manifests cannot intercept every platform-native agent invocation. Unmediated native calls remain possible and unobserved. Immediate interception/enforcement would overclaim repository authority, broaden the decision, and require separate review.
+
+## Recommended architecture boundaries
+
+- Preserve the current repository architecture.
+- Use repository-owned mediated invocation admission with a pure, I/O-free identity/policy core separated from a thin CLI and a local SQLite ledger under the Git common directory.
+- Add no new service, dependency, or application datastore.
+- Recompute the digest-bound Work Contract before every mediated admission evaluation; do not trust caller-supplied classification or route.
+- Use generation-independent Work Contract slot identity for ancestry and cycle detection. Runtime agent or generation identifiers cannot define ancestry.
+- Treat logical invocation identity and attempt identity separately: one logical invocation spans retries, while every execution or retry has its own attempt identity.
+- Persist no task, prompt, source-code, user, artifact, or free-form text. Limit ledger and machine output to versioned policy/route identifiers, digests, bounded role/slot identity, opaque invocation and attempt IDs, lifecycle states, reason codes, and necessary timestamps.
+- Keep errors and diagnostic columns text-free. Trust must verify the privacy, path, and filesystem boundary before any broader use.
+
+## Machine contract and state boundaries
+
+All JSON input and output must be versioned.
+
+Stable v1 exit contract:
+
+- `0`: instrumentation/shadow evaluation completed, including a hypothetical deny;
+- `2`: invalid request, schema, or identity;
+- `3`: policy or Work Contract unavailable, invalid, or mismatched for evaluation;
+- `4`: ledger, transaction, or recovery failure; and
+- `5`: requested mode unavailable or unapproved.
+
+These meanings cannot be repurposed within v1. Cooperative instrument/shadow integration must never gate a native invocation on these exits; it records and continues.
+
+Stable v1 machine reason-code namespace:
+
+- `instrument_recorded`
+- `shadow_would_admit`
+- `shadow_would_deny_cycle`
+- `shadow_would_deny_policy_limit`
+- `invalid_request`
+- `invalid_identity`
+- `work_contract_unavailable`
+- `work_contract_mismatch`
+- `policy_unavailable`
+- `recovery_required`
+- `ledger_unavailable`
+- `enforcement_unavailable`
+- `kill_switch_active`
+- `ledger_initialized`
+- `ledger_ready`
+- `identity_created`
+- `finish_recorded`
+- `finish_idempotent`
+- `recovery_recorded`
+- `kill_switch_updated`
+- `status_reported`
+
+Meanings cannot change within schema v1. Additions are additive and require documentation and tests. Human or task text is not permitted as a reason. Exact policy bounds and tuning remain deferred to approved policy review.
+
+## Consequences
+
+The recommended design provides local durability, transactional lifecycle recording, explicit recovery, and concurrency coordination without changing the application database or introducing a service. Using the Git common directory keeps the ledger aligned with repository lifecycle and worktree-safe discovery.
+
+The same design also has hard limits. It creates no cross-machine authority, no platform-wide denominator for all native invocations, and no claim of repository-native enforcement over unmediated calls. Reports must distinguish mediated coverage from all native invocation volume and must not claim platform-wide protection or a known total denominator.
+
+## Activation boundaries
+
+Only explicit instrument/shadow configuration and cooperative integrations may activate this path. Instrument mode observes lifecycle and identity only. Shadow mode computes the exact would-admit or would-deny result but never blocks dispatch. Enforcement mode must be unavailable and return the stable unavailable result; it cannot silently alias to shadow or instrument.
+
+## Rollback and migration
+
+Rollback disables cooperative hooks and integrations. The disposable local ledger may be retained, archived, or deleted locally. Version mismatch must fail visibly. No irreversible migration is authorized here. Any incompatible ledger migration requires new review. Rollback never activates enforcement.
+
+## Recovery boundary
+
+Crash recovery is explicit and leaf-first: active descendant attempts close or recover before their ancestors, transactionally and idempotently. Elapsed time never implies a crash. No stale timeout or lease is authorized. A new shadow evaluation may report `recovery_required`, but cannot enforce or block.
+
+## Handoffs
+
+- **Engineering:** implement only the accepted instrument/shadow scope and preserve the architectural boundaries above.
+- **Operations:** own future rollout and runtime consequences if a later review broadens scope; the current change adds no production service.
+- **Trust:** verify privacy, filesystem, and path boundaries before any broader use.
+- **Quality:** independently verify the deterministic pure core, Work Contract recomputation, concurrency and transactions, logical invocation versus attempt semantics, ancestry and cycle detection, recovery behavior, exit codes, JSON versioning, no-text persistence, shadow non-blocking behavior, unavailable enforcement behavior, and Local/Cloud parity and limitations.
+
+## Outcome plan and review triggers
+
+Meta/Eval compares shadow outcomes and measures mediated coverage, would-deny categories, false-positive and false-negative rates, human correction rates, and recovery or error rates without recording content. Quality produces verification evidence. Separate review is required before any deferred decision becomes active.
+
+Trigger Architecture and independent review if any implementation proposes or demonstrates a need for:
+
+- a new service, application database use, or cross-machine authority;
+- incompatible ledger schema migration;
+- enforcement or native interception;
+- operating-model version changes;
+- policy-bound tuning;
+- privacy-scope expansion; or
+- evidence that local SQLite is inadequate for the authorized scope.

--- a/docs/dev/agent-invocation-control.md
+++ b/docs/dev/agent-invocation-control.md
@@ -1,0 +1,312 @@
+# Agent invocation control v1
+
+## Status and authorized scope
+
+This document is the durable Engineering Implementation Impact Map and
+Implementation Change for the accepted instrument/shadow implementation. The
+control is repository-owned and cooperatively mediated. It is not native
+launcher interception, cross-machine authority, or global protection.
+Enforcement is unavailable and unapproved.
+
+The proposed ADR remains Proposed — instrument/shadow scope human-authorized;
+final implementation-bound ADR approval pending separate review. This document
+does not approve that ADR or any deferred decision.
+
+## Work Contract linkage
+
+- routing_version: praxys-task-routing-v1
+- operating_model_version: praxys-agentic-operating-model-v1
+- primary_object: agent-system
+- impacts: repository-change, agent-policy-or-autonomy,
+  architecture-boundary
+- risk_triggers: irreversible-or-high-blast-radius-action,
+  out-of-policy-or-out-of-distribution-decision
+- classification_digest:
+  sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2
+- primary_loop: meta-eval
+- nested_loops: delivery
+- lead: meta-eval
+- contributor: architecture
+- executor: engineering
+- verifier: quality
+- required_artifacts: evaluation-report, implementation-impact-map,
+  implementation-change, verification-evidence, policy-change-proposal,
+  architecture-decision-record
+- decision_review: required
+- route_digest:
+  sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51
+
+Every admission recomputes this kind of authoritative Work Contract from the
+bounded classification before ledger access or candidate-policy evaluation.
+Caller-supplied digests and slot roles must match the recomputed contract. The
+guard never changes routing, loops, roles, reviewers, artifacts, autonomy, or
+the operating-model version.
+
+## Accepted decision trail
+
+The governing artifacts are:
+
+- docs/dev/evaluation-report-2026-08-20-agent-invocation-control.md
+- docs/dev/policy-change-proposal-agent-invocation-control-v1.md
+- docs/dev/adr-2026-08-20-agent-invocation-control.md
+
+Independent Decision Review Router outcome: human-review-required.
+
+Recorded human approval timestamp: 2026-08-20T23:38:10.880+08:00
+
+> I approve policy-change-proposal-agent-invocation-control-v1 at
+> sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6
+> for instrument/shadow implementation only.
+
+The proposal digest identifies the approved subject; it is not claimed to be a
+rendered-file hash. Enforcement, native interception, autonomy promotion,
+bound tuning, operating-model changes, and final implementation-bound ADR
+approval remain deferred.
+
+## Implementation Impact Map
+
+| Area | Impact |
+|---|---|
+| Data | Adds only a disposable, local SQLite control ledger under the Git common directory. It is not the application database and stores no task, prompt, source, user, issue, artifact, credential, output, stack-trace, or free-form diagnostic text. |
+| Analysis | Adds analysis/agentic_invocation_control.py, an I/O-free stdlib identity validator and deterministic candidate-policy evaluator. Existing static routing remains authoritative and unchanged. |
+| API | No application API or authentication change. |
+| Clients | Adds a versioned stdin/stdout CLI and cooperative instructions in the Orchestrator and Delivery Loop manifests. No UI, provider, sync, or native-agent API changes. |
+| Operations | Adds no service, deployment setting, secret, alert, or production runtime. Local and Cloud use the same repository protocol, subject to the same native-interception limitation. |
+| Migration | Ledger schema v1 is created only by explicit init. There is no application migration and no in-place incompatible ledger migration; unsupported state is reported visibly. |
+| Tests | Adds pure-policy, lifecycle, boundary, privacy, Work Contract, Local/Cloud parity, and multi-process SQLite regression coverage. Independent Quality verification remains a separate artifact. |
+
+## Implementation Change
+
+The checked-in policy is config/agent-invocation-control.json. It fixes schema
+and policy version 1, the approved modes, unavailable enforcement, and the
+accepted starting limits. The implementation adds:
+
+1. Pure identity and policy evaluation in
+   analysis/agentic_invocation_control.py.
+2. A thin versioned JSON CLI in scripts/agent_invocation_control.py.
+3. A WAL SQLite ledger under
+   git-common-dir/praxys/agent-invocation-control-v1.sqlite3, with foreign keys
+   enabled per connection and BEGIN IMMEDIATE for admission and lifecycle
+   transitions.
+4. Stable opaque contract, slot, generation, logical-invocation, attempt, and
+   decision identities. Slot identity is generation-independent, so a new
+   generation cannot hide a nested slot cycle. Logical and concrete attempt
+   identities remain separate.
+5. Atomic duplicate-active, ancestry, active-count, logical-count, retry,
+   attempt, no-progress, and kill-switch decisions. Ordinary instrument/shadow
+   would-reject decisions are recorded as launched and remain non-blocking. The
+   explicit kill switch records the decision and rejects that mediated launch.
+6. Explicit terminal transitions and leaf-first crash recovery. No lease,
+   heartbeat expiry, elapsed-time inference, or stale timeout exists.
+7. Cooperative Local/Cloud agent-manifest guidance with no native-interception
+   or global-enforcement claim.
+
+scripts/route_agentic_task.py, Decision Review behavior, role/reviewer
+authority, autonomy policy, operating-model version, application storage,
+plugins/praxys, providers, sync, authentication, and UI are outside this
+change.
+
+## Identity and privacy contract
+
+The CLI accepts only exact command-specific key sets. Opaque identities use a
+kind prefix plus 128 random bits. Failure and terminal fingerprints use the
+fpr_ prefix plus 256 hexadecimal bits. Callers hash or otherwise derive a
+privacy-safe fingerprint before invoking the CLI; raw failures and task text
+must never be supplied.
+
+The stable slot identity denotes the composed work slot and is reused across
+its generations. A logical identity spans its permitted retry attempts. Every
+execution gets a fresh attempt identity. Nested calls carry only the active
+parent attempt identity. Contract and slot identities are durably bound to the
+recomputed route and bounded role, and conflicting reuse is invalid.
+
+Permitted ledger facts are versions, route/classification digests, bounded role
+IDs, opaque identities and parent links, lifecycle state, opaque fingerprints,
+policy reasons, booleans, depths, and epoch-millisecond timing facts. The CLI
+rejects unknown fields rather than ignoring possible content.
+
+## Versioned CLI contract
+
+Every request and response is one JSON object with schema_version 1. Requests
+are read from standard input; exactly one compact JSON response is written to
+standard output.
+
+Commands:
+
+- init: explicitly create or validate ledger schema v1.
+- new_identity: create contract, slot, generation, logical, or attempt identity.
+- admit: recompute the Work Contract, evaluate atomically, and record the
+  decision and any authorized instrument/shadow launch.
+- finish: terminally record succeeded or failed with an opaque fingerprint.
+- recover: terminally record recovered with an opaque fingerprint, leaf first.
+- kill_switch: atomically enable or disable mediated-launch rejection.
+- status: report aggregate counts, reason counts, kill-switch state, and opaque
+  active-attempt/parent/depth facts in leaf-first order.
+
+Stable exit meanings:
+
+| Exit | Meaning |
+|---:|---|
+| 0 | Instrument/shadow evaluation or lifecycle command completed, including an ordinary hypothetical deny. |
+| 2 | Invalid request, identity, parent binding, or conflicting terminal transition. |
+| 3 | Policy or recomputed Work Contract unavailable, invalid, or mismatched. |
+| 4 | Ledger, transaction, state validation, or leaf-first recovery failure. |
+| 5 | Requested mode unavailable or unapproved. |
+
+Cooperative instrument/shadow integration records exits and continues native
+dispatch unless the response explicitly has launch_authorized false from the
+kill switch. It must not convert exits 2 through 5 into unapproved enforcement.
+An enforce request returns enforcement_unavailable and does not silently alias
+to another mode.
+
+Stable policy reasons:
+
+| Reason | Meaning |
+|---|---|
+| admit | Candidate guards pass. |
+| work_contract_invalid | Recomputed Work Contract is unavailable or mismatched. |
+| kill_switch_active | Explicitly reject this mediated launch. |
+| duplicate_active | Matching logical or slot-generation work is active. |
+| ancestry_cycle | The generation-independent slot repeats in ancestry. |
+| ancestry_depth_limit | Proposed depth is greater than 6. |
+| active_contract_limit | The next launch crosses 8 active attempts. |
+| logical_contract_limit | The next new logical invocation crosses 32. |
+| retry_fingerprint_limit | One retry for the same failure fingerprint is already recorded. |
+| attempt_limit | Three attempts for the logical invocation are already recorded. |
+| no_progress | The last two terminal fingerprints for the slot are identical. |
+| state_missing | The explicitly initialized ledger is absent. |
+| state_corrupt | The ledger is structurally missing, incomplete, or damaged. |
+| state_unsupported | The readable ledger has an unsupported schema or policy version. |
+
+Stable machine reason codes are `instrument_recorded`,
+`shadow_would_admit`, `shadow_would_deny_cycle`,
+`shadow_would_deny_policy_limit`, `invalid_request`, `invalid_identity`,
+`work_contract_unavailable`, `work_contract_mismatch`, `policy_unavailable`,
+`recovery_required`, `ledger_unavailable`, `enforcement_unavailable`,
+`kill_switch_active`, `ledger_initialized`, `ledger_ready`,
+`identity_created`, `finish_recorded`, `finish_idempotent`,
+`recovery_recorded`, `kill_switch_updated`, and `status_reported`. Additions must
+remain additive within v1.
+
+## Starting limits
+
+| Guard | Bound |
+|---|---:|
+| Maximum ancestry depth | 6 |
+| Maximum active attempts per contract | 8 |
+| Maximum logical invocations per contract | 32 |
+| Maximum attempts per logical invocation | 3 |
+| Retries per failure fingerprint | 1 |
+| Identical terminal fingerprints establishing no progress | 2 |
+
+These values are not runtime tuning knobs. Any change requires evidence and a
+separately reviewed proposal.
+
+## Activation
+
+Use the repository virtual environment. First recompute and retain the exact
+Work Contract:
+
+    .venv/bin/python scripts/route_agentic_task.py       --primary-object agent-system       --impact repository-change       --impact agent-policy-or-autonomy       --impact architecture-boundary       --risk-trigger irreversible-or-high-blast-radius-action       --risk-trigger out-of-policy-or-out-of-distribution-decision
+
+Explicitly initialize the local ledger:
+
+    echo '{"schema_version":1,"command":"init"}' |       .venv/bin/python scripts/agent_invocation_control.py
+
+Create each opaque identity separately, changing kind as needed:
+
+    echo '{"schema_version":1,"command":"new_identity","kind":"contract"}' |       .venv/bin/python scripts/agent_invocation_control.py
+
+Begin with admit requests whose mode is instrument. Each request also carries
+the bounded classification arrays, recomputed classification and route digests,
+contract_id, stable slot_id and slot_role, generation_id, logical_id,
+attempt_id, nullable parent_attempt_id, and nullable retry_fingerprint. Retain
+attempt IDs until their finish or recovery is recorded. Move individual
+cooperative requests to shadow only after instrument lifecycle and recovery
+records are healthy; this is not enforcement promotion.
+
+Check privacy-safe local state with:
+
+    echo '{"schema_version":1,"command":"status"}' |       .venv/bin/python scripts/agent_invocation_control.py
+
+Activate the immediate mediated-launch stop path with:
+
+    echo '{"schema_version":1,"command":"kill_switch","active":true}' |       .venv/bin/python scripts/agent_invocation_control.py
+
+The switch affects only calls that cooperate with this protocol.
+
+## Recovery
+
+There is no stale timeout. A process ending or elapsed time alone never changes
+an active attempt. Use status to read active opaque attempt IDs, parents, and
+depths. Determine that recovery is appropriate outside this content-free
+ledger, then submit recover commands from greatest depth to least depth. An
+ancestor with an active child returns recovery_required without mutation.
+Repeating the exact terminal transition is idempotent; a different status or
+fingerprint conflicts and does not mutate state.
+
+Example request shape:
+
+    {"schema_version":1,"command":"recover","attempt_id":"att_00000000000000000000000000000001","terminal_fingerprint":"fpr_0000000000000000000000000000000000000000000000000000000000000001"}
+
+## Rollback
+
+Stop making cooperative CLI calls from the invoking manifest and retain native
+dispatch behavior. This immediately removes instrument/shadow mediation; it
+does not activate enforcement. The ledger is disposable local metadata. After
+all CLI processes have stopped, it may be retained for evidence, archived
+locally, or removed together with its SQLite WAL and shared-memory companions
+from the Git common directory. No application rollback or database migration is
+needed.
+
+A corrupt or unsupported ledger is never overwritten automatically. Preserve
+it if evidence is needed, move it aside locally, and run explicit init to create
+a new schema-v1 ledger. Instrument/shadow reports state_missing, state_corrupt, or state_unsupported
+with launch_authorized true; only a future separately approved enforce mode
+could fail closed on unavailable state.
+
+## Local and Cloud parity and limits
+
+Local and Cloud use the same checked-in policy, pure evaluator, CLI, Work
+Contract recomputation, manifests, JSON surface, reason codes, and ledger
+semantics. Each clone or ephemeral Cloud checkout has its own Git-common-dir
+ledger. There is no shared or cross-machine authority and no known denominator
+for all platform invocations.
+
+This protocol mediates only agent calls whose repository manifest cooperates.
+The repository has no native hook that can intercept Copilot, platform, user,
+or other unmediated invocations. Those calls remain possible and unknown. Any
+report must distinguish mediated coverage from all native invocation volume and
+must not claim global prevention or enforcement.
+
+## Observation plan and enforcement evidence bar
+
+Run instrument and then shadow across at least five distinct contract/root runs
+over at least seven calendar days. Replay and review at least:
+
+1. valid first launch and clean terminal finish;
+2. active duplicate and nonmatching concurrency;
+3. direct/indirect cycles and ancestry at/beyond depth 6;
+4. active attempts 8/9 and logical invocations 32/33;
+5. attempts 3/4, one same-fingerprint retry, and an additional retry;
+6. two identical terminal fingerprints followed by a proposed launch;
+7. valid, mismatched, unavailable, missing, corrupt, and unsupported contracts
+   or state;
+8. parent mismatch, active-child finish, leaf-first recovery, idempotent finish,
+   and conflicting finish;
+9. kill-switch inactive/active behavior; and
+10. Local and Cloud cooperative coverage with unmediated activity explicitly
+    unknown.
+
+Aggregate mediated coverage, decisions and stable reasons, latency, recovery
+and state errors, corrections, overrides, missed and unnecessary escalations,
+adverse outcomes, reverts, incidents, reviewer effort, target/guardrail
+movement, false blocks, and policy escapes without adding content to the
+ledger.
+
+A later enforcement proposal requires the complete replay corpus and the
+minimum observation window to show zero false blocks, zero policy escapes, and
+zero human corrections. Those are prerequisites, not automatic authorization.
+Enforcement, native interception, bound tuning, autonomy promotion, and
+operating-model version changes still require separate evidence, independent
+decision review, and human approval.

--- a/docs/dev/copilot-execution-parity.md
+++ b/docs/dev/copilot-execution-parity.md
@@ -121,6 +121,22 @@ cannot request them. The Cloud MCP payload is
 provider; built-in Cloud Playwright is an optional extension and is not required
 by portable agents.
 
+## Cooperative invocation mediation
+
+Local and Cloud portable manifests use the same versioned repository protocol
+in `scripts/agent_invocation_control.py` for manifest-coordinated calls. The
+protocol is instrument/shadow only and keeps its disposable SQLite ledger under
+the checkout Git common directory, so it creates no shared cross-machine
+authority. Ordinary hypothetical denies do not block dispatch; only the
+explicit kill switch rejects a mediated launch.
+
+This is cooperative mediation, not native interception. The repository cannot
+intercept platform-native or otherwise unmediated invocations, and those calls
+remain outside coverage. Do not claim a global invocation denominator,
+protection, or enforcement. Activation, recovery, rollback, reason codes, and
+the observation plan are in
+`docs/dev/agent-invocation-control.md`.
+
 ## Checks and drift detection
 
 Run the repository-only check:
@@ -157,6 +173,7 @@ The canonical limitations are machine-readable in
 | Automatic Cloud triggers | `agent-ready` is automatic; other Cloud task types require explicit orchestrator selection. |
 | Default-branch activation | Custom agents and setup changes require a disposable Cloud smoke task after merge. |
 | External source access | Use public sources, record the actual verification level, and block strong claims when full text is unavailable. |
+| Cooperative invocation mediation | Use the same repository instrument/shadow protocol for manifest-coordinated calls; only its explicit kill switch rejects a mediated launch. Native and unmediated calls remain outside repository coverage. |
 
 An unavailable capability never authorizes a weaker substitute. The agent
 records the limitation, leaves the affected artifact unverified, and blocks or

--- a/docs/dev/evaluation-report-2026-08-20-agent-invocation-control.md
+++ b/docs/dev/evaluation-report-2026-08-20-agent-invocation-control.md
@@ -1,0 +1,188 @@
+# Evaluation Report ER-2026-08-20-agent-invocation-control-v1
+
+- **id:** `ER-2026-08-20-agent-invocation-control-v1`
+- **schema_version:** `1`
+- **artifact_type:** `evaluation-report`
+- **artifact implementation status:** repository-native Markdown; not schema-backed
+- **owner_role:** `meta-eval`
+- **status:** Accepted
+- **report_date:** `2026-08-20`
+- **evaluated subject:** `policy-change-proposal-agent-invocation-control-v1`
+- **accepted subject digest:** `sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6`
+
+The accepted subject digest identifies the proposal reviewed and approved by the
+human authority. It is not asserted to be the hash of this rendered Markdown
+file or of this Evaluation Report.
+
+## Work Contract binding
+
+- **routing_version:** `praxys-task-routing-v1`
+- **operating_model_version:** `praxys-agentic-operating-model-v1`
+- **primary_object:** `agent-system`
+- **impacts:** `[repository-change, agent-policy-or-autonomy, architecture-boundary]`
+- **risk_triggers:** `[irreversible-or-high-blast-radius-action, out-of-policy-or-out-of-distribution-decision]`
+- **classification_digest:** `sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2`
+- **primary_loop:** `meta-eval`
+- **nested_loops:** `[delivery]`
+- **lead:** `meta-eval`
+- **contributors:** `[architecture]`
+- **executor:** `engineering`
+- **verifier:** `quality`
+- **required_artifacts:** `[evaluation-report, implementation-impact-map, implementation-change, verification-evidence, policy-change-proposal, architecture-decision-record]`
+- **decision_review:** required
+- **route_digest:** `sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51`
+
+The composition is Meta/Eval-led, with Architecture contributing the
+cross-cutting boundary, Engineering responsible for any later accepted
+implementation, and Quality independently responsible for verification. This
+report does not replace current-change verification.
+
+## Question and recommendation
+
+**Question:** Does available evidence justify deterministic agent-invocation
+control, enforcement, a routing or role change, or an autonomy promotion?
+
+**Recommendation:** Accept only a bounded instrument-then-shadow
+implementation of the separately identified proposal. Do not activate
+blocking enforcement, claim native launcher interception, tune the starting
+bounds, change the operating-model version, change role or routing authority,
+or promote autonomy on this evidence.
+
+## Evaluated baseline and evidence limits
+
+Praxys has deterministic static task routing: an enumerated classification is
+composed into a digest-bound Work Contract. That is not runtime invocation
+admission. No authoritative runtime state currently establishes root run,
+parent, attempt, budget, active-loop, or progress identity and lifecycle.
+Consequently, no reliable denominator exists for native invocations, duplicate
+active work, retries, cycles, escapes, or completed root runs.
+
+The supplied incident narrative reports the following aggregate observations:
+
+| Reported item | Count | Evidence status | Permitted interpretation |
+|---|---:|---|---|
+| Conversation turns | 810 | Unverified | Context volume only; not a completed-decision population |
+| Calls | 1,735 | Unverified | Call volume only; invocation types and denominator are not authoritative |
+| Starts | 19 | Unverified | Candidate starts only; runtime identity and lifecycle are absent |
+| Near-duplicate launches | 7 | Unverified | Candidate anomaly signal only; intent, parentage, and active overlap are unproven |
+
+The counts were not produced by an authoritative runtime ledger and cannot be
+used to calculate rates. Direct self-recursion is not proven. Near-duplicate
+launches do not by themselves prove a cycle, duplicate-active execution,
+policy escape, or adverse outcome.
+
+Prompt-only instructions may discourage duplicate work, recursion, or excess
+launches, but they are advisory and do not constitute deterministic
+interception or enforcement.
+
+## Outcome and review measures
+
+No verified batch of completed decisions with privacy-safe outcome edges was
+available. The accepted report therefore records insufficiency rather than
+manufacturing rates or treating the reported volume as promotion evidence.
+
+| Measure required by Meta/Eval | Accepted result |
+|---|---|
+| Corrections | Not authoritatively captured or attributable |
+| Overrides | Not authoritatively captured or attributable |
+| Missed escalations | Not measurable without routed decision and outcome state |
+| Unnecessary escalations | Not measurable without routed decision and outcome state |
+| Adverse outcomes | None verified from the supplied counts; absence is not evidence of zero |
+| Reverts | Not linked to the reported invocation observations |
+| Incidents | No verified incident count or causal attribution |
+| Target or guardrail movement | No measured baseline or movement |
+| Review effort | Not measured |
+| Decision and execution latency | Not measured |
+| False blocks or policy escapes | Not measurable before instrument/shadow comparison |
+
+These gaps prevent autonomy promotion and prevent a defensible enforcement
+decision. They justify privacy-minimized instrumentation and shadow evaluation
+only.
+
+## Candidate-policy replay and shadow status
+
+No authoritative event stream exists on which to run a valid historical replay
+or live shadow comparison. The proposal is therefore not a promoted policy and
+this report makes no claim that the candidate outperforms the current state.
+The accepted next step creates the evidence needed to compare the current
+prompt-only baseline with deterministic hypothetical admission decisions while
+leaving actual dispatch unchanged.
+
+The observation corpus must cover at least these cases:
+
+1. a valid first logical invocation;
+2. a duplicate invocation while the matching invocation is active;
+3. an ancestry cycle and ancestry at and beyond the starting depth limit;
+4. active invocations at and beyond the per-contract limit;
+5. logical invocations at and beyond the per-contract limit;
+6. attempts at and beyond the per-logical-invocation limit;
+7. a first retry and an additional retry with the same failure fingerprint;
+8. two identical terminal fingerprints followed by another proposed launch;
+9. a valid Work Contract, a mismatched Work Contract, and an unavailable one;
+10. missing, corrupt, and unsupported control state in instrument, shadow, and
+hypothetical enforce modes; and
+11. kill-switch activation, confirming that mediated launches are rejected while
+ordinary instrument/shadow would-reject results do not block dispatch and
+unmediated native activity remains outside coverage.
+
+Until these cases are replayed and shadow outcomes are reconciled to reviewed
+outcomes, the comparison result is `insufficient-evidence`.
+
+## Observation plan and enforcement evidence bar
+
+Instrument mode must first collect privacy-minimized identity, lifecycle,
+decision, reason-code, and timing facts. Shadow mode must then compute the
+candidate result without blocking dispatch. Evidence must be aggregated across
+**at least five distinct root runs observed over at least seven calendar days**.
+This is a minimum observation window, not automatic evidence of sufficiency.
+
+For the replay cases and observed root runs, record:
+
+- mediated coverage and the unknown unmediated-traffic limitation;
+- hypothetical admits and denials by stable reason code;
+- duplicate-active, ancestry, limit, retry, attempt, and no-progress outcomes;
+- corrections, overrides, missed and unnecessary escalations;
+- adverse outcomes, reverts, and incidents;
+- target and guardrail movement;
+- reviewer effort and decision or execution latency; and
+- state-missing, state-corrupt, state-unsupported, recovery, and kill-switch
+outcomes.
+
+A later enforcement proposal requires reconciled replay and shadow evidence
+showing **zero false blocks, zero policy escapes, and zero human corrections**
+in that minimum window. It must then receive separate independent decision
+review and human approval. Meeting the numeric bar does not itself authorize
+enforcement or bound tuning.
+
+## Decision route and authorization
+
+The independent Praxys Decision Review Router returned
+`human-review-required` and recommended accepting instrument/shadow
+implementation only.
+
+Recorded human approval timestamp: `2026-08-20T23:38:10.880+08:00`
+
+> I approve policy-change-proposal-agent-invocation-control-v1 at sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6 for instrument/shadow implementation only.
+
+This approval binds the proposal subject and digest. It does not approve this
+Markdown file by its rendered-file hash and does not authorize any deferred
+decision.
+
+## Conclusions and explicit deferrals
+
+- Deterministic static routing exists; authoritative runtime invocation state
+does not.
+- The reported counts and seven near-duplicates remain unverified.
+- Direct self-recursion remains unproven.
+- Prompt-only safeguards are not deterministic enforcement.
+- No role, routing, reviewer-authority, or autonomy change is justified.
+- Instrument then shadow is the only accepted rollout scope.
+
+Explicitly deferred pending evidence and separate review:
+
+- actual enforcement;
+- native launcher interception;
+- autonomy promotion;
+- tuning any accepted starting bound;
+- operating-model version changes; and
+- final implementation-bound Architecture Decision Record approval.

--- a/docs/dev/policy-change-proposal-agent-invocation-control-v1.md
+++ b/docs/dev/policy-change-proposal-agent-invocation-control-v1.md
@@ -1,0 +1,226 @@
+# Policy Change Proposal: Agent Invocation Control v1
+
+- **id:** `policy-change-proposal-agent-invocation-control-v1`
+- **schema_version:** `1`
+- **artifact_type:** `policy-change-proposal`
+- **artifact implementation status:** repository-native Markdown; not schema-backed
+- **owner_role:** `meta-eval`
+- **status:** Accepted for instrument/shadow implementation only
+- **proposal_date:** `2026-08-20`
+- **digest:** `sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6`
+
+The digest above is the accepted proposal subject identifier supplied to and
+approved by the human authority. It is not asserted to be a hash of this
+rendered Markdown file.
+
+## Work Contract binding
+
+- **routing_version:** `praxys-task-routing-v1`
+- **operating_model_version:** `praxys-agentic-operating-model-v1`
+- **primary_object:** `agent-system`
+- **impacts:** `[repository-change, agent-policy-or-autonomy, architecture-boundary]`
+- **risk_triggers:** `[irreversible-or-high-blast-radius-action, out-of-policy-or-out-of-distribution-decision]`
+- **classification_digest:** `sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2`
+- **primary_loop:** `meta-eval`
+- **nested_loops:** `[delivery]`
+- **lead:** `meta-eval`
+- **contributors:** `[architecture]`
+- **executor:** `engineering`
+- **verifier:** `quality`
+- **required_artifacts:** `[evaluation-report, implementation-impact-map, implementation-change, verification-evidence, policy-change-proposal, architecture-decision-record]`
+- **decision_review:** required
+- **route_digest:** `sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51`
+
+## Proposal contract
+
+- **question:** Should Praxys introduce deterministic agent-invocation admission
+state and policy, and what may be activated on the evidence currently
+available?
+- **options:** Retain prompt-only safeguards; implement instrument/shadow
+admission evaluation; or activate enforcement and native interception.
+- **recommendation:** Implement only instrument mode followed by shadow mode
+using the v1 identity, state, decision, reason-code, guard, and limit contracts
+below. Keep actual dispatch behavior unchanged.
+- **rationale:** Static routing is deterministic, but runtime invocation state
+is not authoritative. The reported incident counts are unverified, direct
+self-recursion is unproven, and no replay-backed batch supports enforcement or
+autonomy promotion. Instrument/shadow operation is the bounded, reversible way
+to establish evidence.
+- **dependencies:**
+  - `ER-2026-08-20-agent-invocation-control-v1`;
+  - the digest-bound Work Contract above;
+  - independent Decision Review Router outcome `human-review-required`;
+  - the exact human approval recorded below; and
+  - Architecture, Engineering, and Quality artifacts required by the Work
+  Contract before any implementation is considered complete.
+- **review_route:** `human-review-required`; approval is limited to
+instrument/shadow implementation.
+- **outcome_plan:** Observe at least five distinct root runs over at least seven
+days, replay the bounded cases below, and require zero false blocks, escapes,
+and human corrections before a separately reviewed enforcement decision.
+
+## Scope of the accepted change
+
+The proposal defines a versioned candidate admission contract. It does not
+itself implement that contract or alter deployed policy. It introduces five
+stable, opaque, non-content identities:
+
+- **contract identity:** the validated Work Contract instance;
+- **slot identity:** the bounded composed role slot within that contract;
+- **generation identity:** one generation of work for that slot;
+- **logical invocation identity:** one logical unit across its permitted
+attempts; and
+- **attempt identity:** one concrete execution attempt.
+
+The identities must remain distinct and stable for their defined lifetimes.
+They may not contain task, prompt, source-code, user, artifact, or free-form
+text. Human-readable content must not be used as identity or persisted as
+control state.
+
+## Work Contract guard invariant
+
+Every decision validates the authoritative digest-bound Work Contract first.
+Caller-supplied role, loop, artifact, reviewer, classification, or route values
+cannot override it. The guard may admit, report, or reject a mediated launch
+according to the active mode, but it may never mutate role composition, loop
+composition, required artifacts, reviewer assignment, or routing policy.
+
+This proposal changes no role boundary, routing table, reviewer authority,
+autonomy class, or operating-model version.
+
+## Atomic admission decisions and stable reason codes
+
+Each mediated admission evaluates the following as atomic decisions against a
+consistent state snapshot. The v1 reason-code vocabulary is stable; meanings
+must not be repurposed within v1.
+
+| Decision | Stable reason code | Accepted meaning |
+|---|---|---|
+| Contract valid and all guards pass | `admit` | The mediated launch is within the candidate policy |
+| Work Contract invalid or mismatched | `work_contract_invalid` | The authoritative Work Contract could not be validated |
+| Kill switch active | `kill_switch_active` | Mediated launches are rejected by the candidate policy |
+| Duplicate active | `duplicate_active` | The matching invocation is already active |
+| Ancestry cycle | `ancestry_cycle` | The proposed ancestry repeats a stable ancestor identity |
+| Ancestry depth | `ancestry_depth_limit` | The proposed launch exceeds the starting ancestry bound |
+| Active per contract | `active_contract_limit` | The launch exceeds the active-invocation bound for the contract |
+| Logical per contract | `logical_contract_limit` | The launch exceeds the logical-invocation bound for the contract |
+| Retry fingerprint | `retry_fingerprint_limit` | The allowed retry for the same failure fingerprint is exhausted |
+| Attempt count | `attempt_limit` | The logical invocation has exhausted its attempt bound |
+| No progress | `no_progress` | Two identical terminal fingerprints establish no progress |
+| Required state missing | `state_missing` | The explicitly initialized ledger is absent |
+| Required state corrupt | `state_corrupt` | The ledger is structurally missing, incomplete, or damaged |
+| Required state unsupported | `state_unsupported` | The readable ledger has an unsupported schema or policy version |
+
+A reason code records a policy result, not task or error text. Instrument and
+shadow modes may record an ordinary would-reject reason without blocking
+dispatch. The explicit kill switch is the mode-independent exception: it
+rejects mediated launches. Missing, corrupt, or unsupported state fails closed
+only in a separately approved eventual enforce mode; in instrument/shadow it is visible
+evidence and does not become enforcement.
+
+## Starting limits
+
+The accepted, untuned starting bounds are:
+
+| Guard | Starting bound |
+|---|---:|
+| Maximum ancestry depth | 6 |
+| Maximum active invocations per contract | 8 |
+| Maximum logical invocations per contract | 32 |
+| Maximum attempts per logical invocation | 3 |
+| Retries for the same failure fingerprint | 1 |
+| No-progress trigger | 2 identical terminal fingerprints |
+
+Crossing a bound yields the corresponding stable decision reason. No agent may
+tune these values under this approval. Bound changes require evidence and a
+separate reviewed proposal.
+
+## Privacy-minimized state
+
+Persist only what is needed to evaluate and audit the candidate policy:
+version identifiers and digests; the five opaque identities; bounded parent and
+ancestry references; lifecycle state; bounded counters; opaque failure and
+terminal fingerprints; stable reason codes; mode; and timing facts required to
+measure latency.
+
+Do not persist task or prompt content, source code, user data, artifact content,
+model output, stack traces, or free-form error text. Reports must aggregate
+privacy-safe outcomes and must distinguish mediated coverage from unknown
+unmediated native activity.
+
+## Modes, kill switch, and reversibility
+
+1. **Instrument:** record the privacy-minimized identity and lifecycle facts;
+ordinary policy results do not change dispatch.
+2. **Shadow:** compute and record the exact candidate admit or reject result;
+ordinary policy results do not change dispatch.
+3. **Enforce:** not approved. If separately approved later, the mediated
+launcher applies every admission decision and missing, corrupt, or
+unsupported state fails closed.
+
+The kill switch is independent of mode and rejects mediated launches. It is an
+immediate stop path, not a claim of native interception. A later enforce
+rollout must also preserve immediate demotion back to shadow or instrument.
+
+No repository-owned cooperative guard may claim to intercept unmediated native
+agent launches. Native launcher interception remains a separate decision.
+
+## Replay and shadow observation plan
+
+Before any enforcement proposal, replay at least the following cases against
+the exact candidate policy and compare the result with reviewed expected
+outcomes:
+
+1. valid first invocation and clean terminal completion;
+2. matching duplicate while active and a nonmatching concurrent invocation;
+3. direct and indirect ancestry cycles;
+4. ancestry at the starting limit and an attempted launch beyond it;
+5. active counts at the starting limit and beyond it;
+6. logical counts at the starting limit and beyond it;
+7. three attempts and an attempted additional attempt;
+8. one retry for a failure fingerprint and an attempted additional retry for
+the same fingerprint;
+9. two identical terminal fingerprints and an attempted further launch;
+10. valid, mismatched, unavailable, missing-state, corrupt-state, and unsupported-state Work
+Contract or control-state cases in every proposed mode; and
+11. kill-switch inactive and active behavior.
+
+Run instrument and then shadow across **at least five distinct root runs over
+at least seven calendar days**. Reconcile candidate decisions with reviewed
+outcomes. Measure corrections, overrides, missed and unnecessary escalations,
+adverse outcomes, reverts, incidents, target and guardrail movement, review
+effort, latency, mediated coverage, reason-code distribution, false blocks,
+and escapes.
+
+A later enforcement proposal requires **zero false blocks, zero policy escapes,
+and zero human corrections** in the minimum observation window and replay
+corpus. These thresholds are prerequisites, not automatic authorization.
+Enforcement still requires independent review and human approval.
+
+## Decision route and exact human approval
+
+The independent Praxys Decision Review Router returned
+`human-review-required` and recommended accepting only instrument/shadow
+implementation.
+
+Recorded human approval timestamp: `2026-08-20T23:38:10.880+08:00`
+
+> I approve policy-change-proposal-agent-invocation-control-v1 at sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6 for instrument/shadow implementation only.
+
+The proposer does not self-approve this policy. The approval is bound to the
+proposal identifier and accepted subject digest, not to an asserted Markdown
+file hash.
+
+## Explicit deferrals
+
+This proposal does not authorize or decide:
+
+- actual enforcement;
+- native launcher interception;
+- autonomy promotion;
+- tuning any starting limit after observation;
+- operating-model version changes; or
+- final implementation-bound Architecture Decision Record approval.
+
+Each deferred item requires evidence from the observation plan and a separate
+independent decision route. No successful single run can promote autonomy.

--- a/docs/dev/verification-evidence-2026-08-20-agent-invocation-control.md
+++ b/docs/dev/verification-evidence-2026-08-20-agent-invocation-control.md
@@ -1,0 +1,208 @@
+# Verification Evidence: Agent Invocation Control v1
+
+- **artifact_type:** `verification-evidence`
+- **owner_role:** `quality`
+- **verification_date:** `2026-08-21`
+- **verdict:** PASS for cooperative instrument/shadow only
+- **reviewed_repository:** `praxys-run/praxys`
+- **reviewed_branch:** `copilot/agent-invocation-control-shadow`
+- **reviewed_commit:** `07d45ceb0801da365c7ce37e10afc7f719d9a5c4`
+- **baseline:** `origin/main` at `de746503532421cbcfe008993fa95b51418ea306`
+- **reviewed_tree:** `59211e9fda3b8f4a23133f13af8fa3c2d50bd9be`
+- **draft_pr:** `#737`
+
+## Independence and attribution
+
+Quality independently inspected and tested the exact committed tree above. This
+verification did not rely on Engineering conclusions and did not modify the
+implementation, configuration, manifests, tests, accepted Meta/Eval or
+Architecture artifacts, or PR state.
+
+The only pre-existing working-tree difference was `plugins/praxys`. The PR tree
+and `origin/main` both pin that gitlink to
+`a074ce4f018d3811f9f8af840c156ff98a335dd9`; the local submodule checkout is
+`7cbaa021234a62a59199ee4e7b45663108f7dc34`. It was excluded from attribution
+and was not touched, reset, updated, staged, or overwritten.
+
+## Governing decision and authorization
+
+The independent Decision Review Router result was `human-review-required`.
+The recorded approval at `2026-08-20T23:38:10.880+08:00` is:
+
+> I approve policy-change-proposal-agent-invocation-control-v1 at sha256:d6b9a136b44ae52d993ae07dd0000d946e201f73ea1b4db5cb116f01bab9e0f6 for instrument/shadow implementation only.
+
+This verification does not widen that approval. Enforcement, native
+interception, autonomy promotion, bound tuning, operating-model version
+changes, and final implementation-bound ADR approval remain deferred.
+
+## Recomputed Work Contract
+
+Independent execution of `scripts/route_agentic_task.py` returned exactly:
+
+- routing version `praxys-task-routing-v1`
+- operating-model version `praxys-agentic-operating-model-v1`
+- primary object `agent-system`
+- impacts `[repository-change, agent-policy-or-autonomy, architecture-boundary]`
+- risk triggers `[irreversible-or-high-blast-radius-action, out-of-policy-or-out-of-distribution-decision]`
+- classification digest `sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2`
+- primary loop `meta-eval`; nested loops `[delivery]`
+- lead `meta-eval`; contributors `[architecture]`; executors `[engineering]`; verifiers `[quality]`
+- required artifacts `[evaluation-report, implementation-impact-map, implementation-change, verification-evidence, policy-change-proposal, architecture-decision-record]`
+- decision review required through `.github/agents/decision-review-router.agent.md`
+- route digest `sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51`
+
+The routing implementation, routing configuration, operating model, autonomy
+policy, and Decision Review Router were unchanged by the reviewed commit.
+
+## Acceptance matrix
+
+| # | Result | Independent evidence |
+|---:|---|---|
+| 1 | PASS | Admission uses SQLite WAL and `BEGIN IMMEDIATE`; the gated six-OS-process test durably produced one `admit`, five `duplicate_active`, six decisions, and six authorized active attempts. Ordinary instrument/shadow candidate denials remain authorized; only the kill switch returns `launch_authorized=false`. |
+| 2 | PASS | Focused tests cover direct and indirect cycles; depth 6/7; active 8/9; logical 32/33; attempts 3/4; first and repeated same-fingerprint retry; two identical terminal fingerprints; kill switch; missing, corrupt, and unsupported state; parent mismatch; active children; leaf-first recovery; idempotent finish; and conflicting finish. |
+| 3 | PASS | A completed stable slot resumes under a changed generation and new logical identity. Slot ancestry ignores generation, so direct and indirect changed-generation cycles still produce `ancestry_cycle`. |
+| 4 | PASS | The new control core and ledger use Python stdlib facilities, including `sqlite3`; no dependency or requirements file changed. Existing internal routing imports are reused. |
+| 5 | PASS | Exact request key sets reject unknown content fields. The strict schema contains only bounded roles, opaque IDs and fingerprints, versions/digests, lifecycle, reasons, booleans, depth, and times. Tests verify WAL, foreign keys, schema columns, sentinel rejection, and absence from persisted database/WAL files. |
+| 6 | PASS | Exact route recomputation matched both supplied digests and composition. Regression tests preserve routing, autonomy default-human behavior, role/reviewer independence, and the executor/verifier split. Protected routing and Decision Review paths have zero PR diff. |
+| 7 | PASS | Manifests, machine-readable parity configuration, and developer docs consistently say cooperative repository mediation, instrument/shadow only, per-clone state, unknown unmediated activity, and no native/global enforcement. Static Local/Cloud parity passed. |
+| 8 | PASS | The Evaluation Report, Policy Change Proposal, proposed ADR, and Engineering impact/change document record the exact decision trail, approval, digests, activation, rollback, explicit leaf-first recovery, stable reasons and limits, five-root/seven-day observation plan, replay corpus, zero-false-block/escape/correction bar, and all deferrals. |
+| 9 | PASS for pre-commit scope | Focused and complete relevant policy/routing/parity/preflight tests, route recomputation, static parity, compilation, protected-boundary diff, and diff checks passed. Final all-tests preflight and GitHub checks were intentionally not claimed and remain post-artifact-commit work. |
+| 10 | PASS | `plugins/praxys` is absent from the PR diff, and its gitlink is identical at baseline and reviewed head. The unrelated dirty local submodule was not changed. |
+
+## Challenged semantic findings
+
+- `scripts/agent_invocation_control.py:886-888` recomputes and validates the
+  Work Contract before loading policy or connecting to the ledger. The
+  mismatched-route/missing-ledger test confirms observable precedence.
+- Ancestry walks active parent attempts and compares stable slot IDs, not
+  generations (`scripts/agent_invocation_control.py:589-609`). A generation
+  cannot launder a nested slot cycle.
+- Logical identities bind to contract and slot; every attempt has a distinct
+  attempt identity. Attempt limits count by logical identity. Retry provenance
+  requires a failed attempt in the same logical invocation; the
+  same-fingerprint retry budget aggregates by stable slot and fingerprint.
+  No-progress aggregates the two newest terminal fingerprints by stable slot.
+  An exploratory scope probe confirmed that a new logical identity does not
+  reset the stable-slot retry budget or no-progress history, while a different
+  slot has an independent retry budget.
+- Policy, decision, and machine reason namespaces are closed in the pure core,
+  checked by response construction, mirrored exactly in durable docs, and
+  exercised by a reason/mapping probe. Every ordinary candidate reason is
+  non-blocking in instrument/shadow; `kill_switch_active` alone is blocking.
+- A readable ledger with a changed schema or policy version reports
+  `state_unsupported`; missing metadata or tables reports `state_corrupt`.
+- Finish and recovery use immediate transactions, require active children to
+  close first, and are idempotent only for an identical terminal transition.
+  No lease, heartbeat, age inference, or timeout recovers an attempt.
+- `enforce` returns exit 5 with `enforcement_unavailable` and null decision
+  fields; it is not aliased to instrument or shadow.
+- The commit changes no application DB, migration, API, service, deployment,
+  dependency, routing implementation/configuration, autonomy policy, Decision
+  Review behavior, or plugin gitlink.
+
+## Commands and results
+
+All commands were run from the repository root against the reviewed head.
+
+```text
+git status --short --branch
+git rev-parse HEAD
+git rev-parse origin/main
+git branch --show-current
+git submodule status plugins/praxys
+```
+
+Result: correct branch; HEAD
+`07d45ceb0801da365c7ce37e10afc7f719d9a5c4`; baseline
+`de746503532421cbcfe008993fa95b51418ea306`; only pre-existing dirty
+`plugins/praxys` reported.
+
+```text
+git diff --name-status origin/main...07d45ceb0801da365c7ce37e10afc7f719d9a5c4
+git diff --stat origin/main...07d45ceb0801da365c7ce37e10afc7f719d9a5c4
+```
+
+Result: 12 attributed files, 3,039 insertions, no deletion, and no
+`plugins/praxys` entry.
+
+```text
+.venv/bin/python scripts/route_agentic_task.py --primary-object agent-system --impact repository-change --impact agent-policy-or-autonomy --impact architecture-boundary --risk-trigger irreversible-or-high-blast-radius-action --risk-trigger out-of-policy-or-out-of-distribution-decision
+```
+
+Result: exact Work Contract and digests recorded above; exit 0.
+
+```text
+.venv/bin/pytest -q tests/test_agentic_invocation_control.py
+```
+
+Result: `15 passed in 6.55s`; exit 0.
+
+```text
+.venv/bin/pytest -q tests/test_agentic_invocation_control.py tests/test_agent_policy.py tests/test_agentic_task_routing.py tests/test_agentic_operating_model.py tests/test_decision_agents.py tests/test_copilot_execution_parity.py tests/test_agent_preflight.py
+```
+
+Result: `57 passed in 6.79s`; exit 0.
+
+```text
+.venv/bin/python scripts/check_copilot_environment_parity.py
+```
+
+Result: `Copilot execution parity passed (static).`; exit 0.
+
+```text
+.venv/bin/python -m py_compile analysis/agentic_invocation_control.py scripts/agent_invocation_control.py tests/test_agentic_invocation_control.py
+git diff --check origin/main...07d45ceb0801da365c7ce37e10afc7f719d9a5c4
+```
+
+Result: no output; both exited 0.
+
+```text
+git diff --exit-code origin/main...07d45ceb0801da365c7ce37e10afc7f719d9a5c4 -- analysis/agentic_task_routing.py scripts/route_agentic_task.py config/agentic-task-routing.json config/agentic-operating-model.json config/agent-loop-policies.json .github/agents/decision-review-router.agent.md requirements.txt api db alembic deploy infra plugins/praxys
+git diff --exit-code origin/main...07d45ceb0801da365c7ce37e10afc7f719d9a5c4 -- plugins/praxys
+```
+
+Result: both exited 0. Baseline and head both contain plugin gitlink
+`a074ce4f018d3811f9f8af840c156ff98a335dd9`.
+
+A separate reason-mapping probe exercised all ten candidate policy reasons.
+It observed `launch_authorized=true` for `admit` and every ordinary hypothetical
+deny, `launch_authorized=false` only for `kill_switch_active`,
+`shadow_would_deny_cycle` only for ancestry cycles, the generic shadow policy
+limit code for other hypothetical denials, and `instrument_recorded` for
+ordinary instrument results. A separate scope probe observed:
+
+```text
+logical1-first-retry admit
+same-slot-new-logical-retry retry_fingerprint_limit
+different-slot-retry admit
+same-slot-new-generation-logical-no-progress no_progress
+```
+
+The unqualified `python` executable and `rg` were unavailable in this
+environment during initial discovery. Authoritative Python commands were rerun
+successfully with `.venv/bin/python`; `grep` and `find` were used for discovery.
+This caused no validation gap.
+
+## Limitations and residual risk
+
+- This is cooperative repository mediation only. Native, user, platform, and
+  otherwise unmediated launches remain possible and unobserved.
+- The ledger is local to one Git common directory and has no cross-machine or
+  global authority.
+- The candidate retry and no-progress scopes still require replay and observed
+  human reconciliation; passing deterministic tests is not outcome evidence.
+- No five-root/seven-day instrument-shadow observation, live Cloud invocation,
+  native interception, enforcement trial, or final ADR approval was performed.
+- Final all-tests preflight and GitHub checks must run after this Quality
+  artifact is committed, as required by the delivery sequence.
+
+## Release recommendation
+
+**Recommend release of this draft implementation for cooperative instrument and
+shadow evaluation only**, after committing this Quality-owned evidence and
+then passing the final all-tests preflight and required GitHub checks. Do not
+activate enforcement, claim native/global interception, tune bounds, promote
+autonomy, change the operating-model version, or treat the proposed ADR as
+finally approved.
+
+No implementation blocker was found within the human-authorized scope.

--- a/scripts/agent_invocation_control.py
+++ b/scripts/agent_invocation_control.py
@@ -1,0 +1,989 @@
+"""Cooperative CLI and local ledger for agent invocation control."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import secrets
+import sqlite3
+import subprocess
+import sys
+import time
+from typing import NoReturn
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from analysis.agentic_invocation_control import (  # noqa: E402
+    APPROVED_MODES,
+    DECISION_REASONS,
+    MACHINE_REASON_CODES,
+    POLICY_REASONS,
+    POLICY_VERSION,
+    SCHEMA_VERSION,
+    AdmissionFacts,
+    InvocationLimits,
+    evaluate_admission,
+    format_identity,
+    is_valid_fingerprint,
+    is_valid_identity,
+)
+from analysis.agentic_task_routing import TaskClassification, TaskRoute, route_task  # noqa: E402
+
+POLICY_PATH = ROOT / 'config' / 'agent-invocation-control.json'
+LEDGER_SCHEMA_VERSION = 1
+EXIT_OK = 0
+EXIT_INVALID = 2
+EXIT_CONTRACT = 3
+EXIT_LEDGER = 4
+EXIT_MODE = 5
+
+
+class RequestFailure(ValueError):
+    """A request does not match the versioned machine contract."""
+
+
+class ContractFailure(RuntimeError):
+    """The recomputed Work Contract is unavailable or mismatched."""
+
+    def __init__(self, reason_code: str) -> None:
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+class StateMissing(RuntimeError):
+    """The explicitly initialized local ledger does not exist."""
+
+
+class StateCorrupt(RuntimeError):
+    """The ledger is structurally corrupt or incomplete."""
+
+
+class StateUnsupported(RuntimeError):
+    """The readable ledger has an unsupported schema or policy version."""
+
+
+class IdentityConflict(RuntimeError):
+    """An opaque identity conflicts with its durable binding."""
+
+
+class RecoveryRequired(RuntimeError):
+    """A parent cannot terminate before its active children."""
+
+
+class FinishConflict(RuntimeError):
+    """A terminal transition conflicts with an existing terminal state."""
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def _response(command: str, reason_code: str, **values: object) -> dict[str, object]:
+    if reason_code not in MACHINE_REASON_CODES:
+        raise ValueError('reason code is outside the v1 machine schema')
+    policy_reason = values.get('policy_reason')
+    if policy_reason is not None and policy_reason not in DECISION_REASONS:
+        raise ValueError('policy reason is outside the v1 decision schema')
+    payload: dict[str, object] = {
+        'schema_version': SCHEMA_VERSION,
+        'policy_version': POLICY_VERSION,
+        'command': command,
+        'reason_code': reason_code,
+    }
+    payload.update(values)
+    return payload
+
+
+def _emit(payload: dict[str, object], exit_code: int) -> NoReturn:
+    print(json.dumps(payload, sort_keys=True, separators=(',', ':')))
+    raise SystemExit(exit_code)
+
+
+def _require_exact_keys(request: dict[str, object], required: set[str]) -> None:
+    if set(request) != required:
+        raise RequestFailure('request keys do not match schema v1')
+
+
+def _read_request() -> dict[str, object]:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RequestFailure('request is not valid JSON') from exc
+    if not isinstance(payload, dict):
+        raise RequestFailure('request must be a JSON object')
+    if payload.get('schema_version') != SCHEMA_VERSION:
+        raise RequestFailure('unsupported request schema')
+    if payload.get('command') not in {
+        'init', 'new_identity', 'admit', 'finish', 'recover',
+        'kill_switch', 'status',
+    }:
+        raise RequestFailure('unsupported command')
+    return payload
+
+
+def _load_policy() -> InvocationLimits:
+    try:
+        payload = json.loads(POLICY_PATH.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContractFailure('policy_unavailable') from exc
+    expected_keys = {
+        'schema_version', 'policy_version', 'status', 'default_mode',
+        'approved_modes', 'enforcement_approved', 'ledger_schema_version',
+        'limits',
+    }
+    if not isinstance(payload, dict) or set(payload) != expected_keys:
+        raise ContractFailure('policy_unavailable')
+    if (
+        payload['schema_version'] != SCHEMA_VERSION
+        or payload['policy_version'] != POLICY_VERSION
+        or payload['status'] != 'instrument-shadow-only'
+        or payload['default_mode'] != 'instrument'
+        or payload['approved_modes'] != list(APPROVED_MODES)
+        or payload['enforcement_approved'] is not False
+        or payload['ledger_schema_version'] != LEDGER_SCHEMA_VERSION
+        or not isinstance(payload['limits'], dict)
+    ):
+        raise ContractFailure('policy_unavailable')
+    try:
+        limits = InvocationLimits.from_mapping(payload['limits'])
+    except ValueError as exc:
+        raise ContractFailure('policy_unavailable') from exc
+    if limits != InvocationLimits(6, 8, 32, 3, 1, 2):
+        raise ContractFailure('policy_unavailable')
+    return limits
+
+
+def _git_common_dir() -> Path:
+    try:
+        completed = subprocess.run(
+            ['git', 'rev-parse', '--path-format=absolute', '--git-common-dir'],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise StateMissing from exc
+    path = Path(completed.stdout.strip()).resolve()
+    if not path.is_dir():
+        raise StateMissing
+    return path
+
+
+def _ledger_path() -> Path:
+    return _git_common_dir() / 'praxys' / 'agent-invocation-control-v1.sqlite3'
+
+
+def _string_list(value: object, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise RequestFailure(f'{label} must be a string list')
+    if len(value) != len(set(value)):
+        raise RequestFailure(f'{label} must be unique')
+    return value
+
+
+def _validate_contract(request: dict[str, object]) -> tuple[TaskRoute, str]:
+    strings = (
+        request['primary_object'], request['classification_digest'],
+        request['route_digest'], request['slot_role'],
+    )
+    if not all(isinstance(value, str) for value in strings):
+        raise RequestFailure('Work Contract fields must be strings')
+    impacts = _string_list(request['impacts'], 'impacts')
+    risks = _string_list(request['risk_triggers'], 'risk_triggers')
+    try:
+        route = route_task(
+            TaskClassification(
+                primary_object=str(request['primary_object']),
+                impacts=impacts,
+                risk_triggers=risks,
+            )
+        )
+    except Exception as exc:
+        raise ContractFailure('work_contract_unavailable') from exc
+    if (
+        route.classification_digest != request['classification_digest']
+        or route.route_digest != request['route_digest']
+    ):
+        raise ContractFailure('work_contract_mismatch')
+    roles = {
+        route.lead_role,
+        *route.contributor_roles,
+        *route.executor_roles,
+        *route.verifier_roles,
+        *route.outcome_observer_roles,
+    }
+    slot_role = str(request['slot_role'])
+    if slot_role not in roles:
+        raise RequestFailure('slot role is not in the Work Contract')
+    return route, slot_role
+
+
+def _validate_identity_fields(request: dict[str, object]) -> None:
+    for field, kind in (
+        ('contract_id', 'contract'), ('slot_id', 'slot'),
+        ('generation_id', 'generation'), ('logical_id', 'logical'),
+        ('attempt_id', 'attempt'),
+    ):
+        if not is_valid_identity(request[field], kind):
+            raise RequestFailure(f'invalid {field}')
+    parent = request['parent_attempt_id']
+    if parent is not None and not is_valid_identity(parent, 'attempt'):
+        raise RequestFailure('invalid parent_attempt_id')
+    retry = request['retry_fingerprint']
+    if retry is not None and not is_valid_fingerprint(retry):
+        raise RequestFailure('invalid retry_fingerprint')
+
+
+def _machine_reason(mode: str, policy_reason: str) -> str:
+    if policy_reason == 'kill_switch_active':
+        return 'kill_switch_active'
+    if mode == 'instrument':
+        return 'instrument_recorded'
+    if policy_reason == 'admit':
+        return 'shadow_would_admit'
+    if policy_reason == 'ancestry_cycle':
+        return 'shadow_would_deny_cycle'
+    return 'shadow_would_deny_policy_limit'
+
+
+_SQL_POLICY_REASONS = ', '.join(f"'{reason}'" for reason in POLICY_REASONS)
+_SCHEMA_COLUMNS = {
+    'metadata': ('key', 'value'),
+    'control': ('singleton', 'kill_switch', 'updated_at_ms'),
+    'contracts': (
+        'contract_id', 'classification_digest', 'route_digest',
+        'routing_version', 'operating_model_version', 'created_at_ms',
+    ),
+    'slots': ('slot_id', 'contract_id', 'role_id', 'created_at_ms'),
+    'generations': (
+        'generation_id', 'contract_id', 'slot_id', 'created_at_ms',
+    ),
+    'logical_invocations': (
+        'logical_id', 'contract_id', 'slot_id', 'created_at_ms',
+    ),
+    'decisions': (
+        'decision_id', 'contract_id', 'slot_id', 'generation_id', 'logical_id',
+        'attempt_id', 'parent_attempt_id', 'mode', 'policy_reason',
+        'would_reject', 'launch_authorized', 'decided_at_ms',
+    ),
+    'attempts': (
+        'attempt_id', 'decision_id', 'contract_id', 'slot_id', 'generation_id',
+        'logical_id', 'parent_attempt_id', 'retry_fingerprint',
+        'terminal_fingerprint', 'lifecycle_status', 'depth', 'admitted_at_ms',
+        'finished_at_ms',
+    ),
+}
+_SCHEMA_INDEXES = {
+    'attempts_active_contract',
+    'attempts_active_match',
+    'attempts_parent_status',
+    'attempts_slot_finished',
+    'decisions_contract_reason',
+}
+_SCHEMA = f"""
+CREATE TABLE metadata (
+    key TEXT PRIMARY KEY CHECK (key IN ('schema_version', 'policy_version')),
+    value TEXT NOT NULL
+) STRICT;
+CREATE TABLE control (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    kill_switch INTEGER NOT NULL CHECK (kill_switch IN (0, 1)),
+    updated_at_ms INTEGER NOT NULL
+) STRICT;
+CREATE TABLE contracts (
+    contract_id TEXT PRIMARY KEY,
+    classification_digest TEXT NOT NULL,
+    route_digest TEXT NOT NULL,
+    routing_version TEXT NOT NULL,
+    operating_model_version TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL
+) STRICT;
+CREATE TABLE slots (
+    slot_id TEXT PRIMARY KEY,
+    contract_id TEXT NOT NULL REFERENCES contracts(contract_id),
+    role_id TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL
+) STRICT;
+CREATE TABLE generations (
+    generation_id TEXT PRIMARY KEY,
+    contract_id TEXT NOT NULL REFERENCES contracts(contract_id),
+    slot_id TEXT NOT NULL REFERENCES slots(slot_id),
+    created_at_ms INTEGER NOT NULL
+) STRICT;
+CREATE TABLE logical_invocations (
+    logical_id TEXT PRIMARY KEY,
+    contract_id TEXT NOT NULL REFERENCES contracts(contract_id),
+    slot_id TEXT NOT NULL REFERENCES slots(slot_id),
+    created_at_ms INTEGER NOT NULL
+) STRICT;
+CREATE TABLE decisions (
+    decision_id TEXT PRIMARY KEY,
+    contract_id TEXT NOT NULL REFERENCES contracts(contract_id),
+    slot_id TEXT NOT NULL REFERENCES slots(slot_id),
+    generation_id TEXT NOT NULL,
+    logical_id TEXT NOT NULL,
+    attempt_id TEXT NOT NULL UNIQUE,
+    parent_attempt_id TEXT,
+    mode TEXT NOT NULL CHECK (mode IN ('instrument', 'shadow')),
+    policy_reason TEXT NOT NULL CHECK (policy_reason IN (
+        {_SQL_POLICY_REASONS}
+    )),
+    would_reject INTEGER NOT NULL CHECK (would_reject IN (0, 1)),
+    launch_authorized INTEGER NOT NULL CHECK (launch_authorized IN (0, 1)),
+    decided_at_ms INTEGER NOT NULL
+) STRICT;
+CREATE TABLE attempts (
+    attempt_id TEXT PRIMARY KEY,
+    decision_id TEXT NOT NULL UNIQUE REFERENCES decisions(decision_id),
+    contract_id TEXT NOT NULL REFERENCES contracts(contract_id),
+    slot_id TEXT NOT NULL REFERENCES slots(slot_id),
+    generation_id TEXT NOT NULL REFERENCES generations(generation_id),
+    logical_id TEXT NOT NULL REFERENCES logical_invocations(logical_id),
+    parent_attempt_id TEXT REFERENCES attempts(attempt_id),
+    retry_fingerprint TEXT,
+    terminal_fingerprint TEXT,
+    lifecycle_status TEXT NOT NULL CHECK (
+        lifecycle_status IN ('active', 'succeeded', 'failed', 'recovered')
+    ),
+    depth INTEGER NOT NULL CHECK (depth >= 1),
+    admitted_at_ms INTEGER NOT NULL,
+    finished_at_ms INTEGER
+) STRICT;
+CREATE INDEX attempts_active_contract
+    ON attempts(contract_id, lifecycle_status);
+CREATE INDEX attempts_active_match
+    ON attempts(contract_id, logical_id, slot_id, generation_id, lifecycle_status);
+CREATE INDEX attempts_parent_status
+    ON attempts(parent_attempt_id, lifecycle_status);
+CREATE INDEX attempts_slot_finished ON attempts(slot_id, finished_at_ms);
+CREATE INDEX decisions_contract_reason ON decisions(contract_id, policy_reason);
+"""
+
+
+class Ledger:
+    """Concurrency-safe local SQLite lifecycle ledger."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def initialize(self) -> bool:
+        """Create the v1 ledger once, or validate an existing ledger."""
+        if self.path.exists():
+            connection = self._connect()
+            connection.close()
+            return False
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.path.parent.chmod(0o700)
+        try:
+            descriptor = os.open(
+                self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600
+            )
+            os.close(descriptor)
+            connection = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+            connection.execute('PRAGMA busy_timeout=30000')
+            mode = connection.execute('PRAGMA journal_mode=WAL').fetchone()
+            if mode is None or mode[0].lower() != 'wal':
+                raise StateCorrupt
+            connection.execute('PRAGMA foreign_keys=ON')
+            connection.execute('BEGIN IMMEDIATE')
+            for statement in _SCHEMA.split(';'):
+                if statement.strip():
+                    connection.execute(statement)
+            connection.executemany(
+                'INSERT INTO metadata(key, value) VALUES (?, ?)',
+                (
+                    ('schema_version', str(LEDGER_SCHEMA_VERSION)),
+                    ('policy_version', POLICY_VERSION),
+                ),
+            )
+            connection.execute(
+                'INSERT INTO control(singleton, kill_switch, updated_at_ms) VALUES (1, 0, ?)',
+                (_now_ms(),),
+            )
+            connection.commit()
+            self.path.chmod(0o600)
+            self._validate(connection)
+            connection.close()
+            return True
+        except (sqlite3.Error, OSError) as exc:
+            raise StateCorrupt from exc
+
+    def _connect(self) -> sqlite3.Connection:
+        if not self.path.is_file():
+            raise StateMissing
+        try:
+            connection = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+            connection.row_factory = sqlite3.Row
+            connection.execute('PRAGMA busy_timeout=30000')
+            connection.execute('PRAGMA foreign_keys=ON')
+            mode = connection.execute('PRAGMA journal_mode=WAL').fetchone()
+            if mode is None or mode[0].lower() != 'wal':
+                raise StateCorrupt
+            self._validate(connection)
+            return connection
+        except (sqlite3.Error, OSError, UnicodeError) as exc:
+            raise StateCorrupt from exc
+
+    @staticmethod
+    def _validate(connection: sqlite3.Connection) -> None:
+        try:
+            integrity = connection.execute('PRAGMA quick_check').fetchone()
+            metadata_columns = tuple(
+                row[1] for row in connection.execute('PRAGMA table_info(metadata)')
+            )
+            if (
+                integrity is None or integrity[0] != 'ok'
+                or metadata_columns != _SCHEMA_COLUMNS['metadata']
+            ):
+                raise StateCorrupt
+            metadata = dict(connection.execute('SELECT key, value FROM metadata'))
+            if set(metadata) != {'schema_version', 'policy_version'}:
+                raise StateCorrupt
+            if metadata != {
+                'schema_version': str(LEDGER_SCHEMA_VERSION),
+                'policy_version': POLICY_VERSION,
+            }:
+                raise StateUnsupported
+
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_schema "
+                    "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+                )
+            }
+            indexes = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_schema "
+                    "WHERE type = 'index' AND sql IS NOT NULL"
+                )
+            }
+            columns = {
+                table: tuple(
+                    row[1]
+                    for row in connection.execute(f'PRAGMA table_info({table})')
+                )
+                for table in _SCHEMA_COLUMNS
+            }
+            foreign_keys = connection.execute('PRAGMA foreign_keys').fetchone()
+            control = connection.execute(
+                'SELECT kill_switch FROM control WHERE singleton = 1'
+            ).fetchone()
+            if (
+                tables != set(_SCHEMA_COLUMNS)
+                or indexes != _SCHEMA_INDEXES
+                or columns != _SCHEMA_COLUMNS
+                or foreign_keys is None or foreign_keys[0] != 1
+                or control is None or control[0] not in (0, 1)
+            ):
+                raise StateCorrupt
+        except sqlite3.Error as exc:
+            raise StateCorrupt from exc
+
+    @staticmethod
+    def _bind(
+        connection: sqlite3.Connection,
+        table: str,
+        identity_column: str,
+        identity: str,
+        expected: tuple[object, ...],
+        columns: tuple[str, ...],
+        insert_values: tuple[object, ...],
+    ) -> bool:
+        selected_columns = ','.join(columns)
+        selected = connection.execute(
+            f'SELECT {selected_columns} FROM {table} WHERE {identity_column} = ?',
+            (identity,),
+        ).fetchone()
+        if selected is None:
+            placeholders = ','.join('?' for _ in range(len(insert_values) + 2))
+            insert_columns = ','.join((identity_column, *columns, 'created_at_ms'))
+            connection.execute(
+                f'INSERT INTO {table}({insert_columns}) VALUES ({placeholders})',
+                (identity, *insert_values, _now_ms()),
+            )
+            return True
+        if tuple(selected) != expected:
+            raise IdentityConflict
+        return False
+
+    def set_kill_switch(self, active: bool) -> None:
+        """Atomically set the mediated-launch kill switch."""
+        connection = self._connect()
+        try:
+            connection.execute('BEGIN IMMEDIATE')
+            connection.execute(
+                'UPDATE control SET kill_switch = ?, updated_at_ms = ? WHERE singleton = 1',
+                (int(active), _now_ms()),
+            )
+            connection.commit()
+        except sqlite3.Error as exc:
+            connection.rollback()
+            raise StateCorrupt from exc
+        finally:
+            connection.close()
+
+    def admit(
+        self,
+        request: dict[str, object],
+        route: TaskRoute,
+        slot_role: str,
+        limits: InvocationLimits,
+    ) -> dict[str, object]:
+        """Evaluate and record admission in one immediate transaction."""
+        connection = self._connect()
+        try:
+            connection.execute('BEGIN IMMEDIATE')
+            now = _now_ms()
+            contract_id = str(request['contract_id'])
+            slot_id = str(request['slot_id'])
+            generation_id = str(request['generation_id'])
+            logical_id = str(request['logical_id'])
+            attempt_id = str(request['attempt_id'])
+            parent_id = request['parent_attempt_id']
+            retry_fingerprint = request['retry_fingerprint']
+            mode = str(request['mode'])
+            self._bind(
+                connection, 'contracts', 'contract_id', contract_id,
+                (
+                    route.classification_digest, route.route_digest,
+                    route.routing_version, route.operating_model_version,
+                ),
+                (
+                    'classification_digest', 'route_digest',
+                    'routing_version', 'operating_model_version',
+                ),
+                (
+                    route.classification_digest, route.route_digest,
+                    route.routing_version, route.operating_model_version,
+                ),
+            )
+            self._bind(
+                connection, 'slots', 'slot_id', slot_id,
+                (contract_id, slot_role), ('contract_id', 'role_id'),
+                (contract_id, slot_role),
+            )
+            generation = connection.execute(
+                'SELECT contract_id, slot_id FROM generations WHERE generation_id = ?',
+                (generation_id,),
+            ).fetchone()
+            logical = connection.execute(
+                'SELECT contract_id, slot_id FROM logical_invocations WHERE logical_id = ?',
+                (logical_id,),
+            ).fetchone()
+            generation_is_new = generation is None
+            logical_is_new = logical is None
+            if generation is not None and tuple(generation) != (contract_id, slot_id):
+                raise IdentityConflict
+            if logical is not None and tuple(logical) != (contract_id, slot_id):
+                raise IdentityConflict
+            if connection.execute(
+                'SELECT 1 FROM decisions WHERE attempt_id = ?', (attempt_id,)
+            ).fetchone() is not None:
+                raise IdentityConflict
+
+            ancestor_slots: list[str] = []
+            proposed_depth = 1
+            current_parent = parent_id
+            seen_attempts: set[str] = set()
+            while current_parent is not None:
+                if str(current_parent) in seen_attempts:
+                    raise StateCorrupt
+                seen_attempts.add(str(current_parent))
+                parent = connection.execute(
+                    """SELECT contract_id, slot_id, parent_attempt_id, lifecycle_status
+                    FROM attempts WHERE attempt_id = ?""",
+                    (current_parent,),
+                ).fetchone()
+                if (
+                    parent is None
+                    or parent['contract_id'] != contract_id
+                    or parent['lifecycle_status'] != 'active'
+                ):
+                    raise IdentityConflict
+                ancestor_slots.append(parent['slot_id'])
+                proposed_depth += 1
+                current_parent = parent['parent_attempt_id']
+
+            duplicate = connection.execute(
+                """SELECT 1 FROM attempts
+                WHERE contract_id = ? AND lifecycle_status = 'active'
+                  AND (logical_id = ? OR (slot_id = ? AND generation_id = ?))
+                LIMIT 1""",
+                (contract_id, logical_id, slot_id, generation_id),
+            ).fetchone() is not None
+            active_count = connection.execute(
+                "SELECT COUNT(*) FROM attempts "
+                "WHERE contract_id = ? AND lifecycle_status = 'active'",
+                (contract_id,),
+            ).fetchone()[0]
+            logical_count = connection.execute(
+                'SELECT COUNT(*) FROM logical_invocations WHERE contract_id = ?',
+                (contract_id,),
+            ).fetchone()[0]
+            attempt_count = connection.execute(
+                'SELECT COUNT(*) FROM attempts WHERE logical_id = ?',
+                (logical_id,),
+            ).fetchone()[0]
+            if attempt_count and retry_fingerprint is None and not duplicate:
+                raise IdentityConflict
+            if retry_fingerprint is not None:
+                prior_failure = connection.execute(
+                    """SELECT 1 FROM attempts
+                    WHERE logical_id = ? AND lifecycle_status = 'failed'
+                      AND terminal_fingerprint = ? LIMIT 1""",
+                    (logical_id, retry_fingerprint),
+                ).fetchone()
+                if prior_failure is None:
+                    raise IdentityConflict
+                retries = connection.execute(
+                    'SELECT COUNT(*) FROM attempts WHERE slot_id = ? AND retry_fingerprint = ?',
+                    (slot_id, retry_fingerprint),
+                ).fetchone()[0]
+            else:
+                retries = 0
+            recent = tuple(
+                row[0]
+                for row in connection.execute(
+                    """SELECT terminal_fingerprint FROM attempts
+                    WHERE slot_id = ? AND terminal_fingerprint IS NOT NULL
+                    ORDER BY finished_at_ms DESC, rowid DESC LIMIT ?""",
+                    (slot_id, limits.no_progress_identical_terminals),
+                )
+            )
+            kill_switch = bool(
+                connection.execute(
+                    'SELECT kill_switch FROM control WHERE singleton = 1'
+                ).fetchone()[0]
+            )
+            decision = evaluate_admission(
+                AdmissionFacts(
+                    kill_switch_active=kill_switch,
+                    duplicate_active=duplicate,
+                    ancestor_slot_ids=tuple(ancestor_slots),
+                    proposed_slot_id=slot_id,
+                    proposed_depth=proposed_depth,
+                    active_count=active_count,
+                    logical_count=logical_count,
+                    is_new_logical=logical_is_new,
+                    retry_fingerprint=(
+                        str(retry_fingerprint) if retry_fingerprint is not None else None
+                    ),
+                    retries_for_fingerprint=retries,
+                    attempt_count=attempt_count,
+                    recent_terminal_fingerprints=recent,
+                ),
+                limits,
+            )
+            decision_id = format_identity('decision', secrets.token_hex(16))
+            if decision.launch_authorized:
+                if generation_is_new:
+                    connection.execute(
+                        'INSERT INTO generations VALUES (?, ?, ?, ?)',
+                        (generation_id, contract_id, slot_id, now),
+                    )
+                if logical_is_new:
+                    connection.execute(
+                        'INSERT INTO logical_invocations VALUES (?, ?, ?, ?)',
+                        (logical_id, contract_id, slot_id, now),
+                    )
+            connection.execute(
+                """INSERT INTO decisions(
+                    decision_id, contract_id, slot_id, generation_id, logical_id,
+                    attempt_id, parent_attempt_id, mode, policy_reason,
+                    would_reject, launch_authorized, decided_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    decision_id, contract_id, slot_id, generation_id, logical_id,
+                    attempt_id, parent_id, mode, decision.policy_reason,
+                    int(decision.would_reject), int(decision.launch_authorized), now,
+                ),
+            )
+            if decision.launch_authorized:
+                connection.execute(
+                    """INSERT INTO attempts(
+                        attempt_id, decision_id, contract_id, slot_id,
+                        generation_id, logical_id, parent_attempt_id,
+                        retry_fingerprint, terminal_fingerprint, lifecycle_status,
+                        depth, admitted_at_ms, finished_at_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 'active', ?, ?, NULL)""",
+                    (
+                        attempt_id, decision_id, contract_id, slot_id,
+                        generation_id, logical_id, parent_id, retry_fingerprint,
+                        proposed_depth, now,
+                    ),
+                )
+            connection.commit()
+            return {
+                'decision_id': decision_id,
+                'policy_reason': decision.policy_reason,
+                'would_reject': decision.would_reject,
+                'launch_authorized': decision.launch_authorized,
+            }
+        except (IdentityConflict, StateCorrupt):
+            connection.rollback()
+            raise
+        except sqlite3.Error as exc:
+            connection.rollback()
+            raise StateCorrupt from exc
+        finally:
+            connection.close()
+
+    def finish(
+        self, attempt_id: str, status: str, terminal_fingerprint: str
+    ) -> tuple[str, bool]:
+        """Finish or recover one leaf attempt, idempotently."""
+        connection = self._connect()
+        try:
+            connection.execute('BEGIN IMMEDIATE')
+            attempt = connection.execute(
+                'SELECT lifecycle_status, terminal_fingerprint FROM attempts WHERE attempt_id = ?',
+                (attempt_id,),
+            ).fetchone()
+            if attempt is None:
+                raise IdentityConflict
+            if attempt['lifecycle_status'] != 'active':
+                if (
+                    attempt['lifecycle_status'] == status
+                    and attempt['terminal_fingerprint'] == terminal_fingerprint
+                ):
+                    connection.commit()
+                    return status, True
+                raise FinishConflict
+            if connection.execute(
+                "SELECT 1 FROM attempts WHERE parent_attempt_id = ? "
+                "AND lifecycle_status = 'active' LIMIT 1",
+                (attempt_id,),
+            ).fetchone() is not None:
+                raise RecoveryRequired
+            connection.execute(
+                """UPDATE attempts
+                SET lifecycle_status = ?, terminal_fingerprint = ?, finished_at_ms = ?
+                WHERE attempt_id = ?""",
+                (status, terminal_fingerprint, _now_ms(), attempt_id),
+            )
+            connection.commit()
+            return status, False
+        except (IdentityConflict, RecoveryRequired, FinishConflict):
+            connection.rollback()
+            raise
+        except sqlite3.Error as exc:
+            connection.rollback()
+            raise StateCorrupt from exc
+        finally:
+            connection.close()
+
+    def status(self) -> dict[str, object]:
+        """Return privacy-safe aggregate ledger state."""
+        connection = self._connect()
+        try:
+            counts = {
+                'contracts': connection.execute('SELECT COUNT(*) FROM contracts').fetchone()[0],
+                'logical_invocations': connection.execute(
+                    'SELECT COUNT(*) FROM logical_invocations'
+                ).fetchone()[0],
+                'active_attempts': connection.execute(
+                    "SELECT COUNT(*) FROM attempts WHERE lifecycle_status = 'active'"
+                ).fetchone()[0],
+                'terminal_attempts': connection.execute(
+                    "SELECT COUNT(*) FROM attempts WHERE lifecycle_status != 'active'"
+                ).fetchone()[0],
+                'decisions': connection.execute('SELECT COUNT(*) FROM decisions').fetchone()[0],
+            }
+            reasons = dict(
+                connection.execute(
+                    'SELECT policy_reason, COUNT(*) FROM decisions GROUP BY policy_reason'
+                )
+            )
+            kill_switch = bool(
+                connection.execute(
+                    'SELECT kill_switch FROM control WHERE singleton = 1'
+                ).fetchone()[0]
+            )
+            active_attempts = [
+                {
+                    'attempt_id': row[0],
+                    'parent_attempt_id': row[1],
+                    'depth': row[2],
+                }
+                for row in connection.execute(
+                    "SELECT attempt_id, parent_attempt_id, depth FROM attempts "
+                    "WHERE lifecycle_status = 'active' "
+                    "ORDER BY depth DESC, admitted_at_ms DESC, rowid DESC"
+                )
+            ]
+            return {
+                'counts': counts,
+                'decision_counts': reasons,
+                'kill_switch_active': kill_switch,
+                'active_attempts': active_attempts,
+            }
+        except sqlite3.Error as exc:
+            raise StateCorrupt from exc
+        finally:
+            connection.close()
+
+
+def _state_error(command: str, mode: object, policy_reason: str) -> NoReturn:
+    values: dict[str, object] = {'policy_reason': policy_reason}
+    if command == 'admit' and mode in APPROVED_MODES:
+        values.update({'would_reject': True, 'launch_authorized': True})
+    _emit(_response(command, 'ledger_unavailable', **values), EXIT_LEDGER)
+
+
+def main() -> int:
+    """Execute one versioned request and emit one versioned response."""
+    try:
+        request = _read_request()
+        command = str(request['command'])
+        if command == 'new_identity':
+            _require_exact_keys(request, {'schema_version', 'command', 'kind'})
+            kind = request['kind']
+            if kind not in {'contract', 'slot', 'generation', 'logical', 'attempt'}:
+                raise RequestFailure('invalid identity kind')
+            _emit(
+                _response(
+                    command, 'identity_created', kind=kind,
+                    identity=format_identity(str(kind), secrets.token_hex(16)),
+                ),
+                EXIT_OK,
+            )
+
+        if command == 'init':
+            _load_policy()
+            _require_exact_keys(request, {'schema_version', 'command'})
+            created = Ledger(_ledger_path()).initialize()
+            _emit(
+                _response(command, 'ledger_initialized' if created else 'ledger_ready'),
+                EXIT_OK,
+            )
+
+        if command == 'admit':
+            _require_exact_keys(
+                request,
+                {
+                    'schema_version', 'command', 'mode', 'primary_object',
+                    'impacts', 'risk_triggers', 'classification_digest',
+                    'route_digest', 'contract_id', 'slot_id', 'slot_role',
+                    'generation_id', 'logical_id', 'attempt_id',
+                    'parent_attempt_id', 'retry_fingerprint',
+                },
+            )
+            mode = request['mode']
+            if mode == 'enforce' or mode not in APPROVED_MODES:
+                _emit(
+                    _response(
+                        command, 'enforcement_unavailable', policy_reason=None,
+                        would_reject=None, launch_authorized=None,
+                    ),
+                    EXIT_MODE,
+                )
+            _validate_identity_fields(request)
+            route, slot_role = _validate_contract(request)
+            limits = _load_policy()
+            ledger = Ledger(_ledger_path())
+            outcome = ledger.admit(request, route, slot_role, limits)
+            _emit(
+                _response(
+                    command,
+                    _machine_reason(str(mode), str(outcome['policy_reason'])),
+                    **outcome,
+                ),
+                EXIT_OK,
+            )
+
+        if command in {'finish', 'recover'}:
+            _load_policy()
+            ledger = Ledger(_ledger_path())
+            required = {'schema_version', 'command', 'attempt_id', 'terminal_fingerprint'}
+            if command == 'finish':
+                required.add('status')
+            _require_exact_keys(request, required)
+            if not is_valid_identity(request['attempt_id'], 'attempt'):
+                raise RequestFailure('invalid attempt_id')
+            if not is_valid_fingerprint(request['terminal_fingerprint']):
+                raise RequestFailure('invalid terminal_fingerprint')
+            if command == 'finish':
+                status = request['status']
+                if status not in {'succeeded', 'failed'}:
+                    raise RequestFailure('invalid finish status')
+            else:
+                status = 'recovered'
+            lifecycle, idempotent = ledger.finish(
+                str(request['attempt_id']), str(status),
+                str(request['terminal_fingerprint']),
+            )
+            reason = 'finish_idempotent' if idempotent else (
+                'recovery_recorded' if command == 'recover' else 'finish_recorded'
+            )
+            _emit(
+                _response(
+                    command, reason, lifecycle_status=lifecycle,
+                    idempotent=idempotent,
+                ),
+                EXIT_OK,
+            )
+
+        if command == 'kill_switch':
+            _load_policy()
+            ledger = Ledger(_ledger_path())
+            _require_exact_keys(request, {'schema_version', 'command', 'active'})
+            if not isinstance(request['active'], bool):
+                raise RequestFailure('active must be boolean')
+            ledger.set_kill_switch(request['active'])
+            _emit(
+                _response(command, 'kill_switch_updated', active=request['active']),
+                EXIT_OK,
+            )
+
+        if command == 'status':
+            _load_policy()
+            ledger = Ledger(_ledger_path())
+            _require_exact_keys(request, {'schema_version', 'command'})
+            _emit(_response(command, 'status_reported', **ledger.status()), EXIT_OK)
+        raise RequestFailure('unsupported command')
+    except RequestFailure:
+        _emit(_response('invalid', 'invalid_request'), EXIT_INVALID)
+    except ContractFailure as exc:
+        command = str(locals().get('command', 'invalid'))
+        local_request = locals().get('request')
+        mode = local_request.get('mode') if isinstance(local_request, dict) else None
+        values: dict[str, object] = {'policy_reason': 'work_contract_invalid'}
+        if command == 'admit' and mode in APPROVED_MODES:
+            values.update({'would_reject': True, 'launch_authorized': True})
+        _emit(_response(command, exc.reason_code, **values), EXIT_CONTRACT)
+    except StateMissing:
+        command = str(locals().get('command', 'invalid'))
+        local_request = locals().get('request')
+        mode = local_request.get('mode') if isinstance(local_request, dict) else None
+        _state_error(command, mode, 'state_missing')
+    except StateCorrupt:
+        command = str(locals().get('command', 'invalid'))
+        local_request = locals().get('request')
+        mode = local_request.get('mode') if isinstance(local_request, dict) else None
+        _state_error(command, mode, 'state_corrupt')
+    except StateUnsupported:
+        command = str(locals().get('command', 'invalid'))
+        local_request = locals().get('request')
+        mode = local_request.get('mode') if isinstance(local_request, dict) else None
+        _state_error(command, mode, 'state_unsupported')
+    except IdentityConflict:
+        command = str(locals().get('command', 'invalid'))
+        local_request = locals().get('request')
+        mode = local_request.get('mode') if isinstance(local_request, dict) else None
+        values: dict[str, object] = {}
+        if command == 'admit' and mode in APPROVED_MODES:
+            values.update({'would_reject': True, 'launch_authorized': True})
+        _emit(_response(command, 'invalid_identity', **values), EXIT_INVALID)
+    except RecoveryRequired:
+        _emit(_response(str(locals().get('command', 'invalid')), 'recovery_required'), EXIT_LEDGER)
+    except FinishConflict:
+        _emit(_response(str(locals().get('command', 'invalid')), 'invalid_request'), EXIT_INVALID)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_agentic_invocation_control.py
+++ b/tests/test_agentic_invocation_control.py
@@ -1,0 +1,845 @@
+"""Agent invocation admission, lifecycle, and ledger contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+
+import pytest
+
+from analysis.agentic_invocation_control import (
+    AdmissionFacts,
+    DECISION_REASONS,
+    InvocationLimits,
+    MACHINE_REASON_CODES,
+    POLICY_REASONS,
+    evaluate_admission,
+    format_identity,
+    is_valid_fingerprint,
+    is_valid_identity,
+)
+from analysis.agentic_task_routing import TaskClassification, TaskRoute, route_task
+from scripts.agent_invocation_control import (
+    FinishConflict,
+    IdentityConflict,
+    Ledger,
+    RecoveryRequired,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / 'scripts' / 'agent_invocation_control.py'
+CLASSIFICATION_DIGEST = 'sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2'
+ROUTE_DIGEST = 'sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51'
+
+CONCURRENT_ADMISSION_WRAPPER = r"""
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+request_path = Path(sys.argv[1])
+ready_path = Path(sys.argv[2])
+gate_path = Path(sys.argv[3])
+script_path = sys.argv[4]
+request = request_path.read_text(encoding='utf-8')
+ready_path.touch()
+deadline = time.monotonic() + 30
+while not gate_path.exists():
+    if time.monotonic() >= deadline:
+        sys.stderr.write('timed out waiting for admission gate')
+        raise SystemExit(124)
+    time.sleep(0.005)
+completed = subprocess.run(
+    [sys.executable, script_path],
+    input=request,
+    capture_output=True,
+    text=True,
+    check=False,
+)
+sys.stdout.write(completed.stdout)
+sys.stderr.write(completed.stderr)
+raise SystemExit(completed.returncode)
+"""
+
+
+def opaque(kind: str, number: int) -> str:
+    return format_identity(kind, f'{number:032x}')
+
+
+def fingerprint(number: int) -> str:
+    return f'fpr_{number:064x}'
+
+
+def accepted_route() -> TaskRoute:
+    return route_task(
+        TaskClassification(
+            primary_object='agent-system',
+            impacts=[
+                'repository-change',
+                'agent-policy-or-autonomy',
+                'architecture-boundary',
+            ],
+            risk_triggers=[
+                'irreversible-or-high-blast-radius-action',
+                'out-of-policy-or-out-of-distribution-decision',
+            ],
+        )
+    )
+
+
+def limits() -> InvocationLimits:
+    return InvocationLimits(6, 8, 32, 3, 1, 2)
+
+
+def admission(
+    number: int,
+    *,
+    contract: int = 1,
+    slot: int | None = None,
+    generation: int | None = None,
+    logical: int | None = None,
+    parent: str | None = None,
+    retry: str | None = None,
+    mode: str = 'shadow',
+    role: str = 'engineering',
+) -> dict[str, object]:
+    return {
+        'schema_version': 1,
+        'command': 'admit',
+        'mode': mode,
+        'primary_object': 'agent-system',
+        'impacts': [
+            'repository-change',
+            'agent-policy-or-autonomy',
+            'architecture-boundary',
+        ],
+        'risk_triggers': [
+            'irreversible-or-high-blast-radius-action',
+            'out-of-policy-or-out-of-distribution-decision',
+        ],
+        'classification_digest': CLASSIFICATION_DIGEST,
+        'route_digest': ROUTE_DIGEST,
+        'contract_id': opaque('contract', contract),
+        'slot_id': opaque('slot', slot if slot is not None else number),
+        'slot_role': role,
+        'generation_id': opaque(
+            'generation', generation if generation is not None else number
+        ),
+        'logical_id': opaque('logical', logical if logical is not None else number),
+        'attempt_id': opaque('attempt', number),
+        'parent_attempt_id': parent,
+        'retry_fingerprint': retry,
+    }
+
+
+def new_ledger(tmp_path: Path) -> Ledger:
+    ledger = Ledger(tmp_path / 'control.sqlite3')
+    assert ledger.initialize() is True
+    return ledger
+
+
+def finish(
+    ledger: Ledger,
+    attempt: int,
+    terminal: int,
+    status: str = 'failed',
+) -> tuple[str, bool]:
+    return ledger.finish(opaque('attempt', attempt), status, fingerprint(terminal))
+
+
+def run_cli(repository: Path, payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=repository,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def init_repository(tmp_path: Path) -> Path:
+    repository = tmp_path / 'repository'
+    repository.mkdir()
+    subprocess.run(['git', 'init', '-q', str(repository)], check=True)
+    initialized = run_cli(repository, {'schema_version': 1, 'command': 'init'})
+    assert initialized.returncode == 0
+    assert json.loads(initialized.stdout)['reason_code'] == 'ledger_initialized'
+    return repository
+
+
+def test_pure_identity_and_policy_precedence() -> None:
+    identity = opaque('contract', 1)
+    assert is_valid_identity(identity, 'contract')
+    assert not is_valid_identity(identity, 'slot')
+    assert is_valid_fingerprint(fingerprint(1))
+    facts = AdmissionFacts(
+        kill_switch_active=False,
+        duplicate_active=True,
+        ancestor_slot_ids=(opaque('slot', 1),),
+        proposed_slot_id=opaque('slot', 1),
+        proposed_depth=7,
+        active_count=8,
+        logical_count=32,
+        is_new_logical=True,
+        retry_fingerprint=fingerprint(1),
+        retries_for_fingerprint=1,
+        attempt_count=3,
+        recent_terminal_fingerprints=(fingerprint(2), fingerprint(2)),
+    )
+    decision = evaluate_admission(facts, limits())
+    assert decision.policy_reason == 'duplicate_active'
+    assert decision.would_reject is True
+    assert decision.launch_authorized is True
+
+
+def test_reason_code_schemas_and_docs_are_exact() -> None:
+    assert POLICY_REASONS == (
+        'admit',
+        'kill_switch_active',
+        'duplicate_active',
+        'ancestry_cycle',
+        'ancestry_depth_limit',
+        'active_contract_limit',
+        'logical_contract_limit',
+        'retry_fingerprint_limit',
+        'attempt_limit',
+        'no_progress',
+    )
+    assert DECISION_REASONS == (
+        'admit',
+        'work_contract_invalid',
+        'kill_switch_active',
+        'duplicate_active',
+        'ancestry_cycle',
+        'ancestry_depth_limit',
+        'active_contract_limit',
+        'logical_contract_limit',
+        'retry_fingerprint_limit',
+        'attempt_limit',
+        'no_progress',
+        'state_missing',
+        'state_corrupt',
+        'state_unsupported',
+    )
+    assert MACHINE_REASON_CODES == (
+        'instrument_recorded',
+        'shadow_would_admit',
+        'shadow_would_deny_cycle',
+        'shadow_would_deny_policy_limit',
+        'invalid_request',
+        'invalid_identity',
+        'work_contract_unavailable',
+        'work_contract_mismatch',
+        'policy_unavailable',
+        'recovery_required',
+        'ledger_unavailable',
+        'enforcement_unavailable',
+        'kill_switch_active',
+        'ledger_initialized',
+        'ledger_ready',
+        'identity_created',
+        'finish_recorded',
+        'finish_idempotent',
+        'recovery_recorded',
+        'kill_switch_updated',
+        'status_reported',
+    )
+
+    implementation = (ROOT / 'docs/dev/agent-invocation-control.md').read_text(
+        encoding='utf-8'
+    )
+    policy_section = implementation.split('Stable policy reasons:', 1)[1].split(
+        'Stable machine reason codes', 1
+    )[0]
+    assert tuple(
+        re.findall(r'^\| ([a-z_]+) \|', policy_section, flags=re.MULTILINE)
+    ) == DECISION_REASONS
+    machine_section = implementation.split(
+        'Stable machine reason codes are', 1
+    )[1].split('Additions must', 1)[0]
+    assert tuple(re.findall(r'`([a-z_]+)`', machine_section)) == (
+        MACHINE_REASON_CODES
+    )
+
+    adr = (ROOT / 'docs/dev/adr-2026-08-20-agent-invocation-control.md').read_text(
+        encoding='utf-8'
+    )
+    adr_machine_section = adr.split(
+        'Stable v1 machine reason-code namespace:', 1
+    )[1].split('Meanings cannot change', 1)[0]
+    assert tuple(re.findall(r'`([a-z_]+)`', adr_machine_section)) == (
+        MACHINE_REASON_CODES
+    )
+
+    proposal = (
+        ROOT / 'docs/dev/policy-change-proposal-agent-invocation-control-v1.md'
+    ).read_text(encoding='utf-8')
+    proposal_policy_section = proposal.split(
+        '## Atomic admission decisions and stable reason codes', 1
+    )[1].split('## Starting limits', 1)[0]
+    assert tuple(
+        re.findall(
+            r'^\| [^|]+ \| `([a-z_]+)` \|',
+            proposal_policy_section,
+            flags=re.MULTILINE,
+        )
+    ) == DECISION_REASONS
+
+
+def test_direct_indirect_cycles_depth_and_generation_semantics(tmp_path: Path) -> None:
+    route = accepted_route()
+
+    direct = new_ledger(tmp_path / 'direct')
+    first = direct.admit(admission(1, slot=1), route, 'engineering', limits())
+    assert first['policy_reason'] == 'admit'
+    changed_generation_cycle = direct.admit(
+        admission(2, slot=1, generation=2, parent=opaque('attempt', 1)),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert changed_generation_cycle['policy_reason'] == 'ancestry_cycle'
+    assert changed_generation_cycle['launch_authorized'] is True
+
+    indirect = new_ledger(tmp_path / 'indirect')
+    indirect.admit(admission(101, slot=11), route, 'engineering', limits())
+    indirect.admit(
+        admission(102, slot=12, parent=opaque('attempt', 101)),
+        route,
+        'engineering',
+        limits(),
+    )
+    cycle = indirect.admit(
+        admission(103, slot=11, generation=103, parent=opaque('attempt', 102)),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert cycle['policy_reason'] == 'ancestry_cycle'
+
+    deep = new_ledger(tmp_path / 'deep')
+    parent = None
+    for number in range(201, 207):
+        result = deep.admit(
+            admission(number, slot=number, parent=parent),
+            route,
+            'engineering',
+            limits(),
+        )
+        assert result['policy_reason'] == 'admit'
+        parent = opaque('attempt', number)
+    beyond = deep.admit(
+        admission(207, slot=207, parent=parent), route, 'engineering', limits()
+    )
+    assert beyond['policy_reason'] == 'ancestry_depth_limit'
+
+    resumed = new_ledger(tmp_path / 'resumed')
+    resumed.admit(admission(301, slot=31), route, 'engineering', limits())
+    finish(resumed, 301, 301, 'succeeded')
+    next_generation = resumed.admit(
+        admission(302, slot=31, generation=302, logical=302),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert next_generation['policy_reason'] == 'admit'
+
+
+def test_active_and_logical_contract_boundaries(tmp_path: Path) -> None:
+    route = accepted_route()
+    active = new_ledger(tmp_path / 'active')
+    for number in range(1, 9):
+        outcome = active.admit(
+            admission(number, slot=number, generation=number, logical=number),
+            route,
+            'engineering',
+            limits(),
+        )
+        assert outcome['policy_reason'] == 'admit'
+    ninth = active.admit(admission(9, slot=9), route, 'engineering', limits())
+    assert ninth['policy_reason'] == 'active_contract_limit'
+    assert ninth['launch_authorized'] is True
+
+    logical = new_ledger(tmp_path / 'logical')
+    for number in range(101, 133):
+        outcome = logical.admit(
+            admission(number, slot=55, generation=number, logical=number),
+            route,
+            'engineering',
+            limits(),
+        )
+        assert outcome['policy_reason'] == 'admit'
+        finish(logical, number, number, 'succeeded')
+    thirty_third = logical.admit(
+        admission(133, slot=55, generation=133, logical=133),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert thirty_third['policy_reason'] == 'logical_contract_limit'
+
+
+def test_attempt_retry_and_no_progress_boundaries(tmp_path: Path) -> None:
+    route = accepted_route()
+    attempts = new_ledger(tmp_path / 'attempts')
+    attempts.admit(admission(1, slot=1, logical=1), route, 'engineering', limits())
+    finish(attempts, 1, 1)
+    attempts.admit(
+        admission(2, slot=1, logical=1, retry=fingerprint(1)),
+        route,
+        'engineering',
+        limits(),
+    )
+    finish(attempts, 2, 2)
+    attempts.admit(
+        admission(3, slot=1, logical=1, retry=fingerprint(2)),
+        route,
+        'engineering',
+        limits(),
+    )
+    finish(attempts, 3, 3)
+    fourth = attempts.admit(
+        admission(4, slot=1, logical=1, retry=fingerprint(3)),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert fourth['policy_reason'] == 'attempt_limit'
+
+    retries = new_ledger(tmp_path / 'retries')
+    retries.admit(admission(11, slot=11, logical=11), route, 'engineering', limits())
+    finish(retries, 11, 11)
+    retries.admit(
+        admission(12, slot=11, logical=11, retry=fingerprint(11)),
+        route,
+        'engineering',
+        limits(),
+    )
+    finish(retries, 12, 12)
+    repeated_retry = retries.admit(
+        admission(13, slot=11, logical=11, retry=fingerprint(11)),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert repeated_retry['policy_reason'] == 'retry_fingerprint_limit'
+
+    progress = new_ledger(tmp_path / 'progress')
+    progress.admit(admission(21, slot=21), route, 'engineering', limits())
+    finish(progress, 21, 99, 'failed')
+    progress.admit(
+        admission(22, slot=21, generation=22, logical=22),
+        route,
+        'engineering',
+        limits(),
+    )
+    finish(progress, 22, 99, 'succeeded')
+    stopped = progress.admit(
+        admission(23, slot=21, generation=23, logical=23),
+        route,
+        'engineering',
+        limits(),
+    )
+    assert stopped['policy_reason'] == 'no_progress'
+
+
+def test_kill_switch_is_the_only_blocking_candidate_decision(tmp_path: Path) -> None:
+    ledger = new_ledger(tmp_path)
+    route = accepted_route()
+    ledger.set_kill_switch(True)
+    blocked = ledger.admit(admission(1), route, 'engineering', limits())
+    assert blocked == {
+        'decision_id': blocked['decision_id'],
+        'policy_reason': 'kill_switch_active',
+        'would_reject': True,
+        'launch_authorized': False,
+    }
+    state = ledger.status()
+    assert state['counts']['decisions'] == 1
+    assert state['counts']['active_attempts'] == 0
+    ledger.set_kill_switch(False)
+    admitted = ledger.admit(admission(2), route, 'engineering', limits())
+    assert admitted['launch_authorized'] is True
+
+
+def test_cli_instrument_duplicate_and_kill_switch_contract(tmp_path: Path) -> None:
+    repository = init_repository(tmp_path)
+    first = admission(1, slot=1, generation=1, logical=1, mode='instrument')
+    assert run_cli(repository, first).returncode == 0
+    duplicate = admission(2, slot=1, generation=1, logical=1, mode='instrument')
+    duplicate_result = run_cli(repository, duplicate)
+    duplicate_payload = json.loads(duplicate_result.stdout)
+    assert duplicate_result.returncode == 0
+    assert duplicate_payload['reason_code'] == 'instrument_recorded'
+    assert duplicate_payload['policy_reason'] == 'duplicate_active'
+    assert duplicate_payload['would_reject'] is True
+    assert duplicate_payload['launch_authorized'] is True
+
+    switched = run_cli(
+        repository,
+        {'schema_version': 1, 'command': 'kill_switch', 'active': True},
+    )
+    assert switched.returncode == 0
+    blocked = run_cli(repository, admission(3, slot=3, mode='shadow'))
+    blocked_payload = json.loads(blocked.stdout)
+    assert blocked.returncode == 0
+    assert blocked_payload['reason_code'] == 'kill_switch_active'
+    assert blocked_payload['policy_reason'] == 'kill_switch_active'
+    assert blocked_payload['would_reject'] is True
+    assert blocked_payload['launch_authorized'] is False
+
+
+def test_parent_binding_leaf_first_recovery_and_finish_idempotency(tmp_path: Path) -> None:
+    ledger = new_ledger(tmp_path)
+    route = accepted_route()
+    ledger.admit(admission(1, contract=1, slot=1), route, 'engineering', limits())
+    with pytest.raises(IdentityConflict):
+        ledger.admit(
+            admission(2, contract=2, slot=2, parent=opaque('attempt', 1)),
+            route,
+            'engineering',
+            limits(),
+        )
+    ledger.admit(
+        admission(3, contract=1, slot=3, parent=opaque('attempt', 1)),
+        route,
+        'engineering',
+        limits(),
+    )
+    with pytest.raises(RecoveryRequired):
+        finish(ledger, 1, 1)
+    assert ledger.finish(opaque('attempt', 3), 'recovered', fingerprint(3)) == (
+        'recovered',
+        False,
+    )
+    assert finish(ledger, 1, 1) == ('failed', False)
+    assert finish(ledger, 1, 1) == ('failed', True)
+    with pytest.raises(FinishConflict):
+        finish(ledger, 1, 2)
+
+
+def test_old_active_attempt_never_recovers_by_timeout(tmp_path: Path) -> None:
+    ledger = new_ledger(tmp_path)
+    ledger.admit(admission(1), accepted_route(), 'engineering', limits())
+    with sqlite3.connect(ledger.path) as connection:
+        connection.execute('UPDATE attempts SET admitted_at_ms = 0')
+    assert ledger.status()['counts']['active_attempts'] == 1
+    assert ledger.initialize() is False
+    assert ledger.status()['counts']['active_attempts'] == 1
+
+
+def test_missing_corrupt_and_unsupported_state_are_visible_non_enforcement(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / 'repository'
+    repository.mkdir()
+    subprocess.run(['git', 'init', '-q', str(repository)], check=True)
+
+    def assert_nonblocking_state(
+        result: subprocess.CompletedProcess[str], expected_reason: str
+    ) -> None:
+        assert result.returncode == 4
+        assert json.loads(result.stdout) == {
+            'schema_version': 1,
+            'policy_version': 'agent-invocation-control-v1',
+            'command': 'admit',
+            'reason_code': 'ledger_unavailable',
+            'policy_reason': expected_reason,
+            'would_reject': True,
+            'launch_authorized': True,
+        }
+
+    assert_nonblocking_state(
+        run_cli(repository, admission(1, mode='instrument')), 'state_missing'
+    )
+    assert_nonblocking_state(
+        run_cli(repository, admission(2, mode='shadow')), 'state_missing'
+    )
+
+    ledger_path = repository / '.git' / 'praxys' / 'agent-invocation-control-v1.sqlite3'
+    ledger_path.parent.mkdir()
+    ledger_path.write_bytes(b'not a sqlite ledger')
+    assert_nonblocking_state(
+        run_cli(repository, admission(3, mode='instrument')), 'state_corrupt'
+    )
+    assert_nonblocking_state(
+        run_cli(repository, admission(4, mode='shadow')), 'state_corrupt'
+    )
+
+    shutil.rmtree(ledger_path.parent)
+    initialized = run_cli(repository, {'schema_version': 1, 'command': 'init'})
+    assert initialized.returncode == 0
+    with sqlite3.connect(ledger_path) as connection:
+        connection.execute("DELETE FROM metadata WHERE key = 'policy_version'")
+    assert_nonblocking_state(
+        run_cli(repository, admission(5, mode='shadow')), 'state_corrupt'
+    )
+
+    shutil.rmtree(ledger_path.parent)
+    initialized = run_cli(repository, {'schema_version': 1, 'command': 'init'})
+    assert initialized.returncode == 0
+    with sqlite3.connect(ledger_path) as connection:
+        connection.execute('DROP TABLE attempts')
+    assert_nonblocking_state(
+        run_cli(repository, admission(6, mode='instrument')), 'state_corrupt'
+    )
+    assert_nonblocking_state(
+        run_cli(repository, admission(16, mode='shadow')), 'state_corrupt'
+    )
+    damaged_status = run_cli(
+        repository, {'schema_version': 1, 'command': 'status'}
+    )
+    assert damaged_status.returncode == 4
+    assert json.loads(damaged_status.stdout)['policy_reason'] == 'state_corrupt'
+
+    shutil.rmtree(ledger_path.parent)
+    initialized = run_cli(repository, {'schema_version': 1, 'command': 'init'})
+    assert initialized.returncode == 0
+    for number, (key, supported_value) in enumerate(
+        (
+            ('schema_version', '1'),
+            ('policy_version', 'agent-invocation-control-v1'),
+        ),
+        start=7,
+    ):
+        with sqlite3.connect(ledger_path) as connection:
+            connection.execute(
+                'UPDATE metadata SET value = ? WHERE key = ?',
+                ('unsupported-v2', key),
+            )
+        assert_nonblocking_state(
+            run_cli(repository, admission(number, mode='instrument')),
+            'state_unsupported',
+        )
+        assert_nonblocking_state(
+            run_cli(repository, admission(number + 10, mode='shadow')),
+            'state_unsupported',
+        )
+        with sqlite3.connect(ledger_path) as connection:
+            connection.execute(
+                'UPDATE metadata SET value = ? WHERE key = ?',
+                (supported_value, key),
+            )
+
+
+def test_work_contract_guard_precedes_missing_ledger_and_enforce_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / 'repository'
+    repository.mkdir()
+    subprocess.run(['git', 'init', '-q', str(repository)], check=True)
+    mismatched = admission(1)
+    mismatched['route_digest'] = 'sha256:' + ('0' * 64)
+    guarded = run_cli(repository, mismatched)
+    payload = json.loads(guarded.stdout)
+    assert guarded.returncode == 3
+    assert payload['reason_code'] == 'work_contract_mismatch'
+    assert payload['policy_reason'] == 'work_contract_invalid'
+    assert payload['launch_authorized'] is True
+
+    enforce = admission(2)
+    enforce['mode'] = 'enforce'
+    unavailable = run_cli(repository, enforce)
+    assert unavailable.returncode == 5
+    assert json.loads(unavailable.stdout) == {
+        'schema_version': 1,
+        'policy_version': 'agent-invocation-control-v1',
+        'command': 'admit',
+        'reason_code': 'enforcement_unavailable',
+        'policy_reason': None,
+        'would_reject': None,
+        'launch_authorized': None,
+    }
+
+
+def test_concurrent_process_duplicate_admissions_are_atomic(tmp_path: Path) -> None:
+    repository = init_repository(tmp_path)
+    coordination = tmp_path / 'concurrent-admission'
+    coordination.mkdir()
+    gate_path = coordination / 'release'
+    processes: list[subprocess.Popen[str]] = []
+    ready_paths: list[Path] = []
+
+    for number in range(1, 7):
+        request_path = coordination / f'request-{number}.json'
+        ready_path = coordination / f'ready-{number}'
+        request_path.write_text(
+            json.dumps(admission(number, slot=1, generation=1, logical=1)),
+            encoding='utf-8',
+        )
+        ready_paths.append(ready_path)
+        processes.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    '-c',
+                    CONCURRENT_ADMISSION_WRAPPER,
+                    str(request_path),
+                    str(ready_path),
+                    str(gate_path),
+                    str(SCRIPT),
+                ],
+                cwd=repository,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+
+    ready_deadline = time.monotonic() + 30
+    while not all(path.exists() for path in ready_paths):
+        failed = [process for process in processes if process.poll() is not None]
+        assert not failed, 'an admission wrapper exited before reaching the gate'
+        assert time.monotonic() < ready_deadline, 'admission wrappers were not ready'
+        time.sleep(0.005)
+
+    gate_path.touch()
+    results = []
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=30)
+        assert process.returncode == 0, stderr
+        results.append(json.loads(stdout))
+
+    reasons = [result['policy_reason'] for result in results]
+    assert reasons.count('admit') == 1
+    assert reasons.count('duplicate_active') == 5
+    assert all(result['launch_authorized'] is True for result in results)
+    assert all(
+        result['reason_code'] in {'shadow_would_admit', 'shadow_would_deny_policy_limit'}
+        for result in results
+    )
+
+    status = run_cli(repository, {'schema_version': 1, 'command': 'status'})
+    assert status.returncode == 0
+    durable = json.loads(status.stdout)
+    assert durable['counts']['decisions'] == 6
+    assert durable['counts']['active_attempts'] == 6
+    assert durable['decision_counts'] == {
+        'admit': 1,
+        'duplicate_active': 5,
+    }
+
+
+def test_ledger_is_wal_foreign_keyed_and_persists_no_raw_content(tmp_path: Path) -> None:
+    repository = init_repository(tmp_path)
+    valid = admission(1, mode='instrument')
+    recorded = run_cli(repository, valid)
+    assert recorded.returncode == 0
+    assert json.loads(recorded.stdout)['reason_code'] == 'instrument_recorded'
+
+    sentinels = {
+        'prompt': 'RAW_PROMPT_SENTINEL',
+        'task': 'RAW_TASK_SENTINEL',
+        'issue': 'RAW_ISSUE_SENTINEL',
+        'user': 'RAW_USER_SENTINEL',
+        'code': 'RAW_CODE_SENTINEL',
+        'credential': 'RAW_CREDENTIAL_SENTINEL',
+        'artifact': 'RAW_ARTIFACT_SENTINEL',
+    }
+    invalid = dict(admission(2))
+    invalid.update(sentinels)
+    rejected = run_cli(repository, invalid)
+    assert rejected.returncode == 2
+    assert json.loads(rejected.stdout)['reason_code'] == 'invalid_request'
+
+    ledger_path = repository / '.git' / 'praxys' / 'agent-invocation-control-v1.sqlite3'
+    with sqlite3.connect(ledger_path) as connection:
+        assert connection.execute('PRAGMA journal_mode').fetchone()[0] == 'wal'
+        connection.execute('PRAGMA foreign_keys=ON')
+        assert connection.execute('PRAGMA foreign_keys').fetchone()[0] == 1
+        columns = {
+            row[1]
+            for table in (
+                'contracts', 'slots', 'generations', 'logical_invocations',
+                'decisions', 'attempts',
+            )
+            for row in connection.execute(f'PRAGMA table_info({table})')
+        }
+        assert not columns & set(sentinels)
+        connection.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+    persisted = b''.join(
+        path.read_bytes()
+        for path in ledger_path.parent.iterdir()
+        if path.is_file()
+    )
+    for sentinel in sentinels.values():
+        assert sentinel.encode() not in persisted
+
+
+def test_exact_work_contract_and_autonomy_composition_are_unchanged() -> None:
+    route = accepted_route()
+    assert route.classification_digest == CLASSIFICATION_DIGEST
+    assert route.route_digest == ROUTE_DIGEST
+    assert route.routing_version == 'praxys-task-routing-v1'
+    assert route.operating_model_version == 'praxys-agentic-operating-model-v1'
+    assert route.primary_loop == 'meta-eval'
+    assert route.nested_loops == ['delivery']
+    assert route.lead_role == 'meta-eval'
+    assert route.contributor_roles == ['architecture']
+    assert route.executor_roles == ['engineering']
+    assert route.verifier_roles == ['quality']
+    assert route.required_artifacts == [
+        'evaluation-report',
+        'implementation-impact-map',
+        'implementation-change',
+        'verification-evidence',
+        'policy-change-proposal',
+        'architecture-decision-record',
+    ]
+    assert route.decision_review_required is True
+    assert route.decision_review_agent == '.github/agents/decision-review-router.agent.md'
+
+    policy = json.loads(
+        (ROOT / 'config' / 'agent-loop-policies.json').read_text(encoding='utf-8')
+    )
+    autonomy = policy['decision_autonomy']
+    assert autonomy['status'] == 'specification-only'
+    assert autonomy['default_judgment_route'] == 'human-review-required'
+    assert autonomy['agent_reviewed_classes'] == []
+    assert autonomy['promoted_judgment_classes'] == []
+    assert autonomy['independence']['executor_may_verify_own_high_risk_work'] is False
+
+
+def test_policy_parity_and_cooperative_manifest_boundaries() -> None:
+    policy = json.loads(
+        (ROOT / 'config' / 'agent-invocation-control.json').read_text(encoding='utf-8')
+    )
+    assert policy == {
+        'schema_version': 1,
+        'policy_version': 'agent-invocation-control-v1',
+        'status': 'instrument-shadow-only',
+        'default_mode': 'instrument',
+        'approved_modes': ['instrument', 'shadow'],
+        'enforcement_approved': False,
+        'ledger_schema_version': 1,
+        'limits': {
+            'maximum_ancestry_depth': 6,
+            'maximum_active_per_contract': 8,
+            'maximum_logical_per_contract': 32,
+            'maximum_attempts_per_logical': 3,
+            'maximum_retries_per_failure_fingerprint': 1,
+            'no_progress_identical_terminals': 2,
+        },
+    }
+    parity = json.loads(
+        (ROOT / 'config' / 'copilot-execution-parity.json').read_text(encoding='utf-8')
+    )
+    assert 'cooperative-invocation-mediation' in {
+        limitation['id'] for limitation in parity['limitations']
+    }
+    for relative in (
+        '.github/agents/praxys-orchestrator.agent.md',
+        '.github/agents/praxys-change-loop.agent.md',
+    ):
+        manifest = (ROOT / relative).read_text(encoding='utf-8')
+        assert 'scripts/agent_invocation_control.py' in manifest
+        assert 'native' in manifest.lower()
+        assert 'instrument' in manifest.lower()
+        assert 'shadow' in manifest.lower()


### PR DESCRIPTION
## Summary

- add repository-mediated agent invocation instrumentation and shadow decisions
- persist privacy-minimized lifecycle state in a local Git-common-dir SQLite ledger
- record the accepted Meta/Eval, proposed Architecture, independent Quality, decision-review, and human-approval trail
- keep enforcement, native interception, autonomy promotion, bound tuning, operating-model changes, and final ADR approval unavailable or deferred

## Validation

- `.venv/bin/python -m pytest -q tests/test_agentic_invocation_control.py` — 15 passed
- `.venv/bin/python -m pytest -q tests/test_agentic_invocation_control.py tests/test_agent_policy.py tests/test_agentic_task_routing.py tests/test_agentic_operating_model.py tests/test_decision_agents.py tests/test_copilot_execution_parity.py tests/test_agent_preflight.py` — 57 passed under independent Quality verification
- `.venv/bin/python scripts/check_copilot_environment_parity.py` — static parity passed
- exact Work Contract recomputation matched classification digest `sha256:3d80f3eca01b1bff2207d6e28cefe8daa3cdfc9f3480c80b99bd3f252dde35a2` and route digest `sha256:dfe65e8c108c06411ad84d7e7d8ec32d8206429780243973a31e840fb7c11f51`
- independent verification: `docs/dev/verification-evidence-2026-08-20-agent-invocation-control.md`
- `python scripts/agent_preflight.py --base origin/main` — passed on a clean linked worktree using the repository virtualenv (`TZ=UTC` and the virtualenv site-packages exported because bare `python` was unavailable); 2579 passed, 1 skipped, clean worktree
- Preflight head: 3d5d2dbbe22c43ff96be08b2be203044c241aa9d

No rendered UI changed. `plugins/praxys` is absent from the PR diff; its pre-existing dirty local checkout was not changed or staged.