### PR TITLE
Fix China launch CORS preflight validation

### DIFF
--- a/scripts/verify_cors_response.sh
+++ b/scripts/verify_cors_response.sh
@@ -58,7 +58,17 @@ shift
 allowed_methods="$(
   header_values access-control-allow-methods | paste -sd, -
 )"
-token_present "${allowed_methods}" "${expected_method}"
+if [[ -n "${allowed_methods}" ]]; then
+  token_present "${allowed_methods}" "${expected_method}"
+else
+  # Fetch treats GET, HEAD, and POST as CORS-safelisted methods. A server may
+  # therefore omit Access-Control-Allow-Methods for those methods, even when
+  # non-safelisted request headers still make a preflight necessary.
+  case "${expected_method^^}" in
+    GET|HEAD|POST) ;;
+    *) exit 1 ;;
+  esac
+fi
 
 allowed_headers="$(
   header_values access-control-allow-headers | paste -sd, -

--- a/tests/test_regional_frontend_config.py
+++ b/tests/test_regional_frontend_config.py
@@ -423,6 +423,26 @@ def test_cors_response_verifier_uses_exact_values_and_tokens(tmp_path) -> None:
     actual_command = command[:4]
     assert subprocess.run(actual_command, check=False).returncode == 0
 
+    # Fetch permits Access-Control-Allow-Methods to be omitted for a
+    # CORS-safelisted method, even when request headers trigger a preflight.
+    without_methods = valid.replace(
+        "Access-Control-Allow-Methods: OPTIONS, GET\r\n", ""
+    ).replace("Access-Control-Allow-Methods: POST\r\n", "")
+    headers.write_text(without_methods, encoding="utf-8")
+    assert subprocess.run(command, check=False).returncode == 0
+
+    non_safelisted_command = command.copy()
+    non_safelisted_command[4] = "PUT"
+    assert subprocess.run(non_safelisted_command, check=False).returncode != 0
+
+    wrong_method = without_methods.replace(
+        "Access-Control-Allow-Origin: https://praxys.cn\r\n",
+        "Access-Control-Allow-Origin: https://praxys.cn\r\n"
+        "Access-Control-Allow-Methods: PUT\r\n",
+    )
+    headers.write_text(wrong_method, encoding="utf-8")
+    assert subprocess.run(command, check=False).returncode != 0
+
     for invalid in (
         valid.replace(
             "https://praxys.cn\r\n",


### PR DESCRIPTION
## Outcome

Fixes the false-negative China launch gate observed in run `33466118739`. Azure App Service returns a valid preflight for requested `GET` with exact `Access-Control-Allow-Origin` and requested `Access-Control-Allow-Headers`, but may omit `Access-Control-Allow-Methods` because `GET` is CORS-safelisted.

The verifier now:

- keeps exact single-origin and requested-header checks;
- accepts an absent methods header only for `GET`, `HEAD`, or `POST`;
- still requires any present methods header to contain the requested method;
- still rejects an absent methods header for non-safelisted methods.

## Verification

- `pytest -q tests/test_regional_frontend_config.py` — 17 passed
- `bash -n scripts/verify_cors_response.sh`
- `shellcheck scripts/verify_cors_response.sh`
- `git diff --check`
- live read-only reproduction against both `.cn` origins returned HTTP 200, exact origin and all requested headers, with no methods header

## Operations

No runtime setting, CORS entry, API behavior, privacy policy, or product behavior changes. China processing remains disabled; a successful merge is required before the separately human-protected enable workflow is retried.

Work Contract route: `sha256:794199dcf279a94a9219dd3ef1ecb6c88c432d08519a6f8bff74a6fb4d1522bf`

Classification: `sha256:d8c97c353de824ea51dfda251310ded00f8e2b4f4f5650e72cf56e6565780351`