### PR TITLE
Harden China cutover preparation controls

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -117,6 +117,11 @@ az webapp create \
   --resource-group rg-trainsight \
   --plan plan-trainsight \
   --runtime "PYTHON:3.12"
+
+az webapp update \
+  --name trainsight-app \
+  --resource-group rg-trainsight \
+  --https-only true
 ```
 
 ### 4. Enable Managed Identity
@@ -169,7 +174,12 @@ az webapp create \
   --plan plan-trainsight \
   --runtime "PYTHON:3.12"
 
-# Startup command + Always On + HTTP/2 + Oryx build during deploy
+# HTTPS-only + startup command + Always On + HTTP/2 + Oryx build during deploy
+az webapp update \
+  --name praxys-frontend \
+  --resource-group rg-trainsight \
+  --https-only true
+
 az webapp config set \
   --name praxys-frontend --resource-group rg-trainsight \
   --startup-file "uvicorn frontend_server.main:app --host 0.0.0.0 --port 8000" \
@@ -197,14 +207,17 @@ commit:
   disables browser-side Application Insights and Statsig until a separate
   regional privacy decision accepts those processors.
 
-EdgeOne Production Auto Deploy remains off until the regional release gates
-pass. The EdgeOne GitHub App receives read-only access only to this repository;
-GitHub Actions stores no EdgeOne deployment token. Cloudflare changes DNS and
-edge delivery only; it does not replace the Azure App Service deployment.
-Project bootstrap, Git access, managed TLS, full-zone DNS migration, origin
-certificate sequencing, CORS, verification, and rollback are documented in
-[`docs/ops/tencent-frontend.md`](./ops/tencent-frontend.md). The API remains
-singular at `https://api.praxys.run` and stays DNS-only in Cloudflare.
+The current EdgeOne Makers project does not expose a reliable Auto Deploy or
+Preview toggle, so release safety does not depend on one. Every accepted
+deployment must trace to protected `main`, required CI, an exact source SHA and
+manifest, and a recorded EdgeOne deployment-history entry. The EdgeOne GitHub
+App receives read-only access only to this repository; GitHub Actions stores no
+EdgeOne deployment token. Cloudflare changes DNS and edge delivery only; it
+does not replace the Azure App Service deployment. Project bootstrap, Git
+access, managed TLS, full-zone DNS migration, CORS, verification, and rollback
+are documented in [`docs/ops/tencent-frontend.md`](./ops/tencent-frontend.md).
+The API remains singular at `https://api.praxys.run` and stays DNS-only in
+Cloudflare.
 
 ### 9. Custom domains + managed certs
 

--- a/docs/ops/config-and-secrets.md
+++ b/docs/ops/config-and-secrets.md
@@ -90,7 +90,8 @@ platform-managed HTTPS. EdgeOne receives read-only access only to this
 repository and uses no build secrets. The filing-free `.run` build will remain
 on Azure behind Cloudflare Free, while `api.praxys.run` stays DNS-only. Azure
 App Service CORS must then include exactly `https://praxys.cn` and
-`https://www.praxys.cn`. Repository access, Auto Deploy, the Cloudflare
+`https://www.praxys.cn` only for an accepted authenticated `.cn` release.
+Repository access, the protected-main deployment boundary, the Cloudflare
 origin-certificate sequence, DNS migration, and rollback commands live in
 `docs/ops/tencent-frontend.md`.
 

--- a/docs/ops/deploy.md
+++ b/docs/ops/deploy.md
@@ -103,8 +103,10 @@ for evidence:
   uploaded by GitHub.
 
 EdgeOne separately checks out protected `main` and runs the same
-`web/edgeone.json` install/build/output configuration. Production Auto Deploy
-stays off until the regional release gates pass. After public cutover,
+`web/edgeone.json` install/build/output configuration. The release boundary
+does not depend on an Auto Deploy switch: protected `main`, required CI, exact
+source/manifest evidence, and the EdgeOne deployment-history entry authorize
+the selected deployment. After public cutover,
 `EDGEONE_CN_PUBLIC_VERIFY_ENABLED` makes GitHub compare both hosts' source SHA
 and served manifest with its independent build evidence. Cloudflare requires no
 application deployment; it proxies the Azure response and honors its cache
@@ -156,13 +158,13 @@ a known-good revision:
 > Config-only revert (a bad App Service setting): fix the GitHub secret/variable
 > and re-deploy — don't hand-edit the portal (it's overwritten next deploy).
 
-EdgeOne rollback is independent: turn Production Auto Deploy off, select a
-known-good deployment whose source SHA and manifest evidence are retained, then
-revert the bad change through protected `main` so source and production
-converge. Re-enable Auto Deploy only after the known-good public SHA, routes,
-and manifest checks pass. Cloudflare proxy rollback must restore a publicly
-trusted Azure certificate before gray-clouding a hostname that uses Cloudflare
-Origin CA. See [tencent-frontend.md](./tencent-frontend.md).
+EdgeOne rollback is independent: select the recorded known-good deployment
+whose source SHA and manifest evidence are retained, then revert the bad change
+through protected `main` so source and production converge. Confirm the
+known-good public SHA, routes, and manifest before resuming merges. Cloudflare
+proxy rollback must restore a publicly trusted Azure certificate before
+gray-clouding a hostname that uses Cloudflare Origin CA. See
+[tencent-frontend.md](./tencent-frontend.md).
 
 ## Related
 
@@ -171,4 +173,4 @@ Origin CA. See [tencent-frontend.md](./tencent-frontend.md).
 - `docs/deployment.md` (one-time Azure setup) · `.github/workflows/`
 
 ---
-_Last reviewed: 2026-08-20 · Owner: @dddtc2005_
+_Last reviewed: 2026-08-22 · Owner: @dddtc2005_

--- a/docs/ops/environment.md
+++ b/docs/ops/environment.md
@@ -17,6 +17,7 @@
 | Resource group | `rg-trainsight` | `.github/workflows/deploy-backend.yml` |
 | Backend App Service | `trainsight-app` | `deploy-backend.yml` (`--name trainsight-app`) |
 | Frontend App Service | `praxys-frontend` | `deploy-frontend-appservice.yml` |
+| App Service transport target | Pending preparation: both sites currently report `httpsOnly=false`; the approved target is `httpsOnly=true`, with HTTP redirecting to HTTPS | [deploy.md](./deploy.md), [tencent-frontend.md](./tencent-frontend.md) |
 | App Service plan | `plan-trainsight` (Linux B1, East Asia) | `docs/deployment.md`, `frontend_server` notes |
 | PostgreSQL (**primary DB**, live 2026-07-04) | `praxys-pg` Flexible Server (Burstable B1ms, PG16, DB `praxys`, Entra auth, PITR 14d) | [postgres-migration.md](./postgres-migration.md); `PRAXYS_PG_SERVER` var |
 | Labs isolated compute (opt-in) | Service Bus namespace tagged `praxysComponent=labs-analysis`, queue `labs-environment-response`; Container Apps environment `cae-praxys-jobs`, job `praxys-labs-environment-worker`, UAMI `id-praxys-labs-worker` | `infra/labs-worker.bicep`; [labs-analysis-worker.md](./labs-analysis-worker.md) |
@@ -36,9 +37,12 @@
 | Planned international frontend edge | Cloudflare Free authoritative zone for `praxys.run`, proxying only apex and `www` to Azure with `Full (strict)` | [tencent-frontend.md](./tencent-frontend.md) |
 | Preserved API boundary | `api.praxys.run` remains DNS-only and resolves to `trainsight-app.azurewebsites.net` | [tencent-frontend.md](./tencent-frontend.md) |
 
-None of these target-state rows becomes current until the runbook's Release
-Evidence exists. Today the frontend remains the Azure App Service named above,
-and EdgeOne Production Auto Deploy is not enabled.
+The EdgeOne Git project and its first candidate deployment exist, but neither
+public `.cn` hostname is bound or resolving. The project UI does not expose a
+reliable Auto Deploy/Preview toggle, so the deployment boundary is protected
+`main`, required CI, exact source/manifest evidence, and a recorded deployment
+history entry. None of the public target-state rows becomes current until the
+runbook's Release Evidence exists.
 
 ## Hostnames
 
@@ -100,4 +104,4 @@ and EdgeOne Production Auto Deploy is not enabled.
 - `docs/deployment.md` (one-time Azure setup) · `docs/perf-baselines/azure-provisioning.md`
 
 ---
-_Last reviewed: 2026-08-20 · Owner: @dddtc2005_
+_Last reviewed: 2026-08-22 · Owner: @dddtc2005_

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -455,6 +455,12 @@ gates; they are not provisioned, enabled, or billed until the accepted
 Operations Decision Record authorizes that step. Costs are the eastasia retail
 rate per the [cost model](#alert-cost-model) below.
 
+Regional availability states are exact:
+
+- **planned** — neither the web test nor its alert exists;
+- **provisioned-disabled** — both resources exist and both are disabled;
+- **live** — both resources exist and both are enabled.
+
 | Rule | Type | Scope | Watches | Eval | Sev | ~USD/mo |
 |---|---|---|---|---|---|---|
 | `praxys-db-health-unhealthy` | log | `appi-praxys-backend` | `praxys.db_health` failure (corrupt/unreachable DB) | 5 min | 1 | **1.50** |
@@ -833,6 +839,189 @@ test**:
    for outside-in traffic. A planned row becomes live in this inventory in the
    same reviewed operations change.
 
+The CLI equivalent below creates an exact test/alert pair in the disabled
+state. Run it once per planned hostname, then enable only a hostname that is
+already public and accepted:
+
+```bash
+set -euo pipefail
+
+RG=rg-trainsight
+SUB="$(az account show --query id -o tsv)"
+AI_ID="$(az resource show -g "$RG" -n appi-trainsight \
+  --resource-type Microsoft.Insights/components --query id -o tsv)"
+AG_ID="$(az monitor action-group show -g "$RG" \
+  -n praxys-feedback-ag --query id -o tsv)"
+
+provision_availability_pair() {
+  name="$1"
+  url="$2"
+  alert_id="/subscriptions/${SUB}/resourceGroups/${RG}/providers/Microsoft.Insights/metricAlerts/${name}"
+
+  if az resource show -g "$RG" -n "$name" \
+      --resource-type Microsoft.Insights/webtests \
+      --api-version 2022-06-15 --output none 2>/dev/null ||
+    az monitor metrics alert show -g "$RG" -n "$name" \
+      --output none 2>/dev/null; then
+    echo "Refusing to overwrite an existing partial or complete pair: ${name}" >&2
+    return 1
+  fi
+
+  az monitor app-insights web-test create \
+    --resource-group "$RG" \
+    --name "$name" \
+    --location eastasia \
+    --web-test-kind standard \
+    --defined-web-test-name "$name" \
+    --synthetic-monitor-id "$name" \
+    --description "Praxys outside-in availability: ${url}" \
+    --enabled false \
+    --frequency 900 \
+    --timeout 30 \
+    --retry-enabled true \
+    --locations Id=us-ca-sjc-azr \
+    --locations Id=apac-hk-hkn-azr \
+    --request-url "$url" \
+    --http-verb GET \
+    --parse-requests false \
+    --follow-redirects false \
+    --expected-status-code 200 \
+    --ignore-status-code false \
+    --ssl-check true \
+    --tags "hidden-link:${AI_ID}=Resource" \
+    --output none
+
+  web_test_id="$(az resource show -g "$RG" -n "$name" \
+    --resource-type Microsoft.Insights/webtests \
+    --api-version 2022-06-15 --query id -o tsv)"
+
+  body="$(jq -n \
+    --arg name "$name" \
+    --arg ai "$AI_ID" \
+    --arg web "$web_test_id" \
+    --arg ag "$AG_ID" \
+    --arg ai_tag "hidden-link:${AI_ID}" \
+    --arg web_tag "hidden-link:${web_test_id}" '
+    {
+      location: "global",
+      tags: {
+        ($ai_tag): "Resource",
+        ($web_tag): "Resource"
+      },
+      properties: {
+        description: ("Availability alert for " + $name),
+        severity: 1,
+        enabled: false,
+        scopes: [$web, $ai],
+        evaluationFrequency: "PT1M",
+        windowSize: "PT5M",
+        criteria: {
+          "odata.type":
+            "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
+          webTestId: $web,
+          componentId: $ai,
+          failedLocationCount: 1
+        },
+        actions: [{actionGroupId: $ag}]
+      }
+    }')"
+
+  if ! az rest --method put \
+      --url "https://management.azure.com${alert_id}?api-version=2018-03-01" \
+      --body "$body" \
+      --output none; then
+    az resource delete --ids "$web_test_id" || true
+    return 1
+  fi
+
+  test "$(az resource show --ids "$web_test_id" \
+    --api-version 2022-06-15 \
+    --query properties.Enabled -o tsv)" = "false"
+  test "$(az monitor metrics alert show -g "$RG" -n "$name" \
+    --query enabled -o tsv)" = "false"
+}
+
+provision_availability_pair wt-praxys-run-apex https://praxys.run/
+provision_availability_pair wt-praxys-cn-apex https://praxys.cn/
+provision_availability_pair wt-praxys-cn-www https://www.praxys.cn/
+```
+
+Enable or disable a pair transactionally. A failed enable compensates back to
+both resources disabled, and every transition is read back:
+
+```bash
+disable_availability_pair() {
+  name="$1"
+  rc=0
+  web_test_id="$(az resource show -g rg-trainsight -n "$name" \
+    --resource-type Microsoft.Insights/webtests \
+    --api-version 2022-06-15 --query id -o tsv)"
+
+  az resource update --ids "$web_test_id" \
+    --api-version 2022-06-15 \
+    --set properties.Enabled=false || rc=1
+  az monitor metrics alert update -g rg-trainsight \
+    -n "$name" --enabled false || rc=1
+
+  test "$(az resource show --ids "$web_test_id" \
+    --api-version 2022-06-15 \
+    --query properties.Enabled -o tsv)" = "false" || rc=1
+  test "$(az monitor metrics alert show -g rg-trainsight -n "$name" \
+    --query enabled -o tsv)" = "false" || rc=1
+
+  return "$rc"
+}
+
+enable_availability_pair() {
+  name="$1"
+  web_test_id="$(az resource show -g rg-trainsight -n "$name" \
+    --resource-type Microsoft.Insights/webtests \
+    --api-version 2022-06-15 --query id -o tsv)"
+
+  if ! az monitor metrics alert update -g rg-trainsight \
+      -n "$name" --enabled true; then
+    disable_availability_pair "$name" || true
+    return 1
+  fi
+
+  if ! az resource update --ids "$web_test_id" \
+      --api-version 2022-06-15 \
+      --set properties.Enabled=true; then
+    disable_availability_pair "$name" || true
+    return 1
+  fi
+
+  if ! test_enabled="$(az resource show --ids "$web_test_id" \
+      --api-version 2022-06-15 \
+      --query properties.Enabled -o tsv)" ||
+    ! alert_enabled="$(az monitor metrics alert show -g rg-trainsight \
+      -n "$name" --query enabled -o tsv)"; then
+    disable_availability_pair "$name" || true
+    return 1
+  fi
+
+  if test "$test_enabled" != "true" ||
+    test "$alert_enabled" != "true"; then
+    disable_availability_pair "$name" || true
+    return 1
+  fi
+}
+
+enable_availability_pair wt-praxys-run-apex
+```
+
+After the approved preparation executes successfully, update both inventory
+tables in the same reviewed follow-up so they state:
+
+| Web test | Required recorded state |
+|---|---|
+| `wt-praxys-run-apex` | `live` |
+| `wt-praxys-cn-apex` | `provisioned-disabled` |
+| `wt-praxys-cn-www` | `provisioned-disabled` |
+
+Until that Azure receipt exists, the source-of-truth inventory remains
+`planned`.
+
 For an aborted cutover, disable the same-named metric alert and web test in the
 same maintenance window, then verify neither continues evaluating. Delete both
 only if the hostname is permanently retired; otherwise keep them disabled for
@@ -892,4 +1081,4 @@ quiescence, so a stale workflow variable snapshot is not the final authority.
 - In-app: Admin → User Feedback (badge + Approve/Retry/Reject).
 
 ---
-_Last reviewed: 2026-07-29 · Owner: @dddtc2005 · Alert inventory + cost model current as of this review._
+_Last reviewed: 2026-08-22 · Owner: @dddtc2005 · Alert inventory + cost model current as of this review._

--- a/docs/ops/tencent-frontend.md
+++ b/docs/ops/tencent-frontend.md
@@ -35,8 +35,9 @@ The `.cn` SPA calls `https://api.praxys.run`, so authenticated account and
 training data can cross the mainland border to Azure. Public production
 acceptance requires a reviewed privacy/legal basis, accurate user disclosure,
 and Trust approval for that cross-border path. Until that evidence and the
-EdgeOne filing/access confirmation exist, keep EdgeOne `Auto Deploy` off, do
-not bind the public `.cn` domains, and do not cut over DNS.
+EdgeOne filing/access confirmation exist, do not bind the public `.cn` domains
+or cut over DNS. A Git-triggered EdgeOne build does not itself create a public
+data path.
 
 The stamped China artifact disables browser-side Azure Application Insights and
 Statsig initialization, including their identity payloads. Re-enabling either
@@ -49,12 +50,16 @@ Production acceptance also requires:
 - outside-in probes and action-group alerts for `.run` apex/`www` and both
   `.cn` hosts, provisioned from the canonical inventory in
   [monitoring-and-alerts.md](./monitoring-and-alerts.md#external-availability);
-- an owned Origin CA expiry check and rotation threshold;
+- Azure App Service `httpsOnly=true` for both frontend and API sites;
 - aggregated Release Evidence retained outside short-lived job logs.
 
-This repository change prepares reversible artifacts only. It does not create
-the EdgeOne project, move nameservers, change DNS, issue certificates, alter
-CORS, or enable production traffic.
+Cloudflare Origin CA is optional `.run` origin hardening, not a `.cn` cutover
+gate while the Azure origin keeps a publicly trusted certificate. If it is
+adopted later, record its expiry and rotation threshold before binding it.
+
+The EdgeOne Git project and first candidate deployment now exist. Preparation
+may harden Azure HTTPS and provision monitoring, but it does not bind public
+`.cn` domains, change DNS, add `.cn` CORS, or enable production traffic.
 
 ## Prerequisites
 
@@ -110,10 +115,12 @@ Create a new Git-integrated project from the outset:
 3. Set the project root to `web`. The checked-in `web/edgeone.json` pins:
    `npm ci --legacy-peer-deps`, `npm run build:edgeone`, output `./dist`, and
    Node `24.11.0`.
-4. Keep Production **Auto Deploy off** and Preview disabled. Do not add build
-   secrets or EdgeOne preview origins to API CORS.
-5. After the release gates are accepted, run one console deployment from the
-   reviewed `main` SHA and inspect it before enabling Auto Deploy.
+4. Record the project's actual Git trigger and preview/default-URL behavior;
+   current Makers projects may not expose Auto Deploy or Preview switches. Do
+   not add build secrets or EdgeOne preview origins to API CORS.
+5. Before release, inspect the deployment-history entry for the reviewed
+   `main` SHA and record the project ID, deployment ID, source SHA, manifest,
+   and known-good rollback deployment.
 6. Add `praxys.cn` and `www.praxys.cn` only after that deployment is accepted.
    Use the exact ownership/CNAME records shown by EdgeOne and wait for
    EdgeOne-managed HTTPS to become active.
@@ -128,22 +135,26 @@ Official references:
 ### 3. Protect the Git deployment boundary
 
 - Require pull-request review and required CI checks on `main`; disable force
-  pushes and branch deletion. Once Auto Deploy is enabled, merging to `main`
-  authorizes an EdgeOne production deployment.
+  pushes and branch deletion. A merge to protected `main` may trigger EdgeOne,
+  but it is accepted for release only when deployment history, source SHA, and
+  manifest evidence all match.
+- Do not use the ruleset admin bypass for a regional release.
 - Keep the EdgeOne GitHub App repository grant read-only and limited to this
   repository. Revoke the grant to stop source access.
 - Configure no EdgeOne build secrets. The regional build hard-codes only the
   public API URL and deliberately clears browser telemetry keys.
-- Keep Preview disabled by default. If it is later enabled, require access
-  control and `noindex`, and never add preview domains to production CORS.
+- Treat preview/default URLs as non-production: require access control and
+  `noindex`, never add them to production CORS, and never accept them as public
+  release evidence.
 - The only GitHub Actions control is
   `EDGEONE_CN_PUBLIC_VERIFY_ENABLED`; leave it false until both public `.cn`
   names resolve to the accepted project.
 
 ### 4. Allow only the two `.cn` browser origins
 
-Azure App Service owns production API CORS. Add exact HTTPS origins before
-public `.cn` traffic:
+Azure App Service owns production API CORS. Add exact HTTPS origins only after
+Trust accepts a full authenticated `.cn` release. A public-only `.cn` site must
+keep both origins absent.
 
 ```bash
 az webapp cors add \
@@ -173,9 +184,10 @@ After the human release gates are accepted, inspect:
 - the EdgeOne project/deployment record and preview;
 - ICP footer isolation, SPA routes, security headers, and the source SHA.
 
-Keep Auto Deploy and `EDGEONE_CN_PUBLIC_VERIFY_ENABLED` off during this
-inspection. If the source SHA and behavior are accepted, enable Auto Deploy for
-Production `main`; branch protection becomes the ongoing deployment gate.
+Keep `EDGEONE_CN_PUBLIC_VERIFY_ENABLED=false` during this inspection. Accept
+only a deployment-history entry whose source SHA and manifest match the
+independent GitHub evidence; protected `main` and required CI remain the
+ongoing deployment gate.
 
 ### 6. Cut over `praxys.cn` inside Tencent
 
@@ -188,10 +200,12 @@ EdgeOne. Wait for:
 - the expected `praxys-cn` deployment selected as production;
 - the ICP footer and source SHA visible through the custom names.
 
-Then set:
+After both hosts are public and accepted, set:
 
 ```bash
-gh variable set EDGEONE_CN_PUBLIC_VERIFY_ENABLED --body true
+gh variable set EDGEONE_CN_PUBLIC_VERIFY_ENABLED \
+  --repo praxys-run/praxys \
+  --body true
 ```
 
 The next frontend deployment verifies both hosts, the deployed SHA, ICP footer,
@@ -405,12 +419,12 @@ alone expire after 90 days.
 
 ### EdgeOne deployment
 
-Turn Production Auto Deploy off while investigating. Use the EdgeOne
-deployment-history rollback only when the prior deployment's source SHA and
-manifest evidence are known, then revert the bad change on protected `main` so
-source and production converge. Verify the known-good SHA before re-enabling
-Auto Deploy. Until public cutover, leave custom domains on their prior records.
-If source access must stop, revoke the EdgeOne GitHub App repository grant.
+Use EdgeOne deployment-history rollback only when the prior deployment's source
+SHA and manifest evidence are known. Select that known-good deployment
+immediately, then revert the bad change through protected `main` so source and
+production converge. Verify the known-good SHA before resuming merges. Until
+public cutover, leave custom domains on their prior records. If source access
+must stop, revoke the EdgeOne GitHub App repository grant.
 
 ### Cloudflare proxy
 
@@ -444,4 +458,4 @@ is required.
 - `web/scripts/stamp-china-compliance.mjs`
 
 ---
-_Last reviewed: 2026-08-20 · Owner: @dddtc2005_
+_Last reviewed: 2026-08-22 · Owner: @dddtc2005_

--- a/tests/test_regional_frontend_config.py
+++ b/tests/test_regional_frontend_config.py
@@ -155,7 +155,10 @@ def test_runbook_preserves_provider_and_data_boundaries() -> None:
     assert "Cloudflare Origin CA" in normalized
     assert "App Service managed certificate" in normalized
     assert "Full (strict)" in normalized
-    assert "EdgeOne `Auto Deploy` off" in normalized
+    assert "does not itself create a public data path" in normalized
+    assert "may not expose Auto Deploy or Preview switches" in normalized
+    assert "deployment-history entry" in normalized
+    assert "Do not use the ruleset admin bypass" in normalized
     assert "cross-border" in normalized
     assert (
         "Do not enable a geographic redirect during the initial cutover"
@@ -181,3 +184,35 @@ def test_operations_docs_match_edgeone_git_and_monitoring_boundaries() -> None:
     assert "wt-praxys-cn-www" in monitoring
     assert "praxys-feedback-ag" in monitoring
     assert "A planned row becomes live" in monitoring
+    assert (
+        "| `wt-praxys-run-apex` | planned | `appi-trainsight` | "
+        "`https://praxys.run/` |"
+    ) in monitoring
+    assert (
+        "| `wt-praxys-cn-apex` | planned | `appi-trainsight` | "
+        "`https://praxys.cn/` |"
+    ) in monitoring
+    assert (
+        "| `wt-praxys-cn-www` | planned | `appi-trainsight` | "
+        "`https://www.praxys.cn/` |"
+    ) in monitoring
+    assert "provisioned-disabled" in monitoring
+    assert "WebtestLocationAvailabilityCriteria" in monitoring
+    assert "--enabled false" in monitoring
+    assert "enabled: false" in monitoring
+    assert "enable_availability_pair wt-praxys-run-apex" in monitoring
+    assert "if ! az monitor metrics alert update" in monitoring
+    assert 'if ! az resource update --ids "$web_test_id"' in monitoring
+    assert "--set properties.Enabled=true; then" in monitoring
+    assert '--set properties.Enabled=false || rc=1' in monitoring
+    assert '-n "$name" --enabled false || rc=1' in monitoring
+    assert 'disable_availability_pair "$name" || true' in monitoring
+    assert 'if ! test_enabled="$(az resource show' in monitoring
+    assert '! alert_enabled="$(az monitor metrics alert show' in monitoring
+    assert "--query properties.Enabled -o tsv" in monitoring
+    assert "--query enabled -o tsv" in monitoring
+    assert "does not depend on an Auto Deploy switch" in deploy_runbook
+    environment = (ROOT / "docs/ops/environment.md").read_text(encoding="utf-8")
+    assert "Pending preparation" in environment
+    assert "currently report `httpsOnly=false`" in environment
+    assert "approved target is `httpsOnly=true`" in environment


### PR DESCRIPTION
## Summary

- replace unavailable EdgeOne Auto Deploy/Preview toggle assumptions with protected-main, required-CI, exact-SHA, manifest, and deployment-history controls
- document the pending Azure HTTPS-only hardening and keep `.cn` domains, DNS, CORS, probes, and public verification inactive
- add transactional Azure availability-test and alert commands with compensation, state readback, and explicit inventory transitions

## Validation

- `/home/feitao/src/tf-personal-pensieve/praxys/.venv/bin/python -m pytest tests/test_regional_frontend_config.py -q`
- extracted regional monitoring Bash blocks: `bash -n`
- `git diff --check`