### PR TITLE
Stabilize time-sensitive CI test fixtures

### DIFF
--- a/tests/test_goal_baseline_api.py
+++ b/tests/test_goal_baseline_api.py
@@ -102,6 +102,17 @@ def _headers(user_id: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {_token(user_id)}"}
 
 
+def _athlete_today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+SCHEDULED_TEST_DATE = _athlete_today() + timedelta(days=1)
+SCHEDULED_TEST_DATE_STR = SCHEDULED_TEST_DATE.isoformat()
+NEXT_SCHEDULED_TEST_DATE_STR = (
+    SCHEDULED_TEST_DATE + timedelta(days=1)
+).isoformat()
+
+
 def _seed_goal_user(
     db_session,
     user_id: str = "goal-baseline-owner",
@@ -460,14 +471,14 @@ def test_optional_test_schedule_creates_canonical_workout_and_revision(goal_api)
         },
         json={
             "action": "schedule",
-            "scheduled_date": "2026-08-20",
+            "scheduled_date": SCHEDULED_TEST_DATE_STR,
         },
     )
     assert scheduled.status_code == 201, scheduled.text
     payload = scheduled.json()
     assert payload["baseline"]["status"] == "pending_test"
     assert payload["test"]["state"] == "scheduled"
-    assert payload["test"]["scheduled_workout"]["date"] == "2026-08-20"
+    assert payload["test"]["scheduled_workout"]["date"] == SCHEDULED_TEST_DATE_STR
 
     from db.models import PlanRevision, TrainingPlan
 
@@ -492,7 +503,7 @@ def test_optional_test_schedule_creates_canonical_workout_and_revision(goal_api)
         },
         json={
             "action": "schedule",
-            "scheduled_date": "2026-08-20",
+            "scheduled_date": SCHEDULED_TEST_DATE_STR,
         },
     )
     assert replayed.status_code == 200, replayed.text
@@ -539,7 +550,7 @@ def test_completion_requires_explicit_protocol_checks_and_never_auto_qualifies(
     _add_activity(
         db_session,
         activity_id="test-attempt",
-        observed_date=date(2026, 8, 20),
+        observed_date=SCHEDULED_TEST_DATE,
         distance_km=5.03,
         duration_sec=1_230,
     )
@@ -559,7 +570,7 @@ def test_completion_requires_explicit_protocol_checks_and_never_auto_qualifies(
             **_headers("goal-baseline-owner"),
             "Idempotency-Key": "goal-test-schedule-complete",
         },
-        json={"action": "schedule", "scheduled_date": "2026-08-20"},
+        json={"action": "schedule", "scheduled_date": SCHEDULED_TEST_DATE_STR},
     )
     assert scheduled.status_code == 201, scheduled.text
 
@@ -597,7 +608,7 @@ def test_schedule_stop_cleans_up_the_scheduled_workout(goal_api) -> None:
     assert client.post(
         "/api/goal/baseline/test",
         headers={**_headers("goal-baseline-owner"), "Idempotency-Key": "goal-test-schedule-cleanup"},
-        json={"action": "schedule", "scheduled_date": "2026-08-20"},
+        json={"action": "schedule", "scheduled_date": SCHEDULED_TEST_DATE_STR},
     ).status_code == 201
     stopped = client.post(
         "/api/goal/baseline/test",
@@ -630,7 +641,7 @@ def test_current_history_retires_pending_optional_test(goal_api) -> None:
     assert client.post(
         "/api/goal/baseline/test",
         headers={**_headers("goal-baseline-owner"), "Idempotency-Key": "goal-test-schedule-retire"},
-        json={"action": "schedule", "scheduled_date": "2026-08-20"},
+        json={"action": "schedule", "scheduled_date": SCHEDULED_TEST_DATE_STR},
     ).status_code == 201
 
     confirmed = client.post(
@@ -684,7 +695,7 @@ def test_shared_history_retires_tests_for_every_plan_purpose(goal_api) -> None:
             **_headers(user_id),
             "Idempotency-Key": "shared-history-current-schedule",
         },
-        json={"action": "schedule", "scheduled_date": "2026-08-20"},
+        json={"action": "schedule", "scheduled_date": SCHEDULED_TEST_DATE_STR},
     ).status_code == 201
     assert client.post(
         "/api/goal/baseline/test",
@@ -702,7 +713,7 @@ def test_shared_history_retires_tests_for_every_plan_purpose(goal_api) -> None:
         },
         json={
             "action": "schedule",
-            "scheduled_date": "2026-08-21",
+            "scheduled_date": NEXT_SCHEDULED_TEST_DATE_STR,
             "purpose": independent_purpose,
         },
     )
@@ -841,7 +852,7 @@ def test_goal_change_retires_pending_baseline_tests(goal_api) -> None:
     assert client.post(
         "/api/goal/baseline/test",
         headers={**_headers("goal-baseline-owner"), "Idempotency-Key": "goal-test-schedule-goal-change"},
-        json={"action": "schedule", "scheduled_date": "2026-08-20"},
+        json={"action": "schedule", "scheduled_date": SCHEDULED_TEST_DATE_STR},
     ).status_code == 201
 
     updated = client.put(
@@ -956,7 +967,7 @@ def test_goal_change_preserves_independent_baseline_test_lineage(goal_api) -> No
         },
         json={
             "action": "schedule",
-            "scheduled_date": "2026-08-20",
+            "scheduled_date": SCHEDULED_TEST_DATE_STR,
             "purpose": purpose,
         },
     )
@@ -1580,14 +1591,14 @@ def test_completed_test_requires_a_candidate_from_the_scheduled_window(goal_api)
     _add_activity(
         db_session,
         activity_id="old-run",
-        observed_date=date(2026, 8, 1),
+        observed_date=SCHEDULED_TEST_DATE - timedelta(days=1),
         distance_km=5.0,
         duration_sec=1300,
     )
     _add_activity(
         db_session,
         activity_id="later-run",
-        observed_date=date(2026, 8, 21),
+        observed_date=SCHEDULED_TEST_DATE + timedelta(days=1),
         distance_km=5.0,
         duration_sec=1_290,
     )
@@ -1599,7 +1610,7 @@ def test_completed_test_requires_a_candidate_from_the_scheduled_window(goal_api)
     assert client.post(
         "/api/goal/baseline/test",
         headers={**_headers("goal-baseline-owner"), "Idempotency-Key": "goal-test-schedule-window"},
-        json={"action": "schedule", "scheduled_date": "2026-08-20"},
+        json={"action": "schedule", "scheduled_date": SCHEDULED_TEST_DATE_STR},
     ).status_code == 201
 
     completed = client.post(

--- a/tests/test_run_praxys_mcp.py
+++ b/tests/test_run_praxys_mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import subprocess
 import sys
@@ -342,7 +343,13 @@ def test_cloud_mcp_launcher_resolves_workspace_from_symlink(
     root = run_praxys_mcp.project_root()
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    (bin_dir / "python").symlink_to(sys.executable)
+    python_launcher = bin_dir / "python"
+    python_launcher.write_text(
+        "#!/usr/bin/env bash\n"
+        f"exec {shlex.quote(sys.executable)} \"$@\"\n",
+        encoding="utf-8",
+    )
+    python_launcher.chmod(0o755)
     installed_launcher = bin_dir / "praxys-local-mcp"
     installed_launcher.symlink_to(
         root / "scripts" / "run_praxys_mcp_cloud.sh",


### PR DESCRIPTION
## Summary

- Derive goal-baseline scheduled test dates from the current UTC athlete date so the API suite does not expire as wall-clock time advances.
- Preserve each test's original scheduling, activity-window, replay, cleanup, and independent-purpose semantics.
- Invoke the active Python interpreter through a temporary wrapper in the cloud-launcher symlink test, so virtualenv dependencies remain available while the launcher path itself is still exercised through a symlink.
- Test-only change; production behavior is unchanged.
- Unblocks the backend checks on #738.

## Validation

- `python -m pytest tests/test_goal_baseline_api.py tests/test_run_praxys_mcp.py::test_cloud_mcp_launcher_resolves_workspace_from_symlink -q` — 28 passed.
- Submodule-dependent regression tests — 16 passed.
- Full backend suite — 2579 passed, 1 skipped.
- `python scripts/agent_preflight.py --base origin/main` — passed with a clean worktree.
