### PR TITLE
Fix China launch SPA root validation

### DIFF
--- a/.github/workflows/launch-cn.yml
+++ b/.github/workflows/launch-cn.yml
@@ -356,7 +356,7 @@ jobs:
             deep_html="${RUNNER_TEMP}/${host}.login.html"
             curl -fsS --max-time 12 "https://${host}/login" \
               > "${deep_html}"
-            grep -F '<div id="root"></div>' "${deep_html}"
+            grep -F '<div id="root">' "${deep_html}"
             asset_path="$(grep -oE \
               '/assets/[A-Za-z0-9._-]+\.js' "${html}" | head -n 1)"
             test -n "${asset_path}"

--- a/tests/test_regional_frontend_config.py
+++ b/tests/test_regional_frontend_config.py
@@ -114,6 +114,8 @@ def test_launch_exact_cors_preconditions_verification_and_compensation() -> None
     assert "${stale_headers}" in workflow
     assert ".china_processing.disabled == true" in workflow
     assert "https://${host}/login" in workflow
+    assert "grep -F '<div id=\"root\">'" in workflow
+    assert "grep -F '<div id=\"root\"></div>'" not in workflow
     assert "https://${host}${asset_path}" in workflow
     assert "content-type" in workflow
     assert "CORS and Azure AI were unchanged" in workflow


### PR DESCRIPTION
## Outcome

Allow the China launch precondition to recognize the production SPA root container when it contains the generated SEO fallback.

The first `launch-cn enable` attempt failed before any mutation because it required the obsolete empty-root serialization `<div id="root"></div>`. The deployed EdgeOne artifact correctly renders `<div id="root">` with the generated fallback inside it.

This keeps all other preconditions unchanged: DNS/TLS, security headers, regional marker, ICP footer, JavaScript asset, health/legal/API tuple, component SHA ancestry, Worker/API match, registration, CORS, Miniapp, and Azure AI.

## Verification

- `python3 -m pytest tests/test_regional_frontend_config.py -q` — 17 passed
- `actionlint .github/workflows/launch-cn.yml` — passed
- `git diff --check` — passed
- Live read-only reproduction: both `https://praxys.cn/login` and `https://www.praxys.cn/login` contain the exact `<div id="root">` opening tag
- Failed enable run `33463493142` stopped in `Verify enable preconditions`; the mutation and compensation steps were skipped; China processing remains disabled and CORS remains base-only

No deployment, DNS, CORS, environment, or processing setting is changed by this PR.
