### PR TITLE
Fix Lingui multiline PO serialization

### DIFF
--- a/scripts/translate_missing.py
+++ b/scripts/translate_missing.py
@@ -360,26 +360,36 @@ def _quote(s: str) -> str:
     return f'"{escaped}"'
 
 
-def _emit_po_string(key: str, value: str) -> list[str]:
+def _emit_po_string(
+    key: str,
+    value: str,
+    *,
+    header: bool = False,
+) -> list[str]:
     """Render a key/value as one or more .po output lines.
 
-    If `value` contains embedded newlines (the PO header is the only common
-    case in Lingui-generated catalogs), write the canonical multi-line
-    continuation form Lingui emits:
+    Lingui keeps the first segment of an ordinary multiline message on the
+    ``msgid`` / ``msgstr`` line and emits later segments as continuations. The
+    empty PO header is the only special case that starts with ``key ""``:
 
-        msgstr ""
-        "line 1\\n"
+        msgstr "line 1\\n"
         "line 2\\n"
 
-    Single-line with `\\n` escapes is valid PO and parses identically, but
-    Lingui rewrites it on every extract — producing pure diff noise. Keep
-    round-trips boringly stable.
+    Both forms parse identically, but using the header form for ordinary
+    messages makes every Lingui extraction rewrite the catalog.
     """
     if "\n" not in value:
         return [f"{key} {_quote(value)}"]
     parts = value.split("\n")
-    out = [f'{key} ""']
-    for i, seg in enumerate(parts):
+    if header:
+        out = [f'{key} ""']
+        start = 0
+    else:
+        first_segment = _quote(parts[0] + "\n")
+        out = [f"{key} {first_segment}"]
+        start = 1
+    for i in range(start, len(parts)):
+        seg = parts[i]
         if i < len(parts) - 1:
             out.append(_quote(seg + "\n"))
         elif seg != "":
@@ -399,7 +409,13 @@ def write_po(path: Path, entries: list[dict], tail: list[str] | None = None) -> 
     for e in entries:
         out.extend(e["prefix_lines"])
         out.extend(_emit_po_string("msgid", e["msgid"]))
-        out.extend(_emit_po_string("msgstr", e["msgstr"]))
+        out.extend(
+            _emit_po_string(
+                "msgstr",
+                e["msgstr"],
+                header=e["msgid"] == "",
+            )
+        )
     if tail:
         out.extend(tail)
     path.write_text("\n".join(out) + "\n", encoding="utf-8")

--- a/tests/test_translate_missing.py
+++ b/tests/test_translate_missing.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 import translate_missing as tm  # noqa: E402
 from translate_missing import (  # noqa: E402
+    _emit_po_string,
     _extract_context,
     _group_by_screen,
     _group_by_semantic_cluster,
@@ -28,7 +29,54 @@ from translate_missing import (  # noqa: E402
     main as translate_cli_main,
     review_translations,
     translate_batch,
+    write_po,
 )
+
+
+class TestPOEmission:
+    def test_header_uses_empty_first_line(self):
+        assert _emit_po_string(
+            "msgstr",
+            "Language: zh\nPlural-Forms: \n",
+            header=True,
+        ) == [
+            'msgstr ""',
+            '"Language: zh\\n"',
+            '"Plural-Forms: \\n"',
+        ]
+
+    def test_ordinary_multiline_keeps_first_segment_on_key_line(self):
+        assert _emit_po_string("msgid", "Subject\n\nBody") == [
+            'msgid "Subject\\n"',
+            '"\\n"',
+            '"Body"',
+        ]
+        assert _emit_po_string("msgstr", "主题\n\n正文") == [
+            'msgstr "主题\\n"',
+            '"\\n"',
+            '"正文"',
+        ]
+        assert _emit_po_string("msgstr", "第一行\n") == [
+            'msgstr "第一行\\n"',
+        ]
+
+    def test_multiline_round_trip_is_byte_stable(self, tmp_path):
+        catalog = tmp_path / "messages.po"
+        canonical = (
+            '#: src/Page.tsx:1\n'
+            'msgid "Subject {name}\\n"\n'
+            '"\\n"\n'
+            '"Body"\n'
+            'msgstr "主题 {name}\\n"\n'
+            '"\\n"\n'
+            '"正文"\n'
+        )
+        catalog.write_text(canonical, encoding="utf-8")
+
+        entries, tail = tm.parse_po(catalog)
+        write_po(catalog, entries, tail)
+
+        assert catalog.read_text(encoding="utf-8") == canonical
 
 
 class TestICUVariableNames:


### PR DESCRIPTION
## Summary

- emit ordinary multiline msgid/msgstr values in Lingui canonical form
- keep the empty first line only for the PO header, identified explicitly by empty msgid
- add header, trailing-newline, ordinary multiline, and byte-stable round-trip coverage

Supersedes #758, whose diff is serialization-only and would be reverted by Lingui extraction.

## Validation

- 74 focused i18n tests passed
- 2163 active Chinese entries passed deterministic quality checks
- full origin/main zh catalog parse/write round-trip is byte-identical
- isolated real Lingui extract leaves the canonical zh catalog unchanged
- Python compile and git diff --check passed

## UI quality

- Impeccable: audit scripts/translate_missing.py
- Visual review: desktop and mobile not applicable - serializer-only change with zero parsed msgid/msgstr changes
- Primary journey: parse canonical PO -> write canonical PO -> Lingui extract produces no diff
- Reviewer handoff: none - byte comparison, focused tests, and isolated Lingui extraction are the review evidence
- States checked: PO header, ordinary multiline source/target, blank middle line, trailing newline, full catalog
- Accessibility: no user-visible content or interaction changed
- Design system impact: none - existing localization system covers this serializer fix
- Miniapp parity: not applicable - no catalog value changed
- Exceptions: rendered verification omitted because parsed translations are identical