### PR TITLE
Record praxys.cn launch evidence

### DIFF
--- a/docs/ops/cn-personal-information-impact-assessment.md
+++ b/docs/ops/cn-personal-information-impact-assessment.md
@@ -271,4 +271,4 @@ runbook and require readback before recovery is claimed.
 - `web/src/components/ChinaProcessingNoticeGate.tsx`
 
 ---
-_Scope updated and exact assessment accepted: 2026-08-31 · Owner: human operator / Trust · Live release verification: pending_
+_Scope updated and exact assessment accepted: 2026-08-31 · Owner: human operator / Trust · Live release verification completed: 2026-09-01_

--- a/docs/ops/cn-web-private-alpha.md
+++ b/docs/ops/cn-web-private-alpha.md
@@ -6,8 +6,8 @@
 > launch.
 
 **Status:** The operator accepted PIPIA `1.2-public-parity` and its overall
-**Medium** residual risk on 2026-08-31. Production enablement remains human-only
-and blocked until the implementation and live controls below are verified.
+**Medium** residual risk on 2026-08-31. Production processing was enabled on
+2026-09-01 after the implementation and live controls below were verified.
 
 ## Boundary
 
@@ -127,6 +127,38 @@ enable never disables an already healthy launch. GitHub logs and the run
 summary are the workflow evidence; no custom evidence JSON or artifact is
 produced.
 
+## 2026-09-01 release evidence
+
+- Conservative first-public-access bound: no later than
+  `2026-09-01T02:09:25Z` (`2026-09-01 10:09:25 CST`), when the first
+  successful status run was dispatched; its live host probes completed by
+  `2026-09-01T02:09:59Z`. Use the earlier bound for the public-security filing
+  window and submit no later than `2026-10-01 10:09:25 CST`.
+- Production processing configuration changed at
+  `2026-09-01T04:02:41Z` (`2026-09-01 12:02:41 CST`). Protected-main enable
+  run [33468253138](https://github.com/praxys-run/praxys/actions/runs/33468253138)
+  succeeded at `da7103ab2094aa036c4608b7ddbd00093c0fce70`; its compensation
+  step was skipped.
+- Post-enable status runs
+  [33468660037](https://github.com/praxys-run/praxys/actions/runs/33468660037)
+  and
+  [33468665442](https://github.com/praxys-run/praxys/actions/runs/33468665442)
+  succeeded. API
+  readiness reported China, Miniapp, and background AI processing enabled.
+  Azure CORS was the exact five-origin set.
+- Both EdgeOne hosts served `praxys-frontend-cn` at
+  `da7103ab2094aa036c4608b7ddbd00093c0fce70` with the accepted legal/API
+  tuple, TLS, HSTS, ICP footer, and security headers. Both origins passed
+  OPTIONS, unauthenticated `401`, and stale-policy
+  `428 CLIENT_PRIVACY_UPDATE_REQUIRED` checks.
+- `wt-praxys-cn-apex` and `wt-praxys-cn-www`, their Sev 1 alerts, and the
+  `praxys-feedback-ag` action group were enabled. Initial East Asia and West US
+  samples were successful. The launch readback contained 8/8 successful apex
+  samples from each region, plus 9/9 East Asia and 8/8 West US `www` samples.
+- Accepted residual risk remains Medium. Browser Statsig remains absent under
+  #754, PITR deletion reconciliation remains tracked by #755, and geographic
+  redirect remains a post-stability operation.
+
 ## Backend deployment
 
 Ordinary backend deployment has its own queue so emergency disable cannot be
@@ -164,4 +196,4 @@ query URL, or icon until the platform issues the exact artifacts.
 - [cn-public-security-filing.md](./cn-public-security-filing.md)
 
 ---
-_Last reviewed: 2026-08-31 · Owner: Operations_
+_Last reviewed: 2026-09-01 · Owner: Operations_

--- a/docs/ops/monitoring-and-alerts.md
+++ b/docs/ops/monitoring-and-alerts.md
@@ -483,8 +483,8 @@ Regional availability states are exact:
 | `praxys-pg-connections-high` | metric | `praxys-pg` | `active_connections` avg > 40 | 5 min | 2 | ~0.10 |
 | `wt-praxys-homepage` | metric (web test) | `appi-trainsight` + homepage test | `https://www.praxys.run/` reachable | 1 min | 1 | ~0.10 |
 | `wt-praxys-run-apex` | metric (web test) | `appi-trainsight` + regional frontend test | `https://praxys.run/` reachable | 1 min | 1 | ~0.10 |
-| `wt-praxys-cn-apex` **provisioned-disabled** | metric (web test) | `appi-trainsight` + regional frontend test | `https://praxys.cn/` reachable | 1 min | 1 | 0 while disabled |
-| `wt-praxys-cn-www` **provisioned-disabled** | metric (web test) | `appi-trainsight` + regional frontend test | `https://www.praxys.cn/` reachable | 1 min | 1 | 0 while disabled |
+| `wt-praxys-cn-apex` | metric (web test) | `appi-trainsight` + regional frontend test | `https://praxys.cn/` reachable | 1 min | 1 | ~0.10 |
+| `wt-praxys-cn-www` | metric (web test) | `appi-trainsight` + regional frontend test | `https://www.praxys.cn/` reachable | 1 min | 1 | ~0.10 |
 | `wt-praxys-api-health` | metric (web test) | `appi-praxys-backend` + API test | `.../api/health` reachable | 1 min | 1 | ~0.10 |
 | `praxys-feedback-needs-review` | log | `appi-praxys-backend` | `praxys.feedback` `status == needs_review` | 15 min | 3 | 0.50 |
 | `praxys-today-latency-regression` | log | `appi-praxys-backend` | `GET /api/today` avg latency > 3000 ms | 1 h | 3 | 0.50 |
@@ -495,9 +495,9 @@ Regional availability states are exact:
 | `praxys-labs-queue-backlog` | metric | dedicated Labs Service Bus namespace / `labs-environment-response` | `ActiveMessages` average > 2 over 30 min | 5 min | 2 | ~0.10 |
 | `praxys-labs-dead-lettered` | metric | dedicated Labs Service Bus namespace / `labs-environment-response` | `DeadletteredMessages` maximum > 0 over 5 min | 5 min | 2 | ~0.10 |
 
-**Current total ≈ 4.6–5.1 USD/mo.** The live `.run` apex pair adds at most
-~0.10 USD/mo before the metric-alert free allotment. Enabling both disabled
-`.cn` pairs later adds at most another ~0.20 USD/mo.
+**Current total ≈ 4.8–5.3 USD/mo.** The live `.run` apex pair adds at most
+~0.10 USD/mo before the metric-alert free allotment. The two live `.cn` pairs
+add at most another ~0.20 USD/mo.
 
 ### Labs analysis worker alerts (deployment-owned)
 
@@ -828,14 +828,14 @@ inside-the-process db-health / readiness probes.
 |---|---|---|---|
 | `wt-praxys-homepage` | live | `appi-trainsight` | `https://www.praxys.run/` |
 | `wt-praxys-run-apex` | live | `appi-trainsight` | `https://praxys.run/` |
-| `wt-praxys-cn-apex` | provisioned-disabled | `appi-trainsight` | `https://praxys.cn/` |
-| `wt-praxys-cn-www` | provisioned-disabled | `appi-trainsight` | `https://www.praxys.cn/` |
+| `wt-praxys-cn-apex` | live | `appi-trainsight` | `https://praxys.cn/` |
+| `wt-praxys-cn-www` | live | `appi-trainsight` | `https://www.praxys.cn/` |
 | `wt-praxys-api-health` | live | `appi-praxys-backend` | `https://trainsight-app.azurewebsites.net/api/health` |
 
-Standard web-test execution is **0.00** in eastasia (free grant); three
-frontend/API availability alerts are live and both `.cn` pairs are
-provisioned-disabled. **Keep each web test and its alert in the same enabled
-state** — a probe that runs while its alert is disabled pays to watch nothing
+Standard web-test execution is **0.00** in eastasia (free grant); all five
+frontend/API availability alerts are live. **Keep each web test and its alert
+in the same enabled state** — a probe that runs while its alert is disabled
+pays to watch nothing
 (found and fixed 2026-07-05). Re-point locations via the availability test's
 *Locations* in the portal or `az resource update`.
 
@@ -1032,16 +1032,18 @@ enable_availability_pair() {
 enable_availability_pair wt-praxys-run-apex
 ```
 
-The 2026-08-22 preparation receipt records:
+The 2026-08-22 preparation receipt and 2026-09-01 launch readback record:
 
-| Web test | Recorded state |
-|---|---|
-| `wt-praxys-run-apex` | `live` |
-| `wt-praxys-cn-apex` | `provisioned-disabled` |
-| `wt-praxys-cn-www` | `provisioned-disabled` |
+| Web test | Recorded state | Last transition verified |
+|---|---|---|
+| `wt-praxys-run-apex` | `live` | 2026-08-22 |
+| `wt-praxys-cn-apex` | `live` | 2026-09-01 |
+| `wt-praxys-cn-www` | `live` | 2026-09-01 |
 
 The first `.run` apex samples succeeded from both
 `apac-hk-hkn-azr` and `us-ca-sjc-azr` at `2026-08-22T03:25:02Z`.
+The first enabled `.cn` samples were read back on 2026-09-01; both host pairs
+reported only successful East Asia and West US results.
 
 For an aborted cutover, disable the same-named metric alert and web test in the
 same maintenance window, then verify neither continues evaluating. Delete both


### PR DESCRIPTION
## Outcome

Records the completed `praxys.cn` production launch and aligns the operations inventory with live Azure state.

- records the conservative first-public-access bound and public-security filing deadline;
- binds the successful enable and post-enable status runs to their exact SHA;
- records API/CORS/EdgeOne/privacy-boundary verification;
- changes both `.cn` availability test/alert pairs from `provisioned-disabled` to `live`;
- marks PIPIA live release verification complete.

No runtime, DNS, EdgeOne, CORS, secret, alert, or application behavior is changed by this PR.

## Verification

- `pytest -q tests/test_regional_frontend_config.py` — 17 passed
- `git diff --check`
- Azure readback: both `.cn` web tests and both Sev 1 alerts enabled, action group enabled, East Asia and West US samples successful
- GitHub readback: enable run `33468253138` and post-enable status runs `33468660037` / `33468665442` successful

Work Contract route: `sha256:794199dcf279a94a9219dd3ef1ecb6c88c432d08519a6f8bff74a6fb4d1522bf`

Classification: `sha256:d8c97c353de824ea51dfda251310ded00f8e2b4f4f5650e72cf56e6565780351`