### PR TITLE
Prepare inactive non-ultra Trail planning core

### DIFF
--- a/analysis/non_ultra_trail_contract.py
+++ b/analysis/non_ultra_trail_contract.py
@@ -11,24 +11,24 @@ from typing import Any
 from analysis.science_artifacts import load_policy_contract
 
 
-NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID = "sdr-trail-running-goal-ontology-v1"
+NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID = "sdr-trail-running-goal-ontology-v2"
 NON_ULTRA_TRAIL_SCIENCE_DECISION_ID = (
-    "sdr-non-ultra-trail-plan-generation-policy-v1"
+    "sdr-non-ultra-trail-plan-generation-policy-v2"
 )
 NON_ULTRA_TRAIL_GENERATOR_VERSION = (
-    "non-ultra-trail-deterministic-generator-v1"
+    "non-ultra-trail-deterministic-generator-v2"
 )
 NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST = (
-    "sha256:cb53936289927d0f5f73268b5b6468e17a5b771532e2eaeee5c5c8781e541774"
+    "sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1"
 )
 NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST = (
-    "sha256:5bf6b47ede65af84af85fb364d148bffa38c1ea330272a3e71553d091a8695dc"
+    "sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c"
 )
 NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST = (
-    "sha256:afc9fecefd55c699a8fdf3d3ab885968c7f7981fadbcba7bf09494fdfcdcd606"
+    "sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe"
 )
 NON_ULTRA_TRAIL_CONTRACT_DIGEST = (
-    "sha256:472c895bc4c3d467eac4a59dbacaeaaf665ddee462fdc76bba4cdf772df8e42b"
+    "sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9"
 )
 
 
@@ -48,6 +48,7 @@ def _assert_exact_contract(
     decision_id: str,
     source_decision_digest: str,
     contract_digest: str,
+    model_version: str,
 ) -> None:
     if contract.decision_id != decision_id:
         raise ValueError(f"{decision_id} contract decision ID mismatch")
@@ -59,6 +60,8 @@ def _assert_exact_contract(
         raise ValueError(f"{decision_id} source decision digest mismatch")
     if contract.contract_digest != contract_digest:
         raise ValueError(f"{decision_id} contract digest mismatch")
+    if contract.model_version != model_version:
+        raise ValueError(f"{decision_id} model version mismatch")
 
 
 _assert_exact_contract(
@@ -66,12 +69,14 @@ _assert_exact_contract(
     decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
     source_decision_digest=NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
     contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+    model_version="trail-course-demand-v2",
 )
 _assert_exact_contract(
     contract=NON_ULTRA_TRAIL_CONTRACT,
     decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
     source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
     contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+    model_version="non-ultra-trail-plan-generation-policy-v2",
 )
 
 NON_ULTRA_TRAIL_POLICY_VERSION = NON_ULTRA_TRAIL_CONTRACT.model_version
@@ -116,6 +121,9 @@ NON_ULTRA_TRAIL_TYPED_OUTCOMES = NON_ULTRA_TRAIL_PARAMETER_VALUES[
 NON_ULTRA_TRAIL_HARD_BOUNDARIES = NON_ULTRA_TRAIL_PARAMETER_VALUES[
     "trail_policy_hard_boundaries"
 ]
+NON_ULTRA_TRAIL_MODULE_STRUCTURE = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_modular_structure"
+]
 
 NON_ULTRA_TRAIL_COURSE_SCHEMA = NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
     "trail_course_demand_schema"
@@ -123,12 +131,37 @@ NON_ULTRA_TRAIL_COURSE_SCHEMA = NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
 NON_ULTRA_TRAIL_PROVENANCE_POLICY = (
     NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES["trail_field_provenance"]
 )
+NON_ULTRA_TRAIL_GRADE_DISTRIBUTION = (
+    NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES["trail_grade_distribution"]
+)
+NON_ULTRA_TRAIL_FOOTING_AND_HAZARDS = (
+    NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
+        "trail_footing_and_hazard_contract"
+    ]
+)
+NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA = (
+    NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
+        "trail_training_constraints_schema"
+    ]
+)
+NON_ULTRA_TRAIL_OPTIONAL_CONTEXT = (
+    NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
+        "trail_optional_context_shapes"
+    ]
+)
 NON_ULTRA_TRAIL_UNKNOWN_POLICY = NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
     "trail_unknown_and_materiality_policy"
 ]
+NON_ULTRA_TRAIL_REVISION_POLICY = (
+    NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
+        "trail_revision_and_confirmation"
+    ]
+)
 
-NON_ULTRA_TRAIL_CAPABILITY_ID = "non_ultra_trail_performance_v1"
-NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID = "non_ultra_trail_constraints_v1"
+NON_ULTRA_TRAIL_CAPABILITY_ID = "non_ultra_trail_performance_v2"
+NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID = str(
+    NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA["schema_id"]
+)
 NON_ULTRA_TRAIL_COURSE_SCHEMA_ID = str(
     NON_ULTRA_TRAIL_COURSE_SCHEMA["schema_id"]
 )
@@ -143,6 +176,11 @@ if (
     != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID
 ):
     raise ValueError("non-ultra Trail course schema dependency mismatch")
+if (
+    NON_ULTRA_TRAIL_SCOPE["requires_constraint_schema"]
+    != NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID
+):
+    raise ValueError("non-ultra Trail constraint schema dependency mismatch")
 
 NON_ULTRA_TRAIL_PROPOSAL_DAYS = int(
     NON_ULTRA_TRAIL_EXECUTION["committed_proposal_days"]
@@ -153,21 +191,57 @@ NON_ULTRA_TRAIL_REASSESSMENT_DAYS = int(
 NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS = int(
     NON_ULTRA_TRAIL_HISTORY["recent_history_lookback_completed_weeks"]
 )
-NON_ULTRA_TRAIL_SUCCESS_CODE = str(
-    NON_ULTRA_TRAIL_TYPED_OUTCOMES["candidate_success"]
+NON_ULTRA_TRAIL_STATUS_PRECEDENCE = tuple(
+    str(value)
+    for value in NON_ULTRA_TRAIL_TYPED_OUTCOMES["status_precedence"]
 )
-NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES = frozenset(
-    str(code) for code in NON_ULTRA_TRAIL_TYPED_OUTCOMES["no_plan"]
+NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG = {
+    str(status): tuple(str(reason) for reason in reasons)
+    for status, reasons in NON_ULTRA_TRAIL_TYPED_OUTCOMES[
+        "detail_reason_catalog"
+    ].items()
+}
+NON_ULTRA_TRAIL_REASON_PAIRS = frozenset(
+    (status, reason)
+    for status, reasons in NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG.items()
+    for reason in reasons
 )
-NON_ULTRA_TRAIL_LIMITED_MODULE_CODES = frozenset(
-    str(code) for code in NON_ULTRA_TRAIL_TYPED_OUTCOMES["limited_modules"]
+NON_ULTRA_TRAIL_MODULE_KEYS = tuple(
+    str(value)
+    for value in NON_ULTRA_TRAIL_TYPED_OUTCOMES["module_availability"][
+        "required_keys_in_fixed_order"
+    ]
 )
-NON_ULTRA_TRAIL_RESULT_CODES = frozenset(
-    {NON_ULTRA_TRAIL_SUCCESS_CODE, *NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES}
+NON_ULTRA_TRAIL_MODULE_STATES = frozenset(
+    str(value)
+    for value in NON_ULTRA_TRAIL_TYPED_OUTCOMES["module_availability"][
+        "allowed_states"
+    ]
 )
+NON_ULTRA_TRAIL_LIMITED_MODULE_ORDER = tuple(
+    str(value)
+    for value in NON_ULTRA_TRAIL_TYPED_OUTCOMES["limited_modules"][
+        "allowed_sorted_order"
+    ]
+)
+NON_ULTRA_TRAIL_RESULT_CODES = frozenset(NON_ULTRA_TRAIL_STATUS_PRECEDENCE)
 NON_ULTRA_TRAIL_ALLOWED_PROVENANCE = frozenset(
-    str(value) for value in NON_ULTRA_TRAIL_PROVENANCE_POLICY["allowed"]
+    str(value)
+    for value in NON_ULTRA_TRAIL_PROVENANCE_POLICY[
+        "server_stamped_provenance_allowed"
+    ]
 )
+
+if len(NON_ULTRA_TRAIL_REASON_PAIRS) != 21:
+    raise ValueError("non-ultra Trail v2 must expose exactly 21 closed reasons")
+if NON_ULTRA_TRAIL_STATUS_PRECEDENCE[-1] != "eligible_proposal":
+    raise ValueError("non-ultra Trail eligible status precedence mismatch")
+if NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG["eligible_proposal"]:
+    raise ValueError("eligible Trail proposals cannot carry a detail reason")
+if set(NON_ULTRA_TRAIL_MODULE_KEYS) != set(
+    NON_ULTRA_TRAIL_LIMITED_MODULE_ORDER
+):
+    raise ValueError("non-ultra Trail module projections disagree")
 
 
 @dataclass(frozen=True)

--- a/analysis/non_ultra_trail_contract.py
+++ b/analysis/non_ultra_trail_contract.py
@@ -1,0 +1,220 @@
+"""Accepted machine-contract helpers for inactive non-ultra Trail planning.
+
+The contracts loaded here are intentionally inactive.  Importing this module
+does not register a capability, expose an API, or authorize runtime use.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from analysis.science_artifacts import load_policy_contract
+
+
+NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID = "sdr-trail-running-goal-ontology-v1"
+NON_ULTRA_TRAIL_SCIENCE_DECISION_ID = (
+    "sdr-non-ultra-trail-plan-generation-policy-v1"
+)
+NON_ULTRA_TRAIL_GENERATOR_VERSION = (
+    "non-ultra-trail-deterministic-generator-v1"
+)
+NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST = (
+    "sha256:cb53936289927d0f5f73268b5b6468e17a5b771532e2eaeee5c5c8781e541774"
+)
+NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST = (
+    "sha256:5bf6b47ede65af84af85fb364d148bffa38c1ea330272a3e71553d091a8695dc"
+)
+NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST = (
+    "sha256:afc9fecefd55c699a8fdf3d3ab885968c7f7981fadbcba7bf09494fdfcdcd606"
+)
+NON_ULTRA_TRAIL_CONTRACT_DIGEST = (
+    "sha256:472c895bc4c3d467eac4a59dbacaeaaf665ddee462fdc76bba4cdf772df8e42b"
+)
+
+
+NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT = load_policy_contract(
+    NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+    require_active=False,
+)
+NON_ULTRA_TRAIL_CONTRACT = load_policy_contract(
+    NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+    require_active=False,
+)
+
+
+def _assert_exact_contract(
+    *,
+    contract: Any,
+    decision_id: str,
+    source_decision_digest: str,
+    contract_digest: str,
+) -> None:
+    if contract.decision_id != decision_id:
+        raise ValueError(f"{decision_id} contract decision ID mismatch")
+    if str(contract.decision_status) not in {"accepted", "RecordStatus.ACCEPTED"}:
+        raise ValueError(f"{decision_id} is not accepted")
+    if str(contract.runtime_state) not in {"inactive", "ArtifactRuntimeState.INACTIVE"}:
+        raise ValueError(f"{decision_id} must remain inactive")
+    if contract.source_decision_digest != source_decision_digest:
+        raise ValueError(f"{decision_id} source decision digest mismatch")
+    if contract.contract_digest != contract_digest:
+        raise ValueError(f"{decision_id} contract digest mismatch")
+
+
+_assert_exact_contract(
+    contract=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT,
+    decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+    source_decision_digest=NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+    contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+)
+_assert_exact_contract(
+    contract=NON_ULTRA_TRAIL_CONTRACT,
+    decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+    source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+    contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+)
+
+NON_ULTRA_TRAIL_POLICY_VERSION = NON_ULTRA_TRAIL_CONTRACT.model_version
+NON_ULTRA_TRAIL_ONTOLOGY_VERSION = (
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.model_version
+)
+NON_ULTRA_TRAIL_PARAMETER_VALUES = NON_ULTRA_TRAIL_CONTRACT.parameter_values
+NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES = (
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.parameter_values
+)
+
+NON_ULTRA_TRAIL_SCOPE = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_scope_and_dependencies"
+]
+NON_ULTRA_TRAIL_REQUIRED_INPUTS = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_required_inputs"
+]
+NON_ULTRA_TRAIL_EXECUTION = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_execution_and_reassessment"
+]
+NON_ULTRA_TRAIL_HISTORY = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_history_guardrails"
+]
+NON_ULTRA_TRAIL_SCHEDULE = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_schedule_construction"
+]
+NON_ULTRA_TRAIL_TEMPLATES = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_workout_templates"
+]
+NON_ULTRA_TRAIL_INTENSITY = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_intensity_and_spacing"
+]
+NON_ULTRA_TRAIL_EXPOSURE_CAPS = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_course_exposure_caps"
+]
+NON_ULTRA_TRAIL_EVENTS = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_event_and_taper"
+]
+NON_ULTRA_TRAIL_TYPED_OUTCOMES = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_typed_outcomes"
+]
+NON_ULTRA_TRAIL_HARD_BOUNDARIES = NON_ULTRA_TRAIL_PARAMETER_VALUES[
+    "trail_policy_hard_boundaries"
+]
+
+NON_ULTRA_TRAIL_COURSE_SCHEMA = NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
+    "trail_course_demand_schema"
+]
+NON_ULTRA_TRAIL_PROVENANCE_POLICY = (
+    NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES["trail_field_provenance"]
+)
+NON_ULTRA_TRAIL_UNKNOWN_POLICY = NON_ULTRA_TRAIL_ONTOLOGY_PARAMETER_VALUES[
+    "trail_unknown_and_materiality_policy"
+]
+
+NON_ULTRA_TRAIL_CAPABILITY_ID = "non_ultra_trail_performance_v1"
+NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID = "non_ultra_trail_constraints_v1"
+NON_ULTRA_TRAIL_COURSE_SCHEMA_ID = str(
+    NON_ULTRA_TRAIL_COURSE_SCHEMA["schema_id"]
+)
+
+if (
+    NON_ULTRA_TRAIL_SCOPE["requires_accepted_ontology"]
+    != NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID
+):
+    raise ValueError("non-ultra Trail ontology dependency mismatch")
+if (
+    NON_ULTRA_TRAIL_SCOPE["requires_course_demand_schema"]
+    != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID
+):
+    raise ValueError("non-ultra Trail course schema dependency mismatch")
+
+NON_ULTRA_TRAIL_PROPOSAL_DAYS = int(
+    NON_ULTRA_TRAIL_EXECUTION["committed_proposal_days"]
+)
+NON_ULTRA_TRAIL_REASSESSMENT_DAYS = int(
+    NON_ULTRA_TRAIL_EXECUTION["advisory_reassessment_after_completed_days"]
+)
+NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS = int(
+    NON_ULTRA_TRAIL_HISTORY["recent_history_lookback_completed_weeks"]
+)
+NON_ULTRA_TRAIL_SUCCESS_CODE = str(
+    NON_ULTRA_TRAIL_TYPED_OUTCOMES["candidate_success"]
+)
+NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES = frozenset(
+    str(code) for code in NON_ULTRA_TRAIL_TYPED_OUTCOMES["no_plan"]
+)
+NON_ULTRA_TRAIL_LIMITED_MODULE_CODES = frozenset(
+    str(code) for code in NON_ULTRA_TRAIL_TYPED_OUTCOMES["limited_modules"]
+)
+NON_ULTRA_TRAIL_RESULT_CODES = frozenset(
+    {NON_ULTRA_TRAIL_SUCCESS_CODE, *NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES}
+)
+NON_ULTRA_TRAIL_ALLOWED_PROVENANCE = frozenset(
+    str(value) for value in NON_ULTRA_TRAIL_PROVENANCE_POLICY["allowed"]
+)
+
+
+@dataclass(frozen=True)
+class NonUltraTrailGuardrailProjection:
+    """Read-only accepted values used by pure generation and explanation."""
+
+    committed_proposal_days: int
+    advisory_reassessment_after_completed_days: int
+    recent_history_lookback_completed_weeks: int
+    minimum_usable_completed_weeks: int
+    minimum_running_sessions_per_usable_week: int
+    latest_run_within_completed_days: int
+    minimum_planned_low_intensity_running_minutes_fraction: float
+    maximum_quality_exposures_per_7_day_unit: int
+
+    def public_payload(self) -> dict[str, int | float]:
+        """Return the response-safe exact-value projection."""
+        return asdict(self)
+
+
+NON_ULTRA_TRAIL_GUARDRAILS = NonUltraTrailGuardrailProjection(
+    committed_proposal_days=NON_ULTRA_TRAIL_PROPOSAL_DAYS,
+    advisory_reassessment_after_completed_days=(
+        NON_ULTRA_TRAIL_REASSESSMENT_DAYS
+    ),
+    recent_history_lookback_completed_weeks=(
+        NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS
+    ),
+    minimum_usable_completed_weeks=int(
+        NON_ULTRA_TRAIL_HISTORY["minimum_usable_completed_weeks"]
+    ),
+    minimum_running_sessions_per_usable_week=int(
+        NON_ULTRA_TRAIL_HISTORY[
+            "minimum_running_sessions_per_usable_week"
+        ]
+    ),
+    latest_run_within_completed_days=int(
+        NON_ULTRA_TRAIL_HISTORY["latest_run_within_completed_days"]
+    ),
+    minimum_planned_low_intensity_running_minutes_fraction=float(
+        NON_ULTRA_TRAIL_INTENSITY[
+            "minimum_planned_low_intensity_running_minutes_fraction"
+        ]
+    ),
+    maximum_quality_exposures_per_7_day_unit=int(
+        NON_ULTRA_TRAIL_INTENSITY[
+            "maximum_quality_exposures_per_7_day_unit"
+        ]
+    ),
+)

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -1,0 +1,1995 @@
+"""Pure deterministic generation for the accepted inactive Trail policy.
+
+This module accepts only typed, already-loaded values.  It never reads a
+database, file, clock, provider, or mutable service state.  It is deliberately
+not registered with a route or capability registry: the governing contracts
+authorize an inactive implementation only.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date, timedelta
+import hashlib
+import json
+import math
+from statistics import median
+from typing import Any, Literal, Mapping, Sequence
+
+from analysis.non_ultra_trail_contract import (
+    NON_ULTRA_TRAIL_ALLOWED_PROVENANCE,
+    NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+    NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+    NON_ULTRA_TRAIL_COURSE_SCHEMA,
+    NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+    NON_ULTRA_TRAIL_GENERATOR_VERSION,
+    NON_ULTRA_TRAIL_HISTORY,
+    NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS,
+    NON_ULTRA_TRAIL_INTENSITY,
+    NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES,
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+    NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+    NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_POLICY_VERSION,
+    NON_ULTRA_TRAIL_PROPOSAL_DAYS,
+    NON_ULTRA_TRAIL_REASSESSMENT_DAYS,
+    NON_ULTRA_TRAIL_SCHEDULE,
+    NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+    NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_SUCCESS_CODE,
+    NON_ULTRA_TRAIL_TEMPLATES,
+)
+
+
+_SCHEDULE_UNIT_DAYS = 7
+_MINIMUM_USABLE_WEEKS = int(
+    NON_ULTRA_TRAIL_HISTORY["minimum_usable_completed_weeks"]
+)
+_MINIMUM_RUNS_PER_USABLE_WEEK = int(
+    NON_ULTRA_TRAIL_HISTORY[
+        "minimum_running_sessions_per_usable_week"
+    ]
+)
+_LATEST_RUN_DAYS = int(
+    NON_ULTRA_TRAIL_HISTORY["latest_run_within_completed_days"]
+)
+_COMPARABLE_REQUIREMENT = NON_ULTRA_TRAIL_HISTORY[
+    "comparable_hilly_or_trail_sessions_within_completed_days"
+]
+_COMPARABLE_COUNT = int(_COMPARABLE_REQUIREMENT["count"])
+_COMPARABLE_WINDOW_DAYS = int(_COMPARABLE_REQUIREMENT["window"])
+_LATEST_COMPARABLE_DAYS = int(
+    NON_ULTRA_TRAIL_HISTORY[
+        "latest_comparable_hilly_or_trail_session_within_completed_days"
+    ]
+)
+_MIN_RUN_DAYS = int(
+    NON_ULTRA_TRAIL_SCHEDULE[
+        "selected_running_days_per_7_day_unit"
+    ]["minimum"]
+)
+_MAX_RUN_DAYS = int(
+    NON_ULTRA_TRAIL_SCHEDULE[
+        "selected_running_days_per_7_day_unit"
+    ]["maximum"]
+)
+_LOW_INTENSITY_FLOOR = float(
+    NON_ULTRA_TRAIL_INTENSITY[
+        "minimum_planned_low_intensity_running_minutes_fraction"
+    ]
+)
+_MAX_QUALITY_PER_UNIT = int(
+    NON_ULTRA_TRAIL_INTENSITY[
+        "maximum_quality_exposures_per_7_day_unit"
+    ]
+)
+_MATERIAL_COURSE_FIELDS = tuple(
+    name
+    for name, specification in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"].items()
+    if specification["material"] is True
+)
+_OBJECT_COURSE_FIELDS = frozenset({
+    name
+    for name, specification in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"].items()
+    if specification["type"] in {"object", "categorical_object"}
+})
+_INTEGER_COURSE_FIELDS = frozenset({
+    name
+    for name, specification in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"].items()
+    if specification["type"] == "integer"
+})
+_HISTORY_ACTIVITY_TYPES = frozenset({"running", "trail_running"})
+_MAX_HISTORY_OBSERVATIONS = 1000
+
+
+@dataclass(frozen=True)
+class ProvenancedValue:
+    """One course-demand value with explicit origin and missingness."""
+
+    value: Any | None
+    provenance: str
+    source_reference: str | None = None
+    source_timestamp: date | None = None
+    model_version: str | None = None
+    athlete_confirmed: bool = False
+
+    @property
+    def is_unknown(self) -> bool:
+        """Return whether the value is explicitly unknown."""
+        return self.provenance == "unknown"
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return the portable value/provenance representation."""
+        return _json_safe_dates(asdict(self))
+
+
+@dataclass(frozen=True)
+class TrailCourseDemand:
+    """Exact ``trail_course_demand_v1`` fields admitted by the policy."""
+
+    expected_duration_seconds: ProvenancedValue
+    distance_meters: ProvenancedValue
+    elevation_gain_meters: ProvenancedValue
+    elevation_loss_meters: ProvenancedValue
+    grade_distribution: ProvenancedValue
+    technicality: ProvenancedValue
+    maximum_altitude_meters: ProvenancedValue
+    environmental_demand: ProvenancedValue
+    aid_and_support: ProvenancedValue
+    training_terrain_access: ProvenancedValue
+    recent_downhill_exposure: ProvenancedValue
+    fueling_practice_experience: ProvenancedValue
+    athlete_confirmed: bool
+    schema_id: str = NON_ULTRA_TRAIL_COURSE_SCHEMA_ID
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return a stable response-safe course snapshot."""
+        return _serialize_course_demand(self)
+
+
+@dataclass(frozen=True)
+class NonUltraTrailGoal:
+    """Preclassified goal tuple admitted by the inactive generator."""
+
+    intent: str
+    event_format: str
+    distance_family: str
+    target_event_date: date
+    event_confirmed: bool
+    clinical_or_return_to_sport: bool = False
+
+
+@dataclass(frozen=True)
+class TrailPlanGenerationConstraints:
+    """Athlete-stated calendar and duration boundaries."""
+
+    adult_confirmed: bool | None
+    current_symptom_stop: bool | None
+    available_weekdays: tuple[int, ...]
+    weekly_time_limit_min: int
+    maximum_session_duration_min: int
+    unavailable_dates: tuple[date, ...] = ()
+    reserved_dates: tuple[date, ...] = ()
+    preferred_longest_easy_weekday: int | None = None
+    schema_id: str = NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID
+
+
+@dataclass(frozen=True)
+class InternalTrailPrevalidation:
+    """Internal-only semantic checks that this core must not invent.
+
+    Course materiality and terrain-category comparison require a separately
+    reviewed caller.  Only literal ``True`` values cross this boundary.
+    Opaque terrain references are propagated, never ordered or classified.
+    """
+
+    course_demand_eligible: bool | None
+    terrain_access_eligible: bool | None
+    nontechnical_uphill_accessible: bool | None
+    training_terrain_reference: str | None
+    technical_terrain_module_supported: bool | None = None
+
+
+@dataclass(frozen=True)
+class TrailRunningHistoryObservation:
+    """One completed activity observation; average power is intentionally absent."""
+
+    activity_id: str
+    observed_date: date
+    activity_type: str
+    duration_min: float
+    distance_km: float | None
+    elevation_gain_meters: int | None
+    elevation_loss_meters: int | None
+    source: str
+
+
+@dataclass(frozen=True)
+class RecentTrailHistoryStatistics:
+    """Reproducible running and direct Trail anchors."""
+
+    usable_completed_weeks: int
+    recent_modal_running_frequency: int
+    recent_median_usable_weekly_minutes: int
+    recent_maximum_usable_weekly_minutes: int
+    recent_maximum_session_minutes: int
+    recent_median_usable_weekly_ascent_meters: int
+    recent_maximum_usable_weekly_ascent_meters: int
+    recent_median_usable_weekly_descent_meters: int
+    recent_maximum_usable_weekly_descent_meters: int
+    recent_maximum_session_ascent_meters: int
+    recent_maximum_session_descent_meters: int
+    latest_run_date: date | None
+    comparable_trail_sessions_within_window: int
+    latest_comparable_trail_session_date: date | None
+
+    @classmethod
+    def empty(cls) -> "RecentTrailHistoryStatistics":
+        """Return the deterministic empty aggregate used for invalid input."""
+        return cls(
+            usable_completed_weeks=0,
+            recent_modal_running_frequency=0,
+            recent_median_usable_weekly_minutes=0,
+            recent_maximum_usable_weekly_minutes=0,
+            recent_maximum_session_minutes=0,
+            recent_median_usable_weekly_ascent_meters=0,
+            recent_maximum_usable_weekly_ascent_meters=0,
+            recent_median_usable_weekly_descent_meters=0,
+            recent_maximum_usable_weekly_descent_meters=0,
+            recent_maximum_session_ascent_meters=0,
+            recent_maximum_session_descent_meters=0,
+            latest_run_date=None,
+            comparable_trail_sessions_within_window=0,
+            latest_comparable_trail_session_date=None,
+        )
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return the JSON-safe aggregate projection."""
+        return _json_safe_dates(asdict(self))
+
+
+@dataclass(frozen=True)
+class TrailWorkoutStep:
+    """One targetless duration/phase/effort step."""
+
+    kind: str
+    phase: str | None = None
+    duration_min: int | None = None
+    intended_intensity: str | None = None
+    repetitions: int | None = None
+    steps: tuple["TrailWorkoutStep", ...] = ()
+
+
+@dataclass(frozen=True)
+class GeneratedTrailWorkout:
+    """One deterministic, non-canonical Trail proposal workout."""
+
+    scheduled_date: date
+    workout_type: Literal["easy", "longest_easy", "controlled_quality"]
+    intensity_bucket: Literal["low", "quality"]
+    planned_duration_min: int
+    ascent_ceiling_meters: int
+    descent_ceiling_meters: int
+    terrain_reference: str
+    template_id: str | None
+    steps: tuple[TrailWorkoutStep, ...]
+    activity_type: Literal["trail_running"] = "trail_running"
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return one JSON-safe proposal workout."""
+        return _json_safe_dates(asdict(self))
+
+
+@dataclass(frozen=True)
+class GeneratedTrailWeek:
+    """One seven-day unit with independently capped ascent and descent."""
+
+    week_number: int
+    start_date: date
+    end_date: date
+    weekly_ascent_ceiling_meters: int
+    weekly_descent_ceiling_meters: int
+    workouts: tuple[GeneratedTrailWorkout, ...]
+
+
+@dataclass(frozen=True)
+class GeneratedNonUltraTrailPlan:
+    """Immutable 14-day suggestion; never a canonical or delivered plan."""
+
+    policy_version: str
+    generator_version: str
+    horizon_start: date
+    horizon_end: date
+    reassessment_dates: tuple[date, ...]
+    course_demand_fingerprint: str
+    history_statistics: RecentTrailHistoryStatistics
+    limited_modules: tuple[str, ...]
+    weeks: tuple[GeneratedTrailWeek, ...]
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return the complete JSON-safe suggestion."""
+        return _json_safe_dates(asdict(self))
+
+
+@dataclass(frozen=True)
+class NonUltraTrailGenerationInput:
+    """All versioned values needed to replay one pure generation decision."""
+
+    policy_version: str
+    science_decision_id: str
+    contract_digest: str
+    source_decision_digest: str
+    ontology_decision_id: str
+    ontology_contract_digest: str
+    ontology_source_decision_digest: str
+    athlete_today: date
+    block_start: date
+    goal: NonUltraTrailGoal
+    course_demand: TrailCourseDemand
+    history: tuple[TrailRunningHistoryObservation, ...]
+    constraints: TrailPlanGenerationConstraints
+    prevalidation: InternalTrailPrevalidation
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return the complete replay input without adding authority."""
+        return serialize_generation_input(self)
+
+
+@dataclass(frozen=True)
+class NonUltraTrailGenerationResult:
+    """Canonical Science outcome plus a separate Product detail reason."""
+
+    policy_version: str
+    generator_version: str
+    science_decision_id: str
+    contract_digest: str
+    source_decision_digest: str
+    code: str
+    detail_reason: str
+    deterministic_input_hash: str
+    plan: GeneratedNonUltraTrailPlan | None
+    history_statistics: RecentTrailHistoryStatistics
+    limited_modules: tuple[str, ...]
+    failed_rule_id: str | None
+    uncertainty_or_missing_field: str | None
+
+    def public_payload(self) -> dict[str, Any]:
+        """Return a JSON-safe outcome without changing its authority."""
+        return serialize_generation_result(self)
+
+
+@dataclass(frozen=True)
+class PlanInvariantViolation:
+    """One stable fail-closed invariant result."""
+
+    rule_id: str
+    detail_reason: str
+
+
+@dataclass(frozen=True)
+class _InputIssue:
+    code: str
+    detail_reason: str
+    rule_id: str
+    missing_field: str | None = None
+
+
+@dataclass(frozen=True)
+class _WorkoutTemplate:
+    template_id: str
+    total_minutes: int
+    low_intensity_minutes: int
+    steps: tuple[TrailWorkoutStep, ...]
+
+
+def _build_template_step(raw: Mapping[str, Any]) -> TrailWorkoutStep:
+    kind = str(raw["kind"])
+    if kind == "repeat":
+        return TrailWorkoutStep(
+            kind="repeat",
+            repetitions=int(raw["repetitions"]),
+            steps=tuple(_build_template_step(item) for item in raw["steps"]),
+        )
+    return TrailWorkoutStep(
+        kind="step",
+        phase=str(raw["phase"]),
+        duration_min=int(raw["duration_minutes"]),
+        intended_intensity=str(raw["intended_intensity"]),
+    )
+
+
+_CONTROLLED_QUALITY_RAW = NON_ULTRA_TRAIL_TEMPLATES["controlled_quality"]
+_CONTROLLED_QUALITY_STEPS = tuple(
+    _build_template_step(step) for step in _CONTROLLED_QUALITY_RAW["steps"]
+)
+
+
+def _steps_duration(steps: Sequence[TrailWorkoutStep]) -> int:
+    total = 0
+    for step in steps:
+        if step.kind == "repeat":
+            total += int(step.repetitions or 0) * _steps_duration(step.steps)
+        else:
+            total += int(step.duration_min or 0)
+    return total
+
+
+def _steps_low_minutes(steps: Sequence[TrailWorkoutStep]) -> int:
+    total = 0
+    for step in steps:
+        if step.kind == "repeat":
+            total += int(step.repetitions or 0) * _steps_low_minutes(step.steps)
+        elif step.intended_intensity == "low":
+            total += int(step.duration_min or 0)
+    return total
+
+
+CONTROLLED_UPHILL_TEMPLATE = _WorkoutTemplate(
+    template_id=str(_CONTROLLED_QUALITY_RAW["template_id"]),
+    total_minutes=int(_CONTROLLED_QUALITY_RAW["total_planned_minutes"]),
+    low_intensity_minutes=_steps_low_minutes(_CONTROLLED_QUALITY_STEPS),
+    steps=_CONTROLLED_QUALITY_STEPS,
+)
+
+if _steps_duration(CONTROLLED_UPHILL_TEMPLATE.steps) != 38:
+    raise ValueError("accepted Trail quality template must total 38 minutes")
+if CONTROLLED_UPHILL_TEMPLATE.total_minutes != 38:
+    raise ValueError("Trail quality template contract total mismatch")
+
+
+def derive_recent_history_statistics(
+    history: Sequence[TrailRunningHistoryObservation],
+    *,
+    athlete_today: date,
+) -> RecentTrailHistoryStatistics:
+    """Derive eight complete-week running anchors and direct Trail exposure.
+
+    ``running`` and ``trail_running`` both contribute to usable running weeks.
+    Only an exact ``trail_running`` observation with independently known gain
+    and loss contributes comparable exposure or vertical anchors.
+    """
+    issue = _history_primitive_issue(history, athlete_today=athlete_today)
+    if issue is not None:
+        raise ValueError(issue.detail_reason)
+
+    completed_observations = tuple(
+        item
+        for item in history
+        if _is_qualifying_run(item) and item.observed_date < athlete_today
+    )
+    current_week_start = athlete_today - timedelta(days=athlete_today.weekday())
+    first_week_start = current_week_start - timedelta(
+        days=(
+            _SCHEDULE_UNIT_DAYS
+            * NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS
+        )
+    )
+    complete_week_observations = tuple(
+        item
+        for item in completed_observations
+        if first_week_start <= item.observed_date < current_week_start
+    )
+
+    week_buckets: dict[date, list[TrailRunningHistoryObservation]] = {}
+    for item in complete_week_observations:
+        week_start = item.observed_date - timedelta(
+            days=item.observed_date.weekday()
+        )
+        week_buckets.setdefault(week_start, []).append(item)
+
+    usable_weeks = tuple(
+        (week_start, tuple(values))
+        for week_start, values in sorted(week_buckets.items())
+        if len(values) >= _MINIMUM_RUNS_PER_USABLE_WEEK
+        and sum(value.duration_min for value in values) > 0
+    )
+    weekly_minutes = tuple(
+        int(sum(item.duration_min for item in values))
+        for _, values in usable_weeks
+    )
+    weekly_ascent = tuple(
+        sum(
+            int(item.elevation_gain_meters or 0)
+            for item in values
+            if _is_comparable_trail(item)
+        )
+        for _, values in usable_weeks
+    )
+    weekly_descent = tuple(
+        sum(
+            int(item.elevation_loss_meters or 0)
+            for item in values
+            if _is_comparable_trail(item)
+        )
+        for _, values in usable_weeks
+    )
+    all_usable = tuple(
+        item for _, values in usable_weeks for item in values
+    )
+    usable_comparable_trail = tuple(
+        item for item in all_usable if _is_comparable_trail(item)
+    )
+
+    comparable_in_window = tuple(
+        item
+        for item in completed_observations
+        if _is_comparable_trail(item)
+        and 1 <= (athlete_today - item.observed_date).days
+        <= _COMPARABLE_WINDOW_DAYS
+    )
+    frequencies = tuple(len(values) for _, values in usable_weeks)
+    return RecentTrailHistoryStatistics(
+        usable_completed_weeks=len(usable_weeks),
+        recent_modal_running_frequency=_conservative_mode(frequencies),
+        recent_median_usable_weekly_minutes=_integer_median(weekly_minutes),
+        recent_maximum_usable_weekly_minutes=max(weekly_minutes, default=0),
+        recent_maximum_session_minutes=int(
+            max((item.duration_min for item in all_usable), default=0)
+        ),
+        recent_median_usable_weekly_ascent_meters=_integer_median(
+            weekly_ascent
+        ),
+        recent_maximum_usable_weekly_ascent_meters=max(
+            weekly_ascent,
+            default=0,
+        ),
+        recent_median_usable_weekly_descent_meters=_integer_median(
+            weekly_descent
+        ),
+        recent_maximum_usable_weekly_descent_meters=max(
+            weekly_descent,
+            default=0,
+        ),
+        recent_maximum_session_ascent_meters=max(
+            (
+                int(item.elevation_gain_meters or 0)
+                for item in usable_comparable_trail
+            ),
+            default=0,
+        ),
+        recent_maximum_session_descent_meters=max(
+            (
+                int(item.elevation_loss_meters or 0)
+                for item in usable_comparable_trail
+            ),
+            default=0,
+        ),
+        latest_run_date=max(
+            (item.observed_date for item in completed_observations),
+            default=None,
+        ),
+        comparable_trail_sessions_within_window=len(comparable_in_window),
+        latest_comparable_trail_session_date=max(
+            (item.observed_date for item in comparable_in_window),
+            default=None,
+        ),
+    )
+
+
+def generate_non_ultra_trail_plan(
+    generation_input: NonUltraTrailGenerationInput,
+) -> NonUltraTrailGenerationResult:
+    """Return an inactive deterministic suggestion or a canonical no-plan code."""
+    primitive_issue = _generation_input_primitive_issue(generation_input)
+    if primitive_issue is not None:
+        return _no_plan(
+            issue=primitive_issue,
+            input_hash=_invalid_input_hash(primitive_issue),
+            statistics=RecentTrailHistoryStatistics.empty(),
+        )
+
+    input_hash = deterministic_input_hash(generation_input)
+    statistics = derive_recent_history_statistics(
+        generation_input.history,
+        athlete_today=generation_input.athlete_today,
+    )
+
+    contract_issue = _contract_issue(generation_input)
+    if contract_issue is not None:
+        return _no_plan(
+            issue=contract_issue,
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+    scope_issue = _scope_issue(generation_input)
+    if scope_issue is not None:
+        return _no_plan(
+            issue=scope_issue,
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+    course_issue = _course_issue(generation_input.course_demand)
+    if course_issue is not None:
+        return _no_plan(
+            issue=course_issue,
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+    prevalidation_issue = _prevalidation_issue(generation_input.prevalidation)
+    if prevalidation_issue is not None:
+        return _no_plan(
+            issue=prevalidation_issue,
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+    history_issue = _history_issue(
+        statistics,
+        athlete_today=generation_input.athlete_today,
+    )
+    if history_issue is not None:
+        return _no_plan(
+            issue=history_issue,
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+    constraint_issue = _constraint_issue(generation_input.constraints)
+    if constraint_issue is not None:
+        return _no_plan(
+            issue=constraint_issue,
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+    if (
+        generation_input.goal.target_event_date
+        - generation_input.block_start
+    ).days <= NON_ULTRA_TRAIL_PROPOSAL_DAYS:
+        return _no_plan(
+            issue=_InputIssue(
+                code="validation_failed",
+                detail_reason="event_inside_unapproved_taper_window",
+                rule_id="event_and_taper",
+                missing_field="accepted Trail taper policy",
+            ),
+            input_hash=input_hash,
+            statistics=statistics,
+        )
+
+    limited_modules = _limited_modules(
+        generation_input.course_demand,
+        generation_input.prevalidation,
+    )
+    weeks = _build_schedule(
+        generation_input=generation_input,
+        statistics=statistics,
+    )
+    if weeks is None:
+        return _no_plan(
+            issue=_InputIssue(
+                code="validation_failed",
+                detail_reason="no_schedule_within_envelope",
+                rule_id="schedule_construction",
+            ),
+            input_hash=input_hash,
+            statistics=statistics,
+            limited_modules=limited_modules,
+        )
+
+    plan = GeneratedNonUltraTrailPlan(
+        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        horizon_start=generation_input.block_start,
+        horizon_end=(
+            generation_input.block_start
+            + timedelta(days=NON_ULTRA_TRAIL_PROPOSAL_DAYS - 1)
+        ),
+        reassessment_dates=(
+            generation_input.block_start
+            + timedelta(days=NON_ULTRA_TRAIL_REASSESSMENT_DAYS),
+        ),
+        course_demand_fingerprint=_canonical_fingerprint(
+            _serialize_course_demand(generation_input.course_demand)
+        ),
+        history_statistics=statistics,
+        limited_modules=limited_modules,
+        weeks=weeks,
+    )
+    violations = validate_generated_plan(plan, generation_input)
+    if violations:
+        violation = violations[0]
+        return _no_plan(
+            issue=_InputIssue(
+                code="validation_failed",
+                detail_reason=violation.detail_reason,
+                rule_id=violation.rule_id,
+            ),
+            input_hash=input_hash,
+            statistics=statistics,
+            limited_modules=limited_modules,
+        )
+    return NonUltraTrailGenerationResult(
+        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        code=NON_ULTRA_TRAIL_SUCCESS_CODE,
+        detail_reason="eligible_rolling_proposal",
+        deterministic_input_hash=input_hash,
+        plan=plan,
+        history_statistics=statistics,
+        limited_modules=limited_modules,
+        failed_rule_id=None,
+        uncertainty_or_missing_field=None,
+    )
+
+
+def deterministic_input_hash(
+    generation_input: NonUltraTrailGenerationInput,
+) -> str:
+    """Return a stable order-independent hash for the complete valid input."""
+    issue = _generation_input_primitive_issue(generation_input)
+    if issue is not None:
+        raise ValueError(issue.detail_reason)
+    return _canonical_fingerprint(serialize_generation_input(generation_input))
+
+
+def serialize_generation_input(
+    generation_input: NonUltraTrailGenerationInput,
+) -> dict[str, Any]:
+    """Return the explicit JSON-safe replay snapshot."""
+    history = [
+        _json_safe_dates(asdict(item))
+        for item in sorted(
+            generation_input.history,
+            key=lambda item: (
+                item.observed_date,
+                item.activity_id,
+                item.activity_type,
+                item.source,
+            ),
+        )
+    ]
+    constraints = generation_input.constraints
+    return {
+        "policy_version": generation_input.policy_version,
+        "science_decision_id": generation_input.science_decision_id,
+        "contract_digest": generation_input.contract_digest,
+        "source_decision_digest": generation_input.source_decision_digest,
+        "ontology_decision_id": generation_input.ontology_decision_id,
+        "ontology_contract_digest": generation_input.ontology_contract_digest,
+        "ontology_source_decision_digest": (
+            generation_input.ontology_source_decision_digest
+        ),
+        "generator_version": NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        "athlete_today": generation_input.athlete_today.isoformat(),
+        "block_start": generation_input.block_start.isoformat(),
+        "goal": _json_safe_dates(asdict(generation_input.goal)),
+        "course_demand": _serialize_course_demand(
+            generation_input.course_demand
+        ),
+        "history": history,
+        "constraints": {
+            "adult_confirmed": constraints.adult_confirmed,
+            "current_symptom_stop": constraints.current_symptom_stop,
+            "available_weekdays": sorted(constraints.available_weekdays),
+            "weekly_time_limit_min": constraints.weekly_time_limit_min,
+            "maximum_session_duration_min": (
+                constraints.maximum_session_duration_min
+            ),
+            "unavailable_dates": sorted(
+                value.isoformat() for value in constraints.unavailable_dates
+            ),
+            "reserved_dates": sorted(
+                value.isoformat() for value in constraints.reserved_dates
+            ),
+            "preferred_longest_easy_weekday": (
+                constraints.preferred_longest_easy_weekday
+            ),
+            "schema_id": constraints.schema_id,
+        },
+        "prevalidation": asdict(generation_input.prevalidation),
+    }
+
+
+def serialize_generation_result(
+    result: NonUltraTrailGenerationResult,
+) -> dict[str, Any]:
+    """Return the explicit JSON-safe result projection."""
+    return _json_safe_dates(asdict(result))
+
+
+def serialize_workout_structure(
+    workout: GeneratedTrailWorkout,
+) -> dict[str, Any]:
+    """Return the provider-neutral targetless step structure."""
+    return {"steps": [_serialize_step(step) for step in workout.steps]}
+
+
+def validate_generated_plan(
+    plan: GeneratedNonUltraTrailPlan,
+    generation_input: NonUltraTrailGenerationInput,
+) -> tuple[PlanInvariantViolation, ...]:
+    """Return every deterministic policy-invariant violation in stable order."""
+    statistics = plan.history_statistics
+    constraints = generation_input.constraints
+    violations: list[PlanInvariantViolation] = []
+    expected_end = generation_input.block_start + timedelta(
+        days=NON_ULTRA_TRAIL_PROPOSAL_DAYS - 1
+    )
+    if (
+        plan.horizon_start != generation_input.block_start
+        or plan.horizon_end != expected_end
+        or len(plan.weeks) != NON_ULTRA_TRAIL_PROPOSAL_DAYS // 7
+    ):
+        violations.append(
+            PlanInvariantViolation("proposal_horizon", "validation_failed")
+        )
+    expected_reassessment = (
+        generation_input.block_start
+        + timedelta(days=NON_ULTRA_TRAIL_REASSESSMENT_DAYS),
+    )
+    if plan.reassessment_dates != expected_reassessment:
+        violations.append(
+            PlanInvariantViolation("reassessment_date", "validation_failed")
+        )
+
+    frequency_cap = min(
+        len(set(constraints.available_weekdays)),
+        statistics.recent_modal_running_frequency,
+        _MAX_RUN_DAYS,
+    )
+    session_duration_cap = min(
+        statistics.recent_maximum_session_minutes,
+        constraints.maximum_session_duration_min,
+    )
+    weekly_minutes_target = min(
+        statistics.recent_median_usable_weekly_minutes,
+        constraints.weekly_time_limit_min,
+    )
+    weekly_minutes_hard_cap = min(
+        statistics.recent_maximum_usable_weekly_minutes,
+        constraints.weekly_time_limit_min,
+    )
+    ascent_target = statistics.recent_median_usable_weekly_ascent_meters
+    ascent_hard_cap = statistics.recent_maximum_usable_weekly_ascent_meters
+    descent_target = statistics.recent_median_usable_weekly_descent_meters
+    descent_hard_cap = statistics.recent_maximum_usable_weekly_descent_meters
+    blocked_dates = set(constraints.unavailable_dates) | set(
+        constraints.reserved_dates
+    )
+    seen_dates: set[date] = set()
+    quality_dates: list[date] = []
+
+    for week_index, week in enumerate(plan.weeks):
+        expected_start = generation_input.block_start + timedelta(
+            days=week_index * _SCHEDULE_UNIT_DAYS
+        )
+        expected_week_end = expected_start + timedelta(days=6)
+        if (
+            week.week_number != week_index + 1
+            or week.start_date != expected_start
+            or week.end_date != expected_week_end
+        ):
+            violations.append(
+                PlanInvariantViolation("week_boundary", "validation_failed")
+            )
+        if not (_MIN_RUN_DAYS <= len(week.workouts) <= frequency_cap):
+            violations.append(
+                PlanInvariantViolation("running_day_count", "validation_failed")
+            )
+
+        total_minutes = sum(item.planned_duration_min for item in week.workouts)
+        low_minutes = sum(_workout_low_minutes(item) for item in week.workouts)
+        quality = tuple(
+            item for item in week.workouts if item.intensity_bucket == "quality"
+        )
+        if len(quality) != _MAX_QUALITY_PER_UNIT:
+            violations.append(
+                PlanInvariantViolation(
+                    "quality_exposure_count",
+                    "validation_failed",
+                )
+            )
+        quality_dates.extend(item.scheduled_date for item in quality)
+        if total_minutes != weekly_minutes_target:
+            violations.append(
+                PlanInvariantViolation("weekly_minutes_target", "validation_failed")
+            )
+        if total_minutes > weekly_minutes_hard_cap:
+            violations.append(
+                PlanInvariantViolation("weekly_minutes_cap", "validation_failed")
+            )
+        if total_minutes <= 0 or low_minutes / total_minutes < _LOW_INTENSITY_FLOOR:
+            violations.append(
+                PlanInvariantViolation("low_intensity_floor", "validation_failed")
+            )
+
+        ascent_sum = sum(item.ascent_ceiling_meters for item in week.workouts)
+        descent_sum = sum(item.descent_ceiling_meters for item in week.workouts)
+        if (
+            ascent_sum != week.weekly_ascent_ceiling_meters
+            or ascent_sum > ascent_target
+            or ascent_sum > ascent_hard_cap
+        ):
+            violations.append(
+                PlanInvariantViolation("weekly_ascent_cap", "validation_failed")
+            )
+        if (
+            descent_sum != week.weekly_descent_ceiling_meters
+            or descent_sum > descent_target
+            or descent_sum > descent_hard_cap
+        ):
+            violations.append(
+                PlanInvariantViolation("weekly_descent_cap", "validation_failed")
+            )
+
+        for workout in week.workouts:
+            if workout.scheduled_date in seen_dates:
+                violations.append(
+                    PlanInvariantViolation("duplicate_date", "validation_failed")
+                )
+            seen_dates.add(workout.scheduled_date)
+            if not (week.start_date <= workout.scheduled_date <= week.end_date):
+                violations.append(
+                    PlanInvariantViolation("workout_week", "validation_failed")
+                )
+            if (
+                workout.scheduled_date in blocked_dates
+                or workout.scheduled_date.weekday()
+                not in constraints.available_weekdays
+            ):
+                violations.append(
+                    PlanInvariantViolation("calendar_constraint", "validation_failed")
+                )
+            if workout.scheduled_date >= generation_input.goal.target_event_date:
+                violations.append(
+                    PlanInvariantViolation("event_boundary", "validation_failed")
+                )
+            if workout.activity_type != "trail_running":
+                violations.append(
+                    PlanInvariantViolation("activity_type", "validation_failed")
+                )
+            if (
+                workout.planned_duration_min <= 0
+                or workout.planned_duration_min > session_duration_cap
+            ):
+                violations.append(
+                    PlanInvariantViolation("session_duration_cap", "validation_failed")
+                )
+            if (
+                workout.ascent_ceiling_meters < 0
+                or workout.ascent_ceiling_meters
+                > statistics.recent_maximum_session_ascent_meters
+            ):
+                violations.append(
+                    PlanInvariantViolation("session_ascent_cap", "validation_failed")
+                )
+            if (
+                workout.descent_ceiling_meters < 0
+                or workout.descent_ceiling_meters
+                > statistics.recent_maximum_session_descent_meters
+            ):
+                violations.append(
+                    PlanInvariantViolation("session_descent_cap", "validation_failed")
+                )
+            if (
+                workout.terrain_reference
+                != generation_input.prevalidation.training_terrain_reference
+            ):
+                violations.append(
+                    PlanInvariantViolation("terrain_reference", "validation_failed")
+                )
+            if workout.intensity_bucket == "quality":
+                if (
+                    workout.template_id != CONTROLLED_UPHILL_TEMPLATE.template_id
+                    or workout.steps != CONTROLLED_UPHILL_TEMPLATE.steps
+                    or workout.planned_duration_min != 38
+                ):
+                    violations.append(
+                        PlanInvariantViolation(
+                            "quality_template",
+                            "validation_failed",
+                        )
+                    )
+            elif (
+                workout.template_id is not None
+                or workout.steps
+                != (
+                    TrailWorkoutStep(
+                        kind="step",
+                        phase="easy",
+                        duration_min=workout.planned_duration_min,
+                        intended_intensity="low",
+                    ),
+                )
+            ):
+                violations.append(
+                    PlanInvariantViolation("easy_template", "validation_failed")
+                )
+
+    for previous, current in zip(quality_dates, quality_dates[1:], strict=False):
+        if (current - previous).days <= 1:
+            violations.append(
+                PlanInvariantViolation("quality_spacing", "validation_failed")
+            )
+    return tuple(violations)
+
+
+def _build_schedule(
+    *,
+    generation_input: NonUltraTrailGenerationInput,
+    statistics: RecentTrailHistoryStatistics,
+) -> tuple[GeneratedTrailWeek, ...] | None:
+    constraints = generation_input.constraints
+    frequency = min(
+        len(constraints.available_weekdays),
+        statistics.recent_modal_running_frequency,
+        _MAX_RUN_DAYS,
+    )
+    if frequency < _MIN_RUN_DAYS:
+        return None
+    session_cap = min(
+        constraints.maximum_session_duration_min,
+        statistics.recent_maximum_session_minutes,
+    )
+    weekly_target = min(
+        constraints.weekly_time_limit_min,
+        statistics.recent_median_usable_weekly_minutes,
+    )
+    weekly_hard_cap = min(
+        constraints.weekly_time_limit_min,
+        statistics.recent_maximum_usable_weekly_minutes,
+    )
+    if (
+        session_cap < CONTROLLED_UPHILL_TEMPLATE.total_minutes
+        or weekly_target <= 0
+        or weekly_target > weekly_hard_cap
+        or statistics.recent_median_usable_weekly_ascent_meters <= 0
+        or statistics.recent_maximum_session_ascent_meters <= 0
+    ):
+        return None
+
+    blocked = set(constraints.unavailable_dates) | set(
+        constraints.reserved_dates
+    )
+    weeks: list[GeneratedTrailWeek] = []
+    previous_quality_date: date | None = None
+    for week_index in range(NON_ULTRA_TRAIL_PROPOSAL_DAYS // 7):
+        week_start = generation_input.block_start + timedelta(
+            days=week_index * _SCHEDULE_UNIT_DAYS
+        )
+        week_end = week_start + timedelta(days=6)
+        available = tuple(
+            value
+            for value in (
+                week_start + timedelta(days=offset)
+                for offset in range(_SCHEDULE_UNIT_DAYS)
+            )
+            if value.weekday() in constraints.available_weekdays
+            and value not in blocked
+            and value < generation_input.goal.target_event_date
+        )
+        unit_frequency = min(frequency, len(available))
+        if unit_frequency < _MIN_RUN_DAYS:
+            return None
+        selected = _select_schedule_dates(
+            available,
+            frequency=unit_frequency,
+            preferred_longest_easy_weekday=(
+                constraints.preferred_longest_easy_weekday
+            ),
+        )
+        if selected is None:
+            return None
+        quality_date = _select_quality_date(
+            selected,
+            preferred_longest_easy_weekday=(
+                constraints.preferred_longest_easy_weekday
+            ),
+            previous_quality_date=previous_quality_date,
+        )
+        if quality_date is None:
+            return None
+        workouts = _build_week_workouts(
+            dates=selected,
+            quality_date=quality_date,
+            total_minutes=weekly_target,
+            session_cap=session_cap,
+            ascent_target=statistics.recent_median_usable_weekly_ascent_meters,
+            ascent_session_cap=(
+                statistics.recent_maximum_session_ascent_meters
+            ),
+            descent_target=(
+                statistics.recent_median_usable_weekly_descent_meters
+            ),
+            descent_session_cap=(
+                statistics.recent_maximum_session_descent_meters
+            ),
+            preferred_longest_easy_weekday=(
+                constraints.preferred_longest_easy_weekday
+            ),
+            terrain_reference=str(
+                generation_input.prevalidation.training_terrain_reference
+            ),
+        )
+        if workouts is None:
+            return None
+        weeks.append(
+            GeneratedTrailWeek(
+                week_number=week_index + 1,
+                start_date=week_start,
+                end_date=week_end,
+                weekly_ascent_ceiling_meters=sum(
+                    item.ascent_ceiling_meters for item in workouts
+                ),
+                weekly_descent_ceiling_meters=sum(
+                    item.descent_ceiling_meters for item in workouts
+                ),
+                workouts=workouts,
+            )
+        )
+        previous_quality_date = quality_date
+    return tuple(weeks)
+
+
+def _build_week_workouts(
+    *,
+    dates: Sequence[date],
+    quality_date: date,
+    total_minutes: int,
+    session_cap: int,
+    ascent_target: int,
+    ascent_session_cap: int,
+    descent_target: int,
+    descent_session_cap: int,
+    preferred_longest_easy_weekday: int | None,
+    terrain_reference: str,
+) -> tuple[GeneratedTrailWorkout, ...] | None:
+    easy_dates = tuple(value for value in sorted(dates) if value != quality_date)
+    remaining_minutes = total_minutes - CONTROLLED_UPHILL_TEMPLATE.total_minutes
+    if remaining_minutes < len(easy_dates):
+        return None
+    easy_allocations = _allocate_easy_minutes(
+        easy_dates,
+        total_minutes=remaining_minutes,
+        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+    )
+    if any(value > session_cap for value in easy_allocations.values()):
+        return None
+    low_minutes = (
+        CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes
+        + sum(easy_allocations.values())
+    )
+    if total_minutes <= 0 or low_minutes / total_minutes < _LOW_INTENSITY_FLOOR:
+        return None
+
+    longest_date = _longest_easy_date(
+        easy_dates,
+        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+    )
+    ascent_allocations = _allocate_integer_ceiling(
+        dates,
+        total_ceiling=ascent_target,
+        per_session_ceiling=ascent_session_cap,
+        priority=(
+            quality_date,
+            *tuple(value for value in dates if value != quality_date),
+        ),
+    )
+    descent_priority = (
+        (longest_date,) if longest_date is not None else ()
+    ) + tuple(value for value in dates if value != longest_date)
+    descent_allocations = _allocate_integer_ceiling(
+        dates,
+        total_ceiling=descent_target,
+        per_session_ceiling=descent_session_cap,
+        priority=descent_priority,
+    )
+    if ascent_allocations is None or descent_allocations is None:
+        return None
+
+    workouts: list[GeneratedTrailWorkout] = []
+    for scheduled_date in sorted(dates):
+        if scheduled_date == quality_date:
+            workouts.append(
+                GeneratedTrailWorkout(
+                    scheduled_date=scheduled_date,
+                    workout_type="controlled_quality",
+                    intensity_bucket="quality",
+                    planned_duration_min=(
+                        CONTROLLED_UPHILL_TEMPLATE.total_minutes
+                    ),
+                    ascent_ceiling_meters=ascent_allocations[scheduled_date],
+                    descent_ceiling_meters=descent_allocations[scheduled_date],
+                    terrain_reference=terrain_reference,
+                    template_id=CONTROLLED_UPHILL_TEMPLATE.template_id,
+                    steps=CONTROLLED_UPHILL_TEMPLATE.steps,
+                )
+            )
+            continue
+        duration = easy_allocations.get(scheduled_date, 0)
+        if duration <= 0:
+            return None
+        workouts.append(
+            GeneratedTrailWorkout(
+                scheduled_date=scheduled_date,
+                workout_type=(
+                    "longest_easy"
+                    if scheduled_date == longest_date
+                    else "easy"
+                ),
+                intensity_bucket="low",
+                planned_duration_min=duration,
+                ascent_ceiling_meters=ascent_allocations[scheduled_date],
+                descent_ceiling_meters=descent_allocations[scheduled_date],
+                terrain_reference=terrain_reference,
+                template_id=None,
+                steps=(
+                    TrailWorkoutStep(
+                        kind="step",
+                        phase="easy",
+                        duration_min=duration,
+                        intended_intensity="low",
+                    ),
+                ),
+            )
+        )
+    return tuple(workouts)
+
+
+def _allocate_easy_minutes(
+    dates: Sequence[date],
+    *,
+    total_minutes: int,
+    preferred_longest_easy_weekday: int | None,
+) -> dict[date, int]:
+    if not dates:
+        return {}
+    base, remainder = divmod(total_minutes, len(dates))
+    allocations = {value: base for value in dates}
+    priority = _easy_allocation_priority(
+        dates,
+        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+    )
+    for value in priority[:remainder]:
+        allocations[value] += 1
+    return allocations
+
+
+def _allocate_integer_ceiling(
+    dates: Sequence[date],
+    *,
+    total_ceiling: int,
+    per_session_ceiling: int,
+    priority: Sequence[date],
+) -> dict[date, int] | None:
+    ordered = tuple(dict.fromkeys(priority))
+    if (
+        not dates
+        or set(ordered) != set(dates)
+        or total_ceiling < 0
+        or per_session_ceiling < 0
+    ):
+        return None
+    effective_total = min(total_ceiling, per_session_ceiling * len(dates))
+    allocations = {value: 0 for value in dates}
+    remaining = effective_total
+    while remaining:
+        progressed = False
+        for value in ordered:
+            if allocations[value] >= per_session_ceiling:
+                continue
+            allocations[value] += 1
+            remaining -= 1
+            progressed = True
+            if remaining == 0:
+                break
+        if not progressed:
+            return None
+    return allocations
+
+
+def _select_schedule_dates(
+    dates: Sequence[date],
+    *,
+    frequency: int,
+    preferred_longest_easy_weekday: int | None,
+) -> tuple[date, ...] | None:
+    ordered = tuple(sorted(set(dates)))
+    if len(ordered) < frequency:
+        return None
+    if len(ordered) == frequency:
+        return ordered
+
+    selected_indexes = {
+        round(index * (len(ordered) - 1) / (frequency - 1))
+        for index in range(frequency)
+    }
+    selected = {ordered[index] for index in selected_indexes}
+    preferred = next(
+        (
+            value
+            for value in ordered
+            if value.weekday() == preferred_longest_easy_weekday
+        ),
+        None,
+    )
+    if preferred is not None and preferred not in selected:
+        selected.remove(max(selected))
+        selected.add(preferred)
+    for value in ordered:
+        if len(selected) >= frequency:
+            break
+        selected.add(value)
+    return tuple(sorted(selected))
+
+
+def _select_quality_date(
+    dates: Sequence[date],
+    *,
+    preferred_longest_easy_weekday: int | None,
+    previous_quality_date: date | None,
+) -> date | None:
+    longest = _longest_easy_date(
+        dates,
+        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+    )
+    unit_start = min(dates, default=None)
+    if unit_start is None:
+        return None
+    candidates = sorted(
+        (value for value in dates if value != longest),
+        key=lambda value: (abs((value - unit_start).days - 2), value),
+    )
+    return next(
+        (
+            value
+            for value in candidates
+            if previous_quality_date is None
+            or (value - previous_quality_date).days > 1
+        ),
+        None,
+    )
+
+
+def _longest_easy_date(
+    dates: Sequence[date],
+    *,
+    preferred_longest_easy_weekday: int | None,
+) -> date | None:
+    if preferred_longest_easy_weekday is not None:
+        preferred = next(
+            (
+                value
+                for value in sorted(dates)
+                if value.weekday() == preferred_longest_easy_weekday
+            ),
+            None,
+        )
+        if preferred is not None:
+            return preferred
+    return max(dates, default=None)
+
+
+def _easy_allocation_priority(
+    dates: Sequence[date],
+    *,
+    preferred_longest_easy_weekday: int | None,
+) -> tuple[date, ...]:
+    longest = _longest_easy_date(
+        dates,
+        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+    )
+    if longest is None:
+        return ()
+    return (longest,) + tuple(value for value in sorted(dates) if value != longest)
+
+
+def _contract_issue(
+    generation_input: NonUltraTrailGenerationInput,
+) -> _InputIssue | None:
+    if (
+        generation_input.ontology_decision_id
+        != NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID
+        or generation_input.ontology_contract_digest
+        != NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST
+        or generation_input.ontology_source_decision_digest
+        != NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+    ):
+        return _InputIssue(
+            code="ontology_not_accepted",
+            detail_reason="ontology_contract_mismatch",
+            rule_id="accepted_ontology_contract",
+        )
+    if (
+        generation_input.policy_version != NON_ULTRA_TRAIL_POLICY_VERSION
+        or generation_input.science_decision_id
+        != NON_ULTRA_TRAIL_SCIENCE_DECISION_ID
+        or generation_input.contract_digest != NON_ULTRA_TRAIL_CONTRACT_DIGEST
+        or generation_input.source_decision_digest
+        != NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST
+    ):
+        return _InputIssue(
+            code="policy_inactive",
+            detail_reason="policy_contract_mismatch",
+            rule_id="accepted_inactive_policy_contract",
+        )
+    return None
+
+
+def _scope_issue(
+    generation_input: NonUltraTrailGenerationInput,
+) -> _InputIssue | None:
+    goal = generation_input.goal
+    constraints = generation_input.constraints
+    if goal.event_format != "single_day" or goal.distance_family != "non_ultra":
+        return _InputIssue(
+            code="unsupported_ultra_or_multiday",
+            detail_reason="unsupported_ultra_or_multiday",
+            rule_id="scope_and_dependencies",
+        )
+    if goal.intent != "performance" or goal.clinical_or_return_to_sport:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="adult_scope_or_constraints_unconfirmed",
+            rule_id="scope_and_dependencies",
+        )
+    if constraints.adult_confirmed is not True:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="adult_scope_or_constraints_unconfirmed",
+            rule_id="adult_scope",
+            missing_field="adult confirmation",
+        )
+    if constraints.current_symptom_stop is None:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="adult_scope_or_constraints_unconfirmed",
+            rule_id="current_symptom_stop",
+            missing_field="current symptom-stop response",
+        )
+    if constraints.current_symptom_stop is True:
+        return _InputIssue(
+            code="current_symptom_stop",
+            detail_reason="current_symptom_stop",
+            rule_id="current_symptom_stop",
+        )
+    if not goal.event_confirmed:
+        return _InputIssue(
+            code="course_clarification_required",
+            detail_reason="course_clarification_required",
+            rule_id="confirmed_event",
+            missing_field="athlete-confirmed event",
+        )
+    if generation_input.block_start < generation_input.athlete_today:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="contradictory_input",
+            rule_id="block_start",
+        )
+    return None
+
+
+def _course_issue(course: TrailCourseDemand) -> _InputIssue | None:
+    if course.schema_id != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID:
+        return _InputIssue(
+            code="ontology_not_accepted",
+            detail_reason="ontology_contract_mismatch",
+            rule_id="course_schema",
+        )
+    if course.athlete_confirmed is not True:
+        return _InputIssue(
+            code="course_clarification_required",
+            detail_reason="course_clarification_required",
+            rule_id="athlete_confirmed_course",
+            missing_field=NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+        )
+    for field_name in _MATERIAL_COURSE_FIELDS:
+        field = getattr(course, field_name)
+        if field.is_unknown:
+            return _InputIssue(
+                code="material_course_demand_unknown",
+                detail_reason="material_course_demand_unknown",
+                rule_id="material_course_demand",
+                missing_field=field_name,
+            )
+        if isinstance(field.value, Mapping) and not field.value:
+            return _InputIssue(
+                code="course_clarification_required",
+                detail_reason="course_clarification_required",
+                rule_id="material_course_demand",
+                missing_field=field_name,
+            )
+        if (
+            field.provenance == "explicit_assumption"
+            and field.athlete_confirmed is not True
+        ):
+            return _InputIssue(
+                code="course_clarification_required",
+                detail_reason="course_clarification_required",
+                rule_id="assumption_confirmation",
+                missing_field=field_name,
+            )
+    return None
+
+
+def _prevalidation_issue(
+    prevalidation: InternalTrailPrevalidation,
+) -> _InputIssue | None:
+    if prevalidation.course_demand_eligible is None:
+        return _InputIssue(
+            code="material_course_demand_unknown",
+            detail_reason="material_course_demand_unknown",
+            rule_id="internal_course_prevalidation",
+        )
+    if prevalidation.course_demand_eligible is not True:
+        return _InputIssue(
+            code="course_clarification_required",
+            detail_reason="course_clarification_required",
+            rule_id="internal_course_prevalidation",
+        )
+    if prevalidation.terrain_access_eligible is None:
+        return _InputIssue(
+            code="material_course_demand_unknown",
+            detail_reason="insufficient_terrain_access",
+            rule_id="internal_terrain_prevalidation",
+        )
+    if prevalidation.terrain_access_eligible is not True:
+        return _InputIssue(
+            code="insufficient_terrain_access",
+            detail_reason="insufficient_terrain_access",
+            rule_id="internal_terrain_prevalidation",
+        )
+    if prevalidation.nontechnical_uphill_accessible is not True:
+        return _InputIssue(
+            code=(
+                "material_course_demand_unknown"
+                if prevalidation.nontechnical_uphill_accessible is None
+                else "insufficient_terrain_access"
+            ),
+            detail_reason="insufficient_terrain_access",
+            rule_id="controlled_uphill_access",
+        )
+    if not str(prevalidation.training_terrain_reference or "").strip():
+        return _InputIssue(
+            code="material_course_demand_unknown",
+            detail_reason="insufficient_terrain_access",
+            rule_id="training_terrain_reference",
+        )
+    return None
+
+
+def _history_issue(
+    statistics: RecentTrailHistoryStatistics,
+    *,
+    athlete_today: date,
+) -> _InputIssue | None:
+    if statistics.usable_completed_weeks < _MINIMUM_USABLE_WEEKS:
+        return _InputIssue(
+            code="insufficient_comparable_history",
+            detail_reason="insufficient_recent_history",
+            rule_id="usable_completed_weeks",
+        )
+    if (
+        statistics.latest_run_date is None
+        or (athlete_today - statistics.latest_run_date).days > _LATEST_RUN_DAYS
+    ):
+        return _InputIssue(
+            code="insufficient_comparable_history",
+            detail_reason="insufficient_recent_history",
+            rule_id="latest_run",
+        )
+    if (
+        statistics.comparable_trail_sessions_within_window < _COMPARABLE_COUNT
+        or statistics.latest_comparable_trail_session_date is None
+        or (
+            athlete_today - statistics.latest_comparable_trail_session_date
+        ).days
+        > _LATEST_COMPARABLE_DAYS
+    ):
+        return _InputIssue(
+            code="insufficient_comparable_history",
+            detail_reason="insufficient_comparable_trail_history",
+            rule_id="comparable_trail_exposure",
+        )
+    return None
+
+
+def _constraint_issue(
+    constraints: TrailPlanGenerationConstraints,
+) -> _InputIssue | None:
+    weekdays = constraints.available_weekdays
+    if constraints.schema_id != NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="contradictory_input",
+            rule_id="constraint_schema",
+        )
+    if len(set(weekdays)) != len(weekdays) or any(
+        value < 0 or value > 6 for value in weekdays
+    ):
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="contradictory_input",
+            rule_id="available_weekdays",
+        )
+    if len(weekdays) < _MIN_RUN_DAYS:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="no_schedule_within_envelope",
+            rule_id="available_weekdays",
+        )
+    if len(weekdays) > _MAX_RUN_DAYS:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="clarification_required",
+            rule_id="available_weekdays",
+        )
+    if (
+        constraints.weekly_time_limit_min <= 0
+        or constraints.maximum_session_duration_min <= 0
+    ):
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="adult_scope_or_constraints_unconfirmed",
+            rule_id="duration_constraints",
+        )
+    preferred = constraints.preferred_longest_easy_weekday
+    if preferred is not None and preferred not in weekdays:
+        return _InputIssue(
+            code="adult_scope_or_constraints_unconfirmed",
+            detail_reason="contradictory_input",
+            rule_id="preferred_longest_easy_weekday",
+        )
+    return None
+
+
+def _limited_modules(
+    course: TrailCourseDemand,
+    prevalidation: InternalTrailPrevalidation,
+) -> tuple[str, ...]:
+    limited: set[str] = set()
+    if (
+        course.maximum_altitude_meters.is_unknown
+        or course.environmental_demand.is_unknown
+    ):
+        limited.add("environment_module_limited")
+    if course.fueling_practice_experience.is_unknown:
+        limited.add("fueling_module_limited")
+    if prevalidation.technical_terrain_module_supported is not True:
+        limited.add("technicality_module_limited")
+    return tuple(sorted(limited))
+
+
+def _generation_input_primitive_issue(
+    generation_input: NonUltraTrailGenerationInput,
+) -> _InputIssue | None:
+    for field_name in (
+        "policy_version",
+        "science_decision_id",
+        "contract_digest",
+        "source_decision_digest",
+        "ontology_decision_id",
+        "ontology_contract_digest",
+        "ontology_source_decision_digest",
+    ):
+        if not isinstance(getattr(generation_input, field_name), str):
+            return _primitive_issue(field_name)
+    if type(generation_input.athlete_today) is not date:
+        return _primitive_issue("athlete_today")
+    if type(generation_input.block_start) is not date:
+        return _primitive_issue("block_start")
+    goal = generation_input.goal
+    if not isinstance(goal, NonUltraTrailGoal):
+        return _primitive_issue("goal")
+    if not all(
+        isinstance(value, str)
+        for value in (goal.intent, goal.event_format, goal.distance_family)
+    ):
+        return _primitive_issue("goal")
+    if type(goal.target_event_date) is not date:
+        return _primitive_issue("target_event_date")
+    if type(goal.event_confirmed) is not bool:
+        return _primitive_issue("event_confirmed")
+    if type(goal.clinical_or_return_to_sport) is not bool:
+        return _primitive_issue("clinical_or_return_to_sport")
+
+    course_issue = _course_primitive_issue(generation_input.course_demand)
+    if course_issue is not None:
+        return course_issue
+    history_issue = _history_primitive_issue(
+        generation_input.history,
+        athlete_today=generation_input.athlete_today,
+    )
+    if history_issue is not None:
+        return history_issue
+    constraints = generation_input.constraints
+    if not isinstance(constraints, TrailPlanGenerationConstraints):
+        return _primitive_issue("constraints")
+    if type(constraints.adult_confirmed) not in {bool, type(None)}:
+        return _primitive_issue("adult_confirmed")
+    if type(constraints.current_symptom_stop) not in {bool, type(None)}:
+        return _primitive_issue("current_symptom_stop")
+    if not isinstance(constraints.available_weekdays, tuple) or any(
+        type(value) is not int for value in constraints.available_weekdays
+    ):
+        return _primitive_issue("available_weekdays")
+    if type(constraints.weekly_time_limit_min) is not int:
+        return _primitive_issue("weekly_time_limit_min")
+    if type(constraints.maximum_session_duration_min) is not int:
+        return _primitive_issue("maximum_session_duration_min")
+    if any(
+        type(value) is not date
+        for value in (*constraints.unavailable_dates, *constraints.reserved_dates)
+    ):
+        return _primitive_issue("blocked_dates")
+    if (
+        constraints.preferred_longest_easy_weekday is not None
+        and type(constraints.preferred_longest_easy_weekday) is not int
+    ):
+        return _primitive_issue("preferred_longest_easy_weekday")
+    if not isinstance(constraints.schema_id, str):
+        return _primitive_issue("constraint_schema")
+    prevalidation = generation_input.prevalidation
+    if not isinstance(prevalidation, InternalTrailPrevalidation):
+        return _primitive_issue("prevalidation")
+    if any(
+        type(value) not in {bool, type(None)}
+        for value in (
+            prevalidation.course_demand_eligible,
+            prevalidation.terrain_access_eligible,
+            prevalidation.nontechnical_uphill_accessible,
+            prevalidation.technical_terrain_module_supported,
+        )
+    ):
+        return _primitive_issue("prevalidation")
+    if (
+        prevalidation.training_terrain_reference is not None
+        and not isinstance(prevalidation.training_terrain_reference, str)
+    ):
+        return _primitive_issue("training_terrain_reference")
+    return None
+
+
+def _course_primitive_issue(course: TrailCourseDemand) -> _InputIssue | None:
+    if not isinstance(course, TrailCourseDemand):
+        return _primitive_issue("course_demand")
+    if type(course.athlete_confirmed) is not bool or not isinstance(
+        course.schema_id,
+        str,
+    ):
+        return _primitive_issue("course_demand")
+    for field_name, field in _course_fields(course):
+        if not isinstance(field, ProvenancedValue):
+            return _primitive_issue(field_name)
+        if field.provenance not in NON_ULTRA_TRAIL_ALLOWED_PROVENANCE:
+            return _primitive_issue(f"{field_name}.provenance")
+        if type(field.athlete_confirmed) is not bool:
+            return _primitive_issue(f"{field_name}.athlete_confirmed")
+        if field.source_reference is not None and (
+            not isinstance(field.source_reference, str)
+            or not field.source_reference.strip()
+        ):
+            return _primitive_issue(f"{field_name}.source_reference")
+        if (
+            field.source_timestamp is not None
+            and type(field.source_timestamp) is not date
+        ):
+            return _primitive_issue(f"{field_name}.source_timestamp")
+        if field.model_version is not None and (
+            not isinstance(field.model_version, str) or not field.model_version.strip()
+        ):
+            return _primitive_issue(f"{field_name}.model_version")
+        if field.is_unknown and field.value is not None:
+            return _primitive_issue(f"{field_name}.unknown_value")
+        if not field.is_unknown and field.value is None:
+            return _primitive_issue(f"{field_name}.value")
+        if field.provenance == "model_inferred" and not field.model_version:
+            return _primitive_issue(f"{field_name}.model_version")
+        if not _is_json_value(field.value):
+            return _primitive_issue(f"{field_name}.value")
+        if field_name in _INTEGER_COURSE_FIELDS and not field.is_unknown:
+            if type(field.value) is not int:
+                return _primitive_issue(field_name)
+            minimum = NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"][field_name].get(
+                "minimum"
+            )
+            if minimum is not None and int(field.value) < int(minimum):
+                return _primitive_issue(field_name)
+        if field_name in _OBJECT_COURSE_FIELDS and not field.is_unknown:
+            if not isinstance(field.value, Mapping):
+                return _primitive_issue(field_name)
+    return None
+
+
+def _history_primitive_issue(
+    history: Sequence[TrailRunningHistoryObservation],
+    *,
+    athlete_today: date,
+) -> _InputIssue | None:
+    if type(athlete_today) is not date:
+        return _primitive_issue("athlete_today")
+    if len(history) > _MAX_HISTORY_OBSERVATIONS:
+        return _primitive_issue("history_observation_count")
+    for item in history:
+        if not isinstance(item, TrailRunningHistoryObservation):
+            return _primitive_issue("history_observation")
+        if (
+            not isinstance(item.activity_id, str)
+            or not item.activity_id.strip()
+            or not isinstance(item.activity_type, str)
+            or type(item.observed_date) is not date
+            or not isinstance(item.source, str)
+            or not item.source.strip()
+        ):
+            return _primitive_issue("history_observation")
+        if not _is_finite_number(item.duration_min):
+            return _primitive_issue("history.duration_min")
+        if item.distance_km is not None and not _is_finite_number(item.distance_km):
+            return _primitive_issue("history.distance_km")
+        for field_name, value in (
+            ("elevation_gain_meters", item.elevation_gain_meters),
+            ("elevation_loss_meters", item.elevation_loss_meters),
+        ):
+            if value is not None and (type(value) is not int or value < 0):
+                return _primitive_issue(f"history.{field_name}")
+    return None
+
+
+def _primitive_issue(field_name: str) -> _InputIssue:
+    return _InputIssue(
+        code="validation_failed",
+        detail_reason="contradictory_input",
+        rule_id="primitive_validation",
+        missing_field=field_name,
+    )
+
+
+def _course_fields(
+    course: TrailCourseDemand,
+) -> tuple[tuple[str, ProvenancedValue], ...]:
+    return tuple(
+        (field_name, getattr(course, field_name))
+        for field_name in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"]
+    )
+
+
+def _serialize_course_demand(course: TrailCourseDemand) -> dict[str, Any]:
+    return {
+        "schema_id": course.schema_id,
+        "athlete_confirmed": course.athlete_confirmed,
+        "fields": {
+            name: value.public_payload()
+            for name, value in sorted(_course_fields(course))
+        },
+    }
+
+
+def _is_qualifying_run(item: TrailRunningHistoryObservation) -> bool:
+    return (
+        item.activity_type in _HISTORY_ACTIVITY_TYPES
+        and item.duration_min > 0
+        and item.distance_km is not None
+        and item.distance_km > 0
+    )
+
+
+def _is_comparable_trail(item: TrailRunningHistoryObservation) -> bool:
+    return (
+        _is_qualifying_run(item)
+        and item.activity_type == "trail_running"
+        and item.elevation_gain_meters is not None
+        and item.elevation_loss_meters is not None
+    )
+
+
+def _workout_low_minutes(workout: GeneratedTrailWorkout) -> int:
+    if workout.intensity_bucket == "low":
+        return workout.planned_duration_min
+    if workout.template_id == CONTROLLED_UPHILL_TEMPLATE.template_id:
+        return CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes
+    return 0
+
+
+def _integer_median(values: Sequence[int]) -> int:
+    return int(median(values)) if values else 0
+
+
+def _conservative_mode(values: Sequence[int]) -> int:
+    if not values:
+        return 0
+    counts = {value: values.count(value) for value in set(values)}
+    maximum = max(counts.values())
+    return min(value for value, count in counts.items() if count == maximum)
+
+
+def _is_finite_number(value: Any) -> bool:
+    return (
+        type(value) in {int, float}
+        and math.isfinite(float(value))
+    )
+
+
+def _is_json_value(value: Any) -> bool:
+    if value is None or type(value) in {bool, int, str}:
+        return True
+    if type(value) is float:
+        return math.isfinite(value)
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str) and _is_json_value(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return all(_is_json_value(item) for item in value)
+    return False
+
+
+def _no_plan(
+    *,
+    issue: _InputIssue,
+    input_hash: str,
+    statistics: RecentTrailHistoryStatistics,
+    limited_modules: tuple[str, ...] = (),
+) -> NonUltraTrailGenerationResult:
+    if issue.code not in NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES:
+        raise ValueError("code must be a canonical accepted no-plan result")
+    return NonUltraTrailGenerationResult(
+        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        code=issue.code,
+        detail_reason=issue.detail_reason,
+        deterministic_input_hash=input_hash,
+        plan=None,
+        history_statistics=statistics,
+        limited_modules=limited_modules,
+        failed_rule_id=issue.rule_id,
+        uncertainty_or_missing_field=issue.missing_field,
+    )
+
+
+def _serialize_step(step: TrailWorkoutStep) -> dict[str, Any]:
+    if step.kind == "repeat":
+        return {
+            "type": "repeat",
+            "repetitions": step.repetitions,
+            "steps": [_serialize_step(child) for child in step.steps],
+        }
+    return {
+        "type": "step",
+        "phase": step.phase,
+        "termination": {
+            "type": "time",
+            "seconds": int(step.duration_min or 0) * 60,
+        },
+        "intended_intensity": step.intended_intensity,
+        "target": {
+            "metric": "none",
+            "unit": "none",
+            "reference": "none",
+        },
+    }
+
+
+def _invalid_input_hash(issue: _InputIssue) -> str:
+    return _canonical_fingerprint({
+        "invalid_input": True,
+        "rule_id": issue.rule_id,
+        "field": issue.missing_field,
+    })
+
+
+def _canonical_fingerprint(value: Any) -> str:
+    canonical = json.dumps(
+        _json_safe_dates(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _json_safe_dates(value: Any) -> Any:
+    if type(value) is date:
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_safe_dates(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_dates(item) for item in value]
+    return value

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 import hashlib
 from itertools import combinations
 import json
@@ -482,10 +483,10 @@ def derive_recent_history_statistics(
         (week_start, tuple(values))
         for week_start, values in sorted(week_buckets.items())
         if len(values) >= _MINIMUM_RUNS_PER_USABLE_WEEK
-        and sum(value.duration_min for value in values) > 0
+        and _duration_minutes_total(values) > 0
     )
     weekly_minutes = tuple(
-        int(sum(item.duration_min for item in values))
+        _duration_minutes_total(values)
         for _, values in usable_weeks
     )
     weekly_ascent = tuple(
@@ -2071,6 +2072,15 @@ def _integer_median(values: Sequence[int]) -> int:
     return (ordered[midpoint - 1] + ordered[midpoint]) // 2
 
 
+def _duration_minutes_total(
+    values: Sequence[TrailRunningHistoryObservation],
+) -> int:
+    return int(sum(
+        (Decimal(str(value.duration_min)) for value in values),
+        start=Decimal(0),
+    ))
+
+
 def _conservative_mode(values: Sequence[int]) -> int:
     if not values:
         return 0
@@ -2080,10 +2090,11 @@ def _conservative_mode(values: Sequence[int]) -> int:
 
 
 def _is_finite_number(value: Any) -> bool:
-    return (
-        type(value) in {int, float}
-        and math.isfinite(float(value))
-    )
+    if type(value) is int:
+        return True
+    if type(value) is float:
+        return math.isfinite(value)
+    return False
 
 
 def _is_json_value(value: Any) -> bool:

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import date, datetime, timedelta
-from decimal import Decimal
+from fractions import Fraction
 import hashlib
 from itertools import combinations
 import json
@@ -2075,10 +2075,18 @@ def _integer_median(values: Sequence[int]) -> int:
 def _duration_minutes_total(
     values: Sequence[TrailRunningHistoryObservation],
 ) -> int:
-    return int(sum(
-        (Decimal(str(value.duration_min)) for value in values),
-        start=Decimal(0),
-    ))
+    total = sum(
+        (_exact_number_fraction(value.duration_min) for value in values),
+        start=Fraction(0),
+    )
+    return int(total)
+
+
+def _exact_number_fraction(value: int | float) -> Fraction:
+    if type(value) is int:
+        return Fraction(value)
+    numerator, denominator = value.as_integer_ratio()
+    return Fraction(numerator, denominator)
 
 
 def _conservative_mode(values: Sequence[int]) -> int:

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -1,14 +1,16 @@
-"""Pure deterministic generation for the accepted inactive Trail policy.
+"""Pure deterministic core for the accepted, inactive Trail v2 policy.
 
-This module accepts only typed, already-loaded values.  It never reads a
-database, file, clock, provider, or mutable service state.  It is deliberately
-not registered with a route or capability registry: the governing contracts
-authorize an inactive implementation only.
+This module has no database, HTTP, clock, provider, credential, registry, or
+capability-discovery dependency. The normal entry point respects the
+materialized ``inactive`` contract and cannot return a proposal. The explicit
+dry-run entry point exists only for synthetic deterministic verification under
+the accepted dry-run policy; it adds no runtime authority or reachability.
 """
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 import hashlib
 from itertools import combinations
@@ -19,24 +21,33 @@ from typing import Any, Literal, Mapping, Sequence
 from analysis.non_ultra_trail_contract import (
     NON_ULTRA_TRAIL_ALLOWED_PROVENANCE,
     NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+    NON_ULTRA_TRAIL_CONTRACT,
     NON_ULTRA_TRAIL_CONTRACT_DIGEST,
-    NON_ULTRA_TRAIL_COURSE_SCHEMA,
     NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+    NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG,
+    NON_ULTRA_TRAIL_FOOTING_AND_HAZARDS,
     NON_ULTRA_TRAIL_GENERATOR_VERSION,
+    NON_ULTRA_TRAIL_GRADE_DISTRIBUTION,
     NON_ULTRA_TRAIL_HISTORY,
     NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS,
     NON_ULTRA_TRAIL_INTENSITY,
-    NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES,
+    NON_ULTRA_TRAIL_LIMITED_MODULE_ORDER,
+    NON_ULTRA_TRAIL_MODULE_KEYS,
+    NON_ULTRA_TRAIL_MODULE_STATES,
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT,
     NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
     NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
     NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+    NON_ULTRA_TRAIL_OPTIONAL_CONTEXT,
     NON_ULTRA_TRAIL_POLICY_VERSION,
     NON_ULTRA_TRAIL_PROPOSAL_DAYS,
+    NON_ULTRA_TRAIL_REASON_PAIRS,
     NON_ULTRA_TRAIL_REASSESSMENT_DAYS,
     NON_ULTRA_TRAIL_SCHEDULE,
     NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
     NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
-    NON_ULTRA_TRAIL_SUCCESS_CODE,
+    NON_ULTRA_TRAIL_STATUS_PRECEDENCE,
     NON_ULTRA_TRAIL_TEMPLATES,
 )
 
@@ -46,9 +57,7 @@ _MINIMUM_USABLE_WEEKS = int(
     NON_ULTRA_TRAIL_HISTORY["minimum_usable_completed_weeks"]
 )
 _MINIMUM_RUNS_PER_USABLE_WEEK = int(
-    NON_ULTRA_TRAIL_HISTORY[
-        "minimum_running_sessions_per_usable_week"
-    ]
+    NON_ULTRA_TRAIL_HISTORY["minimum_running_sessions_per_usable_week"]
 )
 _LATEST_RUN_DAYS = int(
     NON_ULTRA_TRAIL_HISTORY["latest_run_within_completed_days"]
@@ -64,14 +73,10 @@ _LATEST_COMPARABLE_DAYS = int(
     ]
 )
 _MIN_RUN_DAYS = int(
-    NON_ULTRA_TRAIL_SCHEDULE[
-        "selected_running_days_per_7_day_unit"
-    ]["minimum"]
+    NON_ULTRA_TRAIL_SCHEDULE["selected_running_days_per_7_day_unit"]["minimum"]
 )
 _MAX_RUN_DAYS = int(
-    NON_ULTRA_TRAIL_SCHEDULE[
-        "selected_running_days_per_7_day_unit"
-    ]["maximum"]
+    NON_ULTRA_TRAIL_SCHEDULE["selected_running_days_per_7_day_unit"]["maximum"]
 )
 _LOW_INTENSITY_FLOOR = float(
     NON_ULTRA_TRAIL_INTENSITY[
@@ -79,120 +84,182 @@ _LOW_INTENSITY_FLOOR = float(
     ]
 )
 _MAX_QUALITY_PER_UNIT = int(
-    NON_ULTRA_TRAIL_INTENSITY[
-        "maximum_quality_exposures_per_7_day_unit"
-    ]
+    NON_ULTRA_TRAIL_INTENSITY["maximum_quality_exposures_per_7_day_unit"]
 )
-_MATERIAL_COURSE_FIELDS = tuple(
-    name
-    for name, specification in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"].items()
-    if specification["material"] is True
-)
-_OBJECT_COURSE_FIELDS = frozenset({
-    name
-    for name, specification in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"].items()
-    if specification["type"] in {"object", "categorical_object"}
-})
-_INTEGER_COURSE_FIELDS = frozenset({
-    name
-    for name, specification in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"].items()
-    if specification["type"] == "integer"
-})
 _HISTORY_ACTIVITY_TYPES = frozenset({"running", "trail_running"})
 _MAX_HISTORY_OBSERVATIONS = 1000
+_DIGEST_PREFIX = "sha256:"
+_GRADE_KEYS = tuple(
+    str(value)
+    for value in NON_ULTRA_TRAIL_GRADE_DISTRIBUTION["known_value_exact_keys"]
+)
+_FOOTING_VALUES = tuple(
+    str(value)
+    for value in NON_ULTRA_TRAIL_FOOTING_AND_HAZARDS["ordinary_footing"][
+        "allowed"
+    ]
+)
+_FOOTING_ORDER = {value: index for index, value in enumerate(_FOOTING_VALUES)}
+_MANDATORY_GEAR = tuple(
+    str(value)
+    for value in NON_ULTRA_TRAIL_OPTIONAL_CONTEXT["support"]["mandatory_gear"][
+        "allowed"
+    ]
+)
+_GEAR_ORDER = {value: index for index, value in enumerate(_MANDATORY_GEAR)}
+_SECTION_KEYS = (
+    "section.event-duration",
+    "section.grade-footing",
+    "section.training-access",
+    "section.optional-context",
+)
+_MODULE_LIMIT_TARGETS = {
+    "grade_specificity": "course.grade_distribution",
+    "technical_terrain": "course.course_footing",
+    "environment_altitude": "course.optional_context.environment",
+    "fueling": "course.optional_context.support",
+}
 
 
 @dataclass(frozen=True)
 class ProvenancedValue:
-    """One course-demand value with explicit origin and missingness."""
+    """One strict known/unknown v2 value with server-owned source metadata."""
 
-    value: Any | None
+    state: Literal["known", "unknown"]
     provenance: str
-    source_reference: str | None = None
-    source_timestamp: date | None = None
+    source_revision: str
+    value: Any | None = None
+    source_timestamp: datetime | None = None
     model_version: str | None = None
-    athlete_confirmed: bool = False
+    assumption_confirmed_revision: str | None = None
 
     @property
     def is_unknown(self) -> bool:
-        """Return whether the value is explicitly unknown."""
-        return self.provenance == "unknown"
+        return self.state == "unknown"
+
+    @property
+    def is_known(self) -> bool:
+        return self.state == "known"
 
     def public_payload(self) -> dict[str, Any]:
-        """Return the portable value/provenance representation."""
-        return _json_safe_dates(asdict(self))
+        payload: dict[str, Any] = {
+            "state": self.state,
+            "provenance": self.provenance,
+            "source_revision": self.source_revision,
+        }
+        if self.is_known:
+            payload["value"] = _json_safe_dates(self.value)
+        if self.source_timestamp is not None:
+            payload["source_timestamp"] = self.source_timestamp.isoformat()
+        if self.model_version is not None:
+            payload["model_version"] = self.model_version
+        if self.assumption_confirmed_revision is not None:
+            payload["assumption_confirmed_revision"] = (
+                self.assumption_confirmed_revision
+            )
+        return payload
+
+
+@dataclass(frozen=True)
+class TrailPlanningDurationRange:
+    minimum_min: int
+    maximum_min: int
+
+
+@dataclass(frozen=True)
+class TrailGradeDistribution:
+    below_neg_10: int
+    neg_10_to_below_neg_3: int
+    neg_3_to_below_pos_3: int
+    pos_3_to_below_pos_10: int
+    pos_10_and_above: int
+
+
+@dataclass(frozen=True)
+class TrailEnvironmentContext:
+    maximum_altitude_m: ProvenancedValue
+    temperature_min_c: ProvenancedValue
+    temperature_max_c: ProvenancedValue
+    humidity_min_pct: ProvenancedValue
+    humidity_max_pct: ProvenancedValue
+    sun_exposure: ProvenancedValue
+    wind_exposure: ProvenancedValue
+    conditions_basis: ProvenancedValue
+
+
+@dataclass(frozen=True)
+class TrailSupportContext:
+    aid_support_mode: ProvenancedValue
+    aid_station_count: ProvenancedValue
+    max_aid_station_gap_m: ProvenancedValue
+    water_availability: ProvenancedValue
+    food_availability: ProvenancedValue
+    mandatory_gear: ProvenancedValue
+
+
+@dataclass(frozen=True)
+class TrailFuelingContext:
+    longest_practiced_duration_min: ProvenancedValue
+    practice_sessions_last_42_days: ProvenancedValue
+    intake_form: ProvenancedValue
+    gastrointestinal_experience: ProvenancedValue
+
+
+@dataclass(frozen=True)
+class TrailOptionalContext:
+    environment: TrailEnvironmentContext
+    support: TrailSupportContext
+    fueling: TrailFuelingContext
 
 
 @dataclass(frozen=True)
 class TrailCourseDemand:
-    """Exact ``trail_course_demand_v1`` fields admitted by the policy."""
+    """Exact typed ``trail_course_demand_v2`` server response projection."""
 
-    expected_duration_seconds: ProvenancedValue
+    event_id: str
+    event_date: ProvenancedValue
     distance_meters: ProvenancedValue
-    elevation_gain_meters: ProvenancedValue
-    elevation_loss_meters: ProvenancedValue
+    total_ascent_m: ProvenancedValue
+    total_descent_m: ProvenancedValue
+    planning_duration_range: ProvenancedValue
+    event_format: ProvenancedValue
+    distance_family: ProvenancedValue
+    planning_intent: ProvenancedValue
     grade_distribution: ProvenancedValue
-    technicality: ProvenancedValue
-    maximum_altitude_meters: ProvenancedValue
-    environmental_demand: ProvenancedValue
-    aid_and_support: ProvenancedValue
-    training_terrain_access: ProvenancedValue
-    recent_downhill_exposure: ProvenancedValue
-    fueling_practice_experience: ProvenancedValue
-    athlete_confirmed: bool
+    course_footing: ProvenancedValue
+    hands_assist: ProvenancedValue
+    fixed_rope: ProvenancedValue
+    optional_context: TrailOptionalContext
     schema_id: str = NON_ULTRA_TRAIL_COURSE_SCHEMA_ID
 
     def public_payload(self) -> dict[str, Any]:
-        """Return a stable response-safe course snapshot."""
         return _serialize_course_demand(self)
 
 
 @dataclass(frozen=True)
-class NonUltraTrailGoal:
-    """Preclassified goal tuple admitted by the inactive generator."""
-
-    intent: str
-    event_format: str
-    distance_family: str
-    target_event_date: date
-    event_confirmed: bool
-    clinical_or_return_to_sport: bool = False
-
-
-@dataclass(frozen=True)
 class TrailPlanGenerationConstraints:
-    """Athlete-stated calendar and duration boundaries."""
+    """Exact typed ``non_ultra_trail_constraints_v2`` response projection."""
 
-    adult_confirmed: bool | None
-    current_symptom_stop: bool | None
-    available_weekdays: tuple[int, ...]
-    weekly_time_limit_min: int
-    maximum_session_duration_min: int
-    unavailable_dates: tuple[date, ...] = ()
-    reserved_dates: tuple[date, ...] = ()
-    preferred_longest_easy_weekday: int | None = None
+    available_weekdays: ProvenancedValue
+    weekly_time_limit_min: ProvenancedValue
+    maximum_session_duration_min: ProvenancedValue
+    unavailable_dates: ProvenancedValue
+    nontechnical_three_minute_uphill_access: ProvenancedValue
+    controlled_downhill_access: ProvenancedValue
+    accessible_footing: ProvenancedValue
+    adult_nonclinical_scope_confirmed: ProvenancedValue
+    performance_intent_confirmed: ProvenancedValue
+    current_symptom_stop: ProvenancedValue
+    preferred_longest_weekday: int | None = None
     schema_id: str = NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID
 
-
-@dataclass(frozen=True)
-class InternalTrailPrevalidation:
-    """Internal-only semantic checks that this core must not invent.
-
-    Course materiality and terrain-category comparison require a separately
-    reviewed caller.  Only literal ``True`` values cross this boundary.
-    Opaque terrain references are propagated, never ordered or classified.
-    """
-
-    course_demand_eligible: bool | None
-    terrain_access_eligible: bool | None
-    nontechnical_uphill_accessible: bool | None
-    training_terrain_reference: str | None
-    technical_terrain_module_supported: bool | None = None
+    def public_payload(self) -> dict[str, Any]:
+        return _serialize_constraints(self)
 
 
 @dataclass(frozen=True)
 class TrailRunningHistoryObservation:
-    """One completed activity observation; average power is intentionally absent."""
+    """Internal activity input for deriving a minimized v2 history snapshot."""
 
     activity_id: str
     observed_date: date
@@ -201,14 +268,15 @@ class TrailRunningHistoryObservation:
     distance_km: float | None
     elevation_gain_meters: int | None
     elevation_loss_meters: int | None
-    source: str
+    observed_footing: tuple[str, ...] | None
+    source_revision: str
     source_timestamp: datetime
     outdoor_confirmed: bool
 
 
 @dataclass(frozen=True)
 class RecentTrailHistoryStatistics:
-    """Reproducible running and direct Trail anchors."""
+    """Owner-scoped, privacy-minimized, server-derived history snapshot."""
 
     usable_completed_weeks: int
     recent_modal_running_frequency: int
@@ -222,12 +290,14 @@ class RecentTrailHistoryStatistics:
     recent_maximum_session_ascent_meters: int
     recent_maximum_session_descent_meters: int
     latest_run_date: date | None
-    comparable_trail_sessions_within_window: int
-    latest_comparable_trail_session_date: date | None
+    comparable_ascent_sessions_within_window: int
+    latest_comparable_ascent_session_date: date | None
+    comparable_descent_sessions_within_window: int
+    latest_comparable_descent_session_date: date | None
+    recently_observed_footing: tuple[str, ...]
 
     @classmethod
     def empty(cls) -> "RecentTrailHistoryStatistics":
-        """Return the deterministic empty aggregate used for invalid input."""
         return cls(
             usable_completed_weeks=0,
             recent_modal_running_frequency=0,
@@ -241,19 +311,49 @@ class RecentTrailHistoryStatistics:
             recent_maximum_session_ascent_meters=0,
             recent_maximum_session_descent_meters=0,
             latest_run_date=None,
-            comparable_trail_sessions_within_window=0,
-            latest_comparable_trail_session_date=None,
+            comparable_ascent_sessions_within_window=0,
+            latest_comparable_ascent_session_date=None,
+            comparable_descent_sessions_within_window=0,
+            latest_comparable_descent_session_date=None,
+            recently_observed_footing=(),
         )
 
     def public_payload(self) -> dict[str, Any]:
-        """Return the JSON-safe aggregate projection."""
-        return _json_safe_dates(asdict(self))
+        payload = _json_safe_dates(asdict(self))
+        payload["recently_observed_footing"] = list(
+            _canonical_footing(self.recently_observed_footing)
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class TrailSectionConfirmation:
+    section_key: str
+    current_revision: str
+    confirmed_revision: str | None
+
+
+@dataclass(frozen=True)
+class TrailRevisionBindings:
+    course_revision: str
+    planning_context_revision: str
+    history_revision: str
+    composite_revision: str
+    section_confirmations: tuple[TrailSectionConfirmation, ...]
+
+
+@dataclass(frozen=True)
+class TrailWorkloadRequest:
+    """Optional explicit proposal edit; reductions are allowed, increases block."""
+
+    weekly_running_minutes: int | None = None
+    maximum_session_minutes: int | None = None
+    weekly_ascent_meters: int | None = None
+    weekly_descent_meters: int | None = None
 
 
 @dataclass(frozen=True)
 class TrailWorkoutStep:
-    """One targetless duration/phase/effort step."""
-
     kind: str
     phase: str | None = None
     duration_min: int | None = None
@@ -264,28 +364,20 @@ class TrailWorkoutStep:
 
 @dataclass(frozen=True)
 class GeneratedTrailWorkout:
-    """One deterministic, non-canonical Trail proposal workout."""
-
     scheduled_date: date
     workout_type: Literal["easy", "longest_easy", "controlled_quality"]
     intensity_bucket: Literal["low", "quality"]
     planned_duration_min: int
     ascent_ceiling_meters: int
     descent_ceiling_meters: int
-    terrain_reference: str
+    terrain_footing: tuple[str, ...]
     template_id: str | None
     steps: tuple[TrailWorkoutStep, ...]
     activity_type: Literal["trail_running"] = "trail_running"
 
-    def public_payload(self) -> dict[str, Any]:
-        """Return one JSON-safe proposal workout."""
-        return _json_safe_dates(asdict(self))
-
 
 @dataclass(frozen=True)
 class GeneratedTrailWeek:
-    """One seven-day unit with independently capped ascent and descent."""
-
     week_number: int
     start_date: date
     end_date: date
@@ -295,85 +387,117 @@ class GeneratedTrailWeek:
 
 
 @dataclass(frozen=True)
+class ModuleAvailability:
+    module: str
+    state: Literal["not_evaluated", "available", "limited"]
+    reason_target: str | None
+
+
+@dataclass(frozen=True)
+class MatchingReason:
+    status: str
+    detail_reason: str
+
+    @property
+    def namespaced(self) -> str:
+        return f"{self.status}.{self.detail_reason}"
+
+
+@dataclass(frozen=True)
 class GeneratedNonUltraTrailPlan:
-    """Immutable 14-day suggestion; never a canonical or delivered plan."""
+    """Synthetic, non-canonical 14-day candidate for inactive verification."""
 
     policy_version: str
     generator_version: str
+    science_decision_id: str
+    contract_digest: str
+    source_decision_digest: str
+    ontology_version: str
+    ontology_decision_id: str
+    ontology_contract_digest: str
+    ontology_source_decision_digest: str
+    course_schema_id: str
+    constraint_schema_id: str
+    contract_runtime_state: Literal["inactive"]
+    synthetic_verification_only: Literal[True]
+    deterministic_input_hash: str
+    readiness_receipt_digest: str
+    revision_bindings: TrailRevisionBindings
     horizon_start: date
     horizon_end: date
     reassessment_dates: tuple[date, ...]
     course_demand_fingerprint: str
     history_statistics: RecentTrailHistoryStatistics
+    module_availability: tuple[ModuleAvailability, ...]
     limited_modules: tuple[str, ...]
     weeks: tuple[GeneratedTrailWeek, ...]
 
     def public_payload(self) -> dict[str, Any]:
-        """Return the complete JSON-safe suggestion."""
         return _json_safe_dates(asdict(self))
 
 
 @dataclass(frozen=True)
 class NonUltraTrailGenerationInput:
-    """All versioned values needed to replay one pure generation decision."""
-
-    policy_version: str
-    science_decision_id: str
-    contract_digest: str
-    source_decision_digest: str
-    ontology_decision_id: str
-    ontology_contract_digest: str
-    ontology_source_decision_digest: str
-    athlete_today: date
-    block_start: date
-    goal: NonUltraTrailGoal
-    course_demand: TrailCourseDemand
-    history: tuple[TrailRunningHistoryObservation, ...]
-    constraints: TrailPlanGenerationConstraints
-    prevalidation: InternalTrailPrevalidation
-
-    def public_payload(self) -> dict[str, Any]:
-        """Return the complete replay input without adding authority."""
-        return serialize_generation_input(self)
-
-
-@dataclass(frozen=True)
-class NonUltraTrailGenerationResult:
-    """Canonical Science outcome plus a separate Product detail reason."""
+    """Complete replay input bound to exact accepted inactive v2 contracts."""
 
     policy_version: str
     generator_version: str
     science_decision_id: str
     contract_digest: str
     source_decision_digest: str
-    code: str
-    detail_reason: str
-    deterministic_input_hash: str
-    plan: GeneratedNonUltraTrailPlan | None
+    ontology_version: str
+    ontology_decision_id: str
+    ontology_contract_digest: str
+    ontology_source_decision_digest: str
+    athlete_today: date
+    block_start: date
+    course_demand: TrailCourseDemand
     history_statistics: RecentTrailHistoryStatistics
-    limited_modules: tuple[str, ...]
-    failed_rule_id: str | None
-    uncertainty_or_missing_field: str | None
+    constraints: TrailPlanGenerationConstraints
+    revision_bindings: TrailRevisionBindings
+    workload_request: TrailWorkloadRequest | None = None
+    synthetic_verification_only: bool = False
 
     def public_payload(self) -> dict[str, Any]:
-        """Return a JSON-safe outcome without changing its authority."""
+        return serialize_generation_input(self)
+
+
+@dataclass(frozen=True)
+class NonUltraTrailGenerationResult:
+    policy_version: str
+    generator_version: str
+    science_decision_id: str
+    contract_digest: str
+    source_decision_digest: str
+    ontology_version: str
+    ontology_decision_id: str
+    ontology_contract_digest: str
+    ontology_source_decision_digest: str
+    course_schema_id: str
+    constraint_schema_id: str
+    contract_runtime_state: str
+    inactive_dry_run: bool
+    status: str
+    detail_reason: str | None
+    matching_reasons: tuple[MatchingReason, ...]
+    module_availability: tuple[ModuleAvailability, ...]
+    limited_modules: tuple[str, ...]
+    deterministic_input_hash: str
+    readiness_receipt_digest: str
+    revision_bindings: TrailRevisionBindings | None
+    plan: GeneratedNonUltraTrailPlan | None
+    history_statistics: RecentTrailHistoryStatistics
+
+    def public_payload(self) -> dict[str, Any]:
         return serialize_generation_result(self)
 
 
 @dataclass(frozen=True)
 class PlanInvariantViolation:
-    """One stable fail-closed invariant result."""
-
     rule_id: str
-    detail_reason: str
-
-
-@dataclass(frozen=True)
-class _InputIssue:
-    code: str
-    detail_reason: str
-    rule_id: str
-    missing_field: str | None = None
+    detail_reason: Literal["deterministic_invariant_failed"] = (
+        "deterministic_invariant_failed"
+    )
 
 
 @dataclass(frozen=True)
@@ -385,8 +509,7 @@ class _WorkoutTemplate:
 
 
 def _build_template_step(raw: Mapping[str, Any]) -> TrailWorkoutStep:
-    kind = str(raw["kind"])
-    if kind == "repeat":
+    if str(raw["kind"]) == "repeat":
         return TrailWorkoutStep(
             kind="repeat",
             repetitions=int(raw["repetitions"]),
@@ -407,23 +530,23 @@ _CONTROLLED_QUALITY_STEPS = tuple(
 
 
 def _steps_duration(steps: Sequence[TrailWorkoutStep]) -> int:
-    total = 0
-    for step in steps:
-        if step.kind == "repeat":
-            total += int(step.repetitions or 0) * _steps_duration(step.steps)
-        else:
-            total += int(step.duration_min or 0)
-    return total
+    return sum(
+        int(step.repetitions or 0) * _steps_duration(step.steps)
+        if step.kind == "repeat"
+        else int(step.duration_min or 0)
+        for step in steps
+    )
 
 
 def _steps_low_minutes(steps: Sequence[TrailWorkoutStep]) -> int:
-    total = 0
-    for step in steps:
-        if step.kind == "repeat":
-            total += int(step.repetitions or 0) * _steps_low_minutes(step.steps)
-        elif step.intended_intensity == "low":
-            total += int(step.duration_min or 0)
-    return total
+    return sum(
+        int(step.repetitions or 0) * _steps_low_minutes(step.steps)
+        if step.kind == "repeat"
+        else int(step.duration_min or 0)
+        if step.intended_intensity == "low"
+        else 0
+        for step in steps
+    )
 
 
 CONTROLLED_UPHILL_TEMPLATE = _WorkoutTemplate(
@@ -432,11 +555,11 @@ CONTROLLED_UPHILL_TEMPLATE = _WorkoutTemplate(
     low_intensity_minutes=_steps_low_minutes(_CONTROLLED_QUALITY_STEPS),
     steps=_CONTROLLED_QUALITY_STEPS,
 )
-
-if _steps_duration(CONTROLLED_UPHILL_TEMPLATE.steps) != 38:
-    raise ValueError("accepted Trail quality template must total 38 minutes")
-if CONTROLLED_UPHILL_TEMPLATE.total_minutes != 38:
-    raise ValueError("Trail quality template contract total mismatch")
+if (
+    _steps_duration(CONTROLLED_UPHILL_TEMPLATE.steps) != 38
+    or CONTROLLED_UPHILL_TEMPLATE.total_minutes != 38
+):
+    raise ValueError("accepted Trail v2 quality template must total 38 minutes")
 
 
 def derive_recent_history_statistics(
@@ -444,56 +567,41 @@ def derive_recent_history_statistics(
     *,
     athlete_today: date,
 ) -> RecentTrailHistoryStatistics:
-    """Derive eight complete-week running anchors and direct Trail exposure.
-
-    ``running`` and ``trail_running`` both contribute to usable running weeks.
-    Only an exact ``trail_running`` observation with independently known gain
-    and loss contributes comparable exposure or vertical anchors.
-    """
-    issue = _history_primitive_issue(history, athlete_today=athlete_today)
+    """Derive the minimized v2 snapshot without retaining raw activities."""
+    issue = _history_observation_issue(history, athlete_today=athlete_today)
     if issue is not None:
-        raise ValueError(issue.detail_reason)
-
-    completed_observations = tuple(
+        raise ValueError(issue)
+    completed = tuple(
         item
         for item in history
         if _is_qualifying_run(item) and item.observed_date < athlete_today
     )
     current_week_start = athlete_today - timedelta(days=athlete_today.weekday())
     first_week_start = current_week_start - timedelta(
-        days=(
-            _SCHEDULE_UNIT_DAYS
-            * NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS
-        )
+        days=_SCHEDULE_UNIT_DAYS
+        * NON_ULTRA_TRAIL_HISTORY_LOOKBACK_COMPLETED_WEEKS
     )
-    complete_week_observations = tuple(
+    complete = tuple(
         item
-        for item in completed_observations
+        for item in completed
         if first_week_start <= item.observed_date < current_week_start
     )
-
     week_buckets: dict[date, list[TrailRunningHistoryObservation]] = {}
-    for item in complete_week_observations:
-        week_start = item.observed_date - timedelta(
-            days=item.observed_date.weekday()
-        )
+    for item in complete:
+        week_start = item.observed_date - timedelta(days=item.observed_date.weekday())
         week_buckets.setdefault(week_start, []).append(item)
-
     usable_weeks = tuple(
         (week_start, tuple(values))
         for week_start, values in sorted(week_buckets.items())
         if len(values) >= _MINIMUM_RUNS_PER_USABLE_WEEK
         and _duration_minutes_total(values) > 0
     )
-    weekly_minutes = tuple(
-        _duration_minutes_total(values)
-        for _, values in usable_weeks
-    )
+    weekly_minutes = tuple(_duration_minutes_total(values) for _, values in usable_weeks)
     weekly_ascent = tuple(
         sum(
             int(item.elevation_gain_meters or 0)
             for item in values
-            if _is_comparable_trail(item)
+            if _has_comparable_ascent(item)
         )
         for _, values in usable_weeks
     )
@@ -501,24 +609,26 @@ def derive_recent_history_statistics(
         sum(
             int(item.elevation_loss_meters or 0)
             for item in values
-            if _is_comparable_trail(item)
+            if _has_comparable_descent(item)
         )
         for _, values in usable_weeks
     )
-    all_usable = tuple(
-        item for _, values in usable_weeks for item in values
-    )
-    usable_comparable_trail = tuple(
-        item for item in all_usable if _is_comparable_trail(item)
-    )
-
-    comparable_in_window = tuple(
+    all_usable = tuple(item for _, values in usable_weeks for item in values)
+    ascent_usable = tuple(item for item in all_usable if _has_comparable_ascent(item))
+    descent_usable = tuple(item for item in all_usable if _has_comparable_descent(item))
+    windowed = tuple(
         item
-        for item in completed_observations
-        if _is_comparable_trail(item)
-        and 1 <= (athlete_today - item.observed_date).days
-        <= _COMPARABLE_WINDOW_DAYS
+        for item in completed
+        if item.activity_type == "trail_running"
+        and 1 <= (athlete_today - item.observed_date).days <= _COMPARABLE_WINDOW_DAYS
     )
+    ascent_window = tuple(item for item in windowed if _has_comparable_ascent(item))
+    descent_window = tuple(item for item in windowed if _has_comparable_descent(item))
+    observed_footing = {
+        footing
+        for item in windowed
+        for footing in (item.observed_footing or ())
+    }
     frequencies = tuple(len(values) for _, values in usable_weeks)
     return RecentTrailHistoryStatistics(
         usable_completed_weeks=len(usable_weeks),
@@ -528,267 +638,367 @@ def derive_recent_history_statistics(
         recent_maximum_session_minutes=int(
             max((item.duration_min for item in all_usable), default=0)
         ),
-        recent_median_usable_weekly_ascent_meters=_integer_median(
-            weekly_ascent
-        ),
-        recent_maximum_usable_weekly_ascent_meters=max(
-            weekly_ascent,
-            default=0,
-        ),
-        recent_median_usable_weekly_descent_meters=_integer_median(
-            weekly_descent
-        ),
-        recent_maximum_usable_weekly_descent_meters=max(
-            weekly_descent,
-            default=0,
-        ),
+        recent_median_usable_weekly_ascent_meters=_integer_median(weekly_ascent),
+        recent_maximum_usable_weekly_ascent_meters=max(weekly_ascent, default=0),
+        recent_median_usable_weekly_descent_meters=_integer_median(weekly_descent),
+        recent_maximum_usable_weekly_descent_meters=max(weekly_descent, default=0),
         recent_maximum_session_ascent_meters=max(
-            (
-                int(item.elevation_gain_meters or 0)
-                for item in usable_comparable_trail
-            ),
+            (int(item.elevation_gain_meters or 0) for item in ascent_usable),
             default=0,
         ),
         recent_maximum_session_descent_meters=max(
-            (
-                int(item.elevation_loss_meters or 0)
-                for item in usable_comparable_trail
-            ),
+            (int(item.elevation_loss_meters or 0) for item in descent_usable),
             default=0,
         ),
-        latest_run_date=max(
-            (item.observed_date for item in completed_observations),
-            default=None,
+        latest_run_date=max((item.observed_date for item in completed), default=None),
+        comparable_ascent_sessions_within_window=len(ascent_window),
+        latest_comparable_ascent_session_date=max(
+            (item.observed_date for item in ascent_window), default=None
         ),
-        comparable_trail_sessions_within_window=len(comparable_in_window),
-        latest_comparable_trail_session_date=max(
-            (item.observed_date for item in comparable_in_window),
-            default=None,
+        comparable_descent_sessions_within_window=len(descent_window),
+        latest_comparable_descent_session_date=max(
+            (item.observed_date for item in descent_window), default=None
         ),
+        recently_observed_footing=_canonical_footing(observed_footing),
+    )
+
+
+def derive_revision_bindings(
+    *,
+    course_demand: TrailCourseDemand,
+    constraints: TrailPlanGenerationConstraints,
+    history_statistics: RecentTrailHistoryStatistics,
+    confirmed: bool = True,
+) -> TrailRevisionBindings:
+    """Build deterministic server-side revisions for a synthetic current draft."""
+    section_payloads = _section_payloads(course_demand, constraints)
+    confirmations = tuple(
+        TrailSectionConfirmation(
+            section_key=key,
+            current_revision=_revision(value),
+            confirmed_revision=_revision(value) if confirmed else None,
+        )
+        for key, value in section_payloads
+    )
+    course_revision = _revision(_course_revision_payload(course_demand))
+    planning_revision = _revision(
+        _planning_revision_payload(course_demand, constraints)
+    )
+    history_revision = _revision(history_statistics.public_payload())
+    return TrailRevisionBindings(
+        course_revision=course_revision,
+        planning_context_revision=planning_revision,
+        history_revision=history_revision,
+        composite_revision=_composite_revision(
+            course_revision=course_revision,
+            planning_context_revision=planning_revision,
+            history_revision=history_revision,
+            section_confirmations=confirmations,
+        ),
+        section_confirmations=confirmations,
     )
 
 
 def generate_non_ultra_trail_plan(
     generation_input: NonUltraTrailGenerationInput,
 ) -> NonUltraTrailGenerationResult:
-    """Return an inactive deterministic suggestion or a canonical no-plan code."""
+    """Evaluate the actual inactive contract; it cannot return a proposal."""
+    return _evaluate(generation_input, inactive_dry_run=False)
+
+
+def _dry_run_non_ultra_trail_plan(
+    generation_input: NonUltraTrailGenerationInput,
+) -> NonUltraTrailGenerationResult:
+    """Verify the candidate envelope internally using marked synthetic input."""
+    if generation_input.synthetic_verification_only is not True:
+        raise ValueError("synthetic verification requires an explicit marker")
+    return _evaluate(generation_input, inactive_dry_run=True)
+
+
+def _evaluate(
+    generation_input: NonUltraTrailGenerationInput,
+    *,
+    inactive_dry_run: bool,
+) -> NonUltraTrailGenerationResult:
     primitive_issue = _generation_input_primitive_issue(generation_input)
     if primitive_issue is not None:
-        return _no_plan(
-            issue=primitive_issue,
+        reasons = {("validation_failed", "invalid_field_value")}
+        reasons.update(_safely_evaluable_contract_reasons(generation_input))
+        reasons.update(_safely_evaluable_semantic_reasons(generation_input))
+        if not inactive_dry_run:
+            reasons.add(("policy_unavailable", "policy_inactive"))
+        return _result(
+            generation_input,
+            reasons=reasons,
             input_hash=_invalid_input_hash(generation_input, primitive_issue),
             statistics=RecentTrailHistoryStatistics.empty(),
-        )
-
-    input_hash = deterministic_input_hash(generation_input)
-    statistics = derive_recent_history_statistics(
-        generation_input.history,
-        athlete_today=generation_input.athlete_today,
-    )
-
-    contract_issue = _contract_issue(generation_input)
-    if contract_issue is not None:
-        return _no_plan(
-            issue=contract_issue,
-            input_hash=input_hash,
-            statistics=statistics,
-        )
-    scope_issue = _scope_issue(generation_input)
-    if scope_issue is not None:
-        return _no_plan(
-            issue=scope_issue,
-            input_hash=input_hash,
-            statistics=statistics,
-        )
-    course_issue = _course_issue(generation_input.course_demand)
-    if course_issue is not None:
-        return _no_plan(
-            issue=course_issue,
-            input_hash=input_hash,
-            statistics=statistics,
-        )
-    prevalidation_issue = _prevalidation_issue(generation_input.prevalidation)
-    if prevalidation_issue is not None:
-        return _no_plan(
-            issue=prevalidation_issue,
-            input_hash=input_hash,
-            statistics=statistics,
-        )
-    history_issue = _history_issue(
-        statistics,
-        athlete_today=generation_input.athlete_today,
-    )
-    if history_issue is not None:
-        return _no_plan(
-            issue=history_issue,
-            input_hash=input_hash,
-            statistics=statistics,
-        )
-    constraint_issue = _constraint_issue(generation_input.constraints)
-    if constraint_issue is not None:
-        return _no_plan(
-            issue=constraint_issue,
-            input_hash=input_hash,
-            statistics=statistics,
+            inactive_dry_run=inactive_dry_run,
         )
     if (
-        generation_input.goal.target_event_date
-        - generation_input.block_start
-    ).days <= NON_ULTRA_TRAIL_PROPOSAL_DAYS:
-        return _no_plan(
-            issue=_InputIssue(
-                code="validation_failed",
-                detail_reason="event_inside_unapproved_taper_window",
-                rule_id="event_and_taper",
-                missing_field="accepted Trail taper policy",
-            ),
-            input_hash=input_hash,
-            statistics=statistics,
+        _course_domain_invalid(generation_input.course_demand)
+        or _constraints_domain_invalid(
+            generation_input.constraints,
+            block_start=generation_input.block_start,
         )
-
-    limited_modules = _limited_modules(
-        generation_input.course_demand,
-        generation_input.prevalidation,
-    )
-    weeks = _build_schedule(
-        generation_input=generation_input,
+        or _history_statistics_invalid(generation_input.history_statistics)
+        or _workload_request_invalid(generation_input.workload_request)
+    ):
+        reasons = _collect_reasons(
+            generation_input,
+            statistics=generation_input.history_statistics,
+            include_materialized_inactive=not inactive_dry_run,
+        )
+        return _result(
+            generation_input,
+            reasons=reasons,
+            input_hash=_invalid_input_hash(
+                generation_input,
+                "domain_validation",
+            ),
+            statistics=generation_input.history_statistics,
+            inactive_dry_run=inactive_dry_run,
+        )
+    input_hash = deterministic_input_hash(generation_input)
+    statistics = generation_input.history_statistics
+    reasons = _collect_reasons(
+        generation_input,
         statistics=statistics,
+        include_materialized_inactive=not inactive_dry_run,
     )
-    if weeks is None:
-        return _no_plan(
-            issue=_InputIssue(
-                code="validation_failed",
-                detail_reason="no_schedule_within_envelope",
-                rule_id="schedule_construction",
-            ),
-            input_hash=input_hash,
-            statistics=statistics,
-            limited_modules=limited_modules,
-        )
-
-    plan = GeneratedNonUltraTrailPlan(
-        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
-        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
-        horizon_start=generation_input.block_start,
-        horizon_end=(
-            generation_input.block_start
-            + timedelta(days=NON_ULTRA_TRAIL_PROPOSAL_DAYS - 1)
-        ),
-        reassessment_dates=(
-            generation_input.block_start
-            + timedelta(days=NON_ULTRA_TRAIL_REASSESSMENT_DAYS),
-        ),
-        course_demand_fingerprint=_canonical_fingerprint(
-            _serialize_course_demand(generation_input.course_demand)
-        ),
-        history_statistics=statistics,
+    ordered = _ordered_reasons(reasons)
+    status, detail = _primary_result(ordered)
+    modules = _module_availability(
+        status=status,
+        detail_reason=detail,
+        course=generation_input.course_demand,
+    )
+    limited_modules = _limited_projection(modules)
+    receipt_digest = _readiness_receipt_digest(
+        input_hash=input_hash,
+        status=status,
+        detail_reason=detail,
+        reasons=ordered,
+        modules=modules,
         limited_modules=limited_modules,
-        weeks=weeks,
+        revisions=generation_input.revision_bindings,
+        inactive_dry_run=inactive_dry_run,
     )
-    violations = validate_generated_plan(plan, generation_input)
-    if violations:
-        violation = violations[0]
-        return _no_plan(
-            issue=_InputIssue(
-                code="validation_failed",
-                detail_reason=violation.detail_reason,
-                rule_id=violation.rule_id,
-            ),
-            input_hash=input_hash,
+    weeks = None
+    if status == "eligible_proposal":
+        weeks = _build_schedule(
+            generation_input=generation_input,
             statistics=statistics,
-            limited_modules=limited_modules,
         )
+        if weeks is None:
+            reasons.add(("readiness_blocked", "no_schedule_within_envelope"))
+            return _result(
+                generation_input,
+                reasons=reasons,
+                input_hash=input_hash,
+                statistics=statistics,
+                inactive_dry_run=inactive_dry_run,
+            )
+    plan = None
+    if weeks is not None:
+        plan = GeneratedNonUltraTrailPlan(
+            policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+            generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
+            science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+            contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+            source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+            ontology_version=NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+            ontology_decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+            ontology_contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+            ontology_source_decision_digest=(
+                NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+            ),
+            course_schema_id=NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+            constraint_schema_id=NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+            contract_runtime_state="inactive",
+            synthetic_verification_only=True,
+            deterministic_input_hash=input_hash,
+            readiness_receipt_digest=receipt_digest,
+            revision_bindings=generation_input.revision_bindings,
+            horizon_start=generation_input.block_start,
+            horizon_end=generation_input.block_start
+            + timedelta(days=NON_ULTRA_TRAIL_PROPOSAL_DAYS - 1),
+            reassessment_dates=(
+                generation_input.block_start
+                + timedelta(days=NON_ULTRA_TRAIL_REASSESSMENT_DAYS),
+            ),
+            course_demand_fingerprint=_canonical_fingerprint(
+                _serialize_course_demand(generation_input.course_demand)
+            ),
+            history_statistics=statistics,
+            module_availability=modules,
+            limited_modules=limited_modules,
+            weeks=weeks,
+        )
+        if validate_generated_plan(plan, generation_input):
+            reasons.add(("validation_failed", "deterministic_invariant_failed"))
+            return _result(
+                generation_input,
+                reasons=reasons,
+                input_hash=input_hash,
+                statistics=statistics,
+                inactive_dry_run=inactive_dry_run,
+            )
     return NonUltraTrailGenerationResult(
         policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
         generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
         science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
         contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
         source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
-        code=NON_ULTRA_TRAIL_SUCCESS_CODE,
-        detail_reason="eligible_rolling_proposal",
+        ontology_version=NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+        ontology_decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+        ontology_contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        ontology_source_decision_digest=(
+            NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+        ),
+        course_schema_id=NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+        constraint_schema_id=NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+        contract_runtime_state=str(NON_ULTRA_TRAIL_CONTRACT.runtime_state),
+        inactive_dry_run=inactive_dry_run,
+        status=status,
+        detail_reason=detail,
+        matching_reasons=ordered,
+        module_availability=modules,
+        limited_modules=limited_modules,
         deterministic_input_hash=input_hash,
+        readiness_receipt_digest=receipt_digest,
+        revision_bindings=generation_input.revision_bindings,
         plan=plan,
         history_statistics=statistics,
-        limited_modules=limited_modules,
-        failed_rule_id=None,
-        uncertainty_or_missing_field=None,
+    )
+
+
+def _result(
+    generation_input: Any,
+    *,
+    reasons: set[tuple[str, str]],
+    input_hash: str,
+    statistics: RecentTrailHistoryStatistics,
+    inactive_dry_run: bool,
+) -> NonUltraTrailGenerationResult:
+    ordered = _ordered_reasons(reasons)
+    status, detail = _primary_result(ordered)
+    course = (
+        generation_input.course_demand
+        if isinstance(generation_input, NonUltraTrailGenerationInput)
+        and isinstance(generation_input.course_demand, TrailCourseDemand)
+        else None
+    )
+    modules = _module_availability(
+        status=status, detail_reason=detail, course=course
+    )
+    limited = _limited_projection(modules)
+    revisions = (
+        generation_input.revision_bindings
+        if isinstance(generation_input, NonUltraTrailGenerationInput)
+        and isinstance(generation_input.revision_bindings, TrailRevisionBindings)
+        else None
+    )
+    receipt = _readiness_receipt_digest(
+        input_hash=input_hash,
+        status=status,
+        detail_reason=detail,
+        reasons=ordered,
+        modules=modules,
+        limited_modules=limited,
+        revisions=revisions,
+        inactive_dry_run=inactive_dry_run,
+    )
+    return NonUltraTrailGenerationResult(
+        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        ontology_version=NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+        ontology_decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+        ontology_contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        ontology_source_decision_digest=(
+            NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+        ),
+        course_schema_id=NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+        constraint_schema_id=NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+        contract_runtime_state=str(NON_ULTRA_TRAIL_CONTRACT.runtime_state),
+        inactive_dry_run=inactive_dry_run,
+        status=status,
+        detail_reason=detail,
+        matching_reasons=ordered,
+        module_availability=modules,
+        limited_modules=limited,
+        deterministic_input_hash=input_hash,
+        readiness_receipt_digest=receipt,
+        revision_bindings=revisions,
+        plan=None,
+        history_statistics=statistics,
     )
 
 
 def deterministic_input_hash(
     generation_input: NonUltraTrailGenerationInput,
 ) -> str:
-    """Return a stable order-independent hash for the complete valid input."""
     issue = _generation_input_primitive_issue(generation_input)
     if issue is not None:
-        raise ValueError(issue.detail_reason)
+        raise ValueError(issue)
+    if (
+        _course_domain_invalid(generation_input.course_demand)
+        or _constraints_domain_invalid(
+            generation_input.constraints,
+            block_start=generation_input.block_start,
+        )
+        or _history_statistics_invalid(generation_input.history_statistics)
+        or _workload_request_invalid(generation_input.workload_request)
+    ):
+        raise ValueError("domain_validation")
     return _canonical_fingerprint(serialize_generation_input(generation_input))
 
 
 def serialize_generation_input(
     generation_input: NonUltraTrailGenerationInput,
 ) -> dict[str, Any]:
-    """Return the explicit JSON-safe replay snapshot."""
-    history = [
-        _serialize_history_observation(item)
-        for item in sorted(
-            generation_input.history,
-            key=_history_canonical_sort_key,
-        )
-    ]
-    constraints = generation_input.constraints
     return {
         "policy_version": generation_input.policy_version,
+        "generator_version": generation_input.generator_version,
         "science_decision_id": generation_input.science_decision_id,
         "contract_digest": generation_input.contract_digest,
         "source_decision_digest": generation_input.source_decision_digest,
+        "ontology_version": generation_input.ontology_version,
         "ontology_decision_id": generation_input.ontology_decision_id,
         "ontology_contract_digest": generation_input.ontology_contract_digest,
         "ontology_source_decision_digest": (
             generation_input.ontology_source_decision_digest
         ),
-        "generator_version": NON_ULTRA_TRAIL_GENERATOR_VERSION,
         "athlete_today": generation_input.athlete_today.isoformat(),
         "block_start": generation_input.block_start.isoformat(),
-        "goal": _json_safe_dates(asdict(generation_input.goal)),
-        "course_demand": _serialize_course_demand(
-            generation_input.course_demand
+        "course_demand": _serialize_course_demand(generation_input.course_demand),
+        "history_statistics": generation_input.history_statistics.public_payload(),
+        "constraints": _serialize_constraints(generation_input.constraints),
+        "revision_bindings": _json_safe_dates(
+            asdict(generation_input.revision_bindings)
         ),
-        "history": history,
-        "constraints": {
-            "adult_confirmed": constraints.adult_confirmed,
-            "current_symptom_stop": constraints.current_symptom_stop,
-            "available_weekdays": sorted(constraints.available_weekdays),
-            "weekly_time_limit_min": constraints.weekly_time_limit_min,
-            "maximum_session_duration_min": (
-                constraints.maximum_session_duration_min
-            ),
-            "unavailable_dates": sorted(
-                value.isoformat() for value in constraints.unavailable_dates
-            ),
-            "reserved_dates": sorted(
-                value.isoformat() for value in constraints.reserved_dates
-            ),
-            "preferred_longest_easy_weekday": (
-                constraints.preferred_longest_easy_weekday
-            ),
-            "schema_id": constraints.schema_id,
-        },
-        "prevalidation": asdict(generation_input.prevalidation),
+        "workload_request": (
+            asdict(generation_input.workload_request)
+            if generation_input.workload_request is not None
+            else None
+        ),
+        "synthetic_verification_only": (
+            generation_input.synthetic_verification_only
+        ),
     }
 
 
 def serialize_generation_result(
     result: NonUltraTrailGenerationResult,
 ) -> dict[str, Any]:
-    """Return the explicit JSON-safe result projection."""
     return _json_safe_dates(asdict(result))
 
 
 def serialize_workout_structure(
     workout: GeneratedTrailWorkout,
 ) -> dict[str, Any]:
-    """Return the provider-neutral targetless step structure."""
     return {"steps": [_serialize_step(step) for step in workout.steps]}
 
 
@@ -796,77 +1006,90 @@ def validate_generated_plan(
     plan: GeneratedNonUltraTrailPlan,
     generation_input: NonUltraTrailGenerationInput,
 ) -> tuple[PlanInvariantViolation, ...]:
-    """Return every deterministic policy-invariant violation in stable order."""
+    """Return every candidate invariant breach in deterministic rule order."""
     violations: list[PlanInvariantViolation] = []
-    primitive_issue = _generation_input_primitive_issue(generation_input)
-    if primitive_issue is not None:
-        return (
-            PlanInvariantViolation(
-                "generation_input_primitives",
-                primitive_issue.detail_reason,
-            ),
-        )
-    statistics = derive_recent_history_statistics(
-        generation_input.history,
-        athlete_today=generation_input.athlete_today,
-    )
-    constraints = generation_input.constraints
-    if plan.policy_version != NON_ULTRA_TRAIL_POLICY_VERSION:
-        violations.append(
-            PlanInvariantViolation("policy_version", "validation_failed")
-        )
-    if plan.generator_version != NON_ULTRA_TRAIL_GENERATOR_VERSION:
-        violations.append(
-            PlanInvariantViolation("generator_version", "validation_failed")
-        )
-    expected_course_fingerprint = _canonical_fingerprint(
-        _serialize_course_demand(generation_input.course_demand)
-    )
-    if plan.course_demand_fingerprint != expected_course_fingerprint:
-        violations.append(
-            PlanInvariantViolation("course_fingerprint", "validation_failed")
-        )
-    expected_limited_modules = _limited_modules(
-        generation_input.course_demand,
-        generation_input.prevalidation,
-    )
-    if plan.limited_modules != expected_limited_modules:
-        violations.append(
-            PlanInvariantViolation("limited_modules", "validation_failed")
-        )
-    if plan.history_statistics != statistics:
-        violations.append(
-            PlanInvariantViolation("history_statistics", "validation_failed")
-        )
-    eligibility_issues = (
-        _contract_issue(generation_input),
-        _scope_issue(generation_input),
-        _course_issue(generation_input.course_demand),
-        _prevalidation_issue(generation_input.prevalidation),
-        _history_issue(
-            statistics,
-            athlete_today=generation_input.athlete_today,
+    if _generation_input_primitive_issue(generation_input) is not None:
+        return (PlanInvariantViolation("generation_input_primitives"),)
+    if _collect_reasons(
+        generation_input,
+        statistics=generation_input.history_statistics,
+        include_materialized_inactive=False,
+        evaluate_schedule=False,
+    ):
+        violations.append(PlanInvariantViolation("eligibility"))
+    expected_metadata = {
+        "policy_version": NON_ULTRA_TRAIL_POLICY_VERSION,
+        "generator_version": NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        "science_decision_id": NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        "contract_digest": NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        "source_decision_digest": NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        "ontology_version": NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+        "ontology_decision_id": NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+        "ontology_contract_digest": NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        "ontology_source_decision_digest": (
+            NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
         ),
-        _constraint_issue(generation_input.constraints),
+        "course_schema_id": NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+        "constraint_schema_id": NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+        "contract_runtime_state": "inactive",
+        "synthetic_verification_only": True,
+    }
+    for name, expected in expected_metadata.items():
+        if getattr(plan, name) != expected:
+            violations.append(PlanInvariantViolation(name))
+    input_hash = deterministic_input_hash(generation_input)
+    if plan.deterministic_input_hash != input_hash:
+        violations.append(PlanInvariantViolation("deterministic_input_hash"))
+    if plan.revision_bindings != generation_input.revision_bindings:
+        violations.append(PlanInvariantViolation("revision_bindings"))
+    if plan.course_demand_fingerprint != _canonical_fingerprint(
+        _serialize_course_demand(generation_input.course_demand)
+    ):
+        violations.append(PlanInvariantViolation("course_fingerprint"))
+    if plan.history_statistics != generation_input.history_statistics:
+        violations.append(PlanInvariantViolation("history_statistics"))
+    expected_modules = _module_availability(
+        status="eligible_proposal",
+        detail_reason=None,
+        course=generation_input.course_demand,
     )
-    for issue in eligibility_issues:
-        if issue is not None:
-            violations.append(
-                PlanInvariantViolation(
-                    f"eligibility:{issue.rule_id}",
-                    issue.detail_reason,
-                )
-            )
+    if plan.module_availability != expected_modules:
+        violations.append(PlanInvariantViolation("module_availability"))
+    expected_limited = _limited_projection(expected_modules)
+    if plan.limited_modules != expected_limited:
+        violations.append(PlanInvariantViolation("limited_modules"))
+    expected_receipt = _readiness_receipt_digest(
+        input_hash=input_hash,
+        status="eligible_proposal",
+        detail_reason=None,
+        reasons=(),
+        modules=expected_modules,
+        limited_modules=expected_limited,
+        revisions=generation_input.revision_bindings,
+        inactive_dry_run=True,
+    )
+    if plan.readiness_receipt_digest != expected_receipt:
+        violations.append(PlanInvariantViolation("readiness_receipt_digest"))
+    statistics = generation_input.history_statistics
+    constraints = generation_input.constraints
+    available_weekdays = _known_tuple_int(constraints.available_weekdays)
+    unavailable_dates = _known_tuple_date(constraints.unavailable_dates)
+    event_date = _known_date(generation_input.course_demand.event_date)
+    targets = _effective_targets(generation_input, statistics)
     if (
-        generation_input.goal.target_event_date
-        - generation_input.block_start
-    ).days <= NON_ULTRA_TRAIL_PROPOSAL_DAYS:
-        violations.append(
-            PlanInvariantViolation(
-                "eligibility:event_and_taper",
-                "event_inside_unapproved_taper_window",
-            )
-        )
+        available_weekdays is None
+        or unavailable_dates is None
+        or event_date is None
+        or targets is None
+    ):
+        return tuple((*violations, PlanInvariantViolation("known_inputs")))
+    weekly_target, session_cap, ascent_target, descent_target = targets
+    frequency_cap = min(
+        len(available_weekdays), statistics.recent_modal_running_frequency, _MAX_RUN_DAYS
+    )
+    blocked_dates = set(unavailable_dates)
+    seen_dates: set[date] = set()
+    quality_dates: list[date] = []
     expected_end = generation_input.block_start + timedelta(
         days=NON_ULTRA_TRAIL_PROPOSAL_DAYS - 1
     )
@@ -875,63 +1098,24 @@ def validate_generated_plan(
         or plan.horizon_end != expected_end
         or len(plan.weeks) != NON_ULTRA_TRAIL_PROPOSAL_DAYS // 7
     ):
-        violations.append(
-            PlanInvariantViolation("proposal_horizon", "validation_failed")
-        )
-    expected_reassessment = (
+        violations.append(PlanInvariantViolation("proposal_horizon"))
+    if plan.reassessment_dates != (
         generation_input.block_start
         + timedelta(days=NON_ULTRA_TRAIL_REASSESSMENT_DAYS),
-    )
-    if plan.reassessment_dates != expected_reassessment:
-        violations.append(
-            PlanInvariantViolation("reassessment_date", "validation_failed")
-        )
-
-    frequency_cap = min(
-        len(set(constraints.available_weekdays)),
-        statistics.recent_modal_running_frequency,
-        _MAX_RUN_DAYS,
-    )
-    session_duration_cap = min(
-        statistics.recent_maximum_session_minutes,
-        constraints.maximum_session_duration_min,
-    )
-    weekly_minutes_target = min(
-        statistics.recent_median_usable_weekly_minutes,
-        constraints.weekly_time_limit_min,
-    )
-    weekly_minutes_hard_cap = min(
-        statistics.recent_maximum_usable_weekly_minutes,
-        constraints.weekly_time_limit_min,
-    )
-    ascent_target = statistics.recent_median_usable_weekly_ascent_meters
-    ascent_hard_cap = statistics.recent_maximum_usable_weekly_ascent_meters
-    descent_target = statistics.recent_median_usable_weekly_descent_meters
-    descent_hard_cap = statistics.recent_maximum_usable_weekly_descent_meters
-    blocked_dates = set(constraints.unavailable_dates) | set(
-        constraints.reserved_dates
-    )
-    seen_dates: set[date] = set()
-    quality_dates: list[date] = []
-
+    ):
+        violations.append(PlanInvariantViolation("reassessment_date"))
     for week_index, week in enumerate(plan.weeks):
         expected_start = generation_input.block_start + timedelta(
             days=week_index * _SCHEDULE_UNIT_DAYS
         )
-        expected_week_end = expected_start + timedelta(days=6)
         if (
             week.week_number != week_index + 1
             or week.start_date != expected_start
-            or week.end_date != expected_week_end
+            or week.end_date != expected_start + timedelta(days=6)
         ):
-            violations.append(
-                PlanInvariantViolation("week_boundary", "validation_failed")
-            )
+            violations.append(PlanInvariantViolation("week_boundary"))
         if not (_MIN_RUN_DAYS <= len(week.workouts) <= frequency_cap):
-            violations.append(
-                PlanInvariantViolation("running_day_count", "validation_failed")
-            )
-
+            violations.append(PlanInvariantViolation("running_day_count"))
         total_minutes = sum(item.planned_duration_min for item in week.workouts)
         low_minutes = sum(_workout_low_minutes(item) for item in week.workouts)
         quality = tuple(
@@ -941,205 +1125,458 @@ def validate_generated_plan(
             item for item in week.workouts if item.intensity_bucket == "low"
         )
         if len(quality) != _MAX_QUALITY_PER_UNIT:
-            violations.append(
-                PlanInvariantViolation(
-                    "quality_exposure_count",
-                    "validation_failed",
-                )
-            )
+            violations.append(PlanInvariantViolation("quality_exposure_count"))
         quality_dates.extend(item.scheduled_date for item in quality)
-        longest_easy = tuple(
+        longest = tuple(
             item for item in week.workouts if item.workout_type == "longest_easy"
         )
-        expected_longest_date = _longest_easy_date(
+        expected_longest = _longest_easy_date(
             tuple(item.scheduled_date for item in low_workouts),
-            preferred_longest_easy_weekday=(
-                constraints.preferred_longest_easy_weekday
-            ),
+            preferred_longest_weekday=constraints.preferred_longest_weekday,
         )
-        if (
-            len(longest_easy) != 1
-            or expected_longest_date is None
-            or longest_easy[0].scheduled_date != expected_longest_date
-        ):
-            violations.append(
-                PlanInvariantViolation("longest_easy_date", "validation_failed")
-            )
-        expected_easy_minutes = _allocate_easy_minutes(
+        if len(longest) != 1 or longest[0].scheduled_date != expected_longest:
+            violations.append(PlanInvariantViolation("longest_easy_date"))
+        expected_easy = _allocate_easy_minutes(
             tuple(item.scheduled_date for item in low_workouts),
-            total_minutes=(
-                weekly_minutes_target
-                - CONTROLLED_UPHILL_TEMPLATE.total_minutes
-            ),
-            preferred_longest_easy_weekday=(
-                constraints.preferred_longest_easy_weekday
-            ),
+            total_minutes=weekly_target - CONTROLLED_UPHILL_TEMPLATE.total_minutes,
+            preferred_longest_weekday=constraints.preferred_longest_weekday,
         )
         if any(
-            item.planned_duration_min
-            != expected_easy_minutes.get(item.scheduled_date)
+            item.planned_duration_min != expected_easy.get(item.scheduled_date)
             for item in low_workouts
         ):
-            violations.append(
-                PlanInvariantViolation(
-                    "longest_easy_duration",
-                    "validation_failed",
-                )
-            )
-        if total_minutes != weekly_minutes_target:
-            violations.append(
-                PlanInvariantViolation("weekly_minutes_target", "validation_failed")
-            )
-        if total_minutes > weekly_minutes_hard_cap:
-            violations.append(
-                PlanInvariantViolation("weekly_minutes_cap", "validation_failed")
-            )
+            violations.append(PlanInvariantViolation("easy_duration"))
+        if total_minutes != weekly_target:
+            violations.append(PlanInvariantViolation("weekly_minutes_target"))
         if total_minutes <= 0 or low_minutes / total_minutes < _LOW_INTENSITY_FLOOR:
-            violations.append(
-                PlanInvariantViolation("low_intensity_floor", "validation_failed")
-            )
-
+            violations.append(PlanInvariantViolation("low_intensity_floor"))
         ascent_sum = sum(item.ascent_ceiling_meters for item in week.workouts)
         descent_sum = sum(item.descent_ceiling_meters for item in week.workouts)
-        if (
-            ascent_sum != week.weekly_ascent_ceiling_meters
-            or ascent_sum > ascent_target
-            or ascent_sum > ascent_hard_cap
-        ):
-            violations.append(
-                PlanInvariantViolation("weekly_ascent_cap", "validation_failed")
-            )
-        if (
-            descent_sum != week.weekly_descent_ceiling_meters
-            or descent_sum > descent_target
-            or descent_sum > descent_hard_cap
-        ):
-            violations.append(
-                PlanInvariantViolation("weekly_descent_cap", "validation_failed")
-            )
-
+        if ascent_sum != week.weekly_ascent_ceiling_meters or ascent_sum > ascent_target:
+            violations.append(PlanInvariantViolation("weekly_ascent_cap"))
+        if descent_sum != week.weekly_descent_ceiling_meters or descent_sum > descent_target:
+            violations.append(PlanInvariantViolation("weekly_descent_cap"))
         for workout in week.workouts:
             if workout.scheduled_date in seen_dates:
-                violations.append(
-                    PlanInvariantViolation("duplicate_date", "validation_failed")
-                )
+                violations.append(PlanInvariantViolation("duplicate_date"))
             seen_dates.add(workout.scheduled_date)
-            if not (week.start_date <= workout.scheduled_date <= week.end_date):
-                violations.append(
-                    PlanInvariantViolation("workout_week", "validation_failed")
-                )
             if (
                 workout.scheduled_date in blocked_dates
-                or workout.scheduled_date.weekday()
-                not in constraints.available_weekdays
+                or workout.scheduled_date.isoweekday() not in available_weekdays
+                or workout.scheduled_date >= event_date
             ):
-                violations.append(
-                    PlanInvariantViolation("calendar_constraint", "validation_failed")
-                )
-            if workout.scheduled_date >= generation_input.goal.target_event_date:
-                violations.append(
-                    PlanInvariantViolation("event_boundary", "validation_failed")
-                )
+                violations.append(PlanInvariantViolation("calendar_constraint"))
             if workout.activity_type != "trail_running":
-                violations.append(
-                    PlanInvariantViolation("activity_type", "validation_failed")
-                )
-            if (
-                workout.planned_duration_min <= 0
-                or workout.planned_duration_min > session_duration_cap
+                violations.append(PlanInvariantViolation("activity_type"))
+            if not (0 < workout.planned_duration_min <= session_cap):
+                violations.append(PlanInvariantViolation("session_duration_cap"))
+            if not (
+                0 <= workout.ascent_ceiling_meters
+                <= statistics.recent_maximum_session_ascent_meters
             ):
-                violations.append(
-                    PlanInvariantViolation("session_duration_cap", "validation_failed")
-                )
-            if (
-                workout.ascent_ceiling_meters < 0
-                or workout.ascent_ceiling_meters
-                > statistics.recent_maximum_session_ascent_meters
+                violations.append(PlanInvariantViolation("session_ascent_cap"))
+            if not (
+                0 <= workout.descent_ceiling_meters
+                <= statistics.recent_maximum_session_descent_meters
             ):
-                violations.append(
-                    PlanInvariantViolation("session_ascent_cap", "validation_failed")
-                )
-            if (
-                workout.descent_ceiling_meters < 0
-                or workout.descent_ceiling_meters
-                > statistics.recent_maximum_session_descent_meters
+                violations.append(PlanInvariantViolation("session_descent_cap"))
+            if workout.terrain_footing != _proposal_footing(
+                generation_input.course_demand
             ):
-                violations.append(
-                    PlanInvariantViolation("session_descent_cap", "validation_failed")
-                )
-            if (
-                workout.terrain_reference
-                != generation_input.prevalidation.training_terrain_reference
-            ):
-                violations.append(
-                    PlanInvariantViolation("terrain_reference", "validation_failed")
-                )
+                violations.append(PlanInvariantViolation("terrain_footing"))
             if workout.intensity_bucket == "quality":
-                if workout.workout_type != "controlled_quality":
-                    violations.append(
-                        PlanInvariantViolation(
-                            "quality_workout_type",
-                            "validation_failed",
-                        )
-                    )
                 if (
-                    workout.template_id
-                    != CONTROLLED_UPHILL_TEMPLATE.template_id
+                    workout.workout_type != "controlled_quality"
+                    or workout.template_id != CONTROLLED_UPHILL_TEMPLATE.template_id
                     or workout.steps != CONTROLLED_UPHILL_TEMPLATE.steps
                     or workout.planned_duration_min != 38
                 ):
-                    violations.append(
-                        PlanInvariantViolation(
-                            "quality_template",
-                            "validation_failed",
-                        )
-                    )
-            else:
-                if workout.workout_type not in {"easy", "longest_easy"}:
-                    violations.append(
-                        PlanInvariantViolation(
-                            "easy_workout_type",
-                            "validation_failed",
-                        )
-                    )
-                if (
-                    workout.template_id is not None
-                    or workout.steps
-                    != (
-                        TrailWorkoutStep(
-                            kind="step",
-                            phase="easy",
-                            duration_min=workout.planned_duration_min,
-                            intended_intensity="low",
-                        ),
-                    )
-                ):
-                    violations.append(
-                        PlanInvariantViolation(
-                            "easy_template",
-                            "validation_failed",
-                        )
-                    )
-
-    for previous, current in zip(quality_dates, quality_dates[1:], strict=False):
-        if (current - previous).days <= 1:
-            violations.append(
-                PlanInvariantViolation("quality_spacing", "validation_failed")
-            )
-    ordered_running_dates = tuple(sorted(seen_dates))
-    for previous, current in zip(
-        ordered_running_dates,
-        ordered_running_dates[1:],
-        strict=False,
-    ):
-        if (current - previous).days <= 1:
-            violations.append(
-                PlanInvariantViolation(
-                    "adjacent_running_days",
-                    "validation_failed",
+                    violations.append(PlanInvariantViolation("quality_template"))
+            elif (
+                workout.workout_type not in {"easy", "longest_easy"}
+                or workout.template_id is not None
+                or workout.steps
+                != (
+                    TrailWorkoutStep(
+                        kind="step",
+                        phase="easy",
+                        duration_min=workout.planned_duration_min,
+                        intended_intensity="low",
+                    ),
                 )
-            )
+            ):
+                violations.append(PlanInvariantViolation("easy_template"))
+    for previous, current in zip(sorted(quality_dates), sorted(quality_dates)[1:]):
+        if (current - previous).days <= 1:
+            violations.append(PlanInvariantViolation("quality_spacing"))
+    ordered_dates = tuple(sorted(seen_dates))
+    for previous, current in zip(ordered_dates, ordered_dates[1:]):
+        if (current - previous).days <= 1:
+            violations.append(PlanInvariantViolation("adjacent_running_days"))
     return tuple(violations)
+
+
+def _collect_reasons(
+    generation_input: NonUltraTrailGenerationInput,
+    *,
+    statistics: RecentTrailHistoryStatistics,
+    include_materialized_inactive: bool,
+    evaluate_schedule: bool = True,
+    evaluate_revisions: bool = True,
+) -> set[tuple[str, str]]:
+    reasons = _safely_evaluable_contract_reasons(generation_input)
+    if include_materialized_inactive:
+        reasons.add(("policy_unavailable", "policy_inactive"))
+    course = generation_input.course_demand
+    constraints = generation_input.constraints
+    if (
+        course.schema_id != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID
+        or constraints.schema_id != NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID
+    ):
+        reasons.add(("validation_failed", "schema_version_mismatch"))
+    course_invalid = _course_domain_invalid(course)
+    constraints_invalid = _constraints_domain_invalid(
+        constraints,
+        block_start=generation_input.block_start,
+    )
+    history_invalid = _history_statistics_invalid(statistics)
+    workload_invalid = _workload_request_invalid(
+        generation_input.workload_request
+    )
+    if course_invalid or constraints_invalid or history_invalid or workload_invalid:
+        reasons.add(("validation_failed", "invalid_field_value"))
+    if not course.event_id.strip() or any(
+        value.is_unknown
+        for value in (
+            course.event_date,
+            course.distance_meters,
+            course.total_ascent_m,
+            course.total_descent_m,
+            course.planning_duration_range,
+            course.hands_assist,
+            course.fixed_rope,
+        )
+    ):
+        reasons.add(("clarification_required", "material_course_demand_unknown"))
+    if any(
+        value.provenance == "explicit_assumption"
+        and value.assumption_confirmed_revision != value.source_revision
+        for _, value in _all_provenanced_values(course, constraints)
+    ):
+        reasons.add(
+            ("clarification_required", "assumption_confirmation_required")
+        )
+    if any(
+        value.is_unknown
+        for value in (
+            course.event_format,
+            course.distance_family,
+            course.planning_intent,
+            constraints.adult_nonclinical_scope_confirmed,
+            constraints.performance_intent_confirmed,
+        )
+    ):
+        reasons.add(
+            (
+                "clarification_required",
+                "adult_scope_or_constraints_unconfirmed",
+            )
+        )
+    if (
+        _known_str(course.event_format) == "multi_day"
+        or _known_str(course.distance_family) == "ultra"
+    ):
+        reasons.add(("policy_unavailable", "unsupported_ultra_or_multiday"))
+    if (
+        _known_str(course.planning_intent)
+        in {"first_completion", "return_to_consistency"}
+        or _known_bool(constraints.adult_nonclinical_scope_confirmed) is False
+        or _known_bool(constraints.performance_intent_confirmed) is False
+    ):
+        reasons.add(("policy_unavailable", "unsupported_population_or_intent"))
+    if (
+        _known_bool(course.hands_assist) is True
+        or _known_bool(course.fixed_rope) is True
+    ):
+        reasons.add(("policy_unavailable", "technical_features_outside_v2"))
+    required_constraints = (
+        constraints.available_weekdays,
+        constraints.weekly_time_limit_min,
+        constraints.maximum_session_duration_min,
+        constraints.unavailable_dates,
+        constraints.nontechnical_three_minute_uphill_access,
+        constraints.controlled_downhill_access,
+        constraints.current_symptom_stop,
+    )
+    if any(value.is_unknown for value in required_constraints) or (
+        course.course_footing.is_known and constraints.accessible_footing.is_unknown
+    ):
+        reasons.add(("clarification_required", "training_constraints_missing"))
+    weekdays = _known_tuple_int(constraints.available_weekdays)
+    if (
+        weekdays is not None
+        and constraints.preferred_longest_weekday is not None
+        and constraints.preferred_longest_weekday not in weekdays
+    ) or generation_input.block_start < generation_input.athlete_today:
+        reasons.add(("clarification_required", "contradictory_input"))
+    if (
+        evaluate_revisions
+        and not (course_invalid or constraints_invalid or history_invalid)
+        and not _revisions_are_current(generation_input)
+    ):
+        reasons.add(
+            (
+                "clarification_required",
+                "stale_confirmation_or_source_revision",
+            )
+        )
+    if not (workload_invalid or history_invalid) and _workload_above_history(
+        generation_input.workload_request,
+        statistics,
+    ):
+        reasons.add(
+            (
+                "clarification_required",
+                "training_constraints_outside_history_envelope",
+            )
+        )
+    if not history_invalid and (
+        statistics.usable_completed_weeks < _MINIMUM_USABLE_WEEKS
+        or (
+        statistics.latest_run_date is None
+        or (generation_input.athlete_today - statistics.latest_run_date).days
+        > _LATEST_RUN_DAYS
+        )
+    ):
+        reasons.add(
+            ("readiness_blocked", "insufficient_recent_running_history")
+        )
+    if not history_invalid and (
+        statistics.comparable_ascent_sessions_within_window < _COMPARABLE_COUNT
+        or statistics.latest_comparable_ascent_session_date is None
+        or (
+            generation_input.athlete_today
+            - statistics.latest_comparable_ascent_session_date
+        ).days
+        > _LATEST_COMPARABLE_DAYS
+    ):
+        reasons.add(
+            ("readiness_blocked", "insufficient_comparable_trail_history")
+        )
+    if not history_invalid and (
+        statistics.comparable_descent_sessions_within_window < _COMPARABLE_COUNT
+        or statistics.latest_comparable_descent_session_date is None
+        or (
+            generation_input.athlete_today
+            - statistics.latest_comparable_descent_session_date
+        ).days
+        > _LATEST_COMPARABLE_DAYS
+    ):
+        reasons.add(("readiness_blocked", "insufficient_descent_history"))
+    course_footing = _known_footing(course.course_footing)
+    accessible = _known_footing(constraints.accessible_footing)
+    if course_footing is not None and accessible is not None and not set(
+        course_footing
+    ).issubset(accessible):
+        reasons.add(("readiness_blocked", "insufficient_terrain_access"))
+    if not history_invalid and course_footing is not None and not set(
+        course_footing
+    ).issubset(
+        statistics.recently_observed_footing
+    ):
+        reasons.add(
+            ("readiness_blocked", "insufficient_comparable_trail_history")
+        )
+    if (
+        _known_bool(constraints.nontechnical_three_minute_uphill_access) is False
+        or _known_bool(constraints.controlled_downhill_access) is False
+    ):
+        reasons.add(("readiness_blocked", "insufficient_terrain_access"))
+    if _known_bool(constraints.current_symptom_stop) is True:
+        reasons.add(("readiness_blocked", "current_symptom_stop"))
+    event_date = _known_date(course.event_date)
+    if event_date is not None and (
+        event_date - generation_input.block_start
+    ).days <= NON_ULTRA_TRAIL_PROPOSAL_DAYS:
+        reasons.add(
+            ("policy_unavailable", "event_inside_unapproved_taper_window")
+        )
+    if (
+        evaluate_schedule
+        and not (
+            course_invalid
+            or constraints_invalid
+            or history_invalid
+            or workload_invalid
+        )
+        and _schedule_inputs_complete(generation_input)
+    ):
+        if _build_schedule(
+            generation_input=generation_input, statistics=statistics
+        ) is None:
+            reasons.add(("readiness_blocked", "no_schedule_within_envelope"))
+    return reasons
+
+
+def _safely_evaluable_contract_reasons(
+    generation_input: Any,
+) -> set[tuple[str, str]]:
+    if not isinstance(generation_input, NonUltraTrailGenerationInput):
+        return set()
+    expected = (
+        (generation_input.policy_version, NON_ULTRA_TRAIL_POLICY_VERSION),
+        (generation_input.generator_version, NON_ULTRA_TRAIL_GENERATOR_VERSION),
+        (generation_input.science_decision_id, NON_ULTRA_TRAIL_SCIENCE_DECISION_ID),
+        (generation_input.contract_digest, NON_ULTRA_TRAIL_CONTRACT_DIGEST),
+        (
+            generation_input.source_decision_digest,
+            NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        ),
+        (generation_input.ontology_version, NON_ULTRA_TRAIL_ONTOLOGY_VERSION),
+        (generation_input.ontology_decision_id, NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID),
+        (
+            generation_input.ontology_contract_digest,
+            NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        ),
+        (
+            generation_input.ontology_source_decision_digest,
+            NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+        ),
+    )
+    if any(type(actual) is str and actual != wanted for actual, wanted in expected):
+        return {("policy_unavailable", "policy_inactive")}
+    return set()
+
+
+def _safely_evaluable_semantic_reasons(
+    generation_input: Any,
+) -> set[tuple[str, str]]:
+    """Keep independent reasons when unrelated primitive metadata is malformed."""
+    if not isinstance(generation_input, NonUltraTrailGenerationInput):
+        return set()
+    course = generation_input.course_demand
+    constraints = generation_input.constraints
+    statistics = generation_input.history_statistics
+    if (
+        not isinstance(course, TrailCourseDemand)
+        or not isinstance(constraints, TrailPlanGenerationConstraints)
+        or not isinstance(statistics, RecentTrailHistoryStatistics)
+        or type(generation_input.athlete_today) is not date
+        or type(generation_input.block_start) is not date
+        or type(course.event_id) is not str
+        or type(course.schema_id) is not str
+        or type(constraints.schema_id) is not str
+        or (
+            generation_input.workload_request is not None
+            and not isinstance(
+                generation_input.workload_request,
+                TrailWorkloadRequest,
+            )
+        )
+    ):
+        return set()
+    try:
+        values = _all_provenanced_values(course, constraints)
+    except (AttributeError, TypeError):
+        return set()
+    if any(not isinstance(value, ProvenancedValue) for _, value in values):
+        return set()
+    return _collect_reasons(
+        generation_input,
+        statistics=statistics,
+        include_materialized_inactive=False,
+        evaluate_revisions=False,
+    )
+
+
+def _ordered_reasons(
+    reasons: set[tuple[str, str]],
+) -> tuple[MatchingReason, ...]:
+    if not reasons.issubset(NON_ULTRA_TRAIL_REASON_PAIRS):
+        raise ValueError("Trail result contains a non-contract reason")
+    status_order = {
+        status: index for index, status in enumerate(NON_ULTRA_TRAIL_STATUS_PRECEDENCE)
+    }
+    detail_order = {
+        status: {reason: index for index, reason in enumerate(values)}
+        for status, values in NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG.items()
+    }
+    return tuple(
+        MatchingReason(status, detail)
+        for status, detail in sorted(
+            reasons,
+            key=lambda value: (
+                status_order[value[0]], detail_order[value[0]][value[1]]
+            ),
+        )
+    )
+
+
+def _primary_result(
+    reasons: tuple[MatchingReason, ...],
+) -> tuple[str, str | None]:
+    return (
+        ("eligible_proposal", None)
+        if not reasons
+        else (reasons[0].status, reasons[0].detail_reason)
+    )
+
+
+def _module_availability(
+    *,
+    status: str,
+    detail_reason: str | None,
+    course: TrailCourseDemand | None,
+) -> tuple[ModuleAvailability, ...]:
+    if status != "eligible_proposal" or course is None:
+        target = f"{status}.{detail_reason}" if detail_reason is not None else status
+        return tuple(
+            ModuleAvailability(module, "not_evaluated", target)
+            for module in NON_ULTRA_TRAIL_MODULE_KEYS
+        )
+    limited: dict[str, str] = {}
+    if course.grade_distribution.is_unknown:
+        limited["grade_specificity"] = _MODULE_LIMIT_TARGETS["grade_specificity"]
+    if course.course_footing.is_unknown:
+        limited["technical_terrain"] = _MODULE_LIMIT_TARGETS["technical_terrain"]
+    if any(value.is_unknown for value in _environment_values(course.optional_context)):
+        limited["environment_altitude"] = _MODULE_LIMIT_TARGETS[
+            "environment_altitude"
+        ]
+    support_unknown = any(
+        value.is_unknown for value in _support_values(course.optional_context)
+    )
+    fueling_unknown = any(
+        value.is_unknown for value in _fueling_values(course.optional_context)
+    )
+    if support_unknown or fueling_unknown:
+        limited["fueling"] = (
+            _MODULE_LIMIT_TARGETS["fueling"]
+            if support_unknown
+            else "course.optional_context.fueling"
+        )
+    result = tuple(
+        ModuleAvailability(
+            module,
+            "limited" if module in limited else "available",
+            limited.get(module),
+        )
+        for module in NON_ULTRA_TRAIL_MODULE_KEYS
+    )
+    if any(value.state not in NON_ULTRA_TRAIL_MODULE_STATES for value in result):
+        raise ValueError("Trail module state escaped the accepted contract")
+    return result
+
+
+def _limited_projection(
+    modules: tuple[ModuleAvailability, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        module
+        for module in NON_ULTRA_TRAIL_LIMITED_MODULE_ORDER
+        if next(value for value in modules if value.module == module).state
+        == "limited"
+    )
 
 
 def _build_schedule(
@@ -1148,37 +1585,27 @@ def _build_schedule(
     statistics: RecentTrailHistoryStatistics,
 ) -> tuple[GeneratedTrailWeek, ...] | None:
     constraints = generation_input.constraints
-    frequency = min(
-        len(constraints.available_weekdays),
-        statistics.recent_modal_running_frequency,
-        _MAX_RUN_DAYS,
-    )
-    if frequency < _MIN_RUN_DAYS:
+    available_weekdays = _known_tuple_int(constraints.available_weekdays)
+    unavailable_dates = _known_tuple_date(constraints.unavailable_dates)
+    event_date = _known_date(generation_input.course_demand.event_date)
+    if available_weekdays is None or unavailable_dates is None or event_date is None:
         return None
-    session_cap = min(
-        constraints.maximum_session_duration_min,
-        statistics.recent_maximum_session_minutes,
-    )
-    weekly_target = min(
-        constraints.weekly_time_limit_min,
-        statistics.recent_median_usable_weekly_minutes,
-    )
-    weekly_hard_cap = min(
-        constraints.weekly_time_limit_min,
-        statistics.recent_maximum_usable_weekly_minutes,
+    targets = _effective_targets(generation_input, statistics)
+    if targets is None:
+        return None
+    weekly_target, session_cap, ascent_target, descent_target = targets
+    frequency = min(
+        len(available_weekdays), statistics.recent_modal_running_frequency, _MAX_RUN_DAYS
     )
     if (
-        session_cap < CONTROLLED_UPHILL_TEMPLATE.total_minutes
+        frequency < _MIN_RUN_DAYS
+        or session_cap < CONTROLLED_UPHILL_TEMPLATE.total_minutes
         or weekly_target <= 0
-        or weekly_target > weekly_hard_cap
-        or statistics.recent_median_usable_weekly_ascent_meters <= 0
-        or statistics.recent_maximum_session_ascent_meters <= 0
+        or ascent_target <= 0
+        or descent_target <= 0
     ):
         return None
-
-    blocked = set(constraints.unavailable_dates) | set(
-        constraints.reserved_dates
-    )
+    blocked = set(unavailable_dates)
     weeks: list[GeneratedTrailWeek] = []
     previous_quality_date: date | None = None
     previous_workout_date: date | None = None
@@ -1186,16 +1613,15 @@ def _build_schedule(
         week_start = generation_input.block_start + timedelta(
             days=week_index * _SCHEDULE_UNIT_DAYS
         )
-        week_end = week_start + timedelta(days=6)
         available = tuple(
             value
             for value in (
                 week_start + timedelta(days=offset)
                 for offset in range(_SCHEDULE_UNIT_DAYS)
             )
-            if value.weekday() in constraints.available_weekdays
+            if value.isoweekday() in available_weekdays
             and value not in blocked
-            and value < generation_input.goal.target_event_date
+            and value < event_date
         )
         unit_frequency = min(frequency, len(available))
         if unit_frequency < _MIN_RUN_DAYS:
@@ -1203,18 +1629,14 @@ def _build_schedule(
         selected = _select_schedule_dates(
             available,
             frequency=unit_frequency,
-            preferred_longest_easy_weekday=(
-                constraints.preferred_longest_easy_weekday
-            ),
+            preferred_longest_weekday=constraints.preferred_longest_weekday,
             previous_workout_date=previous_workout_date,
         )
         if selected is None:
             return None
         quality_date = _select_quality_date(
             selected,
-            preferred_longest_easy_weekday=(
-                constraints.preferred_longest_easy_weekday
-            ),
+            preferred_longest_weekday=constraints.preferred_longest_weekday,
             previous_quality_date=previous_quality_date,
         )
         if quality_date is None:
@@ -1224,22 +1646,12 @@ def _build_schedule(
             quality_date=quality_date,
             total_minutes=weekly_target,
             session_cap=session_cap,
-            ascent_target=statistics.recent_median_usable_weekly_ascent_meters,
-            ascent_session_cap=(
-                statistics.recent_maximum_session_ascent_meters
-            ),
-            descent_target=(
-                statistics.recent_median_usable_weekly_descent_meters
-            ),
-            descent_session_cap=(
-                statistics.recent_maximum_session_descent_meters
-            ),
-            preferred_longest_easy_weekday=(
-                constraints.preferred_longest_easy_weekday
-            ),
-            terrain_reference=str(
-                generation_input.prevalidation.training_terrain_reference
-            ),
+            ascent_target=ascent_target,
+            ascent_session_cap=statistics.recent_maximum_session_ascent_meters,
+            descent_target=descent_target,
+            descent_session_cap=statistics.recent_maximum_session_descent_meters,
+            preferred_longest_weekday=constraints.preferred_longest_weekday,
+            terrain_footing=_proposal_footing(generation_input.course_demand),
         )
         if workouts is None:
             return None
@@ -1247,12 +1659,12 @@ def _build_schedule(
             GeneratedTrailWeek(
                 week_number=week_index + 1,
                 start_date=week_start,
-                end_date=week_end,
+                end_date=week_start + timedelta(days=6),
                 weekly_ascent_ceiling_meters=sum(
-                    item.ascent_ceiling_meters for item in workouts
+                    value.ascent_ceiling_meters for value in workouts
                 ),
                 weekly_descent_ceiling_meters=sum(
-                    item.descent_ceiling_meters for item in workouts
+                    value.descent_ceiling_meters for value in workouts
                 ),
                 workouts=workouts,
             )
@@ -1260,6 +1672,33 @@ def _build_schedule(
         previous_quality_date = quality_date
         previous_workout_date = max(selected)
     return tuple(weeks)
+
+
+def _effective_targets(
+    generation_input: NonUltraTrailGenerationInput,
+    statistics: RecentTrailHistoryStatistics,
+) -> tuple[int, int, int, int] | None:
+    weekly_limit = _known_int(generation_input.constraints.weekly_time_limit_min)
+    session_limit = _known_int(
+        generation_input.constraints.maximum_session_duration_min
+    )
+    if weekly_limit is None or session_limit is None:
+        return None
+    request = generation_input.workload_request
+    weekly = min(statistics.recent_median_usable_weekly_minutes, weekly_limit)
+    session = min(statistics.recent_maximum_session_minutes, session_limit)
+    ascent = statistics.recent_median_usable_weekly_ascent_meters
+    descent = statistics.recent_median_usable_weekly_descent_meters
+    if request is not None:
+        if request.weekly_running_minutes is not None:
+            weekly = min(weekly, request.weekly_running_minutes)
+        if request.maximum_session_minutes is not None:
+            session = min(session, request.maximum_session_minutes)
+        if request.weekly_ascent_meters is not None:
+            ascent = min(ascent, request.weekly_ascent_meters)
+        if request.weekly_descent_meters is not None:
+            descent = min(descent, request.weekly_descent_meters)
+    return weekly, session, ascent, descent
 
 
 def _build_week_workouts(
@@ -1272,52 +1711,43 @@ def _build_week_workouts(
     ascent_session_cap: int,
     descent_target: int,
     descent_session_cap: int,
-    preferred_longest_easy_weekday: int | None,
-    terrain_reference: str,
+    preferred_longest_weekday: int | None,
+    terrain_footing: tuple[str, ...],
 ) -> tuple[GeneratedTrailWorkout, ...] | None:
     easy_dates = tuple(value for value in sorted(dates) if value != quality_date)
-    remaining_minutes = total_minutes - CONTROLLED_UPHILL_TEMPLATE.total_minutes
-    if remaining_minutes < len(easy_dates):
+    remaining = total_minutes - CONTROLLED_UPHILL_TEMPLATE.total_minutes
+    if remaining < len(easy_dates):
         return None
     easy_allocations = _allocate_easy_minutes(
         easy_dates,
-        total_minutes=remaining_minutes,
-        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+        total_minutes=remaining,
+        preferred_longest_weekday=preferred_longest_weekday,
     )
     if any(value > session_cap for value in easy_allocations.values()):
         return None
-    low_minutes = (
-        CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes
-        + sum(easy_allocations.values())
+    low_minutes = CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes + sum(
+        easy_allocations.values()
     )
     if total_minutes <= 0 or low_minutes / total_minutes < _LOW_INTENSITY_FLOOR:
         return None
-
-    longest_date = _longest_easy_date(
-        easy_dates,
-        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+    longest = _longest_easy_date(
+        easy_dates, preferred_longest_weekday=preferred_longest_weekday
     )
-    ascent_allocations = _allocate_integer_ceiling(
+    ascent = _allocate_integer_ceiling(
         dates,
         total_ceiling=ascent_target,
         per_session_ceiling=ascent_session_cap,
-        priority=(
-            quality_date,
-            *tuple(value for value in dates if value != quality_date),
-        ),
+        priority=(quality_date, *tuple(value for value in dates if value != quality_date)),
     )
-    descent_priority = (
-        (longest_date,) if longest_date is not None else ()
-    ) + tuple(value for value in dates if value != longest_date)
-    descent_allocations = _allocate_integer_ceiling(
+    descent = _allocate_integer_ceiling(
         dates,
         total_ceiling=descent_target,
         per_session_ceiling=descent_session_cap,
-        priority=descent_priority,
+        priority=((longest,) if longest is not None else ())
+        + tuple(value for value in dates if value != longest),
     )
-    if ascent_allocations is None or descent_allocations is None:
+    if ascent is None or descent is None:
         return None
-
     workouts: list[GeneratedTrailWorkout] = []
     for scheduled_date in sorted(dates):
         if scheduled_date == quality_date:
@@ -1326,12 +1756,10 @@ def _build_week_workouts(
                     scheduled_date=scheduled_date,
                     workout_type="controlled_quality",
                     intensity_bucket="quality",
-                    planned_duration_min=(
-                        CONTROLLED_UPHILL_TEMPLATE.total_minutes
-                    ),
-                    ascent_ceiling_meters=ascent_allocations[scheduled_date],
-                    descent_ceiling_meters=descent_allocations[scheduled_date],
-                    terrain_reference=terrain_reference,
+                    planned_duration_min=CONTROLLED_UPHILL_TEMPLATE.total_minutes,
+                    ascent_ceiling_meters=ascent[scheduled_date],
+                    descent_ceiling_meters=descent[scheduled_date],
+                    terrain_footing=terrain_footing,
                     template_id=CONTROLLED_UPHILL_TEMPLATE.template_id,
                     steps=CONTROLLED_UPHILL_TEMPLATE.steps,
                 )
@@ -1343,16 +1771,12 @@ def _build_week_workouts(
         workouts.append(
             GeneratedTrailWorkout(
                 scheduled_date=scheduled_date,
-                workout_type=(
-                    "longest_easy"
-                    if scheduled_date == longest_date
-                    else "easy"
-                ),
+                workout_type="longest_easy" if scheduled_date == longest else "easy",
                 intensity_bucket="low",
                 planned_duration_min=duration,
-                ascent_ceiling_meters=ascent_allocations[scheduled_date],
-                descent_ceiling_meters=descent_allocations[scheduled_date],
-                terrain_reference=terrain_reference,
+                ascent_ceiling_meters=ascent[scheduled_date],
+                descent_ceiling_meters=descent[scheduled_date],
+                terrain_footing=terrain_footing,
                 template_id=None,
                 steps=(
                     TrailWorkoutStep(
@@ -1371,19 +1795,18 @@ def _allocate_easy_minutes(
     dates: Sequence[date],
     *,
     total_minutes: int,
-    preferred_longest_easy_weekday: int | None,
+    preferred_longest_weekday: int | None,
 ) -> dict[date, int]:
     if not dates:
         return {}
     base, remainder = divmod(total_minutes, len(dates))
-    allocations = {value: base for value in dates}
+    result = {value: base for value in dates}
     priority = _easy_allocation_priority(
-        dates,
-        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+        dates, preferred_longest_weekday=preferred_longest_weekday
     )
     for value in priority[:remainder]:
-        allocations[value] += 1
-    return allocations
+        result[value] += 1
+    return result
 
 
 def _allocate_integer_ceiling(
@@ -1403,63 +1826,53 @@ def _allocate_integer_ceiling(
         return None
     effective_total = min(total_ceiling, per_session_ceiling * len(dates))
     quotient, remainder = divmod(effective_total, len(ordered))
-    allocations = {value: quotient for value in ordered}
+    result = {value: quotient for value in ordered}
     for value in ordered[:remainder]:
-        allocations[value] += 1
-    if any(value > per_session_ceiling for value in allocations.values()):
-        return None
-    return allocations
+        result[value] += 1
+    return (
+        result
+        if all(value <= per_session_ceiling for value in result.values())
+        else None
+    )
 
 
 def _select_schedule_dates(
     dates: Sequence[date],
     *,
     frequency: int,
-    preferred_longest_easy_weekday: int | None,
+    preferred_longest_weekday: int | None,
     previous_workout_date: date | None,
 ) -> tuple[date, ...] | None:
     ordered = tuple(sorted(set(dates)))
-    if len(ordered) < frequency:
-        return None
     candidates = tuple(
         candidate
         for candidate in combinations(ordered, frequency)
         if all(
             (current - previous).days > 1
-            for previous, current in zip(
-                candidate,
-                candidate[1:],
-                strict=False,
-            )
+            for previous, current in zip(candidate, candidate[1:])
         )
         and (
             previous_workout_date is None
             or (candidate[0] - previous_workout_date).days > 1
         )
     )
-    if not candidates:
-        return None
-    preferred_candidates = tuple(
+    preferred = tuple(
         candidate
         for candidate in candidates
-        if preferred_longest_easy_weekday is not None
-        and any(
-            value.weekday() == preferred_longest_easy_weekday
-            for value in candidate
-        )
+        if preferred_longest_weekday is not None
+        and any(value.isoweekday() == preferred_longest_weekday for value in candidate)
     )
-    return min(preferred_candidates or candidates)
+    return min(preferred or candidates, default=None)
 
 
 def _select_quality_date(
     dates: Sequence[date],
     *,
-    preferred_longest_easy_weekday: int | None,
+    preferred_longest_weekday: int | None,
     previous_quality_date: date | None,
 ) -> date | None:
     longest = _longest_easy_date(
-        dates,
-        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+        dates, preferred_longest_weekday=preferred_longest_weekday
     )
     unit_start = min(dates, default=None)
     if unit_start is None:
@@ -1482,582 +1895,870 @@ def _select_quality_date(
 def _longest_easy_date(
     dates: Sequence[date],
     *,
-    preferred_longest_easy_weekday: int | None,
+    preferred_longest_weekday: int | None,
 ) -> date | None:
-    if preferred_longest_easy_weekday is not None:
-        preferred = next(
+    if preferred_longest_weekday is not None:
+        selected = next(
             (
                 value
                 for value in sorted(dates)
-                if value.weekday() == preferred_longest_easy_weekday
+                if value.isoweekday() == preferred_longest_weekday
             ),
             None,
         )
-        if preferred is not None:
-            return preferred
+        if selected is not None:
+            return selected
     return max(dates, default=None)
 
 
 def _easy_allocation_priority(
     dates: Sequence[date],
     *,
-    preferred_longest_easy_weekday: int | None,
+    preferred_longest_weekday: int | None,
 ) -> tuple[date, ...]:
     longest = _longest_easy_date(
-        dates,
-        preferred_longest_easy_weekday=preferred_longest_easy_weekday,
+        dates, preferred_longest_weekday=preferred_longest_weekday
     )
-    if longest is None:
-        return ()
-    return (longest,) + tuple(value for value in sorted(dates) if value != longest)
+    return (
+        ()
+        if longest is None
+        else (longest,) + tuple(value for value in sorted(dates) if value != longest)
+    )
 
 
-def _contract_issue(
-    generation_input: NonUltraTrailGenerationInput,
-) -> _InputIssue | None:
-    if (
-        generation_input.ontology_decision_id
-        != NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID
-        or generation_input.ontology_contract_digest
-        != NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST
-        or generation_input.ontology_source_decision_digest
-        != NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
-    ):
-        return _InputIssue(
-            code="ontology_not_accepted",
-            detail_reason="ontology_contract_mismatch",
-            rule_id="accepted_ontology_contract",
-        )
-    if (
-        generation_input.policy_version != NON_ULTRA_TRAIL_POLICY_VERSION
-        or generation_input.science_decision_id
-        != NON_ULTRA_TRAIL_SCIENCE_DECISION_ID
-        or generation_input.contract_digest != NON_ULTRA_TRAIL_CONTRACT_DIGEST
-        or generation_input.source_decision_digest
-        != NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST
-    ):
-        return _InputIssue(
-            code="policy_inactive",
-            detail_reason="policy_contract_mismatch",
-            rule_id="accepted_inactive_policy_contract",
-        )
-    return None
-
-
-def _scope_issue(
-    generation_input: NonUltraTrailGenerationInput,
-) -> _InputIssue | None:
-    goal = generation_input.goal
-    constraints = generation_input.constraints
-    if goal.event_format != "single_day" or goal.distance_family != "non_ultra":
-        return _InputIssue(
-            code="unsupported_ultra_or_multiday",
-            detail_reason="unsupported_ultra_or_multiday",
-            rule_id="scope_and_dependencies",
-        )
-    if goal.intent != "performance" or goal.clinical_or_return_to_sport:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="adult_scope_or_constraints_unconfirmed",
-            rule_id="scope_and_dependencies",
-        )
-    if constraints.adult_confirmed is not True:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="adult_scope_or_constraints_unconfirmed",
-            rule_id="adult_scope",
-            missing_field="adult confirmation",
-        )
-    if constraints.current_symptom_stop is None:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="adult_scope_or_constraints_unconfirmed",
-            rule_id="current_symptom_stop",
-            missing_field="current symptom-stop response",
-        )
-    if constraints.current_symptom_stop is True:
-        return _InputIssue(
-            code="current_symptom_stop",
-            detail_reason="current_symptom_stop",
-            rule_id="current_symptom_stop",
-        )
-    if not goal.event_confirmed:
-        return _InputIssue(
-            code="course_clarification_required",
-            detail_reason="course_clarification_required",
-            rule_id="confirmed_event",
-            missing_field="athlete-confirmed event",
-        )
-    if generation_input.block_start < generation_input.athlete_today:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="contradictory_input",
-            rule_id="block_start",
-        )
-    return None
-
-
-def _course_issue(course: TrailCourseDemand) -> _InputIssue | None:
-    if course.schema_id != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID:
-        return _InputIssue(
-            code="ontology_not_accepted",
-            detail_reason="ontology_contract_mismatch",
-            rule_id="course_schema",
-        )
-    if course.athlete_confirmed is not True:
-        return _InputIssue(
-            code="course_clarification_required",
-            detail_reason="course_clarification_required",
-            rule_id="athlete_confirmed_course",
-            missing_field=NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
-        )
-    for field_name, field in _course_fields(course):
-        if (
-            field.provenance == "explicit_assumption"
-            and field.athlete_confirmed is not True
-        ):
-            return _InputIssue(
-                code="course_clarification_required",
-                detail_reason="course_clarification_required",
-                rule_id="assumption_confirmation",
-                missing_field=field_name,
-            )
-    for field_name in _MATERIAL_COURSE_FIELDS:
-        field = getattr(course, field_name)
-        if field.is_unknown:
-            return _InputIssue(
-                code="material_course_demand_unknown",
-                detail_reason="material_course_demand_unknown",
-                rule_id="material_course_demand",
-                missing_field=field_name,
-            )
-        if isinstance(field.value, Mapping) and not field.value:
-            return _InputIssue(
-                code="course_clarification_required",
-                detail_reason="course_clarification_required",
-                rule_id="material_course_demand",
-                missing_field=field_name,
-            )
-    return None
-
-
-def _prevalidation_issue(
-    prevalidation: InternalTrailPrevalidation,
-) -> _InputIssue | None:
-    if prevalidation.course_demand_eligible is None:
-        return _InputIssue(
-            code="material_course_demand_unknown",
-            detail_reason="material_course_demand_unknown",
-            rule_id="internal_course_prevalidation",
-        )
-    if prevalidation.course_demand_eligible is not True:
-        return _InputIssue(
-            code="course_clarification_required",
-            detail_reason="course_clarification_required",
-            rule_id="internal_course_prevalidation",
-        )
-    if prevalidation.terrain_access_eligible is None:
-        return _InputIssue(
-            code="material_course_demand_unknown",
-            detail_reason="insufficient_terrain_access",
-            rule_id="internal_terrain_prevalidation",
-        )
-    if prevalidation.terrain_access_eligible is not True:
-        return _InputIssue(
-            code="insufficient_terrain_access",
-            detail_reason="insufficient_terrain_access",
-            rule_id="internal_terrain_prevalidation",
-        )
-    if prevalidation.nontechnical_uphill_accessible is not True:
-        return _InputIssue(
-            code=(
-                "material_course_demand_unknown"
-                if prevalidation.nontechnical_uphill_accessible is None
-                else "insufficient_terrain_access"
-            ),
-            detail_reason="insufficient_terrain_access",
-            rule_id="controlled_uphill_access",
-        )
-    if not str(prevalidation.training_terrain_reference or "").strip():
-        return _InputIssue(
-            code="material_course_demand_unknown",
-            detail_reason="insufficient_terrain_access",
-            rule_id="training_terrain_reference",
-        )
-    return None
-
-
-def _history_issue(
-    statistics: RecentTrailHistoryStatistics,
-    *,
-    athlete_today: date,
-) -> _InputIssue | None:
-    if statistics.usable_completed_weeks < _MINIMUM_USABLE_WEEKS:
-        return _InputIssue(
-            code="insufficient_comparable_history",
-            detail_reason="insufficient_recent_history",
-            rule_id="usable_completed_weeks",
-        )
-    if (
-        statistics.latest_run_date is None
-        or (athlete_today - statistics.latest_run_date).days > _LATEST_RUN_DAYS
-    ):
-        return _InputIssue(
-            code="insufficient_comparable_history",
-            detail_reason="insufficient_recent_history",
-            rule_id="latest_run",
-        )
-    if (
-        statistics.comparable_trail_sessions_within_window < _COMPARABLE_COUNT
-        or statistics.latest_comparable_trail_session_date is None
-        or (
-            athlete_today - statistics.latest_comparable_trail_session_date
-        ).days
-        > _LATEST_COMPARABLE_DAYS
-    ):
-        return _InputIssue(
-            code="insufficient_comparable_history",
-            detail_reason="insufficient_comparable_trail_history",
-            rule_id="comparable_trail_exposure",
-        )
-    return None
-
-
-def _constraint_issue(
-    constraints: TrailPlanGenerationConstraints,
-) -> _InputIssue | None:
-    weekdays = constraints.available_weekdays
-    if constraints.schema_id != NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="contradictory_input",
-            rule_id="constraint_schema",
-        )
-    if len(set(weekdays)) != len(weekdays) or any(
-        value < 0 or value > 6 for value in weekdays
-    ):
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="contradictory_input",
-            rule_id="available_weekdays",
-        )
-    if len(weekdays) < _MIN_RUN_DAYS:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="no_schedule_within_envelope",
-            rule_id="available_weekdays",
-        )
-    if len(weekdays) > _MAX_RUN_DAYS:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="clarification_required",
-            rule_id="available_weekdays",
-        )
-    if (
-        constraints.weekly_time_limit_min <= 0
-        or constraints.maximum_session_duration_min <= 0
-    ):
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="adult_scope_or_constraints_unconfirmed",
-            rule_id="duration_constraints",
-        )
-    preferred = constraints.preferred_longest_easy_weekday
-    if preferred is not None and preferred not in weekdays:
-        return _InputIssue(
-            code="adult_scope_or_constraints_unconfirmed",
-            detail_reason="contradictory_input",
-            rule_id="preferred_longest_easy_weekday",
-        )
-    return None
-
-
-def _limited_modules(
-    course: TrailCourseDemand,
-    prevalidation: InternalTrailPrevalidation,
-) -> tuple[str, ...]:
-    limited: set[str] = set()
-    if (
-        course.maximum_altitude_meters.is_unknown
-        or course.environmental_demand.is_unknown
-    ):
-        limited.add("environment_module_limited")
-    if course.fueling_practice_experience.is_unknown:
-        limited.add("fueling_module_limited")
-    if prevalidation.technical_terrain_module_supported is not True:
-        limited.add("technicality_module_limited")
-    return tuple(sorted(limited))
-
-
-def _generation_input_primitive_issue(
-    generation_input: NonUltraTrailGenerationInput,
-) -> _InputIssue | None:
-    for field_name in (
+def _generation_input_primitive_issue(generation_input: Any) -> str | None:
+    if not isinstance(generation_input, NonUltraTrailGenerationInput):
+        return "generation_input"
+    for name in (
         "policy_version",
+        "generator_version",
         "science_decision_id",
         "contract_digest",
         "source_decision_digest",
+        "ontology_version",
         "ontology_decision_id",
         "ontology_contract_digest",
         "ontology_source_decision_digest",
     ):
-        if not isinstance(getattr(generation_input, field_name), str):
-            return _primitive_issue(field_name)
+        if type(getattr(generation_input, name)) is not str:
+            return name
     if type(generation_input.athlete_today) is not date:
-        return _primitive_issue("athlete_today")
+        return "athlete_today"
     if type(generation_input.block_start) is not date:
-        return _primitive_issue("block_start")
-    goal = generation_input.goal
-    if not isinstance(goal, NonUltraTrailGoal):
-        return _primitive_issue("goal")
+        return "block_start"
+    if not isinstance(generation_input.course_demand, TrailCourseDemand):
+        return "course_demand"
+    if not isinstance(generation_input.constraints, TrailPlanGenerationConstraints):
+        return "constraints"
+    if not isinstance(generation_input.history_statistics, RecentTrailHistoryStatistics):
+        return "history_statistics"
+    if not isinstance(generation_input.revision_bindings, TrailRevisionBindings):
+        return "revision_bindings"
+    if generation_input.workload_request is not None and not isinstance(
+        generation_input.workload_request, TrailWorkloadRequest
+    ):
+        return "workload_request"
+    if type(generation_input.synthetic_verification_only) is not bool:
+        return "synthetic_verification_only"
+    for name, value in _all_provenanced_values(
+        generation_input.course_demand, generation_input.constraints
+    ):
+        if not isinstance(value, ProvenancedValue):
+            return name
+        if value.state not in {"known", "unknown"}:
+            return f"{name}.state"
+        if value.provenance not in NON_ULTRA_TRAIL_ALLOWED_PROVENANCE:
+            return f"{name}.provenance"
+        if not _is_digest(value.source_revision):
+            return f"{name}.source_revision"
+        if value.source_timestamp is not None and type(value.source_timestamp) is not datetime:
+            return f"{name}.source_timestamp"
+        if value.model_version is not None and (
+            type(value.model_version) is not str or not value.model_version
+        ):
+            return f"{name}.model_version"
+        if value.assumption_confirmed_revision is not None and not _is_digest(
+            value.assumption_confirmed_revision
+        ):
+            return f"{name}.assumption_confirmed_revision"
+        if value.is_unknown and (
+            value.value is not None or value.provenance != "unknown"
+        ):
+            return f"{name}.unknown"
+        if value.is_known and (
+            value.value is None and name != "support.max_aid_station_gap_m"
+        ):
+            return f"{name}.known"
+        if value.is_known and value.provenance == "unknown":
+            return f"{name}.provenance"
+        if value.provenance == "model_inferred" and not value.model_version:
+            return f"{name}.model_version"
+    bindings = generation_input.revision_bindings
     if not all(
-        isinstance(value, str)
-        for value in (goal.intent, goal.event_format, goal.distance_family)
-    ):
-        return _primitive_issue("goal")
-    if type(goal.target_event_date) is not date:
-        return _primitive_issue("target_event_date")
-    if type(goal.event_confirmed) is not bool:
-        return _primitive_issue("event_confirmed")
-    if type(goal.clinical_or_return_to_sport) is not bool:
-        return _primitive_issue("clinical_or_return_to_sport")
-
-    course_issue = _course_primitive_issue(generation_input.course_demand)
-    if course_issue is not None:
-        return course_issue
-    history_issue = _history_primitive_issue(
-        generation_input.history,
-        athlete_today=generation_input.athlete_today,
-    )
-    if history_issue is not None:
-        return history_issue
-    constraints = generation_input.constraints
-    if not isinstance(constraints, TrailPlanGenerationConstraints):
-        return _primitive_issue("constraints")
-    if type(constraints.adult_confirmed) not in {bool, type(None)}:
-        return _primitive_issue("adult_confirmed")
-    if type(constraints.current_symptom_stop) not in {bool, type(None)}:
-        return _primitive_issue("current_symptom_stop")
-    if not isinstance(constraints.available_weekdays, tuple) or any(
-        type(value) is not int for value in constraints.available_weekdays
-    ):
-        return _primitive_issue("available_weekdays")
-    if type(constraints.weekly_time_limit_min) is not int:
-        return _primitive_issue("weekly_time_limit_min")
-    if type(constraints.maximum_session_duration_min) is not int:
-        return _primitive_issue("maximum_session_duration_min")
-    if any(
-        type(value) is not date
-        for value in (*constraints.unavailable_dates, *constraints.reserved_dates)
-    ):
-        return _primitive_issue("blocked_dates")
-    if (
-        constraints.preferred_longest_easy_weekday is not None
-        and type(constraints.preferred_longest_easy_weekday) is not int
-    ):
-        return _primitive_issue("preferred_longest_easy_weekday")
-    if not isinstance(constraints.schema_id, str):
-        return _primitive_issue("constraint_schema")
-    prevalidation = generation_input.prevalidation
-    if not isinstance(prevalidation, InternalTrailPrevalidation):
-        return _primitive_issue("prevalidation")
-    if any(
-        type(value) not in {bool, type(None)}
+        _is_digest(value)
         for value in (
-            prevalidation.course_demand_eligible,
-            prevalidation.terrain_access_eligible,
-            prevalidation.nontechnical_uphill_accessible,
-            prevalidation.technical_terrain_module_supported,
+            bindings.course_revision,
+            bindings.planning_context_revision,
+            bindings.history_revision,
+            bindings.composite_revision,
         )
     ):
-        return _primitive_issue("prevalidation")
+        return "revision_bindings"
+    if not isinstance(bindings.section_confirmations, tuple) or any(
+        not isinstance(value, TrailSectionConfirmation)
+        or type(value.section_key) is not str
+        or not _is_digest(value.current_revision)
+        or (
+            value.confirmed_revision is not None
+            and not _is_digest(value.confirmed_revision)
+        )
+        for value in bindings.section_confirmations
+    ):
+        return "section_confirmations"
+    return None
+
+
+def _course_domain_invalid(course: TrailCourseDemand) -> bool:
     if (
-        prevalidation.training_terrain_reference is not None
-        and not isinstance(prevalidation.training_terrain_reference, str)
+        type(course.event_id) is not str
+        or not (1 <= len(course.event_id) <= 128)
+        or type(course.schema_id) is not str
     ):
-        return _primitive_issue("training_terrain_reference")
-    return None
+        return True
+    checks = (
+        (course.event_date, lambda value: type(value) is date),
+        (course.distance_meters, lambda value: _integer_in_range(value, 1, 49999)),
+        (course.total_ascent_m, lambda value: _integer_in_range(value, 0, 20000)),
+        (course.total_descent_m, lambda value: _integer_in_range(value, 0, 20000)),
+        (
+            course.planning_duration_range,
+            lambda value: isinstance(value, TrailPlanningDurationRange)
+            and _integer_in_range(value.minimum_min, 1, 1440)
+            and _integer_in_range(value.maximum_min, 1, 1440)
+            and value.minimum_min < value.maximum_min,
+        ),
+        (course.event_format, lambda value: value in {"single_day", "multi_day"}),
+        (course.distance_family, lambda value: value in {"non_ultra", "ultra"}),
+        (
+            course.planning_intent,
+            lambda value: value
+            in {"performance", "first_completion", "return_to_consistency"},
+        ),
+        (course.grade_distribution, _valid_grade_distribution),
+        (course.course_footing, lambda value: _valid_footing(value, allow_empty=False)),
+        (course.hands_assist, lambda value: type(value) is bool),
+        (course.fixed_rope, lambda value: type(value) is bool),
+    )
+    if any(field.is_known and not validator(field.value) for field, validator in checks):
+        return True
+    if course.grade_distribution.is_known and course.grade_distribution.provenance not in {
+        "athlete_stated",
+        "course_verified",
+    }:
+        return True
+    return _optional_context_invalid(course.optional_context)
 
 
-def _course_primitive_issue(course: TrailCourseDemand) -> _InputIssue | None:
-    if not isinstance(course, TrailCourseDemand):
-        return _primitive_issue("course_demand")
-    if type(course.athlete_confirmed) is not bool or not isinstance(
-        course.schema_id,
-        str,
-    ):
-        return _primitive_issue("course_demand")
-    for field_name, field in _course_fields(course):
-        if not isinstance(field, ProvenancedValue):
-            return _primitive_issue(field_name)
-        if field.provenance not in NON_ULTRA_TRAIL_ALLOWED_PROVENANCE:
-            return _primitive_issue(f"{field_name}.provenance")
-        if type(field.athlete_confirmed) is not bool:
-            return _primitive_issue(f"{field_name}.athlete_confirmed")
-        if field.source_reference is not None and (
-            not isinstance(field.source_reference, str)
-            or not field.source_reference.strip()
-        ):
-            return _primitive_issue(f"{field_name}.source_reference")
-        if (
-            field.source_timestamp is not None
-            and type(field.source_timestamp) is not date
-        ):
-            return _primitive_issue(f"{field_name}.source_timestamp")
-        if field.model_version is not None and (
-            not isinstance(field.model_version, str) or not field.model_version.strip()
-        ):
-            return _primitive_issue(f"{field_name}.model_version")
-        if field.is_unknown and field.value is not None:
-            return _primitive_issue(f"{field_name}.unknown_value")
-        if not field.is_unknown and field.value is None:
-            return _primitive_issue(f"{field_name}.value")
-        if field.provenance == "model_inferred" and not field.model_version:
-            return _primitive_issue(f"{field_name}.model_version")
-        if not _is_json_value(field.value):
-            return _primitive_issue(f"{field_name}.value")
-        if field_name in _INTEGER_COURSE_FIELDS and not field.is_unknown:
-            if type(field.value) is not int:
-                return _primitive_issue(field_name)
-            minimum = NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"][field_name].get(
-                "minimum"
-            )
-            if minimum is not None and int(field.value) < int(minimum):
-                return _primitive_issue(field_name)
-        if field_name in _OBJECT_COURSE_FIELDS and not field.is_unknown:
-            if not isinstance(field.value, Mapping):
-                return _primitive_issue(field_name)
-    return None
-
-
-def _history_primitive_issue(
-    history: Sequence[TrailRunningHistoryObservation],
+def _constraints_domain_invalid(
+    constraints: TrailPlanGenerationConstraints,
     *,
-    athlete_today: date,
-) -> _InputIssue | None:
-    if type(athlete_today) is not date:
-        return _primitive_issue("athlete_today")
-    if len(history) > _MAX_HISTORY_OBSERVATIONS:
-        return _primitive_issue("history_observation_count")
-    activity_ids = [
-        item.activity_id
-        for item in history
-        if isinstance(item, TrailRunningHistoryObservation)
-        and isinstance(item.activity_id, str)
-    ]
-    if len(activity_ids) != len(set(activity_ids)):
-        return _primitive_issue("history.duplicate_activity_id")
-    for item in history:
-        if not isinstance(item, TrailRunningHistoryObservation):
-            return _primitive_issue("history_observation")
-        if (
-            not isinstance(item.activity_id, str)
-            or not item.activity_id.strip()
-            or not isinstance(item.activity_type, str)
-            or type(item.observed_date) is not date
-            or not isinstance(item.source, str)
-            or not item.source.strip()
-            or type(item.source_timestamp) is not datetime
-            or type(item.outdoor_confirmed) is not bool
-        ):
-            return _primitive_issue("history_observation")
-        if not _is_finite_number(item.duration_min):
-            return _primitive_issue("history.duration_min")
-        if item.distance_km is not None and not _is_finite_number(item.distance_km):
-            return _primitive_issue("history.distance_km")
-        for field_name, value in (
-            ("elevation_gain_meters", item.elevation_gain_meters),
-            ("elevation_loss_meters", item.elevation_loss_meters),
-        ):
-            if value is not None and (type(value) is not int or value < 0):
-                return _primitive_issue(f"history.{field_name}")
-    return None
+    block_start: date,
+) -> bool:
+    checks = (
+        (
+            constraints.available_weekdays,
+            lambda value: isinstance(value, tuple)
+            and len(value) > 0
+            and len(value) == len(set(value))
+            and all(type(item) is int and 1 <= item <= 7 for item in value),
+        ),
+        (
+            constraints.weekly_time_limit_min,
+            lambda value: _integer_in_range(value, 1, 10080),
+        ),
+        (
+            constraints.maximum_session_duration_min,
+            lambda value: _integer_in_range(value, 1, 1440),
+        ),
+        (
+            constraints.unavailable_dates,
+            lambda value: isinstance(value, tuple)
+            and len(value) <= 14
+            and len(value) == len(set(value))
+            and tuple(sorted(value)) == value
+            and all(
+                type(item) is date
+                and block_start
+                <= item
+                < block_start + timedelta(days=NON_ULTRA_TRAIL_PROPOSAL_DAYS)
+                for item in value
+            ),
+        ),
+        (
+            constraints.nontechnical_three_minute_uphill_access,
+            lambda value: type(value) is bool,
+        ),
+        (constraints.controlled_downhill_access, lambda value: type(value) is bool),
+        (
+            constraints.accessible_footing,
+            lambda value: _valid_footing(value, allow_empty=False),
+        ),
+        (
+            constraints.adult_nonclinical_scope_confirmed,
+            lambda value: type(value) is bool,
+        ),
+        (constraints.performance_intent_confirmed, lambda value: type(value) is bool),
+        (constraints.current_symptom_stop, lambda value: type(value) is bool),
+    )
+    if any(field.is_known and not validator(field.value) for field, validator in checks):
+        return True
+    weekly = _known_int(constraints.weekly_time_limit_min)
+    session = _known_int(constraints.maximum_session_duration_min)
+    if weekly is not None and session is not None and session > weekly:
+        return True
+    if constraints.preferred_longest_weekday is not None and not _integer_in_range(
+        constraints.preferred_longest_weekday, 1, 7
+    ):
+        return True
+    return type(constraints.schema_id) is not str
 
 
-def _primitive_issue(field_name: str) -> _InputIssue:
-    return _InputIssue(
-        code="validation_failed",
-        detail_reason="contradictory_input",
-        rule_id="primitive_validation",
-        missing_field=field_name,
+def _optional_context_invalid(context: TrailOptionalContext) -> bool:
+    if (
+        not isinstance(context, TrailOptionalContext)
+        or not isinstance(context.environment, TrailEnvironmentContext)
+        or not isinstance(context.support, TrailSupportContext)
+        or not isinstance(context.fueling, TrailFuelingContext)
+    ):
+        return True
+    environment = context.environment
+    support = context.support
+    fueling = context.fueling
+    checks = (
+        (environment.maximum_altitude_m, lambda value: _integer_in_range(value, -500, 9000)),
+        (environment.temperature_min_c, lambda value: _decimal_in_range(value, -30, 55)),
+        (environment.temperature_max_c, lambda value: _decimal_in_range(value, -30, 55)),
+        (environment.humidity_min_pct, lambda value: _decimal_in_range(value, 0, 100)),
+        (environment.humidity_max_pct, lambda value: _decimal_in_range(value, 0, 100)),
+        (environment.sun_exposure, lambda value: value in {"low", "mixed", "high"}),
+        (environment.wind_exposure, lambda value: value in {"sheltered", "mixed", "exposed"}),
+        (
+            environment.conditions_basis,
+            lambda value: value
+            in {"organizer_information", "seasonal_expectation", "athlete_assumption"},
+        ),
+        (support.aid_support_mode, lambda value: value in {"organized_aid", "mixed", "self_supported"}),
+        (support.aid_station_count, lambda value: _integer_in_range(value, 0, 50)),
+        (
+            support.max_aid_station_gap_m,
+            lambda value: value is None or _integer_in_range(value, 100, 50000),
+        ),
+        (support.water_availability, lambda value: value in {"none", "some_stations", "all_stations"}),
+        (support.food_availability, lambda value: value in {"none", "some_stations", "all_stations"}),
+        (
+            support.mandatory_gear,
+            lambda value: isinstance(value, tuple)
+            and len(value) == len(set(value))
+            and set(value).issubset(_MANDATORY_GEAR),
+        ),
+        (fueling.longest_practiced_duration_min, lambda value: _integer_in_range(value, 0, 1440)),
+        (fueling.practice_sessions_last_42_days, lambda value: _integer_in_range(value, 0, 84)),
+        (
+            fueling.intake_form,
+            lambda value: value
+            in {"none", "fluids_only", "carbohydrate_drink", "mixed_food_and_drink"},
+        ),
+        (
+            fueling.gastrointestinal_experience,
+            lambda value: value
+            in {"no_plan_altering_issue", "plan_altering_issue"},
+        ),
+    )
+    if any(field.is_known and not validator(field.value) for field, validator in checks):
+        return True
+    temp_min = _known_number(environment.temperature_min_c)
+    temp_max = _known_number(environment.temperature_max_c)
+    humidity_min = _known_number(environment.humidity_min_pct)
+    humidity_max = _known_number(environment.humidity_max_pct)
+    if temp_min is not None and temp_max is not None and temp_min > temp_max:
+        return True
+    if humidity_min is not None and humidity_max is not None and humidity_min > humidity_max:
+        return True
+    return _known_str(environment.conditions_basis) == "athlete_assumption" and (
+        environment.conditions_basis.provenance != "explicit_assumption"
     )
 
 
-def _course_fields(
+def _history_statistics_invalid(statistics: RecentTrailHistoryStatistics) -> bool:
+    integer_values = (
+        statistics.usable_completed_weeks,
+        statistics.recent_modal_running_frequency,
+        statistics.recent_median_usable_weekly_minutes,
+        statistics.recent_maximum_usable_weekly_minutes,
+        statistics.recent_maximum_session_minutes,
+        statistics.recent_median_usable_weekly_ascent_meters,
+        statistics.recent_maximum_usable_weekly_ascent_meters,
+        statistics.recent_median_usable_weekly_descent_meters,
+        statistics.recent_maximum_usable_weekly_descent_meters,
+        statistics.recent_maximum_session_ascent_meters,
+        statistics.recent_maximum_session_descent_meters,
+        statistics.comparable_ascent_sessions_within_window,
+        statistics.comparable_descent_sessions_within_window,
+    )
+    return (
+        any(type(value) is not int or value < 0 for value in integer_values)
+        or any(
+            value is not None and type(value) is not date
+            for value in (
+                statistics.latest_run_date,
+                statistics.latest_comparable_ascent_session_date,
+                statistics.latest_comparable_descent_session_date,
+            )
+        )
+        or not _valid_footing(
+            statistics.recently_observed_footing, allow_empty=True
+        )
+    )
+
+
+def _workload_request_invalid(request: TrailWorkloadRequest | None) -> bool:
+    return request is not None and any(
+        value is not None and (type(value) is not int or value < 0)
+        for value in asdict(request).values()
+    )
+
+
+def _workload_above_history(
+    request: TrailWorkloadRequest | None,
+    statistics: RecentTrailHistoryStatistics,
+) -> bool:
+    if request is None:
+        return False
+    comparisons = (
+        (request.weekly_running_minutes, statistics.recent_maximum_usable_weekly_minutes),
+        (request.maximum_session_minutes, statistics.recent_maximum_session_minutes),
+        (request.weekly_ascent_meters, statistics.recent_maximum_usable_weekly_ascent_meters),
+        (request.weekly_descent_meters, statistics.recent_maximum_usable_weekly_descent_meters),
+    )
+    return any(
+        value is not None and value > ceiling for value, ceiling in comparisons
+    )
+
+
+def _schedule_inputs_complete(generation_input: NonUltraTrailGenerationInput) -> bool:
+    return all(
+        value.is_known
+        for value in (
+            generation_input.course_demand.event_date,
+            generation_input.constraints.available_weekdays,
+            generation_input.constraints.weekly_time_limit_min,
+            generation_input.constraints.maximum_session_duration_min,
+            generation_input.constraints.unavailable_dates,
+        )
+    )
+
+
+def _revisions_are_current(generation_input: NonUltraTrailGenerationInput) -> bool:
+    return generation_input.revision_bindings == derive_revision_bindings(
+        course_demand=generation_input.course_demand,
+        constraints=generation_input.constraints,
+        history_statistics=generation_input.history_statistics,
+        confirmed=True,
+    )
+
+
+def _section_payloads(
     course: TrailCourseDemand,
-) -> tuple[tuple[str, ProvenancedValue], ...]:
-    return tuple(
-        (field_name, getattr(course, field_name))
-        for field_name in NON_ULTRA_TRAIL_COURSE_SCHEMA["fields"]
+    constraints: TrailPlanGenerationConstraints,
+) -> tuple[tuple[str, Any], ...]:
+    course_fields = _serialize_course_demand(course)["fields"]
+    return (
+        (
+            "section.event-duration",
+            {
+                "event_id": course.event_id,
+                **{
+                    key: course_fields[key]
+                    for key in (
+                        "event_date",
+                        "distance_meters",
+                        "total_ascent_m",
+                        "total_descent_m",
+                        "planning_duration_range",
+                        "event_format",
+                        "distance_family",
+                        "planning_intent",
+                    )
+                },
+            },
+        ),
+        (
+            "section.grade-footing",
+            {
+                key: course_fields[key]
+                for key in (
+                    "grade_distribution",
+                    "course_footing",
+                    "hands_assist",
+                    "fixed_rope",
+                )
+            },
+        ),
+        ("section.training-access", _serialize_constraints(constraints)),
+        (
+            "section.optional-context",
+            _serialize_optional_context(course.optional_context),
+        ),
+    )
+
+
+def _course_revision_payload(course: TrailCourseDemand) -> dict[str, Any]:
+    payload = _serialize_course_demand(course)
+    return {
+        "schema_id": payload["schema_id"],
+        "event_id": payload["event_id"],
+        "fields": {
+            key: value
+            for key, value in payload["fields"].items()
+            if key != "optional_context"
+        },
+    }
+
+
+def _planning_revision_payload(
+    course: TrailCourseDemand,
+    constraints: TrailPlanGenerationConstraints,
+) -> dict[str, Any]:
+    return {
+        "constraints": _serialize_constraints(constraints),
+        "optional_context": _serialize_optional_context(course.optional_context),
+    }
+
+
+def _composite_revision(
+    *,
+    course_revision: str,
+    planning_context_revision: str,
+    history_revision: str,
+    section_confirmations: tuple[TrailSectionConfirmation, ...],
+) -> str:
+    return _revision(
+        {
+            "course_revision": course_revision,
+            "planning_context_revision": planning_context_revision,
+            "history_revision": history_revision,
+            "section_confirmations": {
+                value.section_key: value.confirmed_revision
+                for value in sorted(
+                    section_confirmations, key=lambda item: item.section_key
+                )
+            },
+            "course_schema_id": NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+            "constraint_schema_id": NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+            "ontology_decision_id": NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+            "ontology_contract_digest": NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+            "policy_decision_id": NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+            "policy_contract_digest": NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+            "generator_version": NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        }
     )
 
 
 def _serialize_course_demand(course: TrailCourseDemand) -> dict[str, Any]:
     return {
         "schema_id": course.schema_id,
-        "athlete_confirmed": course.athlete_confirmed,
+        "event_id": course.event_id,
         "fields": {
-            name: value.public_payload()
-            for name, value in sorted(_course_fields(course))
+            "event_date": course.event_date.public_payload(),
+            "distance_meters": course.distance_meters.public_payload(),
+            "total_ascent_m": course.total_ascent_m.public_payload(),
+            "total_descent_m": course.total_descent_m.public_payload(),
+            "planning_duration_range": course.planning_duration_range.public_payload(),
+            "event_format": course.event_format.public_payload(),
+            "distance_family": course.distance_family.public_payload(),
+            "planning_intent": course.planning_intent.public_payload(),
+            "grade_distribution": course.grade_distribution.public_payload(),
+            "course_footing": _value_payload(
+                course.course_footing,
+                canonicalizer=lambda value: list(_canonical_footing(value)),
+            ),
+            "hands_assist": course.hands_assist.public_payload(),
+            "fixed_rope": course.fixed_rope.public_payload(),
+            "optional_context": _serialize_optional_context(course.optional_context),
         },
     }
 
 
-def _serialize_history_observation(
-    item: TrailRunningHistoryObservation,
+def _value_payload(
+    value: ProvenancedValue,
+    *,
+    canonicalizer: Any,
+) -> dict[str, Any]:
+    payload = value.public_payload()
+    if value.is_known:
+        payload["value"] = canonicalizer(value.value)
+    return payload
+
+
+def _serialize_optional_context(context: TrailOptionalContext) -> dict[str, Any]:
+    result = {
+        "environment": {
+            field.name: getattr(context.environment, field.name).public_payload()
+            for field in fields(context.environment)
+        },
+        "support": {
+            field.name: getattr(context.support, field.name).public_payload()
+            for field in fields(context.support)
+        },
+        "fueling": {
+            field.name: getattr(context.fueling, field.name).public_payload()
+            for field in fields(context.fueling)
+        },
+    }
+    mandatory_gear = context.support.mandatory_gear
+    result["support"]["mandatory_gear"] = _value_payload(
+        mandatory_gear,
+        canonicalizer=lambda value: list(
+            sorted(value, key=_GEAR_ORDER.__getitem__)
+        ),
+    )
+    return result
+
+
+def _serialize_constraints(
+    constraints: TrailPlanGenerationConstraints,
 ) -> dict[str, Any]:
     return {
-        "activity_id": item.activity_id,
-        "observed_date": item.observed_date.isoformat(),
-        "activity_type": item.activity_type,
-        "duration_min": item.duration_min,
-        "distance_km": item.distance_km,
-        "elevation_gain_meters": item.elevation_gain_meters,
-        "elevation_loss_meters": item.elevation_loss_meters,
-        "source": item.source,
-        "source_timestamp": item.source_timestamp.isoformat(),
-        "outdoor_confirmed": item.outdoor_confirmed,
+        "schema_id": constraints.schema_id,
+        "available_weekdays": _value_payload(
+            constraints.available_weekdays,
+            canonicalizer=lambda value: sorted(value),
+        ),
+        "weekly_time_limit_min": constraints.weekly_time_limit_min.public_payload(),
+        "maximum_session_duration_min": (
+            constraints.maximum_session_duration_min.public_payload()
+        ),
+        "unavailable_dates": _value_payload(
+            constraints.unavailable_dates,
+            canonicalizer=lambda value: [item.isoformat() for item in sorted(value)],
+        ),
+        "preferred_longest_weekday": constraints.preferred_longest_weekday,
+        "nontechnical_three_minute_uphill_access": (
+            constraints.nontechnical_three_minute_uphill_access.public_payload()
+        ),
+        "controlled_downhill_access": (
+            constraints.controlled_downhill_access.public_payload()
+        ),
+        "accessible_footing": _value_payload(
+            constraints.accessible_footing,
+            canonicalizer=lambda value: list(_canonical_footing(value)),
+        ),
+        "adult_nonclinical_scope_confirmed": (
+            constraints.adult_nonclinical_scope_confirmed.public_payload()
+        ),
+        "performance_intent_confirmed": (
+            constraints.performance_intent_confirmed.public_payload()
+        ),
+        "current_symptom_stop": constraints.current_symptom_stop.public_payload(),
     }
 
 
-def _history_canonical_sort_key(
-    item: TrailRunningHistoryObservation,
-) -> str:
-    return json.dumps(
-        _serialize_history_observation(item),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-        allow_nan=False,
+def _all_provenanced_values(
+    course: TrailCourseDemand,
+    constraints: TrailPlanGenerationConstraints,
+) -> tuple[tuple[str, ProvenancedValue], ...]:
+    course_values = tuple(
+        (name, getattr(course, name))
+        for name in (
+            "event_date",
+            "distance_meters",
+            "total_ascent_m",
+            "total_descent_m",
+            "planning_duration_range",
+            "event_format",
+            "distance_family",
+            "planning_intent",
+            "grade_distribution",
+            "course_footing",
+            "hands_assist",
+            "fixed_rope",
+        )
     )
+    optional = tuple(
+        (f"environment.{field.name}", getattr(course.optional_context.environment, field.name))
+        for field in fields(course.optional_context.environment)
+    )
+    support = tuple(
+        (f"support.{field.name}", getattr(course.optional_context.support, field.name))
+        for field in fields(course.optional_context.support)
+    )
+    fueling = tuple(
+        (f"fueling.{field.name}", getattr(course.optional_context.fueling, field.name))
+        for field in fields(course.optional_context.fueling)
+    )
+    constraint_values = tuple(
+        (f"constraints.{name}", getattr(constraints, name))
+        for name in (
+            "available_weekdays",
+            "weekly_time_limit_min",
+            "maximum_session_duration_min",
+            "unavailable_dates",
+            "nontechnical_three_minute_uphill_access",
+            "controlled_downhill_access",
+            "accessible_footing",
+            "adult_nonclinical_scope_confirmed",
+            "performance_intent_confirmed",
+            "current_symptom_stop",
+        )
+    )
+    return (*course_values, *optional, *support, *fueling, *constraint_values)
+
+
+def _environment_values(context: TrailOptionalContext) -> tuple[ProvenancedValue, ...]:
+    return tuple(
+        getattr(context.environment, field.name) for field in fields(context.environment)
+    )
+
+
+def _support_values(context: TrailOptionalContext) -> tuple[ProvenancedValue, ...]:
+    return tuple(getattr(context.support, field.name) for field in fields(context.support))
+
+
+def _fueling_values(context: TrailOptionalContext) -> tuple[ProvenancedValue, ...]:
+    return tuple(getattr(context.fueling, field.name) for field in fields(context.fueling))
+
+
+def _readiness_receipt_digest(
+    *,
+    input_hash: str,
+    status: str,
+    detail_reason: str | None,
+    reasons: tuple[MatchingReason, ...],
+    modules: tuple[ModuleAvailability, ...],
+    limited_modules: tuple[str, ...],
+    revisions: TrailRevisionBindings | None,
+    inactive_dry_run: bool,
+) -> str:
+    return _revision(
+        {
+            "input_hash": input_hash,
+            "status": status,
+            "detail_reason": detail_reason,
+            "matching_reasons": [asdict(value) for value in reasons],
+            "module_availability": [asdict(value) for value in modules],
+            "limited_modules": limited_modules,
+            "revision_bindings": asdict(revisions) if revisions is not None else None,
+            "inactive_dry_run": inactive_dry_run,
+            "policy": {
+                "model_version": NON_ULTRA_TRAIL_POLICY_VERSION,
+                "decision_id": NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+                "source_decision_digest": NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+                "contract_digest": NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+                "runtime_state": str(NON_ULTRA_TRAIL_CONTRACT.runtime_state),
+            },
+            "ontology": {
+                "model_version": NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+                "decision_id": NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+                "source_decision_digest": (
+                    NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+                ),
+                "contract_digest": NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+                "runtime_state": str(NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.runtime_state),
+            },
+            "generator_version": NON_ULTRA_TRAIL_GENERATOR_VERSION,
+            "course_schema_id": NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+            "constraint_schema_id": NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+        }
+    )
+
+
+def _history_observation_issue(
+    history: Sequence[TrailRunningHistoryObservation],
+    *,
+    athlete_today: date,
+) -> str | None:
+    if type(athlete_today) is not date:
+        return "athlete_today"
+    if not isinstance(history, Sequence) or len(history) > _MAX_HISTORY_OBSERVATIONS:
+        return "history_observation_count"
+    ids = [
+        value.activity_id
+        for value in history
+        if isinstance(value, TrailRunningHistoryObservation)
+    ]
+    if len(ids) != len(history) or len(ids) != len(set(ids)):
+        return "history.duplicate_activity_id"
+    for item in history:
+        if (
+            type(item.activity_id) is not str
+            or not item.activity_id
+            or type(item.observed_date) is not date
+            or type(item.activity_type) is not str
+            or not _is_finite_number(item.duration_min)
+            or (
+                item.distance_km is not None
+                and not _is_finite_number(item.distance_km)
+            )
+            or not _is_digest(item.source_revision)
+            or type(item.source_timestamp) is not datetime
+            or item.source_timestamp.tzinfo is None
+            or type(item.outdoor_confirmed) is not bool
+            or (
+                item.observed_footing is not None
+                and not _valid_footing(item.observed_footing, allow_empty=False)
+            )
+        ):
+            return "history_observation"
+        for value in (item.elevation_gain_meters, item.elevation_loss_meters):
+            if value is not None and (type(value) is not int or value < 0):
+                return "history_observation"
+    return None
 
 
 def _is_qualifying_run(item: TrailRunningHistoryObservation) -> bool:
     return (
         item.activity_type in _HISTORY_ACTIVITY_TYPES
         and item.outdoor_confirmed is True
-        and type(item.source_timestamp) is datetime
         and item.duration_min > 0
         and item.distance_km is not None
         and item.distance_km > 0
     )
 
 
-def _is_comparable_trail(item: TrailRunningHistoryObservation) -> bool:
+def _has_comparable_ascent(item: TrailRunningHistoryObservation) -> bool:
     return (
         _is_qualifying_run(item)
         and item.activity_type == "trail_running"
         and item.elevation_gain_meters is not None
-        and item.elevation_loss_meters is not None
+        and item.elevation_gain_meters > 0
     )
 
 
-def _workout_low_minutes(workout: GeneratedTrailWorkout) -> int:
-    if workout.intensity_bucket == "low":
-        return workout.planned_duration_min
-    if workout.template_id == CONTROLLED_UPHILL_TEMPLATE.template_id:
-        return CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes
-    return 0
+def _has_comparable_descent(item: TrailRunningHistoryObservation) -> bool:
+    return (
+        _is_qualifying_run(item)
+        and item.activity_type == "trail_running"
+        and item.elevation_loss_meters is not None
+        and item.elevation_loss_meters > 0
+    )
+
+
+def _proposal_footing(course: TrailCourseDemand) -> tuple[str, ...]:
+    return _known_footing(course.course_footing) or ()
+
+
+def _known_int(value: ProvenancedValue) -> int | None:
+    return value.value if value.is_known and type(value.value) is int else None
+
+
+def _known_number(value: ProvenancedValue) -> Decimal | None:
+    if not value.is_known or not _is_finite_number(value.value):
+        return None
+    return Decimal(str(value.value))
+
+
+def _known_bool(value: ProvenancedValue) -> bool | None:
+    return value.value if value.is_known and type(value.value) is bool else None
+
+
+def _known_str(value: ProvenancedValue) -> str | None:
+    return value.value if value.is_known and type(value.value) is str else None
+
+
+def _known_date(value: ProvenancedValue) -> date | None:
+    return value.value if value.is_known and type(value.value) is date else None
+
+
+def _known_tuple_int(value: ProvenancedValue) -> tuple[int, ...] | None:
+    return (
+        value.value
+        if value.is_known
+        and isinstance(value.value, tuple)
+        and all(type(item) is int for item in value.value)
+        else None
+    )
+
+
+def _known_tuple_date(value: ProvenancedValue) -> tuple[date, ...] | None:
+    return (
+        value.value
+        if value.is_known
+        and isinstance(value.value, tuple)
+        and all(type(item) is date for item in value.value)
+        else None
+    )
+
+
+def _known_footing(value: ProvenancedValue) -> tuple[str, ...] | None:
+    return (
+        _canonical_footing(value.value)
+        if value.is_known and _valid_footing(value.value, allow_empty=False)
+        else None
+    )
+
+
+def _valid_grade_distribution(value: Any) -> bool:
+    return (
+        isinstance(value, TrailGradeDistribution)
+        and all(
+            type(getattr(value, key)) is int
+            and 0 <= getattr(value, key) <= 10000
+            for key in _GRADE_KEYS
+        )
+        and sum(getattr(value, key) for key in _GRADE_KEYS) == 10000
+    )
+
+
+def _valid_footing(value: Any, *, allow_empty: bool) -> bool:
+    return (
+        isinstance(value, tuple)
+        and (allow_empty or bool(value))
+        and len(value) == len(set(value))
+        and all(type(item) is str and item in _FOOTING_ORDER for item in value)
+    )
+
+
+def _canonical_footing(values: Sequence[str] | set[str]) -> tuple[str, ...]:
+    return tuple(sorted(values, key=_FOOTING_ORDER.__getitem__))
+
+
+def _integer_in_range(value: Any, minimum: int, maximum: int) -> bool:
+    return type(value) is int and minimum <= value <= maximum
+
+
+def _decimal_in_range(value: Any, minimum: int, maximum: int) -> bool:
+    if not _is_finite_number(value):
+        return False
+    try:
+        decimal = Decimal(str(value))
+    except InvalidOperation:
+        return False
+    return (
+        decimal.as_tuple().exponent >= -2
+        and Decimal(minimum) <= decimal <= Decimal(maximum)
+    )
+
+
+def _is_finite_number(value: Any) -> bool:
+    return type(value) is int or (type(value) is float and math.isfinite(value))
+
+
+def _duration_minutes_total(
+    values: Sequence[TrailRunningHistoryObservation],
+) -> int:
+    return int(
+        sum(
+            (_exact_number_fraction(value.duration_min) for value in values),
+            start=Fraction(0),
+        )
+    )
+
+
+def _exact_number_fraction(value: int | float) -> Fraction:
+    if type(value) is int:
+        return Fraction(value)
+    numerator, denominator = value.as_integer_ratio()
+    return Fraction(numerator, denominator)
 
 
 def _integer_median(values: Sequence[int]) -> int:
@@ -2067,26 +2768,11 @@ def _integer_median(values: Sequence[int]) -> int:
         raise ValueError("integer median requires nonnegative integers")
     ordered = sorted(values)
     midpoint = len(ordered) // 2
-    if len(ordered) % 2:
-        return ordered[midpoint]
-    return (ordered[midpoint - 1] + ordered[midpoint]) // 2
-
-
-def _duration_minutes_total(
-    values: Sequence[TrailRunningHistoryObservation],
-) -> int:
-    total = sum(
-        (_exact_number_fraction(value.duration_min) for value in values),
-        start=Fraction(0),
+    return (
+        ordered[midpoint]
+        if len(ordered) % 2
+        else (ordered[midpoint - 1] + ordered[midpoint]) // 2
     )
-    return int(total)
-
-
-def _exact_number_fraction(value: int | float) -> Fraction:
-    if type(value) is int:
-        return Fraction(value)
-    numerator, denominator = value.as_integer_ratio()
-    return Fraction(numerator, denominator)
 
 
 def _conservative_mode(values: Sequence[int]) -> int:
@@ -2097,52 +2783,13 @@ def _conservative_mode(values: Sequence[int]) -> int:
     return min(value for value, count in counts.items() if count == maximum)
 
 
-def _is_finite_number(value: Any) -> bool:
-    if type(value) is int:
-        return True
-    if type(value) is float:
-        return math.isfinite(value)
-    return False
-
-
-def _is_json_value(value: Any) -> bool:
-    if value is None or type(value) in {bool, int, str}:
-        return True
-    if type(value) is float:
-        return math.isfinite(value)
-    if isinstance(value, Mapping):
-        return all(
-            isinstance(key, str) and _is_json_value(item)
-            for key, item in value.items()
-        )
-    if isinstance(value, (list, tuple)):
-        return all(_is_json_value(item) for item in value)
-    return False
-
-
-def _no_plan(
-    *,
-    issue: _InputIssue,
-    input_hash: str,
-    statistics: RecentTrailHistoryStatistics,
-    limited_modules: tuple[str, ...] = (),
-) -> NonUltraTrailGenerationResult:
-    if issue.code not in NON_ULTRA_TRAIL_NO_PLAN_RESULT_CODES:
-        raise ValueError("code must be a canonical accepted no-plan result")
-    return NonUltraTrailGenerationResult(
-        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
-        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
-        science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
-        contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
-        source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
-        code=issue.code,
-        detail_reason=issue.detail_reason,
-        deterministic_input_hash=input_hash,
-        plan=None,
-        history_statistics=statistics,
-        limited_modules=limited_modules,
-        failed_rule_id=issue.rule_id,
-        uncertainty_or_missing_field=issue.missing_field,
+def _workout_low_minutes(workout: GeneratedTrailWorkout) -> int:
+    if workout.intensity_bucket == "low":
+        return workout.planned_duration_min
+    return (
+        CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes
+        if workout.template_id == CONTROLLED_UPHILL_TEMPLATE.template_id
+        else 0
     )
 
 
@@ -2151,7 +2798,7 @@ def _serialize_step(step: TrailWorkoutStep) -> dict[str, Any]:
         return {
             "type": "repeat",
             "repetitions": step.repetitions,
-            "steps": [_serialize_step(child) for child in step.steps],
+            "steps": [_serialize_step(value) for value in step.steps],
         }
     return {
         "type": "step",
@@ -2161,24 +2808,18 @@ def _serialize_step(step: TrailWorkoutStep) -> dict[str, Any]:
             "seconds": int(step.duration_min or 0) * 60,
         },
         "intended_intensity": step.intended_intensity,
-        "target": {
-            "metric": "none",
-            "unit": "none",
-            "reference": "none",
-        },
+        "target": {"metric": "none", "unit": "none", "reference": "none"},
     }
 
 
-def _invalid_input_hash(
-    generation_input: NonUltraTrailGenerationInput,
-    issue: _InputIssue,
-) -> str:
-    return _canonical_fingerprint({
-        "invalid_input": True,
-        "rule_id": issue.rule_id,
-        "field": issue.missing_field,
-        "sanitized_input": _sanitize_invalid_value(generation_input),
-    })
+def _invalid_input_hash(value: Any, issue: str) -> str:
+    return _canonical_fingerprint(
+        {
+            "invalid_input": True,
+            "field": issue,
+            "sanitized_input": _sanitize_invalid_value(value),
+        }
+    )
 
 
 def _sanitize_invalid_value(value: Any) -> Any:
@@ -2194,7 +2835,22 @@ def _sanitize_invalid_value(value: Any) -> Any:
                 )
             }
         return value
-    if value is None or type(value) in {bool, int, str}:
+    if type(value) is int:
+        if value.bit_length() <= 63:
+            return value
+        magnitude = abs(value)
+        encoded = magnitude.to_bytes(
+            max(1, (magnitude.bit_length() + 7) // 8),
+            byteorder="big",
+        )
+        return {
+            "__out_of_domain_integer__": {
+                "sign": -1 if value < 0 else 1,
+                "bit_length": magnitude.bit_length(),
+                "magnitude_sha256": hashlib.sha256(encoded).hexdigest(),
+            }
+        }
+    if value is None or type(value) in {bool, str}:
         return value
     if is_dataclass(value) and not isinstance(value, type):
         return {
@@ -2203,25 +2859,33 @@ def _sanitize_invalid_value(value: Any) -> Any:
         }
     if isinstance(value, Mapping):
         pairs = [
-            (
-                _sanitize_invalid_value(key),
-                _sanitize_invalid_value(item),
-            )
+            (_sanitize_invalid_value(key), _sanitize_invalid_value(item))
             for key, item in value.items()
         ]
         return {
             "__mapping__": sorted(
                 pairs,
                 key=lambda pair: json.dumps(
-                    pair[0],
-                    sort_keys=True,
-                    separators=(",", ":"),
+                    pair[0], sort_keys=True, separators=(",", ":")
                 ),
             )
         }
     if isinstance(value, (list, tuple)):
         return [_sanitize_invalid_value(item) for item in value]
     return {"__unsupported_type__": type(value).__qualname__}
+
+
+def _revision(value: Any) -> str:
+    return f"{_DIGEST_PREFIX}{_canonical_fingerprint(value)}"
+
+
+def _is_digest(value: Any) -> bool:
+    return (
+        type(value) is str
+        and value.startswith(_DIGEST_PREFIX)
+        and len(value) == len(_DIGEST_PREFIX) + 64
+        and all(character in "0123456789abcdef" for character in value[7:])
+    )
 
 
 def _canonical_fingerprint(value: Any) -> str:
@@ -2238,11 +2902,13 @@ def _canonical_fingerprint(value: Any) -> str:
 def _json_safe_dates(value: Any) -> Any:
     if type(value) in {date, datetime}:
         return value.isoformat()
-    if isinstance(value, Mapping):
+    if is_dataclass(value) and not isinstance(value, type):
         return {
-            str(key): _json_safe_dates(item)
-            for key, item in value.items()
+            field.name: _json_safe_dates(getattr(value, field.name))
+            for field in fields(value)
         }
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe_dates(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
         return [_json_safe_dates(item) for item in value]
     return value

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -13,7 +13,6 @@ import hashlib
 from itertools import combinations
 import json
 import math
-from statistics import median
 from typing import Any, Literal, Mapping, Sequence
 
 from analysis.non_ultra_trail_contract import (
@@ -937,6 +936,9 @@ def validate_generated_plan(
         quality = tuple(
             item for item in week.workouts if item.intensity_bucket == "quality"
         )
+        low_workouts = tuple(
+            item for item in week.workouts if item.intensity_bucket == "low"
+        )
         if len(quality) != _MAX_QUALITY_PER_UNIT:
             violations.append(
                 PlanInvariantViolation(
@@ -945,6 +947,44 @@ def validate_generated_plan(
                 )
             )
         quality_dates.extend(item.scheduled_date for item in quality)
+        longest_easy = tuple(
+            item for item in week.workouts if item.workout_type == "longest_easy"
+        )
+        expected_longest_date = _longest_easy_date(
+            tuple(item.scheduled_date for item in low_workouts),
+            preferred_longest_easy_weekday=(
+                constraints.preferred_longest_easy_weekday
+            ),
+        )
+        if (
+            len(longest_easy) != 1
+            or expected_longest_date is None
+            or longest_easy[0].scheduled_date != expected_longest_date
+        ):
+            violations.append(
+                PlanInvariantViolation("longest_easy_date", "validation_failed")
+            )
+        expected_easy_minutes = _allocate_easy_minutes(
+            tuple(item.scheduled_date for item in low_workouts),
+            total_minutes=(
+                weekly_minutes_target
+                - CONTROLLED_UPHILL_TEMPLATE.total_minutes
+            ),
+            preferred_longest_easy_weekday=(
+                constraints.preferred_longest_easy_weekday
+            ),
+        )
+        if any(
+            item.planned_duration_min
+            != expected_easy_minutes.get(item.scheduled_date)
+            for item in low_workouts
+        ):
+            violations.append(
+                PlanInvariantViolation(
+                    "longest_easy_duration",
+                    "validation_failed",
+                )
+            )
         if total_minutes != weekly_minutes_target:
             violations.append(
                 PlanInvariantViolation("weekly_minutes_target", "validation_failed")
@@ -1034,8 +1074,16 @@ def validate_generated_plan(
                     PlanInvariantViolation("terrain_reference", "validation_failed")
                 )
             if workout.intensity_bucket == "quality":
+                if workout.workout_type != "controlled_quality":
+                    violations.append(
+                        PlanInvariantViolation(
+                            "quality_workout_type",
+                            "validation_failed",
+                        )
+                    )
                 if (
-                    workout.template_id != CONTROLLED_UPHILL_TEMPLATE.template_id
+                    workout.template_id
+                    != CONTROLLED_UPHILL_TEMPLATE.template_id
                     or workout.steps != CONTROLLED_UPHILL_TEMPLATE.steps
                     or workout.planned_duration_min != 38
                 ):
@@ -1045,21 +1093,32 @@ def validate_generated_plan(
                             "validation_failed",
                         )
                     )
-            elif (
-                workout.template_id is not None
-                or workout.steps
-                != (
-                    TrailWorkoutStep(
-                        kind="step",
-                        phase="easy",
-                        duration_min=workout.planned_duration_min,
-                        intended_intensity="low",
-                    ),
-                )
-            ):
-                violations.append(
-                    PlanInvariantViolation("easy_template", "validation_failed")
-                )
+            else:
+                if workout.workout_type not in {"easy", "longest_easy"}:
+                    violations.append(
+                        PlanInvariantViolation(
+                            "easy_workout_type",
+                            "validation_failed",
+                        )
+                    )
+                if (
+                    workout.template_id is not None
+                    or workout.steps
+                    != (
+                        TrailWorkoutStep(
+                            kind="step",
+                            phase="easy",
+                            duration_min=workout.planned_duration_min,
+                            intended_intensity="low",
+                        ),
+                    )
+                ):
+                    violations.append(
+                        PlanInvariantViolation(
+                            "easy_template",
+                            "validation_failed",
+                        )
+                    )
 
     for previous, current in zip(quality_dates, quality_dates[1:], strict=False):
         if (current - previous).days <= 1:
@@ -1551,6 +1610,17 @@ def _course_issue(course: TrailCourseDemand) -> _InputIssue | None:
             rule_id="athlete_confirmed_course",
             missing_field=NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
         )
+    for field_name, field in _course_fields(course):
+        if (
+            field.provenance == "explicit_assumption"
+            and field.athlete_confirmed is not True
+        ):
+            return _InputIssue(
+                code="course_clarification_required",
+                detail_reason="course_clarification_required",
+                rule_id="assumption_confirmation",
+                missing_field=field_name,
+            )
     for field_name in _MATERIAL_COURSE_FIELDS:
         field = getattr(course, field_name)
         if field.is_unknown:
@@ -1565,16 +1635,6 @@ def _course_issue(course: TrailCourseDemand) -> _InputIssue | None:
                 code="course_clarification_required",
                 detail_reason="course_clarification_required",
                 rule_id="material_course_demand",
-                missing_field=field_name,
-            )
-        if (
-            field.provenance == "explicit_assumption"
-            and field.athlete_confirmed is not True
-        ):
-            return _InputIssue(
-                code="course_clarification_required",
-                detail_reason="course_clarification_required",
-                rule_id="assumption_confirmation",
                 missing_field=field_name,
             )
     return None
@@ -2000,7 +2060,15 @@ def _workout_low_minutes(workout: GeneratedTrailWorkout) -> int:
 
 
 def _integer_median(values: Sequence[int]) -> int:
-    return int(median(values)) if values else 0
+    if not values:
+        return 0
+    if any(type(value) is not int or value < 0 for value in values):
+        raise ValueError("integer median requires nonnegative integers")
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) // 2
 
 
 def _conservative_mode(values: Sequence[int]) -> int:

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -7,9 +7,10 @@ authorize an inactive implementation only.
 """
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from datetime import date, timedelta
+from dataclasses import asdict, dataclass, fields, is_dataclass
+from datetime import date, datetime, timedelta
 import hashlib
+from itertools import combinations
 import json
 import math
 from statistics import median
@@ -201,6 +202,8 @@ class TrailRunningHistoryObservation:
     elevation_gain_meters: int | None
     elevation_loss_meters: int | None
     source: str
+    source_timestamp: datetime
+    outdoor_confirmed: bool
 
 
 @dataclass(frozen=True)
@@ -573,7 +576,7 @@ def generate_non_ultra_trail_plan(
     if primitive_issue is not None:
         return _no_plan(
             issue=primitive_issue,
-            input_hash=_invalid_input_hash(primitive_issue),
+            input_hash=_invalid_input_hash(generation_input, primitive_issue),
             statistics=RecentTrailHistoryStatistics.empty(),
         )
 
@@ -727,15 +730,10 @@ def serialize_generation_input(
 ) -> dict[str, Any]:
     """Return the explicit JSON-safe replay snapshot."""
     history = [
-        _json_safe_dates(asdict(item))
+        _serialize_history_observation(item)
         for item in sorted(
             generation_input.history,
-            key=lambda item: (
-                item.observed_date,
-                item.activity_id,
-                item.activity_type,
-                item.source,
-            ),
+            key=_history_canonical_sort_key,
         )
     ]
     constraints = generation_input.constraints
@@ -799,9 +797,76 @@ def validate_generated_plan(
     generation_input: NonUltraTrailGenerationInput,
 ) -> tuple[PlanInvariantViolation, ...]:
     """Return every deterministic policy-invariant violation in stable order."""
-    statistics = plan.history_statistics
-    constraints = generation_input.constraints
     violations: list[PlanInvariantViolation] = []
+    primitive_issue = _generation_input_primitive_issue(generation_input)
+    if primitive_issue is not None:
+        return (
+            PlanInvariantViolation(
+                "generation_input_primitives",
+                primitive_issue.detail_reason,
+            ),
+        )
+    statistics = derive_recent_history_statistics(
+        generation_input.history,
+        athlete_today=generation_input.athlete_today,
+    )
+    constraints = generation_input.constraints
+    if plan.policy_version != NON_ULTRA_TRAIL_POLICY_VERSION:
+        violations.append(
+            PlanInvariantViolation("policy_version", "validation_failed")
+        )
+    if plan.generator_version != NON_ULTRA_TRAIL_GENERATOR_VERSION:
+        violations.append(
+            PlanInvariantViolation("generator_version", "validation_failed")
+        )
+    expected_course_fingerprint = _canonical_fingerprint(
+        _serialize_course_demand(generation_input.course_demand)
+    )
+    if plan.course_demand_fingerprint != expected_course_fingerprint:
+        violations.append(
+            PlanInvariantViolation("course_fingerprint", "validation_failed")
+        )
+    expected_limited_modules = _limited_modules(
+        generation_input.course_demand,
+        generation_input.prevalidation,
+    )
+    if plan.limited_modules != expected_limited_modules:
+        violations.append(
+            PlanInvariantViolation("limited_modules", "validation_failed")
+        )
+    if plan.history_statistics != statistics:
+        violations.append(
+            PlanInvariantViolation("history_statistics", "validation_failed")
+        )
+    eligibility_issues = (
+        _contract_issue(generation_input),
+        _scope_issue(generation_input),
+        _course_issue(generation_input.course_demand),
+        _prevalidation_issue(generation_input.prevalidation),
+        _history_issue(
+            statistics,
+            athlete_today=generation_input.athlete_today,
+        ),
+        _constraint_issue(generation_input.constraints),
+    )
+    for issue in eligibility_issues:
+        if issue is not None:
+            violations.append(
+                PlanInvariantViolation(
+                    f"eligibility:{issue.rule_id}",
+                    issue.detail_reason,
+                )
+            )
+    if (
+        generation_input.goal.target_event_date
+        - generation_input.block_start
+    ).days <= NON_ULTRA_TRAIL_PROPOSAL_DAYS:
+        violations.append(
+            PlanInvariantViolation(
+                "eligibility:event_and_taper",
+                "event_inside_unapproved_taper_window",
+            )
+        )
     expected_end = generation_input.block_start + timedelta(
         days=NON_ULTRA_TRAIL_PROPOSAL_DAYS - 1
     )
@@ -1001,6 +1066,19 @@ def validate_generated_plan(
             violations.append(
                 PlanInvariantViolation("quality_spacing", "validation_failed")
             )
+    ordered_running_dates = tuple(sorted(seen_dates))
+    for previous, current in zip(
+        ordered_running_dates,
+        ordered_running_dates[1:],
+        strict=False,
+    ):
+        if (current - previous).days <= 1:
+            violations.append(
+                PlanInvariantViolation(
+                    "adjacent_running_days",
+                    "validation_failed",
+                )
+            )
     return tuple(violations)
 
 
@@ -1043,6 +1121,7 @@ def _build_schedule(
     )
     weeks: list[GeneratedTrailWeek] = []
     previous_quality_date: date | None = None
+    previous_workout_date: date | None = None
     for week_index in range(NON_ULTRA_TRAIL_PROPOSAL_DAYS // 7):
         week_start = generation_input.block_start + timedelta(
             days=week_index * _SCHEDULE_UNIT_DAYS
@@ -1067,6 +1146,7 @@ def _build_schedule(
             preferred_longest_easy_weekday=(
                 constraints.preferred_longest_easy_weekday
             ),
+            previous_workout_date=previous_workout_date,
         )
         if selected is None:
             return None
@@ -1118,6 +1198,7 @@ def _build_schedule(
             )
         )
         previous_quality_date = quality_date
+        previous_workout_date = max(selected)
     return tuple(weeks)
 
 
@@ -1261,20 +1342,12 @@ def _allocate_integer_ceiling(
     ):
         return None
     effective_total = min(total_ceiling, per_session_ceiling * len(dates))
-    allocations = {value: 0 for value in dates}
-    remaining = effective_total
-    while remaining:
-        progressed = False
-        for value in ordered:
-            if allocations[value] >= per_session_ceiling:
-                continue
-            allocations[value] += 1
-            remaining -= 1
-            progressed = True
-            if remaining == 0:
-                break
-        if not progressed:
-            return None
+    quotient, remainder = divmod(effective_total, len(ordered))
+    allocations = {value: quotient for value in ordered}
+    for value in ordered[:remainder]:
+        allocations[value] += 1
+    if any(value > per_session_ceiling for value in allocations.values()):
+        return None
     return allocations
 
 
@@ -1283,34 +1356,39 @@ def _select_schedule_dates(
     *,
     frequency: int,
     preferred_longest_easy_weekday: int | None,
+    previous_workout_date: date | None,
 ) -> tuple[date, ...] | None:
     ordered = tuple(sorted(set(dates)))
     if len(ordered) < frequency:
         return None
-    if len(ordered) == frequency:
-        return ordered
-
-    selected_indexes = {
-        round(index * (len(ordered) - 1) / (frequency - 1))
-        for index in range(frequency)
-    }
-    selected = {ordered[index] for index in selected_indexes}
-    preferred = next(
-        (
-            value
-            for value in ordered
-            if value.weekday() == preferred_longest_easy_weekday
-        ),
-        None,
+    candidates = tuple(
+        candidate
+        for candidate in combinations(ordered, frequency)
+        if all(
+            (current - previous).days > 1
+            for previous, current in zip(
+                candidate,
+                candidate[1:],
+                strict=False,
+            )
+        )
+        and (
+            previous_workout_date is None
+            or (candidate[0] - previous_workout_date).days > 1
+        )
     )
-    if preferred is not None and preferred not in selected:
-        selected.remove(max(selected))
-        selected.add(preferred)
-    for value in ordered:
-        if len(selected) >= frequency:
-            break
-        selected.add(value)
-    return tuple(sorted(selected))
+    if not candidates:
+        return None
+    preferred_candidates = tuple(
+        candidate
+        for candidate in candidates
+        if preferred_longest_easy_weekday is not None
+        and any(
+            value.weekday() == preferred_longest_easy_weekday
+            for value in candidate
+        )
+    )
+    return min(preferred_candidates or candidates)
 
 
 def _select_quality_date(
@@ -1800,6 +1878,14 @@ def _history_primitive_issue(
         return _primitive_issue("athlete_today")
     if len(history) > _MAX_HISTORY_OBSERVATIONS:
         return _primitive_issue("history_observation_count")
+    activity_ids = [
+        item.activity_id
+        for item in history
+        if isinstance(item, TrailRunningHistoryObservation)
+        and isinstance(item.activity_id, str)
+    ]
+    if len(activity_ids) != len(set(activity_ids)):
+        return _primitive_issue("history.duplicate_activity_id")
     for item in history:
         if not isinstance(item, TrailRunningHistoryObservation):
             return _primitive_issue("history_observation")
@@ -1810,6 +1896,8 @@ def _history_primitive_issue(
             or type(item.observed_date) is not date
             or not isinstance(item.source, str)
             or not item.source.strip()
+            or type(item.source_timestamp) is not datetime
+            or type(item.outdoor_confirmed) is not bool
         ):
             return _primitive_issue("history_observation")
         if not _is_finite_number(item.duration_min):
@@ -1854,9 +1942,40 @@ def _serialize_course_demand(course: TrailCourseDemand) -> dict[str, Any]:
     }
 
 
+def _serialize_history_observation(
+    item: TrailRunningHistoryObservation,
+) -> dict[str, Any]:
+    return {
+        "activity_id": item.activity_id,
+        "observed_date": item.observed_date.isoformat(),
+        "activity_type": item.activity_type,
+        "duration_min": item.duration_min,
+        "distance_km": item.distance_km,
+        "elevation_gain_meters": item.elevation_gain_meters,
+        "elevation_loss_meters": item.elevation_loss_meters,
+        "source": item.source,
+        "source_timestamp": item.source_timestamp.isoformat(),
+        "outdoor_confirmed": item.outdoor_confirmed,
+    }
+
+
+def _history_canonical_sort_key(
+    item: TrailRunningHistoryObservation,
+) -> str:
+    return json.dumps(
+        _serialize_history_observation(item),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
 def _is_qualifying_run(item: TrailRunningHistoryObservation) -> bool:
     return (
         item.activity_type in _HISTORY_ACTIVITY_TYPES
+        and item.outdoor_confirmed is True
+        and type(item.source_timestamp) is datetime
         and item.duration_min > 0
         and item.distance_km is not None
         and item.distance_km > 0
@@ -1963,12 +2082,59 @@ def _serialize_step(step: TrailWorkoutStep) -> dict[str, Any]:
     }
 
 
-def _invalid_input_hash(issue: _InputIssue) -> str:
+def _invalid_input_hash(
+    generation_input: NonUltraTrailGenerationInput,
+    issue: _InputIssue,
+) -> str:
     return _canonical_fingerprint({
         "invalid_input": True,
         "rule_id": issue.rule_id,
         "field": issue.missing_field,
+        "sanitized_input": _sanitize_invalid_value(generation_input),
     })
+
+
+def _sanitize_invalid_value(value: Any) -> Any:
+    if type(value) in {date, datetime}:
+        return value.isoformat()
+    if type(value) is float:
+        if math.isnan(value):
+            return {"__nonfinite_float__": "nan"}
+        if math.isinf(value):
+            return {
+                "__nonfinite_float__": (
+                    "positive_infinity" if value > 0 else "negative_infinity"
+                )
+            }
+        return value
+    if value is None or type(value) in {bool, int, str}:
+        return value
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _sanitize_invalid_value(getattr(value, field.name))
+            for field in fields(value)
+        }
+    if isinstance(value, Mapping):
+        pairs = [
+            (
+                _sanitize_invalid_value(key),
+                _sanitize_invalid_value(item),
+            )
+            for key, item in value.items()
+        ]
+        return {
+            "__mapping__": sorted(
+                pairs,
+                key=lambda pair: json.dumps(
+                    pair[0],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            )
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_invalid_value(item) for item in value]
+    return {"__unsupported_type__": type(value).__qualname__}
 
 
 def _canonical_fingerprint(value: Any) -> str:
@@ -1983,7 +2149,7 @@ def _canonical_fingerprint(value: Any) -> str:
 
 
 def _json_safe_dates(value: Any) -> Any:
-    if type(value) is date:
+    if type(value) in {date, datetime}:
         return value.isoformat()
     if isinstance(value, Mapping):
         return {

--- a/analysis/non_ultra_trail_plan_generation.py
+++ b/analysis/non_ultra_trail_plan_generation.py
@@ -88,6 +88,7 @@ _MAX_QUALITY_PER_UNIT = int(
 )
 _HISTORY_ACTIVITY_TYPES = frozenset({"running", "trail_running"})
 _MAX_HISTORY_OBSERVATIONS = 1000
+TRAIL_HISTORY_EVALUATOR_SCHEMA_ID = "trail-running-history-statistics-v2"
 _DIGEST_PREFIX = "sha256:"
 _GRADE_KEYS = tuple(
     str(value)
@@ -295,6 +296,10 @@ class RecentTrailHistoryStatistics:
     comparable_descent_sessions_within_window: int
     latest_comparable_descent_session_date: date | None
     recently_observed_footing: tuple[str, ...]
+    observation_window_start: date | None
+    observation_window_end: date | None
+    source_revision_fingerprint: str
+    evaluator_schema_id: str
 
     @classmethod
     def empty(cls) -> "RecentTrailHistoryStatistics":
@@ -316,6 +321,10 @@ class RecentTrailHistoryStatistics:
             comparable_descent_sessions_within_window=0,
             latest_comparable_descent_session_date=None,
             recently_observed_footing=(),
+            observation_window_start=None,
+            observation_window_end=None,
+            source_revision_fingerprint=_revision([]),
+            evaluator_schema_id=TRAIL_HISTORY_EVALUATOR_SCHEMA_ID,
         )
 
     def public_payload(self) -> dict[str, Any]:
@@ -630,6 +639,17 @@ def derive_recent_history_statistics(
         for footing in (item.observed_footing or ())
     }
     frequencies = tuple(len(values) for _, values in usable_weeks)
+    latest_run = max(completed, key=lambda item: item.observed_date, default=None)
+    contributing_revisions = {
+        item.source_revision
+        for item in (*complete, *windowed)
+    }
+    if latest_run is not None:
+        contributing_revisions.add(latest_run.source_revision)
+    observation_window_start = min(
+        first_week_start,
+        athlete_today - timedelta(days=_COMPARABLE_WINDOW_DAYS),
+    )
     return RecentTrailHistoryStatistics(
         usable_completed_weeks=len(usable_weeks),
         recent_modal_running_frequency=_conservative_mode(frequencies),
@@ -650,7 +670,9 @@ def derive_recent_history_statistics(
             (int(item.elevation_loss_meters or 0) for item in descent_usable),
             default=0,
         ),
-        latest_run_date=max((item.observed_date for item in completed), default=None),
+        latest_run_date=(
+            latest_run.observed_date if latest_run is not None else None
+        ),
         comparable_ascent_sessions_within_window=len(ascent_window),
         latest_comparable_ascent_session_date=max(
             (item.observed_date for item in ascent_window), default=None
@@ -660,6 +682,12 @@ def derive_recent_history_statistics(
             (item.observed_date for item in descent_window), default=None
         ),
         recently_observed_footing=_canonical_footing(observed_footing),
+        observation_window_start=observation_window_start,
+        observation_window_end=athlete_today - timedelta(days=1),
+        source_revision_fingerprint=_revision(
+            sorted(contributing_revisions)
+        ),
+        evaluator_schema_id=TRAIL_HISTORY_EVALUATOR_SCHEMA_ID,
     )
 
 
@@ -2218,6 +2246,31 @@ def _history_statistics_invalid(statistics: RecentTrailHistoryStatistics) -> boo
         or not _valid_footing(
             statistics.recently_observed_footing, allow_empty=True
         )
+        or (
+            statistics.observation_window_start is not None
+            and type(statistics.observation_window_start) is not date
+        )
+        or (
+            statistics.observation_window_end is not None
+            and type(statistics.observation_window_end) is not date
+        )
+        or (
+            statistics.observation_window_start is None
+            and statistics.observation_window_end is not None
+        )
+        or (
+            statistics.observation_window_start is not None
+            and statistics.observation_window_end is None
+        )
+        or (
+            statistics.observation_window_start is not None
+            and statistics.observation_window_end is not None
+            and statistics.observation_window_start
+            > statistics.observation_window_end
+        )
+        or not _is_digest(statistics.source_revision_fingerprint)
+        or statistics.evaluator_schema_id
+        != TRAIL_HISTORY_EVALUATOR_SCHEMA_ID
     )
 
 
@@ -2271,7 +2324,9 @@ def _section_payloads(
     course: TrailCourseDemand,
     constraints: TrailPlanGenerationConstraints,
 ) -> tuple[tuple[str, Any], ...]:
-    course_fields = _serialize_course_demand(course)["fields"]
+    course_fields = _revision_payload(
+        _serialize_course_demand(course)["fields"]
+    )
     return (
         (
             "section.event-duration",
@@ -2304,16 +2359,34 @@ def _section_payloads(
                 )
             },
         ),
-        ("section.training-access", _serialize_constraints(constraints)),
+        (
+            "section.training-access",
+            _revision_payload(_serialize_constraints(constraints)),
+        ),
         (
             "section.optional-context",
-            _serialize_optional_context(course.optional_context),
+            _revision_payload(
+                _serialize_optional_context(course.optional_context)
+            ),
         ),
     )
 
 
+def _revision_payload(value: Any) -> Any:
+    """Remove confirmation state from value-and-source revision material."""
+    if isinstance(value, Mapping):
+        return {
+            key: _revision_payload(item)
+            for key, item in value.items()
+            if key != "assumption_confirmed_revision"
+        }
+    if isinstance(value, (tuple, list)):
+        return [_revision_payload(item) for item in value]
+    return value
+
+
 def _course_revision_payload(course: TrailCourseDemand) -> dict[str, Any]:
-    payload = _serialize_course_demand(course)
+    payload = _revision_payload(_serialize_course_demand(course))
     return {
         "schema_id": payload["schema_id"],
         "event_id": payload["event_id"],
@@ -2330,8 +2403,10 @@ def _planning_revision_payload(
     constraints: TrailPlanGenerationConstraints,
 ) -> dict[str, Any]:
     return {
-        "constraints": _serialize_constraints(constraints),
-        "optional_context": _serialize_optional_context(course.optional_context),
+        "constraints": _revision_payload(_serialize_constraints(constraints)),
+        "optional_context": _revision_payload(
+            _serialize_optional_context(course.optional_context)
+        ),
     }
 
 

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -185,6 +185,20 @@ class SettingsUpdate(BaseModel):
     language: str | None = None
 
 
+# Reserved server-owned namespace for the inactive Trail v2 draft. Generic
+# settings clients (including the established MCP settings tool) may neither
+# observe nor author it; the unregistered Trail route is its sole writer.
+_RESERVED_TRAIL_PLAN_GOAL_NAMESPACE = "trail_plan"
+
+
+def _reject_reserved_trail_goal_update(body: SettingsUpdate) -> None:
+    if (
+        body.goal is not None
+        and _RESERVED_TRAIL_PLAN_GOAL_NAMESPACE in body.goal
+    ):
+        raise HTTPException(status_code=404, detail="Not found")
+
+
 def _legacy_execution_target(plan_source: object) -> str | None:
     """Return a plan-capable provider from a legacy preference value."""
     if not isinstance(plan_source, str):
@@ -687,7 +701,9 @@ def _client_visible_settings_config(
     payload = asdict(config) if stryd_enabled else _without_stryd_config(config)
     from api.plan_generation_capabilities import client_visible_goal
 
-    payload["goal"] = client_visible_goal(payload.get("goal"))
+    visible_goal = dict(client_visible_goal(payload.get("goal")))
+    visible_goal.pop(_RESERVED_TRAIL_PLAN_GOAL_NAMESPACE, None)
+    payload["goal"] = visible_goal
     return payload
 
 
@@ -784,6 +800,7 @@ def update_settings(
     db: Session = Depends(get_db),
 ) -> dict:
     """Update user settings and persist to database."""
+    _reject_reserved_trail_goal_update(body)
     token_lease = nullcontext()
     if (
         body.source_options is not None
@@ -802,6 +819,7 @@ def _update_settings(
     db: Session,
 ) -> dict:
     """Apply a settings update after any required provider lease is held."""
+    _reject_reserved_trail_goal_update(body)
     config = load_config_from_db(user_id, db)
     stryd_enabled = stryd_connection_enabled(db, user_id=user_id)
     if not stryd_enabled and _settings_update_requests_stryd(body):
@@ -1140,6 +1158,26 @@ def _update_settings(
     # both the config change and the revision bump atomically.
     from db.cache_revision import bump_revisions
     bump_revisions(db, user_id, ["config"])
+    # The Trail writer and generic settings writer share the config-revision
+    # lock. Re-read the protected namespace after acquiring it so a settings
+    # request that began earlier cannot overwrite a concurrent Trail save or
+    # resurrect a concurrently deleted draft from its stale config snapshot.
+    from db.models import UserConfig as UserConfigModel
+
+    current_row = (
+        db.query(UserConfigModel)
+        .populate_existing()
+        .with_for_update()
+        .filter(UserConfigModel.user_id == user_id)
+        .one_or_none()
+    )
+    current_goal = dict(current_row.goal or {}) if current_row is not None else {}
+    if _RESERVED_TRAIL_PLAN_GOAL_NAMESPACE in current_goal:
+        config.goal[_RESERVED_TRAIL_PLAN_GOAL_NAMESPACE] = current_goal[
+            _RESERVED_TRAIL_PLAN_GOAL_NAMESPACE
+        ]
+    else:
+        config.goal.pop(_RESERVED_TRAIL_PLAN_GOAL_NAMESPACE, None)
     save_config_to_db(user_id, config, db)
     if garmin_region_changed:
         from api.routes.sync import clear_garmin_tokens

--- a/api/routes/trail_plan.py
+++ b/api/routes/trail_plan.py
@@ -1,0 +1,432 @@
+"""Unregistered private routes for the inactive Trail v2 draft slice."""
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+import json
+import unicodedata
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from sqlalchemy.orm import Session
+
+from api.auth import get_authenticated_identity
+from api.legal import TERMS_CONTENT_DIGEST, TERMS_VERSION
+from api.legal_receipts import user_has_current_legal_bundle_for_request
+from api.trail_plan_service import (
+    TrailPlanServiceError,
+    confirm_trail_plan_section,
+    delete_trail_plan_draft,
+    evaluate_trail_plan_readiness,
+    read_trail_plan_draft,
+    reset_trail_plan_draft,
+    save_trail_plan_draft,
+)
+from db.session import get_db
+
+
+MAX_TRAIL_REQUEST_BYTES = 32 * 1024
+MAX_TRAIL_NESTING_DEPTH = 8
+MAX_TRAIL_OBJECT_MEMBERS = 64
+MAX_TRAIL_ARRAY_ENTRIES = 32
+MAX_TRAIL_STRING_SCALARS = 128
+MAX_TRAIL_NUMERIC_TOKEN_LENGTH = 16
+
+_PRIVATE_HEADERS = {
+    "Cache-Control": "private, no-store",
+    "Pragma": "no-cache",
+    "Vary": "Authorization",
+}
+
+router = APIRouter(prefix="/plan/trail", tags=["trail-plan"])
+
+
+class _TrailJsonError(ValueError):
+    pass
+
+
+def _request_error(
+    status_code: int,
+    code: str,
+    message: str,
+) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": code, "message": message},
+        headers=_PRIVATE_HEADERS,
+    )
+
+
+def _private_not_found() -> HTTPException:
+    return HTTPException(
+        status_code=404,
+        detail="Not found",
+        headers=_PRIVATE_HEADERS,
+    )
+
+
+def _trail_owner(request: Request, db: Session) -> str:
+    """Authenticate before body I/O and reject every non-owner actor alike."""
+    try:
+        identity = get_authenticated_identity(request, db)
+    except HTTPException as exc:
+        # A valid context grant is rejected inside the generic identity helper
+        # because this is not a personal-context path. It is nonetheless an
+        # authenticated but ineligible Trail actor, so keep the private 404.
+        if exc.status_code == 403:
+            raise _private_not_found() from exc
+        raise
+    if (
+        identity.credential_kind != "first_party_jwt"
+        or not identity.user.is_active
+        or identity.is_demo
+        or identity.user.is_superuser
+    ):
+        raise _private_not_found()
+    if not user_has_current_legal_bundle_for_request(
+        db,
+        identity.user_id,
+        request,
+    ):
+        raise HTTPException(
+            status_code=428,
+            detail={
+                "code": "TERMS_ACCEPTANCE_REQUIRED",
+                "terms_version": TERMS_VERSION,
+                "terms_digest": TERMS_CONTENT_DIGEST,
+            },
+            headers=_PRIVATE_HEADERS,
+        )
+    return identity.user_id
+
+
+def _parse_int_token(token: str) -> int:
+    if len(token) > MAX_TRAIL_NUMERIC_TOKEN_LENGTH:
+        raise _TrailJsonError("numeric token too long")
+    value = int(token)
+    if not -(2**31) <= value <= 2**31 - 1:
+        raise _TrailJsonError("integer outside structural range")
+    return value
+
+
+def _parse_decimal_token(token: str) -> Decimal:
+    if (
+        len(token) > MAX_TRAIL_NUMERIC_TOKEN_LENGTH
+        or "e" in token.casefold()
+    ):
+        raise _TrailJsonError("invalid decimal token")
+    try:
+        value = Decimal(token)
+    except InvalidOperation:
+        raise _TrailJsonError("invalid decimal token") from None
+    if (
+        not value.is_finite()
+        or abs(value) > Decimal("1000000")
+        or value.as_tuple().exponent < -2
+    ):
+        raise _TrailJsonError("decimal outside structural range")
+    return value
+
+
+def _reject_constant(_token: str) -> None:
+    raise _TrailJsonError("non-finite number")
+
+
+def _normalize_string(value: str) -> str:
+    normalized = unicodedata.normalize("NFC", value)
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in normalized):
+        raise _TrailJsonError("string contains a non-scalar code point")
+    if len(normalized) > MAX_TRAIL_STRING_SCALARS:
+        raise _TrailJsonError("string too long")
+    return normalized
+
+
+def _object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    if len(pairs) > MAX_TRAIL_OBJECT_MEMBERS:
+        raise _TrailJsonError("too many object members")
+    result: dict[str, Any] = {}
+    for raw_key, value in pairs:
+        key = _normalize_string(raw_key)
+        if key in result:
+            raise _TrailJsonError("duplicate object key")
+        result[key] = value
+    return result
+
+
+def _normalize_structure(value: Any, *, depth: int = 1) -> Any:
+    if depth > MAX_TRAIL_NESTING_DEPTH:
+        raise _TrailJsonError("maximum nesting depth exceeded")
+    if isinstance(value, dict):
+        if len(value) > MAX_TRAIL_OBJECT_MEMBERS:
+            raise _TrailJsonError("too many object members")
+        return {
+            key: _normalize_structure(item, depth=depth + 1)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        if len(value) > MAX_TRAIL_ARRAY_ENTRIES:
+            raise _TrailJsonError("too many array entries")
+        return [
+            _normalize_structure(item, depth=depth + 1) for item in value
+        ]
+    if isinstance(value, str):
+        return _normalize_string(value)
+    return value
+
+
+async def read_trail_json_body(request: Request) -> dict[str, Any]:
+    """Read one tightly bounded JSON object without framework body coercion."""
+    content_encoding = request.headers.get("content-encoding", "").strip().casefold()
+    if content_encoding not in {"", "identity"}:
+        raise _request_error(
+            415,
+            "TRAIL_CONTENT_ENCODING_UNSUPPORTED",
+            "Compressed Trail request bodies are not accepted.",
+        )
+    content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().casefold()
+    if content_type != "application/json":
+        raise _request_error(
+            415,
+            "TRAIL_CONTENT_TYPE_UNSUPPORTED",
+            "Trail request bodies must use application/json.",
+        )
+    declared_length: int | None = None
+    raw_length = request.headers.get("content-length")
+    if raw_length is not None:
+        try:
+            declared_length = int(raw_length)
+        except ValueError:
+            raise _request_error(
+                400,
+                "TRAIL_CONTENT_LENGTH_INVALID",
+                "The Trail request Content-Length is invalid.",
+            ) from None
+        if declared_length < 0:
+            raise _request_error(
+                400,
+                "TRAIL_CONTENT_LENGTH_INVALID",
+                "The Trail request Content-Length is invalid.",
+            )
+        if declared_length > MAX_TRAIL_REQUEST_BYTES:
+            raise _request_error(
+                413,
+                "TRAIL_REQUEST_TOO_LARGE",
+                "The Trail request exceeds 32 KiB.",
+            )
+    body = bytearray()
+    try:
+        async for chunk in request.stream():
+            if len(body) + len(chunk) > MAX_TRAIL_REQUEST_BYTES:
+                raise _request_error(
+                    413,
+                    "TRAIL_REQUEST_TOO_LARGE",
+                    "The Trail request exceeds 32 KiB.",
+                )
+            body.extend(chunk)
+    except HTTPException:
+        raise
+    except Exception:
+        raise _request_error(
+            400,
+            "TRAIL_BODY_READ_FAILED",
+            "The Trail request body could not be read.",
+        ) from None
+    if declared_length is not None and declared_length != len(body):
+        raise _request_error(
+            400,
+            "TRAIL_CONTENT_LENGTH_MISMATCH",
+            "The Trail request Content-Length does not match its body.",
+        )
+    try:
+        text = bytes(body).decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise _request_error(
+            400,
+            "TRAIL_UTF8_INVALID",
+            "The Trail request body is not valid UTF-8.",
+        ) from None
+    try:
+        parsed = json.loads(
+            text,
+            object_pairs_hook=_object_pairs,
+            parse_int=_parse_int_token,
+            parse_float=_parse_decimal_token,
+            parse_constant=_reject_constant,
+        )
+        parsed = _normalize_structure(parsed)
+    except (
+        json.JSONDecodeError,
+        _TrailJsonError,
+        RecursionError,
+        ValueError,
+    ):
+        raise _request_error(
+            400,
+            "TRAIL_JSON_INVALID",
+            "The Trail request body is not valid bounded JSON.",
+        ) from None
+    if not isinstance(parsed, dict):
+        raise _request_error(
+            400,
+            "TRAIL_JSON_ROOT_INVALID",
+            "The Trail request body must be an object.",
+        )
+    return parsed
+
+
+def _if_match(request: Request) -> str:
+    value = request.headers.get("if-match", "").strip()
+    if value.startswith("W/"):
+        raise _request_error(
+            400,
+            "TRAIL_IF_MATCH_INVALID",
+            "Trail mutations require one strong revision.",
+        )
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        value = value[1:-1]
+    if not value:
+        return ""
+    if (
+        "," in value
+        or value == "*"
+        or not value.startswith("sha256:")
+        or len(value) != 71
+        or any(character not in "0123456789abcdef" for character in value[7:])
+    ):
+        raise _request_error(
+            400,
+            "TRAIL_IF_MATCH_INVALID",
+            "Trail mutations require one exact revision.",
+        )
+    return value
+
+
+def _service_error(exc: TrailPlanServiceError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail=exc.detail,
+        headers=_PRIVATE_HEADERS,
+    )
+
+
+def _private(response: Response, payload: dict[str, Any]) -> dict[str, Any]:
+    for key, value in _PRIVATE_HEADERS.items():
+        response.headers[key] = value
+    revision = payload.get("composite_revision")
+    if isinstance(revision, str):
+        response.headers["ETag"] = f'"{revision}"'
+    return payload
+
+
+@router.get("/draft", include_in_schema=False)
+def get_trail_draft(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user_id = _trail_owner(request, db)
+    try:
+        payload = read_trail_plan_draft(db, user_id=user_id)
+    except TrailPlanServiceError as exc:
+        raise _service_error(exc) from exc
+    return _private(response, payload)
+
+
+@router.put("/draft", include_in_schema=False)
+async def put_trail_draft(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user_id = _trail_owner(request, db)
+    body = await read_trail_json_body(request)
+    try:
+        payload = save_trail_plan_draft(
+            db,
+            user_id=user_id,
+            request=body,
+            expected_revision=_if_match(request),
+        )
+    except TrailPlanServiceError as exc:
+        raise _service_error(exc) from exc
+    return _private(response, payload)
+
+
+@router.post("/confirm", include_in_schema=False)
+async def post_trail_confirmation(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user_id = _trail_owner(request, db)
+    body = await read_trail_json_body(request)
+    if set(body) != {"section_key", "section_revision"}:
+        raise _request_error(
+            400,
+            "TRAIL_CONFIRMATION_INVALID",
+            "The Trail confirmation request is invalid.",
+        )
+    try:
+        payload = confirm_trail_plan_section(
+            db,
+            user_id=user_id,
+            section_key=body["section_key"],
+            section_revision=body["section_revision"],
+            expected_revision=_if_match(request),
+        )
+    except TrailPlanServiceError as exc:
+        raise _service_error(exc) from exc
+    return _private(response, payload)
+
+
+@router.post("/reset", include_in_schema=False)
+def post_trail_reset(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user_id = _trail_owner(request, db)
+    try:
+        payload = reset_trail_plan_draft(
+            db,
+            user_id=user_id,
+            expected_revision=_if_match(request),
+        )
+    except TrailPlanServiceError as exc:
+        raise _service_error(exc) from exc
+    return _private(response, payload)
+
+
+@router.delete("/draft", include_in_schema=False)
+def delete_trail_draft(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user_id = _trail_owner(request, db)
+    try:
+        payload = delete_trail_plan_draft(
+            db,
+            user_id=user_id,
+            expected_revision=_if_match(request),
+        )
+    except TrailPlanServiceError as exc:
+        raise _service_error(exc) from exc
+    return _private(response, payload)
+
+
+@router.post("/readiness", include_in_schema=False)
+def post_trail_readiness(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user_id = _trail_owner(request, db)
+    try:
+        payload = evaluate_trail_plan_readiness(db, user_id=user_id)
+    except TrailPlanServiceError as exc:
+        raise _service_error(exc) from exc
+    result = _private(response, payload)
+    draft = payload.get("draft")
+    if isinstance(draft, dict) and isinstance(draft.get("composite_revision"), str):
+        response.headers["ETag"] = f'"{draft["composite_revision"]}"'
+    return result

--- a/api/trail_plan_service.py
+++ b/api/trail_plan_service.py
@@ -1,0 +1,1584 @@
+"""Inactive, owner-scoped Trail v2 draft and readiness orchestration.
+
+The module deliberately has no router registration, capability discovery,
+proposal persistence, provider access, or synthetic dry-run entry point.  The
+only durable state is one current draft inside ``UserConfig.goal``.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, replace
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+import hashlib
+import json
+import math
+from typing import Any, Callable, Mapping, Sequence
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from analysis.non_ultra_trail_contract import (
+    NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+    NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+    NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+    NON_ULTRA_TRAIL_GENERATOR_VERSION,
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+    NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+    NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+    NON_ULTRA_TRAIL_POLICY_VERSION,
+    NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+    NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+)
+from analysis.non_ultra_trail_plan_generation import (
+    NonUltraTrailGenerationInput,
+    ProvenancedValue,
+    RecentTrailHistoryStatistics,
+    TrailCourseDemand,
+    TrailEnvironmentContext,
+    TrailFuelingContext,
+    TrailGradeDistribution,
+    TrailOptionalContext,
+    TrailPlanGenerationConstraints,
+    TrailPlanningDurationRange,
+    TrailRevisionBindings,
+    TrailRunningHistoryObservation,
+    TrailSectionConfirmation,
+    TrailSupportContext,
+    derive_recent_history_statistics,
+    derive_revision_bindings,
+    generate_non_ultra_trail_plan,
+)
+from analysis.config import normalize_athlete_timezone
+from api.plan_generation_capabilities import current_goal_reference
+from db.cache_revision import bump_revisions, lock_revision_writes
+from db.models import Activity, UserConfig
+from db.session import begin_serialized_write
+
+
+TRAIL_PLAN_GOAL_NAMESPACE = "trail_plan"
+TRAIL_PLAN_NAMESPACE_VERSION = 1
+TRAIL_EDITABLE_SECTION_KEYS = (
+    "section.event-duration",
+    "section.grade-footing",
+    "section.training-access",
+    "section.optional-context",
+)
+
+_FOOTING = (
+    "firm_smooth",
+    "loose_gravel",
+    "mud",
+    "rocks_or_roots",
+    "built_steps",
+    "water_crossing",
+)
+_FOOTING_ORDER = {value: index for index, value in enumerate(_FOOTING)}
+_GEAR = (
+    "water_carry",
+    "food_carry",
+    "weather_shell",
+    "lighting",
+    "navigation_device",
+    "other_required",
+)
+_GEAR_ORDER = {value: index for index, value in enumerate(_GEAR)}
+_COURSE_FIELDS = frozenset({
+    "event_date",
+    "distance_meters",
+    "total_ascent_m",
+    "total_descent_m",
+    "planning_duration_range",
+    "event_format",
+    "distance_family",
+    "planning_intent",
+    "grade_distribution",
+    "course_footing",
+    "hands_assist",
+    "fixed_rope",
+    "optional_context",
+})
+_CONSTRAINT_FIELDS = frozenset({
+    "schema_id",
+    "available_weekdays",
+    "weekly_time_limit_min",
+    "maximum_session_duration_min",
+    "unavailable_dates",
+    "preferred_longest_weekday",
+    "nontechnical_three_minute_uphill_access",
+    "controlled_downhill_access",
+    "accessible_footing",
+    "adult_nonclinical_scope_confirmed",
+    "performance_intent_confirmed",
+    "current_symptom_stop",
+})
+_ENVIRONMENT_FIELDS = (
+    "maximum_altitude_m",
+    "temperature_min_c",
+    "temperature_max_c",
+    "humidity_min_pct",
+    "humidity_max_pct",
+    "sun_exposure",
+    "wind_exposure",
+    "conditions_basis",
+)
+_SUPPORT_FIELDS = (
+    "aid_support_mode",
+    "aid_station_count",
+    "max_aid_station_gap_m",
+    "water_availability",
+    "food_availability",
+    "mandatory_gear",
+)
+_FUELING_FIELDS = (
+    "longest_practiced_duration_min",
+    "practice_sessions_last_42_days",
+    "intake_form",
+    "gastrointestinal_experience",
+)
+_GRADE_FIELDS = (
+    "below_neg_10",
+    "neg_10_to_below_neg_3",
+    "neg_3_to_below_pos_3",
+    "pos_3_to_below_pos_10",
+    "pos_10_and_above",
+)
+
+
+class TrailPlanServiceError(RuntimeError):
+    """Low-cardinality error safe for the private Trail route adapter."""
+
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        message: str,
+        *,
+        private: bool = False,
+        **details: Any,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.private = private
+        self.details = details
+
+    @property
+    def detail(self) -> str | dict[str, Any]:
+        if self.private:
+            return "Not found"
+        return {"code": self.code, "message": self.message, **self.details}
+
+
+def _invalid(field: str, message: str = "Invalid Trail v2 request.") -> TrailPlanServiceError:
+    return TrailPlanServiceError(
+        400,
+        "TRAIL_INVALID_FIELD_VALUE",
+        message,
+        field=field,
+        status="validation_failed",
+        detail_reason="invalid_field_value",
+    )
+
+
+def _schema_mismatch(field: str) -> TrailPlanServiceError:
+    return TrailPlanServiceError(
+        409,
+        "TRAIL_SCHEMA_VERSION_MISMATCH",
+        "The stored or requested Trail schema is not executable by v2.",
+        field=field,
+        status="validation_failed",
+        detail_reason="schema_version_mismatch",
+    )
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        normalized = value.normalize()
+        return int(normalized) if normalized == normalized.to_integral() else float(normalized)
+    if isinstance(value, TrailPlanningDurationRange):
+        return {"minimum_min": value.minimum_min, "maximum_min": value.maximum_min}
+    if isinstance(value, TrailGradeDistribution):
+        return asdict(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _fingerprint(value: Any) -> str:
+    canonical = json.dumps(
+        _json_safe(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _revision(value: Any) -> str:
+    return f"sha256:{_fingerprint(value)}"
+
+
+def _is_revision(value: Any) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 71
+        and value.startswith("sha256:")
+        and all(character in "0123456789abcdef" for character in value[7:])
+    )
+
+
+ABSENT_TRAIL_PLAN_REVISION = _revision({
+    "namespace": TRAIL_PLAN_GOAL_NAMESPACE,
+    "state": "absent",
+})
+
+
+def _mapping(
+    value: Any,
+    *,
+    field: str,
+    required: Sequence[str],
+    optional: Sequence[str] = (),
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _invalid(field)
+    keys = set(value)
+    required_keys = set(required)
+    if not required_keys.issubset(keys) or not keys.issubset(
+        required_keys | set(optional)
+    ):
+        raise _invalid(field)
+    return value
+
+
+def _strict_int(value: Any, *, field: str, minimum: int, maximum: int) -> int:
+    if type(value) is not int or not minimum <= value <= maximum:
+        raise _invalid(field)
+    return value
+
+
+def _strict_bool(value: Any, *, field: str) -> bool:
+    if type(value) is not bool:
+        raise _invalid(field)
+    return value
+
+
+def _enum(value: Any, *, field: str, allowed: Sequence[str]) -> str:
+    if type(value) is not str or value not in allowed:
+        raise _invalid(field)
+    return value
+
+
+def _decimal_number(
+    value: Any,
+    *,
+    field: str,
+    minimum: int,
+    maximum: int,
+) -> int | float:
+    if type(value) is bool or not isinstance(value, (int, float, Decimal)):
+        raise _invalid(field)
+    if isinstance(value, float) and not math.isfinite(value):
+        raise _invalid(field)
+    try:
+        numeric = value if isinstance(value, Decimal) else Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise _invalid(field) from None
+    if not numeric.is_finite() or numeric.as_tuple().exponent < -2:
+        raise _invalid(field)
+    if numeric < minimum or numeric > maximum:
+        raise _invalid(field)
+    normalized = numeric.normalize()
+    return int(normalized) if normalized == normalized.to_integral() else float(normalized)
+
+
+def _iso_date(value: Any, *, field: str) -> date:
+    if type(value) is not str:
+        raise _invalid(field)
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        raise _invalid(field) from None
+    if parsed.isoformat() != value:
+        raise _invalid(field)
+    return parsed
+
+
+def _closed_set(
+    value: Any,
+    *,
+    field: str,
+    allowed: Sequence[Any],
+    allow_empty: bool,
+    require_sorted: bool = False,
+) -> tuple[Any, ...]:
+    if not isinstance(value, list) or (not allow_empty and not value):
+        raise _invalid(field)
+    if any(type(item) is not type(allowed[0]) or item not in allowed for item in value):
+        raise _invalid(field)
+    if len(value) != len(set(value)):
+        raise _invalid(field)
+    if require_sorted and value != sorted(value):
+        raise _invalid(field)
+    order = {item: index for index, item in enumerate(allowed)}
+    return tuple(sorted(value, key=order.__getitem__))
+
+
+def _date_set(value: Any, *, field: str) -> tuple[date, ...]:
+    if not isinstance(value, list) or len(value) > 14:
+        raise _invalid(field)
+    parsed = tuple(_iso_date(item, field=field) for item in value)
+    if len(parsed) != len(set(parsed)) or tuple(sorted(parsed)) != parsed:
+        raise _invalid(field)
+    return parsed
+
+
+def _duration_range(value: Any, *, field: str) -> TrailPlanningDurationRange:
+    raw = _mapping(
+        value,
+        field=field,
+        required=("minimum_min", "maximum_min"),
+    )
+    minimum = _strict_int(raw["minimum_min"], field=f"{field}.minimum_min", minimum=1, maximum=1440)
+    maximum = _strict_int(raw["maximum_min"], field=f"{field}.maximum_min", minimum=1, maximum=1440)
+    if minimum >= maximum:
+        raise _invalid(field)
+    return TrailPlanningDurationRange(minimum, maximum)
+
+
+def _grade(value: Any, *, field: str) -> TrailGradeDistribution:
+    raw = _mapping(value, field=field, required=_GRADE_FIELDS)
+    shares = {
+        name: _strict_int(raw[name], field=f"{field}.{name}", minimum=0, maximum=10000)
+        for name in _GRADE_FIELDS
+    }
+    if sum(shares.values()) != 10000:
+        raise _invalid(field)
+    return TrailGradeDistribution(**shares)
+
+
+def _envelope(
+    value: Any,
+    *,
+    field: str,
+    validator: Callable[[Any], Any],
+    known_null: bool = False,
+) -> dict[str, Any]:
+    if not isinstance(value, dict) or type(value.get("state")) is not str:
+        raise _invalid(field)
+    if value["state"] == "unknown":
+        if set(value) != {"state"}:
+            raise _invalid(field)
+        return {"state": "unknown"}
+    if value["state"] != "known" or set(value) != {"state", "value"}:
+        raise _invalid(field)
+    if value["value"] is None and known_null:
+        return {"state": "known", "value": None}
+    if value["value"] is None:
+        raise _invalid(field)
+    return {"state": "known", "value": validator(value["value"])}
+
+
+def _validate_optional_context(value: Any) -> dict[str, dict[str, dict[str, Any]]]:
+    raw = _mapping(
+        value,
+        field="course_demand.fields.optional_context",
+        required=("environment", "support", "fueling"),
+    )
+    environment = _mapping(
+        raw["environment"],
+        field="course_demand.fields.optional_context.environment",
+        required=_ENVIRONMENT_FIELDS,
+    )
+    support = _mapping(
+        raw["support"],
+        field="course_demand.fields.optional_context.support",
+        required=_SUPPORT_FIELDS,
+    )
+    fueling = _mapping(
+        raw["fueling"],
+        field="course_demand.fields.optional_context.fueling",
+        required=_FUELING_FIELDS,
+    )
+    env_path = "course_demand.fields.optional_context.environment"
+    support_path = "course_demand.fields.optional_context.support"
+    fueling_path = "course_demand.fields.optional_context.fueling"
+    normalized_environment = {
+        "maximum_altitude_m": _envelope(environment["maximum_altitude_m"], field=f"{env_path}.maximum_altitude_m", validator=lambda item: _strict_int(item, field=f"{env_path}.maximum_altitude_m.value", minimum=-500, maximum=9000)),
+        "temperature_min_c": _envelope(environment["temperature_min_c"], field=f"{env_path}.temperature_min_c", validator=lambda item: _decimal_number(item, field=f"{env_path}.temperature_min_c.value", minimum=-30, maximum=55)),
+        "temperature_max_c": _envelope(environment["temperature_max_c"], field=f"{env_path}.temperature_max_c", validator=lambda item: _decimal_number(item, field=f"{env_path}.temperature_max_c.value", minimum=-30, maximum=55)),
+        "humidity_min_pct": _envelope(environment["humidity_min_pct"], field=f"{env_path}.humidity_min_pct", validator=lambda item: _decimal_number(item, field=f"{env_path}.humidity_min_pct.value", minimum=0, maximum=100)),
+        "humidity_max_pct": _envelope(environment["humidity_max_pct"], field=f"{env_path}.humidity_max_pct", validator=lambda item: _decimal_number(item, field=f"{env_path}.humidity_max_pct.value", minimum=0, maximum=100)),
+        "sun_exposure": _envelope(environment["sun_exposure"], field=f"{env_path}.sun_exposure", validator=lambda item: _enum(item, field=f"{env_path}.sun_exposure.value", allowed=("low", "mixed", "high"))),
+        "wind_exposure": _envelope(environment["wind_exposure"], field=f"{env_path}.wind_exposure", validator=lambda item: _enum(item, field=f"{env_path}.wind_exposure.value", allowed=("sheltered", "mixed", "exposed"))),
+        "conditions_basis": _envelope(environment["conditions_basis"], field=f"{env_path}.conditions_basis", validator=lambda item: _enum(item, field=f"{env_path}.conditions_basis.value", allowed=("organizer_information", "seasonal_expectation", "athlete_assumption"))),
+    }
+    normalized_support = {
+        "aid_support_mode": _envelope(support["aid_support_mode"], field=f"{support_path}.aid_support_mode", validator=lambda item: _enum(item, field=f"{support_path}.aid_support_mode.value", allowed=("organized_aid", "mixed", "self_supported"))),
+        "aid_station_count": _envelope(support["aid_station_count"], field=f"{support_path}.aid_station_count", validator=lambda item: _strict_int(item, field=f"{support_path}.aid_station_count.value", minimum=0, maximum=50)),
+        "max_aid_station_gap_m": _envelope(support["max_aid_station_gap_m"], field=f"{support_path}.max_aid_station_gap_m", validator=lambda item: _strict_int(item, field=f"{support_path}.max_aid_station_gap_m.value", minimum=100, maximum=50000), known_null=True),
+        "water_availability": _envelope(support["water_availability"], field=f"{support_path}.water_availability", validator=lambda item: _enum(item, field=f"{support_path}.water_availability.value", allowed=("none", "some_stations", "all_stations"))),
+        "food_availability": _envelope(support["food_availability"], field=f"{support_path}.food_availability", validator=lambda item: _enum(item, field=f"{support_path}.food_availability.value", allowed=("none", "some_stations", "all_stations"))),
+        "mandatory_gear": _envelope(support["mandatory_gear"], field=f"{support_path}.mandatory_gear", validator=lambda item: _closed_set(item, field=f"{support_path}.mandatory_gear.value", allowed=_GEAR, allow_empty=True)),
+    }
+    normalized_fueling = {
+        "longest_practiced_duration_min": _envelope(fueling["longest_practiced_duration_min"], field=f"{fueling_path}.longest_practiced_duration_min", validator=lambda item: _strict_int(item, field=f"{fueling_path}.longest_practiced_duration_min.value", minimum=0, maximum=1440)),
+        "practice_sessions_last_42_days": _envelope(fueling["practice_sessions_last_42_days"], field=f"{fueling_path}.practice_sessions_last_42_days", validator=lambda item: _strict_int(item, field=f"{fueling_path}.practice_sessions_last_42_days.value", minimum=0, maximum=84)),
+        "intake_form": _envelope(fueling["intake_form"], field=f"{fueling_path}.intake_form", validator=lambda item: _enum(item, field=f"{fueling_path}.intake_form.value", allowed=("none", "fluids_only", "carbohydrate_drink", "mixed_food_and_drink"))),
+        "gastrointestinal_experience": _envelope(fueling["gastrointestinal_experience"], field=f"{fueling_path}.gastrointestinal_experience", validator=lambda item: _enum(item, field=f"{fueling_path}.gastrointestinal_experience.value", allowed=("no_plan_altering_issue", "plan_altering_issue"))),
+    }
+    for minimum_key, maximum_key in (
+        ("temperature_min_c", "temperature_max_c"),
+        ("humidity_min_pct", "humidity_max_pct"),
+    ):
+        minimum_value = normalized_environment[minimum_key]
+        maximum_value = normalized_environment[maximum_key]
+        if (
+            minimum_value["state"] == "known"
+            and maximum_value["state"] == "known"
+            and minimum_value["value"] > maximum_value["value"]
+        ):
+            raise _invalid(f"{env_path}.{minimum_key}")
+    return {
+        "environment": normalized_environment,
+        "support": normalized_support,
+        "fueling": normalized_fueling,
+    }
+
+
+def validate_trail_draft_request(value: Any) -> dict[str, Any]:
+    """Validate and normalize the exact client-writable Trail v2 DTO."""
+    root = _mapping(
+        value,
+        field="body",
+        required=("course_demand", "constraints"),
+    )
+    course = _mapping(
+        root["course_demand"],
+        field="course_demand",
+        required=("schema_id", "fields"),
+    )
+    if course["schema_id"] != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID:
+        raise _schema_mismatch("course_demand.schema_id")
+    fields = _mapping(
+        course["fields"],
+        field="course_demand.fields",
+        required=tuple(_COURSE_FIELDS),
+    )
+    course_path = "course_demand.fields"
+    normalized_course = {
+        "event_date": _envelope(fields["event_date"], field=f"{course_path}.event_date", validator=lambda item: _iso_date(item, field=f"{course_path}.event_date.value")),
+        "distance_meters": _envelope(fields["distance_meters"], field=f"{course_path}.distance_meters", validator=lambda item: _strict_int(item, field=f"{course_path}.distance_meters.value", minimum=1, maximum=49999)),
+        "total_ascent_m": _envelope(fields["total_ascent_m"], field=f"{course_path}.total_ascent_m", validator=lambda item: _strict_int(item, field=f"{course_path}.total_ascent_m.value", minimum=0, maximum=20000)),
+        "total_descent_m": _envelope(fields["total_descent_m"], field=f"{course_path}.total_descent_m", validator=lambda item: _strict_int(item, field=f"{course_path}.total_descent_m.value", minimum=0, maximum=20000)),
+        "planning_duration_range": _envelope(fields["planning_duration_range"], field=f"{course_path}.planning_duration_range", validator=lambda item: _duration_range(item, field=f"{course_path}.planning_duration_range.value")),
+        "event_format": _envelope(fields["event_format"], field=f"{course_path}.event_format", validator=lambda item: _enum(item, field=f"{course_path}.event_format.value", allowed=("single_day", "multi_day"))),
+        "distance_family": _envelope(fields["distance_family"], field=f"{course_path}.distance_family", validator=lambda item: _enum(item, field=f"{course_path}.distance_family.value", allowed=("non_ultra", "ultra"))),
+        "planning_intent": _envelope(fields["planning_intent"], field=f"{course_path}.planning_intent", validator=lambda item: _enum(item, field=f"{course_path}.planning_intent.value", allowed=("performance", "first_completion", "return_to_consistency"))),
+        "grade_distribution": _envelope(fields["grade_distribution"], field=f"{course_path}.grade_distribution", validator=lambda item: _grade(item, field=f"{course_path}.grade_distribution.value")),
+        "course_footing": _envelope(fields["course_footing"], field=f"{course_path}.course_footing", validator=lambda item: _closed_set(item, field=f"{course_path}.course_footing.value", allowed=_FOOTING, allow_empty=False)),
+        "hands_assist": _envelope(fields["hands_assist"], field=f"{course_path}.hands_assist", validator=lambda item: _strict_bool(item, field=f"{course_path}.hands_assist.value")),
+        "fixed_rope": _envelope(fields["fixed_rope"], field=f"{course_path}.fixed_rope", validator=lambda item: _strict_bool(item, field=f"{course_path}.fixed_rope.value")),
+        "optional_context": _validate_optional_context(fields["optional_context"]),
+    }
+    constraints = _mapping(
+        root["constraints"],
+        field="constraints",
+        required=tuple(_CONSTRAINT_FIELDS - {"preferred_longest_weekday"}),
+        optional=("preferred_longest_weekday",),
+    )
+    if constraints["schema_id"] != NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID:
+        raise _schema_mismatch("constraints.schema_id")
+    constraint_path = "constraints"
+    preferred = None
+    if "preferred_longest_weekday" in constraints:
+        if constraints["preferred_longest_weekday"] is None:
+            raise _invalid("constraints.preferred_longest_weekday")
+        preferred = _strict_int(
+            constraints["preferred_longest_weekday"],
+            field=f"{constraint_path}.preferred_longest_weekday",
+            minimum=1,
+            maximum=7,
+        )
+    normalized_constraints = {
+        "available_weekdays": _envelope(constraints["available_weekdays"], field=f"{constraint_path}.available_weekdays", validator=lambda item: _closed_set(item, field=f"{constraint_path}.available_weekdays.value", allowed=(1, 2, 3, 4, 5, 6, 7), allow_empty=False)),
+        "weekly_time_limit_min": _envelope(constraints["weekly_time_limit_min"], field=f"{constraint_path}.weekly_time_limit_min", validator=lambda item: _strict_int(item, field=f"{constraint_path}.weekly_time_limit_min.value", minimum=1, maximum=10080)),
+        "maximum_session_duration_min": _envelope(constraints["maximum_session_duration_min"], field=f"{constraint_path}.maximum_session_duration_min", validator=lambda item: _strict_int(item, field=f"{constraint_path}.maximum_session_duration_min.value", minimum=1, maximum=1440)),
+        "unavailable_dates": _envelope(constraints["unavailable_dates"], field=f"{constraint_path}.unavailable_dates", validator=lambda item: _date_set(item, field=f"{constraint_path}.unavailable_dates.value")),
+        "preferred_longest_weekday": preferred,
+        "nontechnical_three_minute_uphill_access": _envelope(constraints["nontechnical_three_minute_uphill_access"], field=f"{constraint_path}.nontechnical_three_minute_uphill_access", validator=lambda item: _strict_bool(item, field=f"{constraint_path}.nontechnical_three_minute_uphill_access.value")),
+        "controlled_downhill_access": _envelope(constraints["controlled_downhill_access"], field=f"{constraint_path}.controlled_downhill_access", validator=lambda item: _strict_bool(item, field=f"{constraint_path}.controlled_downhill_access.value")),
+        "accessible_footing": _envelope(constraints["accessible_footing"], field=f"{constraint_path}.accessible_footing", validator=lambda item: _closed_set(item, field=f"{constraint_path}.accessible_footing.value", allowed=_FOOTING, allow_empty=False)),
+        "adult_nonclinical_scope_confirmed": _envelope(constraints["adult_nonclinical_scope_confirmed"], field=f"{constraint_path}.adult_nonclinical_scope_confirmed", validator=lambda item: _strict_bool(item, field=f"{constraint_path}.adult_nonclinical_scope_confirmed.value")),
+        "performance_intent_confirmed": _envelope(constraints["performance_intent_confirmed"], field=f"{constraint_path}.performance_intent_confirmed", validator=lambda item: _strict_bool(item, field=f"{constraint_path}.performance_intent_confirmed.value")),
+        "current_symptom_stop": _envelope(constraints["current_symptom_stop"], field=f"{constraint_path}.current_symptom_stop", validator=lambda item: _strict_bool(item, field=f"{constraint_path}.current_symptom_stop.value")),
+    }
+    weekly = normalized_constraints["weekly_time_limit_min"]
+    session = normalized_constraints["maximum_session_duration_min"]
+    if weekly["state"] == session["state"] == "known" and session["value"] > weekly["value"]:
+        raise _invalid("constraints.maximum_session_duration_min")
+    weekdays = normalized_constraints["available_weekdays"]
+    if preferred is not None and weekdays["state"] == "known" and preferred not in weekdays["value"]:
+        # The pure core preserves this as contradictory input; both values are
+        # individually valid, so do not collapse it into transport validation.
+        pass
+    return {
+        "course_demand": {
+            "schema_id": NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+            "fields": normalized_course,
+        },
+        "constraints": {
+            "schema_id": NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+            **normalized_constraints,
+        },
+    }
+
+
+def _unknown_envelope() -> dict[str, str]:
+    return {"state": "unknown"}
+
+
+def _reset_request() -> dict[str, Any]:
+    optional = {
+        "environment": {name: _unknown_envelope() for name in _ENVIRONMENT_FIELDS},
+        "support": {name: _unknown_envelope() for name in _SUPPORT_FIELDS},
+        "fueling": {name: _unknown_envelope() for name in _FUELING_FIELDS},
+    }
+    return {
+        "course_demand": {
+            "schema_id": NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+            "fields": {
+                **{
+                    name: _unknown_envelope()
+                    for name in _COURSE_FIELDS
+                    if name != "optional_context"
+                },
+                "optional_context": optional,
+            },
+        },
+        "constraints": {
+            "schema_id": NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+            **{
+                name: _unknown_envelope()
+                for name in _CONSTRAINT_FIELDS
+                if name not in {"schema_id", "preferred_longest_weekday"}
+            },
+            "preferred_longest_weekday": None,
+        },
+    }
+
+
+def _client_projection(value: ProvenancedValue) -> dict[str, Any]:
+    payload: dict[str, Any] = {"state": value.state}
+    if value.is_known:
+        payload["value"] = _json_safe(value.value)
+    return payload
+
+
+def _stamp(
+    envelope: Mapping[str, Any],
+    *,
+    field: str,
+    now: datetime,
+    previous: ProvenancedValue | None,
+    force_new: bool,
+) -> ProvenancedValue:
+    provenance = "unknown"
+    if envelope["state"] == "known":
+        provenance = (
+            "explicit_assumption"
+            if field == "environment.conditions_basis"
+            and envelope["value"] == "athlete_assumption"
+            else "athlete_stated"
+        )
+    if (
+        not force_new
+        and previous is not None
+        and previous.provenance == provenance
+        and _client_projection(previous) == _json_safe(dict(envelope))
+    ):
+        return previous
+    source_revision = _revision({
+        "field": field,
+        "previous": previous.source_revision if previous is not None else None,
+        "value": envelope,
+        "mutation": uuid4().hex,
+    })
+    return ProvenancedValue(
+        state=str(envelope["state"]),  # type: ignore[arg-type]
+        provenance=provenance,
+        source_revision=source_revision,
+        value=envelope.get("value"),
+        source_timestamp=now,
+    )
+
+
+def _previous_values(
+    course: TrailCourseDemand | None,
+    constraints: TrailPlanGenerationConstraints | None,
+) -> dict[str, ProvenancedValue]:
+    if course is None or constraints is None:
+        return {}
+    values: dict[str, ProvenancedValue] = {
+        name: getattr(course, name)
+        for name in _COURSE_FIELDS
+        if name != "optional_context"
+    }
+    values.update({
+        f"environment.{name}": getattr(course.optional_context.environment, name)
+        for name in _ENVIRONMENT_FIELDS
+    })
+    values.update({
+        f"support.{name}": getattr(course.optional_context.support, name)
+        for name in _SUPPORT_FIELDS
+    })
+    values.update({
+        f"fueling.{name}": getattr(course.optional_context.fueling, name)
+        for name in _FUELING_FIELDS
+    })
+    values.update({
+        f"constraints.{name}": getattr(constraints, name)
+        for name in _CONSTRAINT_FIELDS
+        if name not in {"schema_id", "preferred_longest_weekday"}
+    })
+    return values
+
+
+def _build_models(
+    request: Mapping[str, Any],
+    *,
+    event_id: str,
+    now: datetime,
+    previous_course: TrailCourseDemand | None,
+    previous_constraints: TrailPlanGenerationConstraints | None,
+    force_new: bool = False,
+) -> tuple[TrailCourseDemand, TrailPlanGenerationConstraints]:
+    previous = _previous_values(previous_course, previous_constraints)
+    course_fields = request["course_demand"]["fields"]
+    optional = course_fields["optional_context"]
+
+    def stamp(path: str, envelope: Mapping[str, Any]) -> ProvenancedValue:
+        return _stamp(
+            envelope,
+            field=path,
+            now=now,
+            previous=previous.get(path),
+            force_new=force_new,
+        )
+
+    environment = TrailEnvironmentContext(**{
+        name: stamp(f"environment.{name}", optional["environment"][name])
+        for name in _ENVIRONMENT_FIELDS
+    })
+    support = TrailSupportContext(**{
+        name: stamp(f"support.{name}", optional["support"][name])
+        for name in _SUPPORT_FIELDS
+    })
+    fueling = TrailFuelingContext(**{
+        name: stamp(f"fueling.{name}", optional["fueling"][name])
+        for name in _FUELING_FIELDS
+    })
+    course = TrailCourseDemand(
+        event_id=event_id,
+        optional_context=TrailOptionalContext(
+            environment=environment,
+            support=support,
+            fueling=fueling,
+        ),
+        **{
+            name: stamp(name, course_fields[name])
+            for name in _COURSE_FIELDS
+            if name != "optional_context"
+        },
+    )
+    constraint_request = request["constraints"]
+    constraints = TrailPlanGenerationConstraints(
+        preferred_longest_weekday=constraint_request.get(
+            "preferred_longest_weekday"
+        ),
+        **{
+            name: stamp(f"constraints.{name}", constraint_request[name])
+            for name in _CONSTRAINT_FIELDS
+            if name not in {"schema_id", "preferred_longest_weekday"}
+        },
+    )
+    return course, constraints
+
+
+def _stored_value(
+    raw: Any,
+    *,
+    field: str,
+    converter: Callable[[Any], Any] = lambda value: value,
+) -> ProvenancedValue:
+    value = _mapping(
+        raw,
+        field=field,
+        required=("state", "provenance", "source_revision"),
+        optional=(
+            "value",
+            "source_timestamp",
+            "model_version",
+            "assumption_confirmed_revision",
+        ),
+    )
+    state = value["state"]
+    if state not in {"known", "unknown"}:
+        raise _schema_mismatch(field)
+    if state == "known" and "value" not in value:
+        raise _schema_mismatch(field)
+    if state == "unknown" and "value" in value:
+        raise _schema_mismatch(field)
+    timestamp = None
+    if value.get("source_timestamp") is not None:
+        try:
+            timestamp = datetime.fromisoformat(str(value["source_timestamp"]))
+        except ValueError:
+            raise _schema_mismatch(field) from None
+        if timestamp.tzinfo is None:
+            raise _schema_mismatch(field)
+    converted = converter(value.get("value")) if state == "known" else None
+    return ProvenancedValue(
+        state=state,
+        provenance=str(value["provenance"]),
+        source_revision=str(value["source_revision"]),
+        value=converted,
+        source_timestamp=timestamp,
+        model_version=value.get("model_version"),
+        assumption_confirmed_revision=value.get(
+            "assumption_confirmed_revision"
+        ),
+    )
+
+
+def _deserialize_models(raw: Mapping[str, Any]) -> tuple[TrailCourseDemand, TrailPlanGenerationConstraints, dict[str, str | None]]:
+    if raw.get("namespace_version") != TRAIL_PLAN_NAMESPACE_VERSION:
+        raise _schema_mismatch("trail_plan.namespace_version")
+    course_raw = _mapping(
+        raw.get("course_demand"),
+        field="trail_plan.course_demand",
+        required=("schema_id", "event_id", "fields"),
+    )
+    if course_raw["schema_id"] != NON_ULTRA_TRAIL_COURSE_SCHEMA_ID:
+        raise _schema_mismatch("trail_plan.course_demand.schema_id")
+    fields_raw = _mapping(
+        course_raw["fields"],
+        field="trail_plan.course_demand.fields",
+        required=tuple(_COURSE_FIELDS),
+    )
+    optional_raw = _mapping(
+        fields_raw["optional_context"],
+        field="trail_plan.course_demand.fields.optional_context",
+        required=("environment", "support", "fueling"),
+    )
+    environment_raw = _mapping(optional_raw["environment"], field="trail_plan.environment", required=_ENVIRONMENT_FIELDS)
+    support_raw = _mapping(optional_raw["support"], field="trail_plan.support", required=_SUPPORT_FIELDS)
+    fueling_raw = _mapping(optional_raw["fueling"], field="trail_plan.fueling", required=_FUELING_FIELDS)
+    converters: dict[str, Callable[[Any], Any]] = {
+        "event_date": lambda value: date.fromisoformat(str(value)),
+        "planning_duration_range": lambda value: TrailPlanningDurationRange(
+            int(value["minimum_min"]), int(value["maximum_min"])
+        ),
+        "grade_distribution": lambda value: TrailGradeDistribution(**{
+            key: int(value[key]) for key in _GRADE_FIELDS
+        }),
+        "course_footing": lambda value: tuple(value),
+    }
+    course = TrailCourseDemand(
+        event_id=str(course_raw["event_id"]),
+        optional_context=TrailOptionalContext(
+            environment=TrailEnvironmentContext(**{
+                name: _stored_value(environment_raw[name], field=f"environment.{name}")
+                for name in _ENVIRONMENT_FIELDS
+            }),
+            support=TrailSupportContext(**{
+                name: _stored_value(
+                    support_raw[name],
+                    field=f"support.{name}",
+                    converter=(lambda value: tuple(value)) if name == "mandatory_gear" else (lambda value: value),
+                )
+                for name in _SUPPORT_FIELDS
+            }),
+            fueling=TrailFuelingContext(**{
+                name: _stored_value(fueling_raw[name], field=f"fueling.{name}")
+                for name in _FUELING_FIELDS
+            }),
+        ),
+        **{
+            name: _stored_value(
+                fields_raw[name],
+                field=name,
+                converter=converters.get(name, lambda value: value),
+            )
+            for name in _COURSE_FIELDS
+            if name != "optional_context"
+        },
+    )
+    constraints_raw = _mapping(
+        raw.get("constraints"),
+        field="trail_plan.constraints",
+        required=tuple(_CONSTRAINT_FIELDS),
+    )
+    if constraints_raw["schema_id"] != NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID:
+        raise _schema_mismatch("trail_plan.constraints.schema_id")
+    constraint_converters: dict[str, Callable[[Any], Any]] = {
+        "available_weekdays": lambda value: tuple(value),
+        "unavailable_dates": lambda value: tuple(
+            date.fromisoformat(str(item)) for item in value
+        ),
+        "accessible_footing": lambda value: tuple(value),
+    }
+    constraints = TrailPlanGenerationConstraints(
+        preferred_longest_weekday=constraints_raw["preferred_longest_weekday"],
+        **{
+            name: _stored_value(
+                constraints_raw[name],
+                field=f"constraints.{name}",
+                converter=constraint_converters.get(name, lambda value: value),
+            )
+            for name in _CONSTRAINT_FIELDS
+            if name not in {"schema_id", "preferred_longest_weekday"}
+        },
+    )
+    confirmations_raw = _mapping(
+        raw.get("confirmations"),
+        field="trail_plan.confirmations",
+        required=TRAIL_EDITABLE_SECTION_KEYS,
+    )
+    confirmations: dict[str, str | None] = {}
+    for key in TRAIL_EDITABLE_SECTION_KEYS:
+        confirmed = confirmations_raw[key]
+        if confirmed is not None and (
+            type(confirmed) is not str
+            or not confirmed.startswith("sha256:")
+            or len(confirmed) != 71
+        ):
+            raise _schema_mismatch("trail_plan.confirmations")
+        confirmations[key] = confirmed
+    return course, constraints, confirmations
+
+
+def _serialize_stored(
+    course: TrailCourseDemand,
+    constraints: TrailPlanGenerationConstraints,
+    confirmations: Mapping[str, str | None],
+    bindings: TrailRevisionBindings,
+) -> dict[str, Any]:
+    return {
+        "namespace_version": TRAIL_PLAN_NAMESPACE_VERSION,
+        "course_demand": course.public_payload(),
+        "constraints": constraints.public_payload(),
+        "confirmations": {
+            key: confirmations.get(key) for key in TRAIL_EDITABLE_SECTION_KEYS
+        },
+        "last_revision_bindings": _json_safe(asdict(bindings)),
+    }
+
+
+def _current_goal_event_id(*, user_id: str, goal: Mapping[str, Any]) -> str:
+    base_goal = dict(goal)
+    base_goal.pop(TRAIL_PLAN_GOAL_NAMESPACE, None)
+    if not base_goal:
+        raise TrailPlanServiceError(
+            404,
+            "TRAIL_GOAL_NOT_FOUND",
+            "Not found",
+            private=True,
+        )
+    reference = current_goal_reference(user_id=user_id, goal=base_goal)
+    if reference is None:
+        raise TrailPlanServiceError(
+            404,
+            "TRAIL_GOAL_NOT_FOUND",
+            "Not found",
+            private=True,
+        )
+    return reference.goal_id
+
+
+def _parse_source_timestamp(
+    value: Any,
+    *,
+    athlete_timezone: str | None,
+) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        return parsed
+    if athlete_timezone is None:
+        return None
+    return parsed.replace(tzinfo=ZoneInfo(athlete_timezone))
+
+
+def _whole_nonnegative_int(value: Any) -> int | None:
+    if type(value) is int and value >= 0:
+        return value
+    if type(value) is float and math.isfinite(value) and value >= 0 and value.is_integer():
+        return int(value)
+    return None
+
+
+def _history_statistics(
+    db: Session,
+    *,
+    user_id: str,
+    athlete_today: date,
+    athlete_timezone: str | None,
+) -> RecentTrailHistoryStatistics:
+    """Derive only evidence represented authoritatively by current tables.
+
+    ``Activity`` has no descent or footing fields, so neither is inferred.
+    Canonical Garmin/COROS ``running`` values exclude their separately named
+    treadmill activity types and can support general running continuity;
+    ``trail_running`` additionally supports direct ascent context.
+    """
+    rows = db.execute(
+        select(Activity)
+        .where(
+            Activity.user_id == user_id,
+            Activity.date >= athlete_today - timedelta(days=70),
+            Activity.date < athlete_today,
+        )
+        .order_by(Activity.date, Activity.id)
+    ).scalars().all()
+    observations: list[TrailRunningHistoryObservation] = []
+    for row in rows:
+        activity_type = str(row.activity_type or "").strip().casefold()
+        source = str(row.source or "").strip().casefold()
+        outdoor_confirmed = activity_type == "trail_running" or (
+            activity_type == "running" and source in {"garmin", "coros"}
+        )
+        timestamp = _parse_source_timestamp(
+            row.start_time,
+            athlete_timezone=athlete_timezone,
+        )
+        if not outdoor_confirmed or timestamp is None:
+            continue
+        if (
+            not isinstance(row.duration_sec, (int, float))
+            or isinstance(row.duration_sec, bool)
+            or not math.isfinite(float(row.duration_sec))
+            or float(row.duration_sec) <= 0
+            or not isinstance(row.distance_km, (int, float))
+            or isinstance(row.distance_km, bool)
+            or not math.isfinite(float(row.distance_km))
+            or float(row.distance_km) <= 0
+        ):
+            continue
+        source_revision = _revision({
+            "activity_id": str(row.activity_id),
+            "source": source,
+            "date": row.date.isoformat(),
+            "activity_type": activity_type,
+            "duration_sec": float(row.duration_sec),
+            "distance_km": float(row.distance_km),
+            "elevation_gain_m": row.elevation_gain_m,
+            "start_time": timestamp.isoformat(),
+        })
+        observations.append(
+            TrailRunningHistoryObservation(
+                activity_id=str(row.activity_id),
+                observed_date=row.date,
+                activity_type=activity_type,
+                duration_min=float(row.duration_sec) / 60.0,
+                distance_km=float(row.distance_km),
+                elevation_gain_meters=_whole_nonnegative_int(
+                    row.elevation_gain_m
+                ),
+                elevation_loss_meters=None,
+                observed_footing=None,
+                source_revision=source_revision,
+                source_timestamp=timestamp,
+                outdoor_confirmed=outdoor_confirmed,
+            )
+        )
+    try:
+        return derive_recent_history_statistics(
+            tuple(observations),
+            athlete_today=athlete_today,
+        )
+    except ValueError:
+        return RecentTrailHistoryStatistics.empty()
+
+
+def _composite_revision(
+    *,
+    course_revision: str,
+    planning_context_revision: str,
+    history_revision: str,
+    confirmations: Sequence[TrailSectionConfirmation],
+) -> str:
+    return _revision({
+        "course_revision": course_revision,
+        "planning_context_revision": planning_context_revision,
+        "history_revision": history_revision,
+        "section_confirmations": {
+            item.section_key: item.confirmed_revision
+            for item in sorted(confirmations, key=lambda item: item.section_key)
+        },
+        "course_schema_id": NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+        "constraint_schema_id": NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
+        "ontology_decision_id": NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+        "ontology_contract_digest": NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        "policy_decision_id": NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        "policy_contract_digest": NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        "generator_version": NON_ULTRA_TRAIL_GENERATOR_VERSION,
+    })
+
+
+def _bindings(
+    course: TrailCourseDemand,
+    constraints: TrailPlanGenerationConstraints,
+    statistics: RecentTrailHistoryStatistics,
+    confirmations: Mapping[str, str | None],
+) -> TrailRevisionBindings:
+    base = derive_revision_bindings(
+        course_demand=course,
+        constraints=constraints,
+        history_statistics=statistics,
+        confirmed=False,
+    )
+    section_confirmations = tuple(
+        TrailSectionConfirmation(
+            section_key=item.section_key,
+            current_revision=item.current_revision,
+            confirmed_revision=confirmations.get(item.section_key),
+        )
+        for item in base.section_confirmations
+    )
+    if all(
+        item.confirmed_revision == item.current_revision
+        for item in section_confirmations
+    ):
+        # Use the core's exact fully-confirmed representation so readiness can
+        # compare it without a second implementation of accepted semantics.
+        return derive_revision_bindings(
+            course_demand=course,
+            constraints=constraints,
+            history_statistics=statistics,
+            confirmed=True,
+        )
+    return TrailRevisionBindings(
+        course_revision=base.course_revision,
+        planning_context_revision=base.planning_context_revision,
+        history_revision=base.history_revision,
+        composite_revision=_composite_revision(
+            course_revision=base.course_revision,
+            planning_context_revision=base.planning_context_revision,
+            history_revision=base.history_revision,
+            confirmations=section_confirmations,
+        ),
+        section_confirmations=section_confirmations,
+    )
+
+
+def _row(db: Session, *, user_id: str, for_update: bool = False) -> UserConfig:
+    statement = select(UserConfig).where(UserConfig.user_id == user_id)
+    if for_update:
+        statement = statement.with_for_update()
+    row = db.execute(statement).scalar_one_or_none()
+    if row is None:
+        raise TrailPlanServiceError(
+            404,
+            "TRAIL_GOAL_NOT_FOUND",
+            "Not found",
+            private=True,
+        )
+    return row
+
+
+def _unknown_state(raw: Any) -> dict[str, Any]:
+    return {
+        "state": "unknown_schema",
+        "namespace": deepcopy(raw),
+        "composite_revision": _revision({"trail_plan": raw}),
+    }
+
+
+def _current(
+    db: Session,
+    *,
+    user_id: str,
+    row: UserConfig,
+    athlete_today: date,
+) -> tuple[dict[str, Any], TrailCourseDemand | None, TrailPlanGenerationConstraints | None, RecentTrailHistoryStatistics | None, dict[str, str | None] | None, TrailRevisionBindings | None]:
+    goal = dict(row.goal or {})
+    if TRAIL_PLAN_GOAL_NAMESPACE not in goal:
+        return (
+            {"state": "absent", "composite_revision": ABSENT_TRAIL_PLAN_REVISION},
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    raw = goal[TRAIL_PLAN_GOAL_NAMESPACE]
+    if not isinstance(raw, Mapping):
+        return _unknown_state(raw), None, None, None, None, None
+    try:
+        course, constraints, confirmations = _deserialize_models(raw)
+    except (TrailPlanServiceError, TypeError, ValueError, KeyError):
+        return _unknown_state(raw), None, None, None, None, None
+    event_id = _current_goal_event_id(user_id=user_id, goal=goal)
+    if course.event_id != event_id:
+        course = replace(course, event_id=event_id)
+    statistics = _history_statistics(
+        db,
+        user_id=user_id,
+        athlete_today=athlete_today,
+        athlete_timezone=normalize_athlete_timezone(
+            (row.source_options or {}).get("athlete_timezone")
+        ),
+    )
+    bindings = _bindings(course, constraints, statistics, confirmations)
+    return (
+        {
+            "state": "current",
+            "namespace_version": TRAIL_PLAN_NAMESPACE_VERSION,
+            "course_demand": course.public_payload(),
+            "constraints": constraints.public_payload(),
+            "revision_bindings": _json_safe(asdict(bindings)),
+            "composite_revision": bindings.composite_revision,
+        },
+        course,
+        constraints,
+        statistics,
+        confirmations,
+        bindings,
+    )
+
+
+def _assert_match(expected_revision: str, current_revision: str) -> None:
+    if not expected_revision:
+        raise TrailPlanServiceError(
+            428,
+            "TRAIL_IF_MATCH_REQUIRED",
+            "An exact If-Match revision is required.",
+        )
+    if expected_revision != current_revision:
+        raise TrailPlanServiceError(
+            412,
+            "TRAIL_REVISION_CONFLICT",
+            "The Trail draft changed. Fetch the current revision before retrying.",
+            current_revision=current_revision,
+        )
+
+
+def _athlete_today(value: date | None) -> date:
+    return value if value is not None else datetime.now(timezone.utc).date()
+
+
+def _validate_unavailable_date_horizon(
+    request: Mapping[str, Any],
+    *,
+    block_start: date,
+) -> None:
+    unavailable = request["constraints"]["unavailable_dates"]
+    if unavailable["state"] != "known":
+        return
+    horizon_end = block_start + timedelta(days=14)
+    if any(
+        item < block_start or item >= horizon_end
+        for item in unavailable["value"]
+    ):
+        raise _invalid("constraints.unavailable_dates")
+
+
+def read_trail_plan_draft(
+    db: Session,
+    *,
+    user_id: str,
+    athlete_today: date | None = None,
+) -> dict[str, Any]:
+    row = _row(db, user_id=user_id)
+    state, *_ = _current(
+        db,
+        user_id=user_id,
+        row=row,
+        athlete_today=_athlete_today(athlete_today),
+    )
+    return state
+
+
+def _begin_write(db: Session, *, user_id: str) -> UserConfig:
+    db.rollback()
+    begin_serialized_write(db)
+    lock_revision_writes(db, user_id)
+    return _row(db, user_id=user_id, for_update=True)
+
+
+def _commit_namespace(
+    db: Session,
+    *,
+    row: UserConfig,
+    user_id: str,
+    namespace: Any | None,
+) -> None:
+    goal = dict(row.goal or {})
+    if namespace is None:
+        goal.pop(TRAIL_PLAN_GOAL_NAMESPACE, None)
+    else:
+        goal[TRAIL_PLAN_GOAL_NAMESPACE] = namespace
+    row.goal = goal
+    bump_revisions(db, user_id, ("config", "goals"))
+    db.commit()
+
+
+def save_trail_plan_draft(
+    db: Session,
+    *,
+    user_id: str,
+    request: Any,
+    expected_revision: str,
+    athlete_today: date | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    normalized = validate_trail_draft_request(request)
+    today = _athlete_today(athlete_today)
+    _validate_unavailable_date_horizon(normalized, block_start=today)
+    timestamp = now or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    try:
+        row = _begin_write(db, user_id=user_id)
+        current, old_course, old_constraints, statistics, old_confirmations, old_bindings = _current(
+            db, user_id=user_id, row=row, athlete_today=today
+        )
+        _assert_match(expected_revision, current["composite_revision"])
+        if current["state"] == "unknown_schema":
+            raise _schema_mismatch("trail_plan")
+        event_id = _current_goal_event_id(user_id=user_id, goal=dict(row.goal or {}))
+        course, constraints = _build_models(
+            normalized,
+            event_id=event_id,
+            now=timestamp,
+            previous_course=old_course,
+            previous_constraints=old_constraints,
+        )
+        statistics = statistics or _history_statistics(
+            db,
+            user_id=user_id,
+            athlete_today=today,
+            athlete_timezone=normalize_athlete_timezone(
+                (row.source_options or {}).get("athlete_timezone")
+            ),
+        )
+        provisional = _bindings(course, constraints, statistics, {})
+        confirmations: dict[str, str | None] = {}
+        old_by_key = {
+            item.section_key: item for item in old_bindings.section_confirmations
+        } if old_bindings is not None else {}
+        new_by_key = {
+            item.section_key: item for item in provisional.section_confirmations
+        }
+        for key in TRAIL_EDITABLE_SECTION_KEYS:
+            old_item = old_by_key.get(key)
+            confirmations[key] = (
+                (old_confirmations or {}).get(key)
+                if old_item is not None
+                and old_item.current_revision == new_by_key[key].current_revision
+                else None
+            )
+        bindings = _bindings(course, constraints, statistics, confirmations)
+        namespace = _serialize_stored(course, constraints, confirmations, bindings)
+        if (
+            current["state"] == "current"
+            and isinstance((row.goal or {}).get(TRAIL_PLAN_GOAL_NAMESPACE), Mapping)
+            and namespace == (row.goal or {})[TRAIL_PLAN_GOAL_NAMESPACE]
+        ):
+            db.rollback()
+            return current
+        response = {
+            "state": "current",
+            "namespace_version": TRAIL_PLAN_NAMESPACE_VERSION,
+            "course_demand": course.public_payload(),
+            "constraints": constraints.public_payload(),
+            "revision_bindings": _json_safe(asdict(bindings)),
+            "composite_revision": bindings.composite_revision,
+        }
+        _commit_namespace(
+            db,
+            row=row,
+            user_id=user_id,
+            namespace=namespace,
+        )
+        return response
+    except Exception:
+        db.rollback()
+        raise
+
+
+def confirm_trail_plan_section(
+    db: Session,
+    *,
+    user_id: str,
+    section_key: str,
+    section_revision: str,
+    expected_revision: str,
+    athlete_today: date | None = None,
+) -> dict[str, Any]:
+    if section_key not in TRAIL_EDITABLE_SECTION_KEYS:
+        raise _invalid("section_key")
+    if not _is_revision(section_revision):
+        raise _invalid("section_revision")
+    today = _athlete_today(athlete_today)
+    try:
+        row = _begin_write(db, user_id=user_id)
+        current, course, constraints, statistics, confirmations, bindings = _current(
+            db, user_id=user_id, row=row, athlete_today=today
+        )
+        _assert_match(expected_revision, current["composite_revision"])
+        if current["state"] != "current" or None in (
+            course,
+            constraints,
+            statistics,
+            confirmations,
+            bindings,
+        ):
+            raise _schema_mismatch("trail_plan")
+        assert course is not None
+        assert constraints is not None
+        assert statistics is not None
+        assert confirmations is not None
+        assert bindings is not None
+        target = next(
+            item
+            for item in bindings.section_confirmations
+            if item.section_key == section_key
+        )
+        if section_revision != target.current_revision:
+            raise TrailPlanServiceError(
+                412,
+                "TRAIL_SECTION_REVISION_CONFLICT",
+                "The section changed before it was confirmed.",
+                current_section_revision=target.current_revision,
+            )
+        assumption_updated = False
+        if section_key == "section.optional-context":
+            conditions = course.optional_context.environment.conditions_basis
+            if (
+                conditions.provenance == "explicit_assumption"
+                and conditions.assumption_confirmed_revision
+                != conditions.source_revision
+            ):
+                environment = replace(
+                    course.optional_context.environment,
+                    conditions_basis=replace(
+                        conditions,
+                        assumption_confirmed_revision=conditions.source_revision,
+                    ),
+                )
+                course = replace(
+                    course,
+                    optional_context=replace(
+                        course.optional_context,
+                        environment=environment,
+                    ),
+                )
+                assumption_updated = True
+        if (
+            not assumption_updated
+            and target.confirmed_revision == target.current_revision
+        ):
+            db.rollback()
+            return current
+        provisional = _bindings(course, constraints, statistics, confirmations)
+        next_target = next(
+            item
+            for item in provisional.section_confirmations
+            if item.section_key == section_key
+        )
+        next_confirmations = dict(confirmations)
+        next_confirmations[section_key] = next_target.current_revision
+        next_bindings = _bindings(
+            course,
+            constraints,
+            statistics,
+            next_confirmations,
+        )
+        namespace = _serialize_stored(
+            course,
+            constraints,
+            next_confirmations,
+            next_bindings,
+        )
+        response = {
+            "state": "current",
+            "namespace_version": TRAIL_PLAN_NAMESPACE_VERSION,
+            "course_demand": course.public_payload(),
+            "constraints": constraints.public_payload(),
+            "revision_bindings": _json_safe(asdict(next_bindings)),
+            "composite_revision": next_bindings.composite_revision,
+        }
+        _commit_namespace(
+            db,
+            row=row,
+            user_id=user_id,
+            namespace=namespace,
+        )
+        return response
+    except Exception:
+        db.rollback()
+        raise
+
+
+def reset_trail_plan_draft(
+    db: Session,
+    *,
+    user_id: str,
+    expected_revision: str,
+    athlete_today: date | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    today = _athlete_today(athlete_today)
+    timestamp = now or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    try:
+        row = _begin_write(db, user_id=user_id)
+        current, *_ = _current(db, user_id=user_id, row=row, athlete_today=today)
+        _assert_match(expected_revision, current["composite_revision"])
+        event_id = _current_goal_event_id(user_id=user_id, goal=dict(row.goal or {}))
+        course, constraints = _build_models(
+            _reset_request(),
+            event_id=event_id,
+            now=timestamp,
+            previous_course=None,
+            previous_constraints=None,
+            force_new=True,
+        )
+        statistics = _history_statistics(
+            db,
+            user_id=user_id,
+            athlete_today=today,
+            athlete_timezone=normalize_athlete_timezone(
+                (row.source_options or {}).get("athlete_timezone")
+            ),
+        )
+        confirmations = {key: None for key in TRAIL_EDITABLE_SECTION_KEYS}
+        bindings = _bindings(course, constraints, statistics, confirmations)
+        namespace = _serialize_stored(course, constraints, confirmations, bindings)
+        response = {
+            "state": "current",
+            "namespace_version": TRAIL_PLAN_NAMESPACE_VERSION,
+            "course_demand": course.public_payload(),
+            "constraints": constraints.public_payload(),
+            "revision_bindings": _json_safe(asdict(bindings)),
+            "composite_revision": bindings.composite_revision,
+            "reset_is_erasure": False,
+        }
+        _commit_namespace(db, row=row, user_id=user_id, namespace=namespace)
+        return response
+    except Exception:
+        db.rollback()
+        raise
+
+
+def delete_trail_plan_draft(
+    db: Session,
+    *,
+    user_id: str,
+    expected_revision: str,
+    athlete_today: date | None = None,
+) -> dict[str, Any]:
+    today = _athlete_today(athlete_today)
+    try:
+        row = _begin_write(db, user_id=user_id)
+        current, *_ = _current(db, user_id=user_id, row=row, athlete_today=today)
+        _assert_match(expected_revision, current["composite_revision"])
+        if current["state"] == "absent":
+            db.rollback()
+            return {
+                "status": "absent",
+                "composite_revision": ABSENT_TRAIL_PLAN_REVISION,
+            }
+        _commit_namespace(db, row=row, user_id=user_id, namespace=None)
+        return {
+            "status": "deleted",
+            "composite_revision": ABSENT_TRAIL_PLAN_REVISION,
+        }
+    except Exception:
+        db.rollback()
+        raise
+
+
+def evaluate_trail_plan_readiness(
+    db: Session,
+    *,
+    user_id: str,
+    athlete_today: date | None = None,
+) -> dict[str, Any]:
+    """Evaluate the real inactive contract without writing or creating a plan."""
+    today = _athlete_today(athlete_today)
+    row = _row(db, user_id=user_id)
+    current, course, constraints, statistics, _, bindings = _current(
+        db,
+        user_id=user_id,
+        row=row,
+        athlete_today=today,
+    )
+    if current["state"] != "current" or None in (
+        course,
+        constraints,
+        statistics,
+        bindings,
+    ):
+        if current["state"] == "unknown_schema":
+            raise _schema_mismatch("trail_plan")
+        raise TrailPlanServiceError(
+            409,
+            "TRAIL_DRAFT_REQUIRED",
+            "Save a current Trail v2 draft before checking readiness.",
+        )
+    assert course is not None
+    assert constraints is not None
+    assert statistics is not None
+    assert bindings is not None
+    generation_input = NonUltraTrailGenerationInput(
+        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
+        science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        ontology_version=NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
+        ontology_decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+        ontology_contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        ontology_source_decision_digest=(
+            NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+        ),
+        athlete_today=today,
+        block_start=today,
+        course_demand=course,
+        history_statistics=statistics,
+        constraints=constraints,
+        revision_bindings=bindings,
+        workload_request=None,
+        synthetic_verification_only=False,
+    )
+    result = generate_non_ultra_trail_plan(generation_input)
+    if result.plan is not None or result.inactive_dry_run:
+        raise TrailPlanServiceError(
+            500,
+            "TRAIL_INACTIVE_INVARIANT_FAILED",
+            "The inactive Trail policy attempted to return a proposal.",
+        )
+    return {
+        "draft": current,
+        "readiness": result.public_payload(),
+    }

--- a/data/science/REGISTRY.md
+++ b/data/science/REGISTRY.md
@@ -55,7 +55,10 @@ _None._
 
 ### Science decisions
 
-_None._
+| Record | Version | Topic/model | Reviewed/decided |
+|---|---:|---|---|
+| [sdr-non-ultra-trail-plan-generation-policy-v2](decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml) — Bind the non-ultra Trail policy to the strict v2 readiness receipt | 2 | non-ultra-trail-plan-generation-policy-v2 | 2026-09-04 |
+| [sdr-trail-running-goal-ontology-v2](decisions/sdr-trail-running-goal-ontology-v2.yaml) — Define the strict v2 Trail course-demand and constraint envelope | 2 | trail-course-demand-v2 | 2026-09-04 |
 
 ## Superseded
 

--- a/data/science/REGISTRY.md
+++ b/data/science/REGISTRY.md
@@ -38,14 +38,14 @@ Evidence reviews record what the literature supports. Science Decision Records (
 | [sdr-adult-running-plan-population-routing-v1](decisions/sdr-adult-running-plan-population-routing-v1.yaml) — Bound scientific applicability for adult running-plan populations | 1 | adult-running-plan-population-routing-v1 | 2026-08-16 |
 | [sdr-environmental-performance-v4](decisions/sdr-environmental-performance-v4.yaml) — Center comparable-power support on each athlete's observed training workload | 4 | environmental-performance-context-v4 | 2026-08-10 |
 | [sdr-heat-adaptation-v1](decisions/sdr-heat-adaptation-v1.yaml) — Interpret recent heat exposure as qualitative adaptation evidence | 1 | heat-adaptation-v8 | 2026-07-26 |
-| [sdr-non-ultra-trail-plan-generation-policy-v1](decisions/sdr-non-ultra-trail-plan-generation-policy-v1.yaml) — Use a history-anchored 14-day non-ultra trail performance block | 1 | non-ultra-trail-plan-generation-policy-v1 | 2026-09-01 |
+| [sdr-non-ultra-trail-plan-generation-policy-v2](decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml) — Bind the non-ultra Trail policy to the strict v2 readiness receipt | 2 | non-ultra-trail-plan-generation-policy-v2 | 2026-09-04 |
 | [sdr-outdoor-5k-plan-generation-policy-v1](decisions/sdr-outdoor-5k-plan-generation-policy-v1.yaml) — Use a history-anchored 28-day outdoor 5 km plan block | 1 | outdoor-5k-plan-generation-policy-v1 | 2026-08-13 |
 | [sdr-plan-generation-eligibility-safety-v1](decisions/sdr-plan-generation-eligibility-safety-v1.yaml) — Match plan generation by capability, history, and non-medical safety state | 1 | plan-generation-eligibility-safety-v1 | 2026-08-14 |
 | [sdr-preplan-baseline-policy-v1](decisions/sdr-preplan-baseline-policy-v1.yaml) — Use qualified 5 km history before offering an opt-in same-protocol baseline | 1 | preplan-baseline-policy-v1 | 2026-08-10 |
 | [sdr-road-10k-plan-generation-policy-v2](decisions/sdr-road-10k-plan-generation-policy-v2.yaml) — Generator-ready adult outdoor road 10 km performance policy | 2 | road-10k-plan-generation-policy-v2 | 2026-08-18 |
 | [sdr-road-half-marathon-plan-generation-policy-v1](decisions/sdr-road-half-marathon-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road half-marathon performance policy | 1 | road-half-marathon-plan-generation-policy-v1 | 2026-08-14 |
 | [sdr-road-marathon-plan-generation-policy-v1](decisions/sdr-road-marathon-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road-marathon performance policy | 1 | road-marathon-plan-generation-policy-v1 | 2026-08-15 |
-| [sdr-trail-running-goal-ontology-v1](decisions/sdr-trail-running-goal-ontology-v1.yaml) — Represent trail goals with an explicit course-demand vector | 1 | trail-course-demand-v1 | 2026-09-01 |
+| [sdr-trail-running-goal-ontology-v2](decisions/sdr-trail-running-goal-ontology-v2.yaml) — Define the strict v2 Trail course-demand and constraint envelope | 2 | trail-course-demand-v2 | 2026-09-04 |
 
 ## Pending
 
@@ -55,10 +55,7 @@ _None._
 
 ### Science decisions
 
-| Record | Version | Topic/model | Reviewed/decided |
-|---|---:|---|---|
-| [sdr-non-ultra-trail-plan-generation-policy-v2](decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml) — Bind the non-ultra Trail policy to the strict v2 readiness receipt | 2 | non-ultra-trail-plan-generation-policy-v2 | 2026-09-04 |
-| [sdr-trail-running-goal-ontology-v2](decisions/sdr-trail-running-goal-ontology-v2.yaml) — Define the strict v2 Trail course-demand and constraint envelope | 2 | trail-course-demand-v2 | 2026-09-04 |
+_None._
 
 ## Superseded
 
@@ -73,7 +70,9 @@ _None._
 | [sdr-environmental-performance-v1](decisions/sdr-environmental-performance-v1.yaml) — Present environmental conditions as bounded performance context | 1 | environmental-performance-context-v1 | 2026-07-26 |
 | [sdr-environmental-performance-v2](decisions/sdr-environmental-performance-v2.yaml) — Present a private historical environmental-response experiment | 2 | environmental-performance-context-v2 | 2026-08-08 |
 | [sdr-environmental-performance-v3](decisions/sdr-environmental-performance-v3.yaml) — Display supported environmental-response subdomains without bridging gaps | 3 | environmental-performance-context-v3 | 2026-08-09 |
+| [sdr-non-ultra-trail-plan-generation-policy-v1](decisions/sdr-non-ultra-trail-plan-generation-policy-v1.yaml) — Use a history-anchored 14-day non-ultra trail performance block | 1 | non-ultra-trail-plan-generation-policy-v1 | 2026-09-01 |
 | [sdr-road-10k-plan-generation-policy-v1](decisions/sdr-road-10k-plan-generation-policy-v1.yaml) — History-anchored adult outdoor road 10 km performance policy | 1 | road-10k-plan-generation-policy-v1 | 2026-08-14 |
+| [sdr-trail-running-goal-ontology-v1](decisions/sdr-trail-running-goal-ontology-v1.yaml) — Represent trail goals with an explicit course-demand vector | 1 | trail-course-demand-v1 | 2026-09-01 |
 
 ## Retired
 

--- a/data/science/approvals/sdr-non-ultra-trail-plan-generation-policy-v2--decision_approver--github-dddtc2005.yaml
+++ b/data/science/approvals/sdr-non-ultra-trail-plan-generation-policy-v2--decision_approver--github-dddtc2005.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+subject_kind: science_decision
+subject_id: sdr-non-ultra-trail-plan-generation-policy-v2
+subject_digest: sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe
+reviewer: github:dddtc2005
+role: decision_approver
+reviewed_on: '2026-09-04'
+scopes:
+- activation_boundary
+- applicability
+- claim_limits
+- decision_interpretation
+- parameters
+- safety_and_privacy
+source_ref: https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653739

--- a/data/science/approvals/sdr-trail-running-goal-ontology-v2--decision_approver--github-dddtc2005.yaml
+++ b/data/science/approvals/sdr-trail-running-goal-ontology-v2--decision_approver--github-dddtc2005.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+subject_kind: science_decision
+subject_id: sdr-trail-running-goal-ontology-v2
+subject_digest: sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1
+reviewer: github:dddtc2005
+role: decision_approver
+reviewed_on: '2026-09-04'
+scopes:
+- activation_boundary
+- applicability
+- claim_limits
+- decision_interpretation
+- parameters
+- safety_and_privacy
+source_ref: https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653482

--- a/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v1.yaml
+++ b/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v1.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 id: sdr-non-ultra-trail-plan-generation-policy-v1
 version: 1
 title: "Use a history-anchored 14-day non-ultra trail performance block"
-status: accepted
+status: superseded
 approval_mode: artifact
 decision_date: 2026-09-01
 owners:
@@ -656,7 +656,7 @@ affected_surfaces:
 artifact_policy:
   runtime_state: inactive
 supersedes: []
-superseded_by:
+superseded_by: sdr-non-ultra-trail-plan-generation-policy-v2
 decision_notes:
   - "This artifact-mode decision addresses issue #692 and remains draft and inactive."
   - "It depends on separate acceptance of sdr-trail-running-goal-ontology-v1."

--- a/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
+++ b/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
@@ -45,11 +45,12 @@ accepted_interpretation: >
   ascent/descent caps remain reversible Praxys guardrails rather than
   published optima or safety laws. A deterministic v2 receipt returns exactly
   one of five statuses, one cataloged primary detail when applicable, every
-  independently safe matching reason, and sorted limited modules. It never
+  independently safe matching reason, authoritative availability for four
+  modules, and a redundant sorted limited-module projection. It never
   hides a lower-precedence reason, interprets malformed data to manufacture
   more reasons, selects a road fallback, uses activity-average power, or
   authorizes a provider or runtime behavior. Taper, progression above history,
-  fixed fueling, strength, hiking, technical-terrain or recovery dose,
+  fixed fueling, strength, hiking, taper, technical-terrain or recovery dose,
   back-to-back sessions, universal targets, and personal performance or safety
   predictions remain unaccepted.
 decision_review:
@@ -65,12 +66,15 @@ decision_review:
     seven-day reassessment, history qualification, no-initial-progression
     schedule, targetless controlled-uphill template, intensity spacing,
     separate ascent and descent caps, event-window behavior, and hard Science
-    boundaries. I approve the five-status exhaustive reason receipt and sorted
-    limited modules as reversible Praxys operational guardrails, not as
+    boundaries. I approve the five-status exhaustive reason receipt,
+    authoritative four-module availability, and redundant sorted limitation
+    projection as reversible Praxys operational guardrails, not as
     published biological rules, validated safe doses, equivalences, or
-    predictions. This approval authorizes only preparation and review of a
-    separately reviewed inactive implementation bound to this exact decision
-    and contract. It does not approve lifecycle supersession, merge,
+    predictions. Hiking, strength, and taper remain disabled because v2 has no
+    accepted input and dose contract for them. This approval authorizes only
+    preparation and review of a separately reviewed inactive implementation
+    bound to this exact decision and contract. It does not approve lifecycle
+    supersession, merge,
     deployment, production data use, dogfood, catalog visibility, provider
     behavior, delivery, or runtime activation.
   items:
@@ -79,11 +83,13 @@ decision_review:
       disposition: approve
       question: >
         Should the history-rich adult non-ultra performance policy require the
-        accepted v2 ontology, confirmed v2 course and constraint revisions,
-        server-derived history, and the same conditional module structure?
+        accepted v2 ontology, confirmed v2 course and full schedule-constraint
+        revisions, server-derived history, and an explicitly bounded module
+        structure?
       proposed_decision: >
-        Update only the dependency and schema identities while preserving the
-        accepted scope, evidence use, and modular scientific interpretation.
+        Update the dependency and schema identities, preserve the accepted
+        scope and evidence interpretation, and explicitly disable hiking,
+        strength, and taper until accepted inputs and doses exist.
       approval_effect:
         - A future inactive evaluator can require exact v2 inputs without widening the eligible population.
         - Known or unknown context cannot silently enable a module.
@@ -102,12 +108,14 @@ decision_review:
       title: Carry the accepted early-block construction forward unchanged
       disposition: approve
       question: >
-        Should v2 retain every accepted execution, reassessment, history,
-        schedule, and workout-template value exactly as v1?
+        Should v2 retain every accepted execution, reassessment, history
+        threshold, schedule construction, and workout-template value from v1,
+        while normalizing bare results to cataloged status/detail pairs?
       proposed_decision: >
         Preserve the exact fourteen-day, seven-day, history qualification,
         no-progression scheduling, and targetless 38-minute uphill-template
-        guardrails without presenting them as biological optima.
+        guardrails without presenting them as biological optima; change only
+        their receipt representation where a pair is required.
       approval_effect:
         - The successor changes readiness semantics without silently changing the generated training envelope.
       does_not_authorize:
@@ -150,11 +158,12 @@ decision_review:
       question: >
         Should every safely classified evaluation return one status by fixed
         precedence, the first cataloged primary detail, every matching reason,
-        and a separate sorted limited-module set?
+        authoritative state for all four modules, and a redundant sorted
+        limited-module projection?
       proposed_decision: >
         Accept the exact status, detail, namespacing, de-duplication, ordering,
-        independent-evaluation, and module serialization rules from Product v2
-        as reversible operational guardrails.
+        independent-evaluation, condition mapping, module-availability, and
+        projection rules from Product v2 as reversible operational guardrails.
       approval_effect:
         - Clients receive one next-action status without losing simultaneous lower-precedence findings.
         - Malformed fields are never dereferenced merely to fill the receipt.
@@ -180,6 +189,8 @@ decision_review:
         - Taper, progression, fixed dose, broader scope, provider behavior, deployment, or activation.
       parameter_names:
         - trail_policy_event_and_taper
+        - trail_policy_modular_structure
+        - trail_policy_evidence_use
         - trail_policy_deferred_scope
         - trail_policy_non_science_authority
       evidence_claim_ids:
@@ -256,8 +267,16 @@ model_parameters:
         - stable_recent_running_history
         - comparable_recent_ascent_exposure
         - comparable_recent_descent_exposure
-        - available_training_days_and_limits
-        - accessible_training_terrain
+        - available_weekdays
+        - weekly_time_limit_min
+        - maximum_session_duration_min
+        - unavailable_dates_within_14_day_horizon
+        - optional_preferred_longest_weekday_when_supplied
+        - nontechnical_three_minute_uphill_access
+        - controlled_downhill_access
+        - accessible_footing
+        - adult_nonclinical_scope_confirmation
+        - performance_intent_confirmation
         - current_symptom_stop
       server_derived:
         - recent_running_continuity
@@ -317,7 +336,18 @@ model_parameters:
         - usable_elevation_gain_and_loss_or_explicit_unknown
         - source_timestamp
       unknown_descent_or_terrain_cannot_satisfy_comparable_exposure: true
-      sparse_or_stale_result: insufficient_comparable_trail_history
+      insufficient_recent_running_result:
+        status: readiness_blocked
+        detail_reason: insufficient_recent_running_history
+      insufficient_ascent_or_trail_result:
+        status: readiness_blocked
+        detail_reason: insufficient_comparable_trail_history
+      insufficient_recent_descent_result:
+        status: readiness_blocked
+        detail_reason: insufficient_descent_history
+      known_course_footing_not_observed_result:
+        status: readiness_blocked
+        detail_reason: insufficient_comparable_trail_history
       thresholds_are_published_biological_laws: false
     classification: guardrail
     evidence_claim_ids:
@@ -325,9 +355,9 @@ model_parameters:
       - non-ultra-trail.course-specific-policy-required
       - non-ultra-trail.uphill-downhill-require-distinct-handling
     rationale: >
-      Carried unchanged from accepted v1. The counts prevent extrapolation from
-      sparse records and remain conservative qualifications, not safety,
-      adaptation, or readiness laws.
+      The accepted v1 counts and windows are unchanged. Only bare outcomes are
+      normalized to cataloged status/detail pairs; the qualifications remain
+      conservative guardrails, not safety, adaptation, or readiness laws.
     applies_to: owner-scoped readiness history
   - name: trail_policy_schedule_construction
     value:
@@ -335,8 +365,12 @@ model_parameters:
         minimum: 3
         maximum: 6
         deterministic_value: minimum_of_available_days_recent_modal_days_and_policy_maximum
-      below_minimum_result: no_schedule_within_envelope
-      requested_above_maximum_result: clarification_required
+      below_minimum_result:
+        status: readiness_blocked
+        detail_reason: no_schedule_within_envelope
+      explicit_request_above_history_envelope_result:
+        status: clarification_required
+        detail_reason: training_constraints_outside_history_envelope
       weekly_running_minutes_target: minimum_of_recent_median_usable_weekly_minutes_and_athlete_limit
       weekly_running_minutes_hard_cap: minimum_of_recent_maximum_usable_weekly_minutes_and_athlete_limit
       non_taper_progression_above_recent_median: false
@@ -348,15 +382,17 @@ model_parameters:
         remaining_minutes_distributed_across_non_quality_days: true
         preferred_longest_easy_day_used_when_available: true
         automatic_longest_easy_increase: false
-      no_schedule_result: no_schedule_within_envelope
+      no_schedule_result:
+        status: readiness_blocked
+        detail_reason: no_schedule_within_envelope
     classification: guardrail
     evidence_claim_ids:
       - eligibility.fixed-progression-and-acwr-not-safety-laws
       - non-ultra-trail.training-specificity-promising-not-prescriptive
     rationale: >
-      Carried unchanged from accepted v1. Median, maximum, and athlete caps
-      organize existing exposure without automatic progression; one quality
-      session is a conservative Product choice, not a universal optimum.
+      The accepted v1 construction values are unchanged. Only bare outcomes
+      are normalized to cataloged status/detail pairs. Median, maximum, and
+      athlete caps organize existing exposure without automatic progression.
     applies_to: deterministic early-block schedule
   - name: trail_policy_workout_templates
     value:
@@ -420,7 +456,10 @@ model_parameters:
       session_ascent_hard_cap: recent_maximum_completed_session_ascent
       session_descent_hard_cap: recent_maximum_completed_session_descent
       technicality: no_more_difficult_than_recently_observed_and_currently_accessible_category
-      unknown_descent_or_technicality_result: clarification_or_limited_module
+      unknown_descent_result:
+        status: clarification_required
+        detail_reason: material_course_demand_unknown
+      unknown_course_footing_module_state: limited
       high_speed_or_maximal_downhill_repeats: false
       road_or_flat_substitution_claimed_equivalent: false
       automatic_vertical_progression: false
@@ -436,8 +475,10 @@ model_parameters:
   - name: trail_policy_event_and_taper
     value:
       imported_event_must_be_athlete_confirmed: true
-      target_more_than_14_days_after_start: normal_14_day_rolling_proposal
-      target_within_14_days_of_start: event_inside_unapproved_taper_window
+      target_more_than_14_days_after_start_adds_reason: false
+      target_within_14_days_of_start_result:
+        status: policy_unavailable
+        detail_reason: event_inside_unapproved_taper_window
       taper_implementation: not_accepted
       event_or_race_counts_as_quality_and_load: true
       event_day_generated_as_training_workout: false
@@ -445,9 +486,9 @@ model_parameters:
     evidence_claim_ids:
       - non-ultra-trail.taper-direction-indirect
     rationale: >
-      Carried unchanged from accepted v1. General endurance evidence remains
-      insufficient to select a Trail-specific taper; the event-near path fails
-      closed pending a successor decision.
+      The accepted v1 event-window behavior is unchanged and its bare outcome
+      is normalized to a cataloged pair. General endurance evidence remains
+      insufficient to select a Trail-specific taper.
     applies_to: dated Trail goals
   - name: trail_policy_typed_outcomes
     value:
@@ -480,9 +521,60 @@ model_parameters:
           - assumption_confirmation_required
           - adult_scope_or_constraints_unconfirmed
           - training_constraints_missing
+          - training_constraints_outside_history_envelope
+          - stale_confirmation_or_source_revision
           - contradictory_input
         eligible_proposal: []
       namespaced_reason_identity: "<status>.<detail_reason>"
+      condition_reason_mapping:
+        - condition: invalid_type_nonfinite_out_of_domain_duplicate_forbidden_or_internally_inconsistent_value
+          result: {status: validation_failed, detail_reason: invalid_field_value}
+        - condition: course_or_constraint_schema_id_is_not_exact_v2
+          result: {status: validation_failed, detail_reason: schema_version_mismatch}
+        - condition: canonical_replay_receipt_proposal_or_other_invariant_fails
+          result: {status: validation_failed, detail_reason: deterministic_invariant_failed}
+        - condition: required_ontology_policy_or_specialist_dependency_missing_mismatched_inactive_or_not_runtime_authorized
+          result: {status: policy_unavailable, detail_reason: policy_inactive}
+        - condition: event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown
+          result: {status: clarification_required, detail_reason: material_course_demand_unknown}
+        - condition: explicit_assumption_not_confirmed_at_exact_revision
+          result: {status: clarification_required, detail_reason: assumption_confirmation_required}
+        - condition: adult_nonclinical_or_performance_scope_confirmation_missing_or_unknown
+          result: {status: clarification_required, detail_reason: adult_scope_or_constraints_unconfirmed}
+        - condition: schedule_capacity_unavailable_dates_access_footing_or_symptom_input_missing_or_unknown
+          result: {status: clarification_required, detail_reason: training_constraints_missing}
+        - condition: explicit_requested_workload_or_proposal_edit_above_server_history_envelope
+          result: {status: clarification_required, detail_reason: training_constraints_outside_history_envelope}
+        - condition: required_confirmation_course_constraint_or_history_source_revision_stale
+          result: {status: clarification_required, detail_reason: stale_confirmation_or_source_revision}
+        - condition: individually_valid_values_conflict_including_preferred_weekday_outside_available_set
+          result: {status: clarification_required, detail_reason: contradictory_input}
+        - condition: server_derived_recent_running_continuity_insufficient
+          result: {status: readiness_blocked, detail_reason: insufficient_recent_running_history}
+        - condition: server_derived_recent_ascent_or_trail_exposure_insufficient
+          result: {status: readiness_blocked, detail_reason: insufficient_comparable_trail_history}
+        - condition: known_course_footing_not_subset_of_recently_observed_footing
+          result: {status: readiness_blocked, detail_reason: insufficient_comparable_trail_history}
+        - condition: server_derived_recent_descent_exposure_insufficient
+          result: {status: readiness_blocked, detail_reason: insufficient_descent_history}
+        - condition: known_uphill_or_downhill_access_false
+          result: {status: readiness_blocked, detail_reason: insufficient_terrain_access}
+        - condition: known_course_footing_not_subset_of_accessible_footing
+          result: {status: readiness_blocked, detail_reason: insufficient_terrain_access}
+        - condition: current_symptom_stop_known_true
+          result: {status: readiness_blocked, detail_reason: current_symptom_stop}
+        - condition: complete_valid_constraints_history_caps_and_spacing_leave_no_14_day_schedule
+          result: {status: readiness_blocked, detail_reason: no_schedule_within_envelope}
+        - condition: event_within_unapproved_14_day_taper_window
+          result: {status: policy_unavailable, detail_reason: event_inside_unapproved_taper_window}
+        - condition: event_ultra_distance_or_multiday
+          result: {status: policy_unavailable, detail_reason: unsupported_ultra_or_multiday}
+        - condition: population_clinical_return_to_sport_or_intent_outside_scope
+          result: {status: policy_unavailable, detail_reason: unsupported_population_or_intent}
+        - condition: hands_assist_or_fixed_rope_known_true
+          result: {status: policy_unavailable, detail_reason: technical_features_outside_v2}
+        - condition: no_higher_precedence_reason_matches
+          result: {status: eligible_proposal, detail_reason: null}
       top_level_status: highest_precedence_matching_status
       detail_reason: first_matching_reason_in_selected_status_catalog_order
       matching_reasons:
@@ -492,7 +584,42 @@ model_parameters:
         order_by: [status_precedence, detail_reason_catalog_order]
         malformed_value_may_be_dereferenced_to_find_more_reasons: false
         independently_evaluable_lower_precedence_reasons_preserved: true
+      module_availability:
+        authoritative: true
+        required_keys_in_sorted_order:
+          - environment_altitude
+          - fueling
+          - grade_specificity
+          - technical_terrain
+        value_exact_keys: [state, reason_target]
+        allowed_states:
+          - not_evaluated
+          - available
+          - limited
+        state_rules:
+          not_evaluated:
+            when: validation_policy_clarification_or_core_readiness_prevents_safe_module_decision
+            reason_target: one_applicable_namespaced_matching_reason
+          available:
+            when: module_inputs_and_science_boundary_permit_generation_to_consider_the_module
+            reason_target: null
+            guarantees_proposal_inclusion: false
+          limited:
+            when: accepted_non_core_unknown_requires_omission_or_descriptive_only_handling
+            reason_target: closed_first_party_field_or_section_target
+            may_be_included_in_proposal: false
+        limited_reason_targets:
+          environment_altitude: [course.environment_and_altitude]
+          fueling:
+            - course.aid_and_support
+            - course.fueling_and_gastrointestinal_context
+          grade_specificity: [course.grade_distribution]
+          technical_terrain: [course.course_footing]
+        reason_target_may_be_url_fragment_value_identifier_or_client_string: false
+        actual_included_or_omitted_state_exists_only_in_immutable_proposal: true
       limited_modules:
+        source_of_truth: false
+        projection_of: module_availability_state_limited
         allowed_sorted_order:
           - environment_altitude
           - fueling
@@ -503,6 +630,7 @@ model_parameters:
         changes_top_level_status: false
         hides_matching_reason: false
         empty_means_eligible: false
+        empty_means_included: false
         generic_or_road_replacement_allowed: false
       authorization_failures_occur_before_product_receipt: true
       road_fallback: false
@@ -519,18 +647,27 @@ model_parameters:
     applies_to: v2 validation, policy availability, readiness, and proposal eligibility receipts
   - name: trail_policy_modular_structure
     value:
-      modules:
+      candidate_modules:
         - readiness_and_history
         - easy_and_aerobic
         - ascent_specificity
         - descent_and_neuromuscular_exposure
         - technical_terrain
-        - hiking
-        - strength
         - longest_session_and_fueling_practice
-        - taper
         - environment_and_altitude
         - reassessment_and_outcome
+      disabled_deferred_modules:
+        hiking:
+          state: not_accepted
+          reason: no_accepted_v2_input_and_dose_contract
+        strength:
+          state: not_accepted
+          reason: no_accepted_v2_input_and_dose_contract
+        taper:
+          state: not_accepted
+          reason: no_accepted_v2_input_and_dose_contract
+      disabled_modules_are_module_availability_keys: false
+      disabled_modules_may_be_included_in_v2_proposal: false
       module_requires_matching_input: true
       unavailable_module_may_be_silently_replaced: false
     classification: guardrail
@@ -540,15 +677,16 @@ model_parameters:
       - non-ultra-trail.taper-direction-indirect
       - non-ultra-trail.fueling-duration-and-practice-context
     rationale: >
-      Carried unchanged from accepted v1. Modular handling preserves distinct
-      demands and uncertainty without claiming one universal Trail schedule.
+      V2 preserves distinct demand handling but explicitly disables hiking,
+      strength, and taper because no accepted v2 input and dose contract exists.
+      This is a deferral, not evidence that those modules lack value.
     applies_to: future deterministic generator envelope
   - name: trail_policy_evidence_use
     value:
       trail_specificity: conditional_candidate_module
-      strength_and_multimodal: conditional_candidate_module
-      hiking: conditional_candidate_module
-      taper: indirect_direction_only
+      strength_and_multimodal: disabled_deferred_no_accepted_v2_input_or_dose
+      hiking: disabled_deferred_no_accepted_v2_input_or_dose
+      taper: disabled_deferred_no_accepted_v2_input_or_dose
       fueling: expected_duration_and_practice_context_only
       observed_load_associations: descriptive_only
       injury_and_fatigue_findings: safety_context_only
@@ -560,8 +698,8 @@ model_parameters:
       - non-ultra-trail.taper-direction-indirect
       - non-ultra-trail.fueling-duration-and-practice-context
     rationale: >
-      Carried unchanged from accepted v1. This keeps evidence-supported
-      directions separate from exact prescriptions the sources do not establish.
+      Evidence-supported directions remain distinct from exact prescriptions;
+      v2 disables modules whose required inputs and dose are not accepted.
     applies_to: module selection and ScienceNote claims
   - name: trail_policy_hard_boundaries
     value:
@@ -671,15 +809,15 @@ privacy_implications:
   - Activity-average power is neither collected nor used as readiness or intensity evidence.
   - Owner-scoped goal, readiness, proposal, adoption, reset, export, deletion, and account-deletion controls remain mandatory.
 validation_plan:
-  - Prove every execution, history, schedule, template, intensity, exposure, event, and hard-boundary value is structurally equal to the accepted v1 contract except the named v2 dependency and receipt groups.
-  - Exhaustively exercise every status and detail reason, every pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, and sorted limited modules.
+  - Prove every behavior-driving execution, history threshold, schedule construction, template, intensity, exposure, event-window, and hard-boundary value equals accepted v1; allow only the named dependency, pair-normalization, receipt, and disabled-module changes.
+  - Exhaustively exercise every status and detail reason, every condition mapping, pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, authoritative four-module state, and sorted redundant limited-module projection.
   - Verify malformed values are not dereferenced while all independently safe policy, history, schedule, and missingness reasons remain present.
   - Unit-test history qualification, schedule allocation, targetless template steps, low-intensity fraction, quality spacing, and separate ascent/descent/terrain caps against immutable owner-scoped snapshots.
   - Verify no proposal is returned from an inactive contract, a core unknown, a failed gate, a stale revision, route/provider input, or any road fallback.
   - Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests.
 falsification_conditions:
-  - Any accepted v1 execution, history, schedule, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency and receipt groups.
-  - Status selection, primary detail, matching-reason ordering, de-duplication, or limited-module sorting is nondeterministic or loses a safely evaluable reason.
+  - Any accepted v1 behavior-driving execution, history threshold, schedule construction, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency, pair-normalization, receipt, and disabled-module groups.
+  - Status selection, condition mapping, primary detail, matching-reason ordering, de-duplication, module availability, or limited-module projection is nondeterministic or loses a safely evaluable reason.
   - A malformed field is interpreted to manufacture a reason, or a core unknown or failed gate produces eligible_proposal.
   - An exact value outside the accepted early-block guardrails is inferred despite literal not_accepted status.
   - Uphill and downhill collapse, terrain or history access is ignored, or an unsupported module is silently substituted.
@@ -710,5 +848,8 @@ decision_notes:
   - "Every exact value outside the v2 dependency and receipt groups is carried unchanged from accepted v1 and remains classified as a reversible Praxys guardrail."
   - "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md."
   - "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md."
+  - "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md."
+  - "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md."
+  - "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact."
   - "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607."
   - "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."

--- a/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
+++ b/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 id: sdr-non-ultra-trail-plan-generation-policy-v2
 version: 2
 title: "Bind the non-ultra Trail policy to the strict v2 readiness receipt"
-status: draft
+status: accepted
 approval_mode: artifact
 decision_date: 2026-09-04
 owners:
@@ -851,7 +851,8 @@ affected_surfaces:
     - Why a complete deterministic receipt is not a biological readiness score
 artifact_policy:
   runtime_state: inactive
-supersedes: []
+supersedes:
+  - sdr-non-ultra-trail-plan-generation-policy-v1
 superseded_by:
 decision_notes:
   - "Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim."

--- a/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
+++ b/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
@@ -529,6 +529,8 @@ model_parameters:
       condition_reason_mapping:
         - condition: invalid_type_nonfinite_out_of_domain_duplicate_forbidden_or_internally_inconsistent_value
           result: {status: validation_failed, detail_reason: invalid_field_value}
+        - condition: unrecognized_event_format_distance_family_or_planning_intent_literal
+          result: {status: validation_failed, detail_reason: invalid_field_value}
         - condition: course_or_constraint_schema_id_is_not_exact_v2
           result: {status: validation_failed, detail_reason: schema_version_mismatch}
         - condition: canonical_replay_receipt_proposal_or_other_invariant_fails
@@ -537,6 +539,8 @@ model_parameters:
           result: {status: policy_unavailable, detail_reason: policy_inactive}
         - condition: event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown
           result: {status: clarification_required, detail_reason: material_course_demand_unknown}
+        - condition: recognized_event_format_distance_family_or_planning_intent_unknown
+          result: {status: clarification_required, detail_reason: adult_scope_or_constraints_unconfirmed}
         - condition: explicit_assumption_not_confirmed_at_exact_revision
           result: {status: clarification_required, detail_reason: assumption_confirmation_required}
         - condition: adult_nonclinical_or_performance_scope_confirmation_missing_or_unknown
@@ -567,9 +571,9 @@ model_parameters:
           result: {status: readiness_blocked, detail_reason: no_schedule_within_envelope}
         - condition: event_within_unapproved_14_day_taper_window
           result: {status: policy_unavailable, detail_reason: event_inside_unapproved_taper_window}
-        - condition: event_ultra_distance_or_multiday
+        - condition: recognized_event_format_multi_day_or_distance_family_ultra
           result: {status: policy_unavailable, detail_reason: unsupported_ultra_or_multiday}
-        - condition: population_clinical_return_to_sport_or_intent_outside_scope
+        - condition: unsupported_population_or_clinical_state_or_recognized_first_completion_or_return_to_consistency_intent
           result: {status: policy_unavailable, detail_reason: unsupported_population_or_intent}
         - condition: hands_assist_or_fixed_rope_known_true
           result: {status: policy_unavailable, detail_reason: technical_features_outside_v2}
@@ -577,6 +581,8 @@ model_parameters:
           result: {status: eligible_proposal, detail_reason: null}
       top_level_status: highest_precedence_matching_status
       detail_reason: first_matching_reason_in_selected_status_catalog_order
+      primary_namespaced_reason: deterministic_top_level_status_dot_detail_reason
+      eligible_proposal_detail_reason: null
       matching_reasons:
         include_every_independently_and_safely_evaluable_match: true
         pair_fields: [status, detail_reason]
@@ -586,11 +592,11 @@ model_parameters:
         independently_evaluable_lower_precedence_reasons_preserved: true
       module_availability:
         authoritative: true
-        required_keys_in_sorted_order:
-          - environment_altitude
-          - fueling
+        required_keys_in_fixed_order:
           - grade_specificity
           - technical_terrain
+          - environment_altitude
+          - fueling
         value_exact_keys: [state, reason_target]
         allowed_states:
           - not_evaluated
@@ -598,21 +604,27 @@ model_parameters:
           - limited
         state_rules:
           not_evaluated:
-            when: validation_policy_clarification_or_core_readiness_prevents_safe_module_decision
-            reason_target: one_applicable_namespaced_matching_reason
+            when: top_level_status_is_not_eligible_proposal
+            reason_target: top_level_primary_namespaced_reason
+            all_four_modules_use_same_reason_target: true
           available:
-            when: module_inputs_and_science_boundary_permit_generation_to_consider_the_module
+            when: top_level_status_is_eligible_proposal_and_module_inputs_and_science_boundary_permit_consideration
             reason_target: null
             guarantees_proposal_inclusion: false
           limited:
-            when: accepted_non_core_unknown_requires_omission_or_descriptive_only_handling
+            when: top_level_status_is_eligible_proposal_and_accepted_non_core_unknown_requires_omission_or_descriptive_only_handling
             reason_target: closed_first_party_field_or_section_target
             may_be_included_in_proposal: false
+        non_eligible_status_evaluates_individual_modules: false
+        multiple_matching_reasons_choose_primary_by:
+          - status_precedence
+          - detail_reason_catalog_order
+        arbitrary_reason_selection_allowed: false
         limited_reason_targets:
-          environment_altitude: [course.environment_and_altitude]
+          environment_altitude: [course.optional_context.environment]
           fueling:
-            - course.aid_and_support
-            - course.fueling_and_gastrointestinal_context
+            - course.optional_context.support
+            - course.optional_context.fueling
           grade_specificity: [course.grade_distribution]
           technical_terrain: [course.course_footing]
         reason_target_may_be_url_fragment_value_identifier_or_client_string: false
@@ -850,6 +862,6 @@ decision_notes:
   - "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md."
   - "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md."
   - "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md."
-  - "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact."
+  - "This revision incorporates the frozen Product wire semantics at repository commit f9678d64 and Architecture boundary at a52d23ce; it does not approve either role-owned artifact."
   - "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607."
   - "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."

--- a/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
+++ b/data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml
@@ -1,0 +1,714 @@
+schema_version: 1
+id: sdr-non-ultra-trail-plan-generation-policy-v2
+version: 2
+title: "Bind the non-ultra Trail policy to the strict v2 readiness receipt"
+status: draft
+approval_mode: artifact
+decision_date: 2026-09-04
+owners:
+  - team:praxys
+human_reviewers: []
+model_version: non-ultra-trail-plan-generation-policy-v2
+evidence_review_ids:
+  - evidence-trail-running-goal-ontology-v1
+  - evidence-non-ultra-trail-plan-generation-policy-v1
+  - evidence-plan-generation-eligibility-safety-v1
+evidence_claim_ids:
+  - trail-ontology.course-demand-is-multidimensional
+  - trail-ontology.uphill-downhill-demands-differ
+  - trail-ontology.technicality-and-downhill-vary-performance
+  - trail-ontology.heart-rate-and-road-pace-are-insufficient-alone
+  - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+  - non-ultra-trail.course-specific-policy-required
+  - non-ultra-trail.uphill-downhill-require-distinct-handling
+  - non-ultra-trail.hr-and-road-pace-not-sole-targets
+  - non-ultra-trail.training-specificity-promising-not-prescriptive
+  - non-ultra-trail.injury-fatigue-no-safe-dose
+  - non-ultra-trail.observed-load-does-not-prove-prescription
+  - non-ultra-trail.taper-direction-indirect
+  - non-ultra-trail.fueling-duration-and-practice-context
+  - eligibility.recent-history-anchor-without-universal-threshold
+  - eligibility.fixed-progression-and-acwr-not-safety-laws
+  - eligibility.goal-relevant-current-capability-task-specific
+  - eligibility.current-symptoms-support-stop-not-clearance
+accepted_interpretation: >
+  If separately accepted after the ontology successor, this record would bind
+  the accepted history-rich adult non-ultra Trail policy to
+  trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing
+  any accepted v1 execution, history, schedule, workout-template, intensity,
+  exposure, event-window, taper deferral, or hard scientific boundary. The
+  fourteen-day proposal, seven-day reassessment, eight-week history window,
+  four usable weeks, three-run usable-week floor, ten-day recent-run check,
+  42/21-day comparable-history checks, no-initial-progression schedule,
+  targetless 38-minute controlled-uphill template, 75-percent low-intensity
+  floor, one nonconsecutive quality exposure, and separate history-anchored
+  ascent/descent caps remain reversible Praxys guardrails rather than
+  published optima or safety laws. A deterministic v2 receipt returns exactly
+  one of five statuses, one cataloged primary detail when applicable, every
+  independently safe matching reason, and sorted limited modules. It never
+  hides a lower-precedence reason, interprets malformed data to manufacture
+  more reasons, selects a road fallback, uses activity-average power, or
+  authorizes a provider or runtime behavior. Taper, progression above history,
+  fixed fueling, strength, hiking, technical-terrain or recovery dose,
+  back-to-back sessions, universal targets, and personal performance or safety
+  predictions remain unaccepted.
+decision_review:
+  reviewer_task: >
+    Decide whether the six proposed v2 actions preserve every accepted v1
+    policy guardrail while replacing ambiguous readiness input and output with
+    strict v2 dependencies and a deterministic complete receipt. Approve the
+    sheet as a unit or request changes by item ID.
+  approval_statement: >
+    I approve the non-ultra Trail policy v2 as a strict successor candidate
+    bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I
+    approve carrying forward unchanged the accepted v1 fourteen-day execution,
+    seven-day reassessment, history qualification, no-initial-progression
+    schedule, targetless controlled-uphill template, intensity spacing,
+    separate ascent and descent caps, event-window behavior, and hard Science
+    boundaries. I approve the five-status exhaustive reason receipt and sorted
+    limited modules as reversible Praxys operational guardrails, not as
+    published biological rules, validated safe doses, equivalences, or
+    predictions. This approval authorizes only preparation and review of a
+    separately reviewed inactive implementation bound to this exact decision
+    and contract. It does not approve lifecycle supersession, merge,
+    deployment, production data use, dogfood, catalog visibility, provider
+    behavior, delivery, or runtime activation.
+  items:
+    - id: v2-scope-dependencies-and-modules
+      title: Bind the narrow accepted policy to the two strict v2 schemas
+      disposition: approve
+      question: >
+        Should the history-rich adult non-ultra performance policy require the
+        accepted v2 ontology, confirmed v2 course and constraint revisions,
+        server-derived history, and the same conditional module structure?
+      proposed_decision: >
+        Update only the dependency and schema identities while preserving the
+        accepted scope, evidence use, and modular scientific interpretation.
+      approval_effect:
+        - A future inactive evaluator can require exact v2 inputs without widening the eligible population.
+        - Known or unknown context cannot silently enable a module.
+      does_not_authorize:
+        - A broader population, first-completion plan, ultra plan, fixed module dose, or runtime use.
+      parameter_names:
+        - trail_policy_scope_and_dependencies
+        - trail_policy_required_inputs
+        - trail_policy_modular_structure
+        - trail_policy_evidence_use
+      evidence_claim_ids:
+        - non-ultra-trail.course-specific-policy-required
+        - non-ultra-trail.uphill-downhill-require-distinct-handling
+        - non-ultra-trail.training-specificity-promising-not-prescriptive
+    - id: unchanged-early-block-construction
+      title: Carry the accepted early-block construction forward unchanged
+      disposition: approve
+      question: >
+        Should v2 retain every accepted execution, reassessment, history,
+        schedule, and workout-template value exactly as v1?
+      proposed_decision: >
+        Preserve the exact fourteen-day, seven-day, history qualification,
+        no-progression scheduling, and targetless 38-minute uphill-template
+        guardrails without presenting them as biological optima.
+      approval_effect:
+        - The successor changes readiness semantics without silently changing the generated training envelope.
+      does_not_authorize:
+        - Load progression, a new template, fixed target zones, or a claim of optimality or safety.
+      parameter_names:
+        - trail_policy_execution_and_reassessment
+        - trail_policy_history_guardrails
+        - trail_policy_schedule_construction
+        - trail_policy_workout_templates
+      evidence_claim_ids:
+        - eligibility.recent-history-anchor-without-universal-threshold
+        - eligibility.fixed-progression-and-acwr-not-safety-laws
+        - non-ultra-trail.training-specificity-promising-not-prescriptive
+    - id: unchanged-intensity-exposure-event-and-safety
+      title: Carry the accepted intensity, exposure, event, and hard boundaries forward
+      disposition: approve
+      question: >
+        Should v2 keep the 75-percent low-intensity floor, one-quality ceiling,
+        spacing, separate history caps, event-window behavior, and all hard
+        Science prohibitions unchanged?
+      proposed_decision: >
+        Preserve those exact v1 guardrails and keep ascent, descent, terrain,
+        symptoms, athlete action, and intensity provenance separate.
+      approval_effect:
+        - A new receipt cannot weaken the generated-plan invariants or claim boundaries.
+      does_not_authorize:
+        - Taper dose, catch-up, target-gap escalation, road substitution, medical advice, or personal guarantees.
+      parameter_names:
+        - trail_policy_intensity_and_spacing
+        - trail_policy_course_exposure_caps
+        - trail_policy_event_and_taper
+        - trail_policy_hard_boundaries
+      evidence_claim_ids:
+        - non-ultra-trail.hr-and-road-pace-not-sole-targets
+        - non-ultra-trail.injury-fatigue-no-safe-dose
+        - eligibility.current-symptoms-support-stop-not-clearance
+    - id: deterministic-complete-v2-receipt
+      title: Adopt the five-status exhaustive deterministic receipt
+      disposition: approve
+      question: >
+        Should every safely classified evaluation return one status by fixed
+        precedence, the first cataloged primary detail, every matching reason,
+        and a separate sorted limited-module set?
+      proposed_decision: >
+        Accept the exact status, detail, namespacing, de-duplication, ordering,
+        independent-evaluation, and module serialization rules from Product v2
+        as reversible operational guardrails.
+      approval_effect:
+        - Clients receive one next-action status without losing simultaneous lower-precedence findings.
+        - Malformed fields are never dereferenced merely to fill the receipt.
+      does_not_authorize:
+        - A biological readiness score, risk rank, hidden reason, client-created reason, or eligibility from an empty module list.
+      parameter_names:
+        - trail_policy_typed_outcomes
+      evidence_claim_ids:
+        - trail-ontology.course-demand-is-multidimensional
+        - eligibility.recent-history-anchor-without-universal-threshold
+    - id: unresolved-dose-and-scope-stays-deferred
+      title: Keep taper, progression, fixed dose, and wider authority unaccepted
+      disposition: defer
+      question: >
+        Should every literal not_accepted value in the event, deferred-scope,
+        and non-Science authority groups remain unavailable?
+      proposed_decision: >
+        Retain all existing deferrals and require a future evidence-consistent
+        successor plus role-scoped review before any expansion.
+      approval_effect:
+        - The v2 receipt cannot turn descriptive context into a prescription or activation path.
+      does_not_authorize:
+        - Taper, progression, fixed dose, broader scope, provider behavior, deployment, or activation.
+      parameter_names:
+        - trail_policy_event_and_taper
+        - trail_policy_deferred_scope
+        - trail_policy_non_science_authority
+      evidence_claim_ids:
+        - non-ultra-trail.training-specificity-promising-not-prescriptive
+        - non-ultra-trail.injury-fatigue-no-safe-dose
+        - non-ultra-trail.taper-direction-indirect
+        - non-ultra-trail.fueling-duration-and-practice-context
+    - id: inactive-evaluation-and-role-boundary
+      title: Preserve dry-run checks and require separate authority for all exposure
+      disposition: approve
+      question: >
+        Should deterministic zero-tolerance dry-run checks remain available
+        while every owner, provider, deployment, and runtime action stays under
+        separate Product, Trust, Quality, Operations, and human authority?
+      proposed_decision: >
+        Carry the accepted evaluation thresholds and non-Science boundary
+        forward without starting observation, pilot, delivery, or activation.
+      approval_effect:
+        - Inactive verification can detect invariant or replay failures before any exposure.
+      does_not_authorize:
+        - Collecting value telemetry, starting owner dogfood, sending workouts, deploying, or activating.
+      parameter_names:
+        - trail_policy_runtime_evaluation
+        - trail_policy_non_science_authority
+      evidence_claim_ids:
+        - non-ultra-trail.injury-fatigue-no-safe-dose
+        - eligibility.fixed-progression-and-acwr-not-safety-laws
+rejected_alternatives:
+  - alternative: "Change the readiness receipt while also tuning the training schedule"
+    rationale: >
+      That would confound an input/output contract repair with unreviewed dose
+      and make the v1-to-v2 training envelope impossible to audit.
+  - alternative: "Return only the highest-precedence reason"
+    rationale: >
+      One reason would hide other safely evaluable actions and make the receipt
+      unstable as fields are corrected.
+  - alternative: "Let clients invent reason strings or infer eligibility from module limits"
+    rationale: >
+      Client-specific interpretation would break replay and could transform an
+      omitted module into a false readiness claim.
+  - alternative: "Use a road policy, route inference, provider payload, or AI output to complete missing Trail input"
+    rationale: >
+      Those inputs and fallbacks are outside the accepted evidence and privacy
+      boundary and cannot manufacture an exact capability match.
+model_parameters:
+  - name: trail_policy_scope_and_dependencies
+    value:
+      minimum_age_years: 18
+      intent: performance
+      event_format: single_day
+      distance_family: non_ultra
+      clinical_or_return_to_sport: false
+      requires_accepted_ontology: sdr-trail-running-goal-ontology-v2
+      requires_course_demand_schema: trail_course_demand_v2
+      requires_constraint_schema: non_ultra_trail_constraints_v2
+      requires_confirmed_course_revision: true
+      requires_confirmed_constraint_revision: true
+      requires_server_derived_history_revision: true
+      suggestion_only: true
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.course-specific-policy-required
+      - eligibility.goal-relevant-current-capability-task-specific
+    rationale: >
+      Only dependency and schema identities change. The narrow v1 population
+      and intent remain unchanged; exact revisions are operational replay
+      guardrails rather than published eligibility thresholds.
+    applies_to: non-ultra-trail-plan-generation-policy-v2
+  - name: trail_policy_required_inputs
+    value:
+      required:
+        - athlete_confirmed_trail_course_demand_v2
+        - athlete_confirmed_non_ultra_trail_constraints_v2
+        - stable_recent_running_history
+        - comparable_recent_ascent_exposure
+        - comparable_recent_descent_exposure
+        - available_training_days_and_limits
+        - accessible_training_terrain
+        - current_symptom_stop
+      server_derived:
+        - recent_running_continuity
+        - recent_ascent_exposure
+        - recent_descent_exposure
+        - recently_observed_footing
+      conditional:
+        - grade_distribution
+        - course_footing
+        - altitude_and_environment_context
+        - aid_and_support_context
+        - fueling_practice_experience
+      material_unknown_behavior: canonical_status_or_named_limited_module
+      client_supplied_history_allowed: false
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.course-specific-policy-required
+      - non-ultra-trail.uphill-downhill-require-distinct-handling
+      - eligibility.recent-history-anchor-without-universal-threshold
+    rationale: >
+      The v2 names make the accepted course, access, and history boundary
+      explicit without changing history thresholds or inventing a dose.
+    applies_to: v2 capability matching and readiness
+  - name: trail_policy_execution_and_reassessment
+    value:
+      calendar_schedule_unit_days: 7
+      committed_proposal_days: 14
+      advisory_reassessment_after_completed_days: 7
+      proposal_end_inclusive: true
+      continued_goal_horizon_requires_successor: true
+      each_successor_requires_fresh_history_course_and_constraints: true
+      automatic_successor_adoption: false
+      automatic_overwrite_of_adopted_future_days: false
+      biological_optimum_claim: false
+    classification: guardrail
+    evidence_claim_ids:
+      - eligibility.recent-history-anchor-without-universal-threshold
+      - non-ultra-trail.course-specific-policy-required
+    rationale: >
+      Carried unchanged from accepted v1. Fourteen days is the Product-selected
+      minimum complete two-unit experience and seven days is an advisory review
+      point; neither is a biological optimum.
+    applies_to: early non-ultra Trail rolling proposals
+  - name: trail_policy_history_guardrails
+    value:
+      recent_history_lookback_completed_weeks: 8
+      minimum_usable_completed_weeks: 4
+      minimum_running_sessions_per_usable_week: 3
+      latest_run_within_completed_days: 10
+      comparable_hilly_or_trail_sessions_within_completed_days:
+        count: 2
+        window: 42
+      latest_comparable_hilly_or_trail_session_within_completed_days: 21
+      qualifying_activity_requires:
+        - outdoor_running_or_trail_running
+        - positive_duration_and_distance
+        - usable_elevation_gain_and_loss_or_explicit_unknown
+        - source_timestamp
+      unknown_descent_or_terrain_cannot_satisfy_comparable_exposure: true
+      sparse_or_stale_result: insufficient_comparable_trail_history
+      thresholds_are_published_biological_laws: false
+    classification: guardrail
+    evidence_claim_ids:
+      - eligibility.recent-history-anchor-without-universal-threshold
+      - non-ultra-trail.course-specific-policy-required
+      - non-ultra-trail.uphill-downhill-require-distinct-handling
+    rationale: >
+      Carried unchanged from accepted v1. The counts prevent extrapolation from
+      sparse records and remain conservative qualifications, not safety,
+      adaptation, or readiness laws.
+    applies_to: owner-scoped readiness history
+  - name: trail_policy_schedule_construction
+    value:
+      selected_running_days_per_7_day_unit:
+        minimum: 3
+        maximum: 6
+        deterministic_value: minimum_of_available_days_recent_modal_days_and_policy_maximum
+      below_minimum_result: no_schedule_within_envelope
+      requested_above_maximum_result: clarification_required
+      weekly_running_minutes_target: minimum_of_recent_median_usable_weekly_minutes_and_athlete_limit
+      weekly_running_minutes_hard_cap: minimum_of_recent_maximum_usable_weekly_minutes_and_athlete_limit
+      non_taper_progression_above_recent_median: false
+      target_time_gap_may_raise_load: false
+      session_duration_hard_cap: minimum_of_recent_maximum_completed_session_and_athlete_limit
+      quality_sessions_per_7_day_unit: 1
+      easy_and_longest_easy_allocation:
+        quality_minutes_allocated_first: true
+        remaining_minutes_distributed_across_non_quality_days: true
+        preferred_longest_easy_day_used_when_available: true
+        automatic_longest_easy_increase: false
+      no_schedule_result: no_schedule_within_envelope
+    classification: guardrail
+    evidence_claim_ids:
+      - eligibility.fixed-progression-and-acwr-not-safety-laws
+      - non-ultra-trail.training-specificity-promising-not-prescriptive
+    rationale: >
+      Carried unchanged from accepted v1. Median, maximum, and athlete caps
+      organize existing exposure without automatic progression; one quality
+      session is a conservative Product choice, not a universal optimum.
+    applies_to: deterministic early-block schedule
+  - name: trail_policy_workout_templates
+    value:
+      easy: duration_only_with_optional_accessible_terrain_category
+      longest_easy: duration_only_with_observed_duration_and_course_exposure_caps
+      controlled_quality:
+        template_id: trail-controlled-uphill-quality-v1
+        total_planned_minutes: 38
+        steps:
+          - {kind: step, phase: warmup, duration_minutes: 10, intended_intensity: low}
+          - kind: repeat
+            repetitions: 4
+            steps:
+              - {kind: step, phase: work, duration_minutes: 3, intended_intensity: controlled_uphill_effort}
+              - {kind: step, phase: recovery, duration_minutes: 2, intended_intensity: low}
+          - {kind: step, phase: cooldown, duration_minutes: 8, intended_intensity: low}
+      work_step_requires_accessible_non_technical_uphill: true
+      downhill_recovery_may_be_prescribed: false
+      target_expression: duration_phase_and_effort_label_only
+      exact_hr_pace_power_or_rpe_target: false
+      template_must_fit_history_constraint_and_exposure_caps: true
+      template_optimum_claim: false
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.training-specificity-promising-not-prescriptive
+      - non-ultra-trail.hr-and-road-pace-not-sole-targets
+      - non-ultra-trail.uphill-downhill-require-distinct-handling
+    rationale: >
+      Carried unchanged from accepted v1. The targetless uphill template is a
+      transparent reversible Product guardrail and prescribes no downhill
+      speed or universal target zone.
+    applies_to: eligible early-block quality session
+  - name: trail_policy_intensity_and_spacing
+    value:
+      minimum_planned_low_intensity_running_minutes_fraction: 0.75
+      maximum_quality_exposures_per_7_day_unit: 1
+      quality_exposures_include:
+        - controlled_quality_template
+        - confirmed_race_or_maximal_effort
+      consecutive_quality_running_days_allowed: false
+      minimum_intervening_easy_rest_or_non_running_days: 1
+      missed_quality_makeup_allowed: false
+      reduce_or_remove_quality_before_adding_minutes: true
+      historical_intensity_source_priority: [activity_splits, activity_samples]
+      activity_average_power_allowed: false
+      low_intensity_fraction_is_optimum_claim: false
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.hr-and-road-pace-not-sole-targets
+      - non-ultra-trail.training-specificity-promising-not-prescriptive
+    rationale: >
+      Carried unchanged from accepted v1. The floor, ceiling, and spacing are
+      conservative no-progression guardrails, not published universal values.
+    applies_to: all planned running minutes
+  - name: trail_policy_course_exposure_caps
+    value:
+      weekly_ascent_target: no_more_than_recent_median_usable_weekly_ascent
+      weekly_descent_target: no_more_than_recent_median_usable_weekly_descent
+      weekly_ascent_hard_cap: recent_maximum_usable_weekly_ascent
+      weekly_descent_hard_cap: recent_maximum_usable_weekly_descent
+      session_ascent_hard_cap: recent_maximum_completed_session_ascent
+      session_descent_hard_cap: recent_maximum_completed_session_descent
+      technicality: no_more_difficult_than_recently_observed_and_currently_accessible_category
+      unknown_descent_or_technicality_result: clarification_or_limited_module
+      high_speed_or_maximal_downhill_repeats: false
+      road_or_flat_substitution_claimed_equivalent: false
+      automatic_vertical_progression: false
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.uphill-downhill-require-distinct-handling
+      - non-ultra-trail.injury-fatigue-no-safe-dose
+      - eligibility.fixed-progression-and-acwr-not-safety-laws
+    rationale: >
+      Carried unchanged from accepted v1. Separate observed ascent, descent,
+      and terrain caps avoid inventing a conversion, dose, or progression.
+    applies_to: early-block terrain and vertical exposure
+  - name: trail_policy_event_and_taper
+    value:
+      imported_event_must_be_athlete_confirmed: true
+      target_more_than_14_days_after_start: normal_14_day_rolling_proposal
+      target_within_14_days_of_start: event_inside_unapproved_taper_window
+      taper_implementation: not_accepted
+      event_or_race_counts_as_quality_and_load: true
+      event_day_generated_as_training_workout: false
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.taper-direction-indirect
+    rationale: >
+      Carried unchanged from accepted v1. General endurance evidence remains
+      insufficient to select a Trail-specific taper; the event-near path fails
+      closed pending a successor decision.
+    applies_to: dated Trail goals
+  - name: trail_policy_typed_outcomes
+    value:
+      status_precedence:
+        - validation_failed
+        - policy_unavailable
+        - readiness_blocked
+        - clarification_required
+        - eligible_proposal
+      detail_reason_catalog:
+        validation_failed:
+          - invalid_field_value
+          - schema_version_mismatch
+          - deterministic_invariant_failed
+        policy_unavailable:
+          - policy_inactive
+          - event_inside_unapproved_taper_window
+          - unsupported_ultra_or_multiday
+          - unsupported_population_or_intent
+          - technical_features_outside_v2
+        readiness_blocked:
+          - insufficient_recent_running_history
+          - insufficient_comparable_trail_history
+          - insufficient_descent_history
+          - insufficient_terrain_access
+          - current_symptom_stop
+          - no_schedule_within_envelope
+        clarification_required:
+          - material_course_demand_unknown
+          - assumption_confirmation_required
+          - adult_scope_or_constraints_unconfirmed
+          - training_constraints_missing
+          - contradictory_input
+        eligible_proposal: []
+      namespaced_reason_identity: "<status>.<detail_reason>"
+      top_level_status: highest_precedence_matching_status
+      detail_reason: first_matching_reason_in_selected_status_catalog_order
+      matching_reasons:
+        include_every_independently_and_safely_evaluable_match: true
+        pair_fields: [status, detail_reason]
+        de_duplicate: true
+        order_by: [status_precedence, detail_reason_catalog_order]
+        malformed_value_may_be_dereferenced_to_find_more_reasons: false
+        independently_evaluable_lower_precedence_reasons_preserved: true
+      limited_modules:
+        allowed_sorted_order:
+          - environment_altitude
+          - fueling
+          - grade_specificity
+          - technical_terrain
+        set_semantics: true
+        serialize_sorted: true
+        changes_top_level_status: false
+        hides_matching_reason: false
+        empty_means_eligible: false
+        generic_or_road_replacement_allowed: false
+      authorization_failures_occur_before_product_receipt: true
+      road_fallback: false
+      goal_remains_recorded: true
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.course-demand-is-multidimensional
+      - eligibility.recent-history-anchor-without-universal-threshold
+    rationale: >
+      The evidence supports explicit missingness and bounded applicability, but
+      the five statuses, exact reason catalog, precedence, and serialization
+      are reversible Product-selected operational guardrails rather than a
+      biological readiness or risk model.
+    applies_to: v2 validation, policy availability, readiness, and proposal eligibility receipts
+  - name: trail_policy_modular_structure
+    value:
+      modules:
+        - readiness_and_history
+        - easy_and_aerobic
+        - ascent_specificity
+        - descent_and_neuromuscular_exposure
+        - technical_terrain
+        - hiking
+        - strength
+        - longest_session_and_fueling_practice
+        - taper
+        - environment_and_altitude
+        - reassessment_and_outcome
+      module_requires_matching_input: true
+      unavailable_module_may_be_silently_replaced: false
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.uphill-downhill-require-distinct-handling
+      - non-ultra-trail.training-specificity-promising-not-prescriptive
+      - non-ultra-trail.taper-direction-indirect
+      - non-ultra-trail.fueling-duration-and-practice-context
+    rationale: >
+      Carried unchanged from accepted v1. Modular handling preserves distinct
+      demands and uncertainty without claiming one universal Trail schedule.
+    applies_to: future deterministic generator envelope
+  - name: trail_policy_evidence_use
+    value:
+      trail_specificity: conditional_candidate_module
+      strength_and_multimodal: conditional_candidate_module
+      hiking: conditional_candidate_module
+      taper: indirect_direction_only
+      fueling: expected_duration_and_practice_context_only
+      observed_load_associations: descriptive_only
+      injury_and_fatigue_findings: safety_context_only
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.training-specificity-promising-not-prescriptive
+      - non-ultra-trail.injury-fatigue-no-safe-dose
+      - non-ultra-trail.observed-load-does-not-prove-prescription
+      - non-ultra-trail.taper-direction-indirect
+      - non-ultra-trail.fueling-duration-and-practice-context
+    rationale: >
+      Carried unchanged from accepted v1. This keeps evidence-supported
+      directions separate from exact prescriptions the sources do not establish.
+    applies_to: module selection and ScienceNote claims
+  - name: trail_policy_hard_boundaries
+    value:
+      road_policy_fallback: false
+      universal_distance_vertical_conversion: false
+      universal_ascent_descent_equivalence: false
+      target_gap_may_raise_dose: false
+      missed_work_may_create_catch_up: false
+      activity_average_power_valid_for_intensity: false
+      valid_intensity_sources: [activity_splits, activity_samples]
+      heart_rate_or_level_pace_may_be_sole_hilly_controller: false
+      diagnosis_or_clearance: false
+      personal_finish_probability: false
+      performance_injury_or_safety_guarantee: false
+      canonical_adoption_requires_explicit_athlete_action: true
+      provider_delivery_requires_separate_explicit_consent: true
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.hr-and-road-pace-not-sole-targets
+      - non-ultra-trail.injury-fatigue-no-safe-dose
+      - eligibility.fixed-progression-and-acwr-not-safety-laws
+      - eligibility.current-symptoms-support-stop-not-clearance
+    rationale: >
+      Carried unchanged from accepted v1. These boundaries prevent unsupported
+      inference, hidden load escalation, medical claims, and authority expansion.
+    applies_to: all future policy and implementation surfaces
+  - name: trail_policy_deferred_scope
+    value:
+      progression_above_recent_typical_load: not_accepted
+      vertical_or_downhill_progression_above_recent_history: not_accepted
+      technical_terrain_dose: not_accepted
+      hiking_threshold_or_dose: not_accepted
+      strength_frequency_or_dose: not_accepted
+      back_to_back_sessions: not_accepted
+      hr_pace_power_or_rpe_targets: not_accepted
+      taper_duration_and_reduction: not_accepted
+      fueling_amount_or_frequency: not_accepted
+      recovery_interval: not_accepted
+      outcome_window_or_meaningful_change: not_accepted
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.training-specificity-promising-not-prescriptive
+      - non-ultra-trail.injury-fatigue-no-safe-dose
+      - non-ultra-trail.taper-direction-indirect
+      - non-ultra-trail.fueling-duration-and-practice-context
+    rationale: >
+      Carried unchanged from accepted v1. These higher-load, event-near,
+      fixed-dose, and target-specific behaviors need a future decision.
+    applies_to: scope outside the early rolling block
+  - name: trail_policy_runtime_evaluation
+    value:
+      dry_run:
+        deterministic_invariant_breach_tolerance: 0
+        replay_mismatch_tolerance: 0
+        unsupported_or_material_unknown_plan_tolerance: 0
+      owner_only_pilot:
+        maximum_major_edit_fraction: 0.30
+        major_edit_definition: session_duration_or_vertical_change_over_twenty_percent_or_two_scheduled_days_changed
+        serious_plausibly_related_report_pause_threshold: 1
+      efficacy_or_safety_claim_from_process_pilot: false
+      pause_or_revise_when_threshold_crossed: true
+    classification: guardrail
+    evidence_claim_ids:
+      - non-ultra-trail.injury-fatigue-no-safe-dose
+      - eligibility.fixed-progression-and-acwr-not-safety-laws
+    rationale: >
+      Carried unchanged from accepted v1. These are evaluation guardrails for
+      inactive verification or a separately authorized future pilot; this
+      successor authorizes neither exposure nor value telemetry.
+    applies_to: inactive dry run and separately authorized owner pilot
+  - name: trail_policy_non_science_authority
+    value:
+      implementation_review: required
+      lifecycle_supersession: not_accepted
+      owner_only_pilot: not_accepted
+      provider_mapping_or_delivery: not_accepted
+      product_visibility_or_catalog: not_accepted
+      production_data_use: not_accepted
+      runtime_activation: not_accepted
+      deployment: not_accepted
+    classification: guardrail
+    rationale: >
+      Science cannot originate or widen Product, Design, Engineering, Trust,
+      Quality, Operations, provider, rollout, or activation authority.
+    applies_to: work outside Science authority
+applicability:
+  - Adults with stable recent comparable running, ascent, descent, and Trail exposure
+  - Single-day non-ultra Trail performance intent
+  - Complete confirmed trail_course_demand_v2 and non_ultra_trail_constraints_v2 revisions
+  - Server-derived owner-scoped recent-history snapshot
+  - Suggestion-only plan proposals and scientific claim limits
+user_facing_claim_limits:
+  - Do not present the five statuses, reason order, module list, DTO values, or exact v1 guardrails as a biological readiness score, validated safe dose, or scientific optimum.
+  - Do not present the policy as a road plan adjusted for elevation or infer route, grade, footing, or course demand from provider data.
+  - Do not claim one universal vertical, descent, technicality, hiking, strength, long-session, taper, fueling, recovery, HR, pace, power, or RPE dose.
+  - Do not use heart rate, road pace, ACWR, or activity-average power as a sole or safety-validating controller.
+  - Do not show a personal finish probability, target guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance.
+safety_implications:
+  - Current symptoms stop performance optimization and route outside this nonclinical policy without creating a diagnosis.
+  - Missing core course demand, history, schedule, hazard, or terrain access fails closed; only ontology-approved non-core unknowns can limit a named module.
+  - No catch-up, target-gap load escalation, fixed progression law, road fallback, route inference, or provider completion is allowed.
+  - Downhill and technical exposure stay within the accepted separate history-anchored bounds.
+  - A complete reason receipt does not weaken the highest-precedence status or permit unsafe dereferencing of malformed fields.
+privacy_implications:
+  - Consume only normalized confirmed v2 course/constraint revisions and owner-scoped aggregate history snapshots required for deterministic replay.
+  - Do not copy raw activities, samples, GPS, routes, free text, provider payloads or identifiers, device identifiers, or target values into generic audit or telemetry.
+  - Activity-average power is neither collected nor used as readiness or intensity evidence.
+  - Owner-scoped goal, readiness, proposal, adoption, reset, export, deletion, and account-deletion controls remain mandatory.
+validation_plan:
+  - Prove every execution, history, schedule, template, intensity, exposure, event, and hard-boundary value is structurally equal to the accepted v1 contract except the named v2 dependency and receipt groups.
+  - Exhaustively exercise every status and detail reason, every pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, and sorted limited modules.
+  - Verify malformed values are not dereferenced while all independently safe policy, history, schedule, and missingness reasons remain present.
+  - Unit-test history qualification, schedule allocation, targetless template steps, low-intensity fraction, quality spacing, and separate ascent/descent/terrain caps against immutable owner-scoped snapshots.
+  - Verify no proposal is returned from an inactive contract, a core unknown, a failed gate, a stale revision, route/provider input, or any road fallback.
+  - Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests.
+falsification_conditions:
+  - Any accepted v1 execution, history, schedule, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency and receipt groups.
+  - Status selection, primary detail, matching-reason ordering, de-duplication, or limited-module sorting is nondeterministic or loses a safely evaluable reason.
+  - A malformed field is interpreted to manufacture a reason, or a core unknown or failed gate produces eligible_proposal.
+  - An exact value outside the accepted early-block guardrails is inferred despite literal not_accepted status.
+  - Uphill and downhill collapse, terrain or history access is ignored, or an unsupported module is silently substituted.
+  - Activity-average power, ACWR, road pace, or heart rate becomes a safe sole controller, or a personal performance, safety, injury, diagnosis, or clearance claim appears.
+  - The generated contract becomes active or any provider/runtime behavior appears without separate role-scoped authority.
+affected_surfaces:
+  models:
+    - inactive non-ultra Trail deterministic early-block policy v2
+    - v2 Trail validation, readiness, and complete reason receipt
+    - trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching
+  apis:
+    - future inactive v2 Trail readiness and proposal contracts
+  clients:
+    - future inactive Praxys Web Trail course-ledger and readiness receipt
+    - future unavailable miniapp Trail setup handoff
+  science_notes:
+    - Why Trail plans match course demand rather than distance alone
+    - Why exact schedule values are reversible guardrails rather than safe-dose claims
+    - Why a complete deterministic receipt is not a biological readiness score
+artifact_policy:
+  runtime_state: inactive
+supersedes: []
+superseded_by:
+decision_notes:
+  - "Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim."
+  - "Proposed predecessor transition: after separate digest-bound human approval and coordinated lifecycle review, this record may replace sdr-non-ultra-trail-plan-generation-policy-v1; no supersession link is active in this draft."
+  - "It depends on separate acceptance and coordinated lifecycle handling of sdr-trail-running-goal-ontology-v2."
+  - "Every exact value outside the v2 dependency and receipt groups is carried unchanged from accepted v1 and remains classified as a reversible Praxys guardrail."
+  - "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md."
+  - "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md."
+  - "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607."
+  - "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."

--- a/data/science/decisions/sdr-trail-running-goal-ontology-v1.yaml
+++ b/data/science/decisions/sdr-trail-running-goal-ontology-v1.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 id: sdr-trail-running-goal-ontology-v1
 version: 1
 title: "Represent trail goals with an explicit course-demand vector"
-status: accepted
+status: superseded
 approval_mode: artifact
 decision_date: 2026-09-01
 owners:
@@ -347,7 +347,7 @@ affected_surfaces:
 artifact_policy:
   runtime_state: inactive
 supersedes: []
-superseded_by:
+superseded_by: sdr-trail-running-goal-ontology-v2
 decision_notes:
   - "This artifact-mode decision addresses issue #690 and remains draft and inactive."
   - "Work Contract classification digest: sha256:55c4da66e7f504dd0d40c681c2a006fdbe7079c0cd06de43cb95802e679f78f5."

--- a/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
+++ b/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 id: sdr-trail-running-goal-ontology-v2
 version: 2
 title: "Define the strict v2 Trail course-demand and constraint envelope"
-status: draft
+status: accepted
 approval_mode: artifact
 decision_date: 2026-09-04
 owners:
@@ -961,7 +961,8 @@ affected_surfaces:
     - Why planning duration is context rather than a prediction
 artifact_policy:
   runtime_state: inactive
-supersedes: []
+supersedes:
+  - sdr-trail-running-goal-ontology-v1
 superseded_by:
 decision_notes:
   - "Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim."

--- a/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
+++ b/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
@@ -1,0 +1,870 @@
+schema_version: 1
+id: sdr-trail-running-goal-ontology-v2
+version: 2
+title: "Define the strict v2 Trail course-demand and constraint envelope"
+status: draft
+approval_mode: artifact
+decision_date: 2026-09-04
+owners:
+  - team:praxys
+human_reviewers: []
+model_version: trail-course-demand-v2
+evidence_review_ids:
+  - evidence-trail-running-goal-ontology-v1
+evidence_claim_ids:
+  - trail-ontology.course-demand-is-multidimensional
+  - trail-ontology.uphill-downhill-demands-differ
+  - trail-ontology.technicality-and-downhill-vary-performance
+  - trail-ontology.heart-rate-and-road-pace-are-insufficient-alone
+  - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+  - trail-ontology.environment-and-altitude-are-distinct-context
+  - trail-ontology.duration-and-fueling-practice-are-context
+accepted_interpretation: >
+  If separately accepted by the decision approver, this successor would keep
+  every accepted v1 science and safety boundary while defining
+  trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict,
+  provider-neutral, revision-bound data contracts. Reviewable fields carry an
+  explicit known value or explicit unknown state; the server, never the
+  client, stamps provenance and source revisions. Core course, scope, hazard,
+  schedule, terrain-access, symptom, and recent-history gates fail closed.
+  Unknown grade, ordinary course footing, environment, support, or fueling
+  context can limit only their named module after all core gates pass. Five
+  signed-grade basis-point buckets, six unordered footing flags, exact footing
+  set containment, and bounded optional context are reversible Praxys
+  operational guardrails, not validated difficulty scores, training doses,
+  equivalence formulas, predictions, or safety thresholds. No route, GPS,
+  free-text planning, provider payload, activity-average power, road fallback,
+  personal performance prediction, or runtime behavior is accepted.
+decision_review:
+  reviewer_task: >
+    Decide whether the six proposed v2 ontology actions preserve the accepted
+    v1 evidence, uncertainty, safety, and privacy boundaries while making the
+    inactive input contract deterministic enough to implement. Approve the
+    sheet as a unit or request changes by item ID.
+  approval_statement: >
+    I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as
+    strict revision-bound Trail planning envelopes: explicit known or unknown
+    fields, server-owned provenance, separate ascent and descent, descriptive
+    signed-grade shares, closed footing and hazard vocabularies, exact footing
+    containment, bounded optional context, and fail-closed core materiality. I
+    approve the exact DTO values only as reversible Praxys operational
+    guardrails, not as published biological findings, difficulty or safety
+    scores, doses, equivalences, or predictions. This approval authorizes only
+    preparation and review of a separately reviewed inactive implementation
+    bound to this exact decision and contract. It does not approve lifecycle
+    supersession, merge, deployment, production data use, dogfood, catalog
+    visibility, provider behavior, delivery, or runtime activation.
+  items:
+    - id: strict-value-provenance-envelope
+      title: Adopt explicit field states and server-owned provenance
+      disposition: approve
+      question: >
+        Should every reviewable v2 field use an exact known-or-unknown envelope
+        while provenance, source metadata, and history hashes remain
+        server-owned and revision-bound?
+      proposed_decision: >
+        Accept the closed envelope, provenance categories, field-specific
+        provenance restrictions, immutable revisions, and confirmation
+        invalidation rules as operational guardrails.
+      approval_effect:
+        - Missing values cannot be represented as zero, empty text, or a client-selected source.
+        - Readiness and proposals can bind the exact confirmed source revisions used.
+      does_not_authorize:
+        - Source scraping, route inference, model truth claims, or automatic confirmation.
+      parameter_names:
+        - trail_field_provenance
+        - trail_revision_and_confirmation
+      evidence_claim_ids:
+        - trail-ontology.course-demand-is-multidimensional
+    - id: core-course-and-planning-context
+      title: Adopt the v2 core course tuple and planning-duration range
+      disposition: approve
+      question: >
+        Should event identity, date, distance, ascent, descent, scope, intent,
+        hazard gates, and a confirmed planning-duration range be core inputs?
+      proposed_decision: >
+        Require those typed fields and treat planning duration only as
+        athlete-confirmed planning context, never as a finish-time prediction.
+      approval_effect:
+        - Distance and ascent alone cannot select a Trail policy.
+        - A material core unknown prevents an eligible proposal.
+      does_not_authorize:
+        - A finish-time estimate, feasibility verdict, performance promise, or course equivalence.
+      parameter_names:
+        - trail_course_demand_schema
+        - trail_planning_duration_range
+      evidence_claim_ids:
+        - trail-ontology.course-demand-is-multidimensional
+        - trail-ontology.uphill-downhill-demands-differ
+        - trail-ontology.duration-and-fueling-practice-are-context
+    - id: descriptive-course-and-access-vocabularies
+      title: Adopt descriptive grade, footing, hazard, and terrain-access DTOs
+      disposition: approve
+      question: >
+        Should v2 use the exact five signed-grade share buckets, six unordered
+        footing flags, two tri-state hazard gates, and weekday/uphill/downhill/
+        footing access fields?
+      proposed_decision: >
+        Accept these closed DTOs and exact set-containment rules as
+        deterministic descriptions, not as technicality scores or doses.
+      approval_effect:
+        - Grade boundaries and footing matching replay identically.
+        - Course footing cannot be approximated by synonyms or a road category.
+      does_not_authorize:
+        - Route-derived grade, a technical score, downhill dose, or terrain equivalence.
+      parameter_names:
+        - trail_grade_distribution
+        - trail_footing_and_hazard_contract
+        - trail_training_constraints_schema
+      evidence_claim_ids:
+        - trail-ontology.uphill-downhill-demands-differ
+        - trail-ontology.technicality-and-downhill-vary-performance
+    - id: bounded-context-and-materiality
+      title: Adopt bounded optional context and exact block-versus-limit rules
+      disposition: approve
+      question: >
+        Should environment, altitude, aid, equipment, fueling, and
+        gastrointestinal context use closed bounded shapes, with only named
+        non-core unknowns limiting dependent modules?
+      proposed_decision: >
+        Accept the bounded shapes, exact core/limited mapping, sorted module
+        vocabulary, and course-footing containment against access and observed
+        history.
+      approval_effect:
+        - Optional unknowns remain visible without becoming hidden defaults.
+        - A known mismatch still blocks the affected core access or history gate.
+      does_not_authorize:
+        - An environment, altitude, equipment, fueling, gastrointestinal, or safety prescription.
+      parameter_names:
+        - trail_optional_context_shapes
+        - trail_unknown_and_materiality_policy
+        - trail_distinct_demand_invariants
+      evidence_claim_ids:
+        - trail-ontology.course-demand-is-multidimensional
+        - trail-ontology.environment-and-altitude-are-distinct-context
+        - trail-ontology.duration-and-fueling-practice-are-context
+    - id: science-safety-and-privacy-boundary
+      title: Preserve the accepted nonclinical, intensity, claim, and privacy limits
+      disposition: approve
+      question: >
+        Should v2 preserve the adult nonclinical scope, symptom stop,
+        split/sample intensity provenance, minimum normalized storage, and all
+        prohibitions on personal guarantees and sensitive planning payloads?
+      proposed_decision: >
+        Carry the accepted v1 boundaries forward unchanged and apply them to
+        every v2 field, receipt, and later implementation surface.
+      approval_effect:
+        - Activity-average power cannot satisfy intensity provenance.
+        - Route, GPS, free-text, diagnosis, and provider payloads remain outside the contract.
+      does_not_authorize:
+        - Diagnosis, clearance, treatment, injury prevention, safety assurance, or personal performance prediction.
+      parameter_names:
+        - trail_science_safety_and_privacy_boundary
+      evidence_claim_ids:
+        - trail-ontology.heart-rate-and-road-pace-are-insufficient-alone
+        - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+    - id: unresolved-values-and-authority-deferred
+      title: Keep dose, scoring, equivalence, provider, and activation decisions deferred
+      disposition: defer
+      question: >
+        Should every technicality score, route inference, dose, progression,
+        equivalence, prediction, provider, rollout, and activation behavior
+        remain unaccepted?
+      proposed_decision: >
+        Preserve literal not_accepted values and the inactive role boundary
+        until separate specialist and human review authorizes a successor.
+      approval_effect:
+        - Exact DTO validation cannot silently become scientific prescription or runtime authority.
+      does_not_authorize:
+        - Any behavior listed as not_accepted or any lifecycle transition for v1.
+      parameter_names:
+        - trail_exact_values
+        - trail_non_science_authority_boundary
+      evidence_claim_ids:
+        - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+rejected_alternatives:
+  - alternative: "Keep the ambiguous v1 object fields and let each caller interpret them"
+    rationale: >
+      Caller-specific interpretation would make missingness, provenance,
+      materiality, and replay nondeterministic.
+  - alternative: "Infer grade, footing, or technical demand from a route or provider payload"
+    rationale: >
+      v2 does not collect those payloads, and the evidence does not validate a
+      universal inference or technicality score.
+  - alternative: "Require every optional course descriptor before any proposal"
+    rationale: >
+      Core-versus-limited materiality can preserve uncertainty without hiding
+      it or inventing a dependent module.
+  - alternative: "Treat an unknown or inaccessible Trail field as ordinary road running"
+    rationale: >
+      That would erase course-specific demand and violate the accepted no-road-
+      fallback boundary.
+model_parameters:
+  - name: trail_course_demand_schema
+    value:
+      schema_id: trail_course_demand_v2
+      strict_unknown_fields_rejected: true
+      event_identity:
+        field: event_id
+        type: server_owned_identifier
+        client_writable: false
+        materiality: core
+      fields:
+        event_date:
+          type: iso_date
+          envelope: known_or_unknown
+          materiality: core
+        distance_meters:
+          type: integer
+          unit: meters
+          minimum: 1
+          envelope: known_or_unknown
+          materiality: core
+        total_ascent_m:
+          type: integer
+          unit: meters
+          minimum: 0
+          envelope: known_or_unknown
+          materiality: core
+        total_descent_m:
+          type: integer
+          unit: meters
+          minimum: 0
+          envelope: known_or_unknown
+          materiality: core
+        planning_duration_range:
+          type: integer_range
+          unit: minutes
+          envelope: known_or_unknown
+          materiality: core
+        event_format:
+          type: closed_enum
+          allowed: [single_day]
+          envelope: known_or_unknown
+          materiality: core
+        distance_family:
+          type: closed_enum
+          allowed: [non_ultra]
+          envelope: known_or_unknown
+          materiality: core
+        planning_intent:
+          type: closed_enum
+          allowed: [performance]
+          envelope: known_or_unknown
+          materiality: core
+        grade_distribution:
+          type: five_bucket_basis_point_object
+          envelope: known_or_unknown
+          materiality: limited
+          limited_module: grade_specificity
+        course_footing:
+          type: nonempty_unordered_closed_set
+          envelope: known_or_unknown
+          materiality: limited_with_core_matching_when_known
+          limited_module: technical_terrain
+        hands_assist:
+          type: tri_state
+          allowed: ["yes", "no", unknown]
+          materiality: core
+        fixed_rope:
+          type: tri_state
+          allowed: ["yes", "no", unknown]
+          materiality: core
+        environment_and_altitude:
+          type: bounded_object
+          envelope: known_or_unknown
+          materiality: limited
+          limited_module: environment_altitude
+        aid_and_support:
+          type: bounded_object
+          envelope: known_or_unknown
+          materiality: limited
+          limited_module: fueling
+        fueling_and_gastrointestinal_context:
+          type: bounded_object
+          envelope: known_or_unknown
+          materiality: limited
+          limited_module: fueling
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.course-demand-is-multidimensional
+      - trail-ontology.uphill-downhill-demands-differ
+    rationale: >
+      The evidence supports explicit distinct dimensions; field names, types,
+      units, and the core/limited representation are reversible Praxys DTO
+      choices selected to make missingness and replay unambiguous.
+    applies_to: trail_course_demand_v2
+  - name: trail_field_provenance
+    value:
+      request_envelope:
+        known:
+          exact_keys: [state, value]
+          state_literal: known
+          schema_valid_value_required: true
+        unknown:
+          exact_keys: [state]
+          state_literal: unknown
+          value_forbidden: true
+        missing_state_invalid: true
+        empty_string_invalid: true
+        sentinel_number_invalid: true
+        guessed_zero_invalid: true
+        arbitrary_object_invalid: true
+        null_invalid_except_explicit_aid_gap_case: true
+        numeric_values_must_be_finite: true
+      server_stamped_provenance_allowed:
+        - athlete_stated
+        - course_verified
+        - history_observed
+        - model_inferred
+        - explicit_assumption
+        - unknown
+      client_may_submit_provenance: false
+      client_may_submit_source_revision: false
+      client_may_submit_model_version: false
+      client_may_submit_source_timestamp: false
+      client_may_submit_history_hash: false
+      field_restrictions:
+        event_id: server_owned
+        grade_distribution: [athlete_stated, course_verified, unknown]
+        recent_history: [history_observed]
+        athlete_assumption_conditions: [explicit_assumption]
+      inferred_requires_server_model_version: true
+      assumption_requires_revision_bound_confirmation: true
+      unknown_is_preserved: true
+    classification: guardrail
+    rationale: >
+      A strict server-owned provenance envelope prevents client-selected trust,
+      hidden defaults, and stale source metadata. These are operational
+      integrity controls, not published scientific values.
+    applies_to: every reviewable v2 course, constraint, and history field
+  - name: trail_planning_duration_range
+    value:
+      field: planning_duration_range
+      unit: integer_minutes
+      minimum_value: 1
+      minimum_strictly_less_than_maximum: true
+      athlete_confirmed: true
+      purpose: planning_context
+      finish_time_prediction: false
+      feasibility_verdict: false
+      performance_promise: false
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.duration-and-fueling-practice-are-context
+    rationale: >
+      Expected duration is relevant context, while the exact range shape is a
+      reversible Product DTO and cannot be presented as a prediction.
+    applies_to: trail_course_demand_v2 core confirmation
+  - name: trail_grade_distribution
+    value:
+      unit: basis_points_of_course_distance
+      known_value_exact_keys:
+        - below_neg_10
+        - neg_10_to_below_neg_3
+        - neg_3_to_below_pos_3
+        - pos_3_to_below_pos_10
+        - pos_10_and_above
+      buckets:
+        below_neg_10:
+          interval: "g < -10%"
+          upper_bound_percent: -10
+          upper_inclusive: false
+        neg_10_to_below_neg_3:
+          interval: "-10% <= g < -3%"
+          lower_bound_percent: -10
+          lower_inclusive: true
+          upper_bound_percent: -3
+          upper_inclusive: false
+        neg_3_to_below_pos_3:
+          interval: "-3% <= g < 3%"
+          lower_bound_percent: -3
+          lower_inclusive: true
+          upper_bound_percent: 3
+          upper_inclusive: false
+        pos_3_to_below_pos_10:
+          interval: "3% <= g < 10%"
+          lower_bound_percent: 3
+          lower_inclusive: true
+          upper_bound_percent: 10
+          upper_inclusive: false
+        pos_10_and_above:
+          interval: "g >= 10%"
+          lower_bound_percent: 10
+          lower_inclusive: true
+      each_share_type: integer
+      each_share_minimum: 0
+      exact_sum: 10000
+      ordering_semantic: false
+      descriptive_only: true
+      difficulty_score: false
+      equivalence_or_prediction_input: false
+      workout_dose_input: false
+      safety_threshold: false
+      allowed_provenance: [athlete_stated, course_verified]
+      route_or_model_inference: false
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.uphill-downhill-demands-differ
+    rationale: >
+      Literature supports keeping signed grade demand explicit but does not
+      validate these exact bins. The half-open intervals and basis-point sum are
+      reversible deterministic description guardrails only.
+    applies_to: known grade_distribution in trail_course_demand_v2
+  - name: trail_footing_and_hazard_contract
+    value:
+      ordinary_footing:
+        type: nonempty_unordered_set
+        allowed:
+          - firm_smooth
+          - loose_gravel
+          - mud
+          - rocks_or_roots
+          - built_steps
+          - water_crossing
+        duplicates_invalid: true
+        unknown_members_invalid: true
+        other_value_allowed: false
+        free_text_allowed: false
+        difficulty_score: false
+      hazard_gates:
+        hands_assist:
+          allowed: ["yes", "no", unknown]
+          unknown_result: clarification_required
+          yes_result: policy_unavailable.technical_features_outside_v2
+          eligible_value: "no"
+        fixed_rope:
+          allowed: ["yes", "no", unknown]
+          unknown_result: clarification_required
+          yes_result: policy_unavailable.technical_features_outside_v2
+          eligible_value: "no"
+        reducible_to_ordinary_footing: false
+        technical_skill_or_safety_score: false
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.technicality-and-downhill-vary-performance
+      - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+    rationale: >
+      Footing and hazards must remain explicit, but the exact vocabulary and
+      gates are Product-selected operational categories rather than validated
+      technicality or safety scores.
+    applies_to: course, access, and observed-history footing plus v2 hazard gates
+  - name: trail_training_constraints_schema
+    value:
+      schema_id: non_ultra_trail_constraints_v2
+      client_reviewable_fields:
+        available_weekdays:
+          type: unique_unordered_set
+          allowed_iso_weekdays: [1, 2, 3, 4, 5, 6, 7]
+          envelope: known_or_unknown
+          materiality: core
+          unknown_result: clarification_required.training_constraints_missing
+        nontechnical_continuous_three_minute_uphill_accessible:
+          type: strict_boolean
+          envelope: known_or_unknown
+          materiality: core
+          false_or_unknown_result: readiness_blocked.insufficient_terrain_access
+        controlled_downhill_terrain_accessible:
+          type: strict_boolean
+          envelope: known_or_unknown
+          materiality: core
+          duration_distance_grade_speed_or_repeat_fields_allowed: false
+          false_or_unknown_result: readiness_blocked.insufficient_terrain_access
+        accessible_footing:
+          type: nonempty_unordered_closed_set
+          vocabulary: trail_footing_and_hazard_contract.ordinary_footing.allowed
+          envelope: known_or_unknown
+          materiality: core_when_course_footing_known
+          missing_required_member_result: readiness_blocked.insufficient_terrain_access
+        adult_nonclinical_scope_confirmed:
+          type: strict_boolean
+          required_value_for_eligibility: true
+          materiality: core
+          false_or_unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+        performance_intent_confirmed:
+          type: strict_boolean
+          required_value_for_eligibility: true
+          materiality: core
+          false_or_unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+        current_symptom_stop:
+          type: tri_state_boolean
+          envelope: known_or_unknown
+          stop_value: true
+          materiality: core
+          true_result: readiness_blocked.current_symptom_stop
+          unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+      server_derived_history_fields:
+        - recent_running_continuity
+        - recent_ascent_exposure
+        - recent_descent_exposure
+        - recently_observed_footing
+      client_may_submit_or_attest_history: false
+      history_provenance: history_observed
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.course-demand-is-multidimensional
+      - trail-ontology.uphill-downhill-demands-differ
+      - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+    rationale: >
+      Schedule and terrain access must be explicit and recent history must
+      remain server-derived. The exact closed DTO is an operational guardrail;
+      it does not establish a safe terrain dose.
+    applies_to: non_ultra_trail_constraints_v2 and owner-scoped readiness
+  - name: trail_optional_context_shapes
+    value:
+      environment_and_altitude:
+        maximum_altitude_m:
+          type: integer
+          minimum: -500
+          maximum: 9000
+        temperature_range_c:
+          type: finite_number_range
+          minimum: -30
+          maximum: 55
+          minimum_may_equal_maximum: true
+        humidity_range_pct:
+          type: finite_number_range
+          minimum: 0
+          maximum: 100
+          minimum_may_equal_maximum: true
+        sun_exposure:
+          known_allowed: [low, mixed, high]
+          unknown_uses_field_envelope: true
+        wind_exposure:
+          known_allowed: [sheltered, mixed, exposed]
+          unknown_uses_field_envelope: true
+        conditions_basis:
+          known_allowed:
+            - organizer_information
+            - seasonal_expectation
+            - athlete_assumption
+          athlete_assumption_provenance: explicit_assumption
+          athlete_assumption_requires_confirmation: true
+      aid_and_support:
+        aid_support_mode:
+          known_allowed: [organized_aid, mixed, self_supported]
+        aid_station_count:
+          type: integer
+          minimum: 0
+          maximum: 50
+        max_aid_station_gap_km:
+          type: finite_number
+          minimum: 0.1
+          maximum: 50
+          null_allowed_only_for: no_applicable_gap
+        water_availability:
+          known_allowed: [none, some_stations, all_stations]
+          unknown_uses_field_envelope: true
+        food_availability:
+          known_allowed: [none, some_stations, all_stations]
+          unknown_uses_field_envelope: true
+        mandatory_gear:
+          type: unordered_closed_set
+          allowed:
+            - water_carry
+            - food_carry
+            - weather_shell
+            - lighting
+            - navigation_device
+            - other_required
+          other_required_has_no_label_or_free_text: true
+      fueling_and_gastrointestinal_context:
+        longest_practiced_duration_min:
+          type: integer
+          minimum: 0
+          maximum: 1440
+        practice_sessions_last_42_days:
+          type: integer
+          minimum: 0
+          maximum: 84
+        intake_form:
+          known_allowed:
+            - none
+            - fluids_only
+            - carbohydrate_drink
+            - mixed_food_and_drink
+        gastrointestinal_experience:
+          known_allowed:
+            - no_plan_altering_issue
+            - plan_altering_issue
+          unknown_uses_field_envelope: true
+          non_diagnostic: true
+      notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed: false
+      fixed_prescription_from_known_context: false
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.environment-and-altitude-are-distinct-context
+      - trail-ontology.duration-and-fueling-practice-are-context
+    rationale: >
+      Environment and fueling are relevant context, while every exact bound and
+      enum is a reversible minimization and validation choice. None establishes
+      an exposure, equipment, fueling, gastrointestinal, or safety prescription.
+    applies_to: optional v2 course context only
+  - name: trail_unknown_and_materiality_policy
+    value:
+      core_fields:
+        - event_id
+        - event_date
+        - distance_meters
+        - total_ascent_m
+        - total_descent_m
+        - planning_duration_range
+        - event_format
+        - distance_family
+        - planning_intent
+        - hands_assist
+        - fixed_rope
+        - adult_nonclinical_scope_confirmed
+        - performance_intent_confirmed
+        - current_symptom_stop
+        - available_weekdays
+        - nontechnical_continuous_three_minute_uphill_accessible
+        - controlled_downhill_terrain_accessible
+        - accessible_footing_when_course_footing_known
+        - recent_running_continuity
+        - recent_ascent_exposure
+        - recent_descent_exposure
+        - recently_observed_footing_when_course_footing_known
+      limited_unknown_mapping:
+        grade_distribution: grade_specificity
+        course_footing: technical_terrain
+        environment_and_altitude: environment_altitude
+        aid_and_support: fueling
+        fueling_and_gastrointestinal_context: fueling
+      limited_modules_sorted_allowed:
+        - environment_altitude
+        - fueling
+        - grade_specificity
+        - technical_terrain
+      material_unknown_result:
+        - clarification_required
+        - policy_unavailable
+      bounded_alternative_requires_separate_review: true
+      unknown_defaults_to_zero: false
+      unknown_defaults_to_easy: false
+      unknown_defaults_to_nontechnical: false
+      unknown_defaults_to_road: false
+      limited_module_may_substitute_generic_or_road_behavior: false
+      known_value_automatically_enables_module: false
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.course-demand-is-multidimensional
+      - trail-ontology.technicality-and-downhill-vary-performance
+    rationale: >
+      This exact Product-selected block-versus-limit mapping keeps material
+      missingness visible without manufacturing certainty or broadening the
+      accepted Science scope.
+    applies_to: v2 capability matching and readiness receipts
+  - name: trail_distinct_demand_invariants
+    value:
+      ascent_and_descent_separate: true
+      grade_distribution_descriptive_only: true
+      technicality_score_allowed: false
+      downhill_history_required_when_descent_material: true
+      heart_rate_alone_sufficient_for_hilly_intensity: false
+      level_pace_alone_sufficient_for_hilly_intensity: false
+      activity_average_power_allowed: false
+      universal_distance_vertical_equivalence: false
+      footing_set_containment:
+        course_set_symbol: C
+        accessible_set_symbol: A
+        observed_history_set_symbol: H
+        access_requirement: "C subset_of A"
+        access_failure_reason: readiness_blocked.insufficient_terrain_access
+        history_requirement: "C subset_of H"
+        history_failure_reason: readiness_blocked.insufficient_comparable_trail_history
+        similarity_synonyms_or_model_inference_allowed: false
+        applies_only_when_course_footing_known: true
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.uphill-downhill-demands-differ
+      - trail-ontology.technicality-and-downhill-vary-performance
+      - trail-ontology.heart-rate-and-road-pace-are-insufficient-alone
+    rationale: >
+      Distinct demands follow the evidence; exact set containment is a
+      deterministic conservative matching guardrail, not a validated safety or
+      similarity model.
+    applies_to: v2 course, access, history, and intensity boundaries
+  - name: trail_revision_and_confirmation
+    value:
+      mutation_creates_new_immutable_revision: true
+      confirmation_scope: exact_visible_field_or_section_revision
+      confirm_all_allowed: false
+      confirmation_invalidated_by:
+        - value_change
+        - known_unknown_state_change
+        - server_stamped_source_change
+        - source_revision_change
+      readiness_binds_exact_revisions:
+        - goal
+        - course
+        - constraints
+        - history_snapshot
+        - policy
+        - generator
+      proposal_binds_same_exact_revisions: true
+      stale_confirmation_rebound_allowed: false
+      stale_source_revision_rebound_allowed: false
+      confirmation_is_truth_safety_or_eligibility_attestation: false
+    classification: guardrail
+    rationale: >
+      Exact revisions prevent stale confirmation from silently acquiring new
+      meaning. This is an operational replay and user-control guardrail.
+    applies_to: every v2 mutation, readiness receipt, and later proposal
+  - name: trail_science_safety_and_privacy_boundary
+    value:
+      minimum_age_years: 18
+      nonclinical_only: true
+      suggestion_only: true
+      symptom_stop_required: true
+      diagnosis_treatment_clearance_or_return_to_sport: false
+      personal_finish_probability: false
+      performance_injury_or_safety_guarantee: false
+      activity_average_power_valid_for_intensity: false
+      valid_intensity_sources: [activity_splits, activity_samples]
+      minimum_normalized_storage_only: true
+      permitted_persisted_categories:
+        - canonical_field_values_and_unknown_states
+        - server_stamped_provenance
+        - source_and_field_or_section_revisions
+        - confirmations
+        - owner_scoped_history_snapshot_reference_and_hash
+        - readiness_and_proposal_binding_digests
+      forbidden_collection_or_persistence:
+        - gps_points
+        - route_files
+        - polylines
+        - maps
+        - inferred_course_geometry
+        - course_source_urls
+        - scraped_course_content
+        - provider_request_or_response_payloads
+        - provider_account_activity_or_workout_ids
+        - device_identifiers
+        - free_text_health_symptom_fueling_surface_or_course_narratives
+        - diagnoses_or_medical_clearance
+        - injury_probability
+        - activity_average_power
+        - road_equivalent_distance_pace_or_load
+      authenticated_owner_scoped_reset_export_and_deletion_required: true
+      inferred_and_athlete_stated_fields_correctable_and_deletable: true
+      generic_audit_or_telemetry_may_copy_sensitive_payloads: false
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.heart-rate-and-road-pace-are-insufficient-alone
+      - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+    rationale: >
+      These preserve the accepted v1 nonclinical, intensity, claim, and
+      minimization boundaries while making the v2 storage exclusion explicit.
+    applies_to: all v2 science, storage, API, client, audit, and deletion surfaces
+  - name: trail_exact_values
+    value:
+      signed_grade_buckets: descriptive_operational_guardrail_only
+      footing_vocabulary: descriptive_operational_guardrail_only
+      core_and_limited_materiality: operational_guardrail_only
+      planning_duration_range_shape: operational_guardrail_only
+      optional_context_bounds: operational_guardrail_only
+      technicality_score: not_accepted
+      route_or_provider_inference: not_accepted
+      distance_vertical_conversion: not_accepted
+      road_trail_equivalence: not_accepted
+      finish_time_prediction: not_accepted
+      downhill_progression: not_accepted
+      vertical_progression: not_accepted
+      technical_terrain_dose: not_accepted
+      fueling_amount_or_frequency: not_accepted
+      environment_or_altitude_dose: not_accepted
+    classification: guardrail
+    evidence_claim_ids:
+      - trail-ontology.uphill-downhill-demands-differ
+      - trail-ontology.training-and-injury-evidence-does-not-set-safe-dose
+    rationale: >
+      The accepted evidence supports explicit dimensions but not universal
+      scoring, inference, equivalence, prediction, progression, or dose. Only
+      the closed validation DTO is proposed here.
+    applies_to: unresolved ontology and prescription values
+  - name: trail_non_science_authority_boundary
+    value:
+      science_authority:
+        - evidence
+        - applicability
+        - uncertainty
+        - claim_limits
+        - safety_scope
+      product_and_experience_dependency: human_acceptance_required
+      implementation_review: required
+      lifecycle_supersession: not_accepted
+      owner_only_dogfood: not_accepted
+      provider_mapping_or_delivery: not_accepted
+      product_visibility_or_catalog: not_accepted
+      production_data_use: not_accepted
+      deployment: not_accepted
+      runtime_activation: not_accepted
+    classification: guardrail
+    rationale: >
+      A Science successor cannot originate or widen Product, Design,
+      Engineering, Trust, Operations, provider, rollout, or activation authority.
+    applies_to: all work outside the Science role
+applicability:
+  - Adult nonclinical single-day non-ultra Trail performance goal representation
+  - Strict provider-neutral course and athlete-constraint capture before capability matching
+  - Server-derived owner-scoped recent-history context
+  - Evidence, uncertainty, claim limits, safety, and privacy boundaries only
+user_facing_claim_limits:
+  - Do not claim the exact v2 DTO, bins, footing vocabulary, bounds, or materiality map is scientifically optimal or validated as a safety rule.
+  - Do not claim planning duration is a finish-time prediction, feasibility verdict, or performance promise.
+  - Do not claim distance and ascent alone describe Trail demand or present a universal road-equivalent distance, grade, ascent, or descent conversion.
+  - Do not present unknown footing, hazard, environment, support, fueling, or gastrointestinal context as known, easy, safe, or average.
+  - Do not present a technicality score, personal finish probability, performance guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance.
+safety_implications:
+  - Every core unknown or failed gate prevents an eligible proposal; only named non-core unknowns can limit a dependent module.
+  - Uphill, downhill, ordinary footing, hazards, altitude, heat, support, and fueling context remain distinct when applicable.
+  - Hands-assist or fixed-rope use stays outside v2; unknown hazard gates require clarification.
+  - Current symptoms stop performance optimization without creating a diagnosis.
+  - Intensity provenance uses activity splits or samples, never activity-average power.
+privacy_implications:
+  - Collect and persist only normalized typed values, explicit unknown states, server provenance, revisions, confirmations, and owner-scoped replay references.
+  - Do not ingest GPS, routes, maps, source URLs, scraped content, provider payloads or identifiers, device identifiers, or free-text planning narratives.
+  - Reset invalidates confirmation and creates a new revision; export and deletion include the current owner-scoped v2 state under existing data-rights controls.
+  - No public sharing, cross-user aggregate, administrator planning access, or value telemetry is authorized.
+validation_plan:
+  - Validate every closed enum, set, integer, finite number, range relation, explicit unknown state, and field-specific provenance rule deterministically.
+  - Boundary-test all five signed-grade intervals and require nonnegative integer shares summing exactly to 10000.
+  - Replay reordered footing and weekday sets and verify one canonical digest; reject duplicates, unknown members, synonyms, and free text.
+  - Verify exact course-footing containment against both accessible and observed-history sets and preserve the distinct access and history failures.
+  - Mutate every field value, state, and server source revision and verify the prior confirmation and readiness binding becomes stale.
+  - Exercise every core unknown and limited unknown and verify no road policy, hidden default, provider behavior, or success-shaped plan is selected.
+  - Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests.
+falsification_conditions:
+  - A malformed or stale v2 value is treated as confirmed, or client-provided provenance or history is accepted.
+  - A grade share falls into two buckets, the five shares do not total 10000, or grade becomes a difficulty, dose, equivalence, or prediction input.
+  - Footing comparison uses order, similarity, synonyms, inference, or a road category instead of exact set containment.
+  - A core unknown yields eligible_proposal, or a limited unknown silently enables or substitutes a module.
+  - Ascent and descent collapse, route or provider data enters the contract, free text is retained, or activity-average power drives intensity.
+  - A personal safety, finish, or performance claim appears, or the generated contract becomes active without separate implementation review and activation authority.
+affected_surfaces:
+  models:
+    - trail_course_demand_v2 ontology
+    - non_ultra_trail_constraints_v2 input and confirmation envelope
+    - future v2 Trail capability matching contract
+  apis:
+    - future inactive Trail course, constraint, confirmation, and readiness contracts
+  clients:
+    - future inactive Praxys Web Trail course-ledger experience
+    - future unavailable miniapp Trail setup handoff
+  science_notes:
+    - Why Trail demand needs more than distance and ascent
+    - Why grade shares and footing flags are descriptive operational guardrails
+    - Why planning duration is context rather than a prediction
+artifact_policy:
+  runtime_state: inactive
+supersedes: []
+superseded_by:
+decision_notes:
+  - "Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim."
+  - "Proposed predecessor transition: after separate digest-bound human approval and coordinated lifecycle review, this record may replace sdr-trail-running-goal-ontology-v1; no supersession link is active in this draft."
+  - "The accepted evidence remains sufficient only because every new exact value is classified as a reversible operational guardrail rather than a published biological rule."
+  - "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md."
+  - "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md."
+  - "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607."
+  - "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."

--- a/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
+++ b/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
@@ -66,8 +66,9 @@ decision_review:
         server-owned and revision-bound?
       proposed_decision: >
         Accept the closed envelope, provenance categories, field-specific
-        provenance restrictions, immutable revisions, and confirmation
-        invalidation rules as operational guardrails.
+        provenance restrictions, replaceable current revision tokens,
+        proposal-time immutable snapshots, and confirmation invalidation rules
+        as operational guardrails.
       approval_effect:
         - Missing values cannot be represented as zero, empty text, or a client-selected source.
         - Readiness and proposals can bind the exact confirmed source revisions used.
@@ -244,17 +245,23 @@ model_parameters:
           materiality: core
         event_format:
           type: closed_enum
-          allowed: [single_day]
+          recognized: [single_day, multi_day]
+          supported_value: single_day
           envelope: known_or_unknown
           materiality: core
         distance_family:
           type: closed_enum
-          allowed: [non_ultra]
+          recognized: [non_ultra, ultra]
+          supported_value: non_ultra
           envelope: known_or_unknown
           materiality: core
         planning_intent:
           type: closed_enum
-          allowed: [performance]
+          recognized:
+            - performance
+            - first_completion
+            - return_to_consistency
+          supported_value: performance
           envelope: known_or_unknown
           materiality: core
         grade_distribution:
@@ -275,21 +282,26 @@ model_parameters:
           type: strict_boolean
           envelope: known_or_unknown
           materiality: core
-        environment_and_altitude:
-          type: bounded_object
-          envelope: known_or_unknown
-          materiality: limited
-          limited_module: environment_altitude
-        aid_and_support:
-          type: bounded_object
-          envelope: known_or_unknown
-          materiality: limited
-          limited_module: fueling
-        fueling_and_gastrointestinal_context:
-          type: bounded_object
-          envelope: known_or_unknown
-          materiality: limited
-          limited_module: fueling
+        optional_context:
+          type: strict_fixed_key_object
+          exact_groups: [environment, support, fueling]
+          group_envelope_allowed: false
+          every_declared_leaf_required: true
+          every_leaf_envelope: known_or_unknown
+          materiality: limited_by_leaf
+      scope_enum_results:
+        unknown_recognized_scope:
+          status: clarification_required
+          detail_reason: adult_scope_or_constraints_unconfirmed
+        recognized_multi_day_or_ultra:
+          status: policy_unavailable
+          detail_reason: unsupported_ultra_or_multiday
+        recognized_non_performance_intent:
+          status: policy_unavailable
+          detail_reason: unsupported_population_or_intent
+        unrecognized_literal:
+          status: validation_failed
+          detail_reason: invalid_field_value
     classification: guardrail
     evidence_claim_ids:
       - trail-ontology.course-demand-is-multidimensional
@@ -557,53 +569,81 @@ model_parameters:
     applies_to: non_ultra_trail_constraints_v2 and owner-scoped readiness
   - name: trail_optional_context_shapes
     value:
-      environment_and_altitude:
+      type: strict_fixed_key_object
+      exact_groups: [environment, support, fueling]
+      group_envelope_allowed: false
+      every_declared_leaf_required: true
+      common_leaf_envelope: known_or_unknown
+      group_unknown_control_is_leaf_batch_action_only: true
+      enum_unknown_literals_allowed: false
+      environment:
         maximum_altitude_m:
+          envelope: known_or_unknown
           type: integer
           minimum: -500
           maximum: 9000
-        temperature_range_c:
-          type: finite_number_range
+        temperature_min_c:
+          envelope: known_or_unknown
+          type: finite_number
           minimum: -30
           maximum: 55
-          minimum_may_equal_maximum: true
-        humidity_range_pct:
-          type: finite_number_range
+        temperature_max_c:
+          envelope: known_or_unknown
+          type: finite_number
+          minimum: -30
+          maximum: 55
+        humidity_min_pct:
+          envelope: known_or_unknown
+          type: finite_number
           minimum: 0
           maximum: 100
-          minimum_may_equal_maximum: true
+        humidity_max_pct:
+          envelope: known_or_unknown
+          type: finite_number
+          minimum: 0
+          maximum: 100
         sun_exposure:
+          envelope: known_or_unknown
           known_allowed: [low, mixed, high]
-          unknown_uses_field_envelope: true
         wind_exposure:
+          envelope: known_or_unknown
           known_allowed: [sheltered, mixed, exposed]
-          unknown_uses_field_envelope: true
         conditions_basis:
+          envelope: known_or_unknown
           known_allowed:
             - organizer_information
             - seasonal_expectation
             - athlete_assumption
           athlete_assumption_provenance: explicit_assumption
           athlete_assumption_requires_confirmation: true
-      aid_and_support:
+        cross_field_rules:
+          temperature_order_when_both_known: temperature_min_c_lte_temperature_max_c
+          humidity_order_when_both_known: humidity_min_pct_lte_humidity_max_pct
+          one_unknown_leaf_remains_unknown_without_inventing_other_bound: true
+      support:
         aid_support_mode:
+          envelope: known_or_unknown
           known_allowed: [organized_aid, mixed, self_supported]
         aid_station_count:
+          envelope: known_or_unknown
           type: integer
           minimum: 0
           maximum: 50
-        max_aid_station_gap_km:
-          type: finite_number
-          minimum: 0.1
-          maximum: 50
-          null_allowed_only_for: no_applicable_gap
+        max_aid_station_gap_m:
+          envelope: known_or_unknown
+          known_value_type: integer_or_explicit_null
+          integer_minimum: 100
+          integer_maximum: 50000
+          known_null_meaning: not_applicable
+          kilometer_wire_or_storage_field_allowed: false
         water_availability:
+          envelope: known_or_unknown
           known_allowed: [none, some_stations, all_stations]
-          unknown_uses_field_envelope: true
         food_availability:
+          envelope: known_or_unknown
           known_allowed: [none, some_stations, all_stations]
-          unknown_uses_field_envelope: true
         mandatory_gear:
+          envelope: known_or_unknown
           type: unordered_closed_set
           allowed:
             - water_carry
@@ -613,26 +653,29 @@ model_parameters:
             - navigation_device
             - other_required
           other_required_has_no_label_or_free_text: true
-      fueling_and_gastrointestinal_context:
+      fueling:
         longest_practiced_duration_min:
+          envelope: known_or_unknown
           type: integer
           minimum: 0
           maximum: 1440
         practice_sessions_last_42_days:
+          envelope: known_or_unknown
           type: integer
           minimum: 0
           maximum: 84
         intake_form:
+          envelope: known_or_unknown
           known_allowed:
             - none
             - fluids_only
             - carbohydrate_drink
             - mixed_food_and_drink
         gastrointestinal_experience:
+          envelope: known_or_unknown
           known_allowed:
             - no_plan_altering_issue
             - plan_altering_issue
-          unknown_uses_field_envelope: true
           non_diagnostic: true
       notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed: false
       fixed_prescription_from_known_context: false
@@ -677,9 +720,9 @@ model_parameters:
       limited_unknown_mapping:
         grade_distribution: grade_specificity
         course_footing: technical_terrain
-        environment_and_altitude: environment_altitude
-        aid_and_support: fueling
-        fueling_and_gastrointestinal_context: fueling
+        "optional_context.environment.*": environment_altitude
+        "optional_context.support.*": fueling
+        "optional_context.fueling.*": fueling
       limited_modules_sorted_allowed:
         - environment_altitude
         - fueling
@@ -736,7 +779,15 @@ model_parameters:
     applies_to: v2 course, access, history, and intensity boundaries
   - name: trail_revision_and_confirmation
     value:
-      mutation_creates_new_immutable_revision: true
+      current_unproposed_draft_revision_is_mutable_state: true
+      successful_edit_atomically_overwrites:
+        - current_draft_value
+        - current_revision_token
+        - invalidated_confirmation_state
+      prior_draft_value_retained: false
+      prior_revision_token_retained: false
+      pre_proposal_immutable_edit_or_confirmation_history: false
+      immutable_snapshot_begins_only_with_proposal: true
       confirmation_scope: exact_visible_field_or_section_revision
       confirm_all_allowed: false
       confirmation_invalidated_by:
@@ -775,10 +826,11 @@ model_parameters:
       permitted_persisted_categories:
         - canonical_field_values_and_unknown_states
         - server_stamped_provenance
-        - source_and_field_or_section_revisions
-        - confirmations
+        - current_source_and_field_or_section_revisions
+        - current_confirmations
         - owner_scoped_history_snapshot_reference_and_hash
         - readiness_and_proposal_binding_digests
+        - immutable_snapshot_only_after_proposal_creation
       forbidden_collection_or_persistence:
         - gps_points
         - route_files
@@ -919,6 +971,6 @@ decision_notes:
   - "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md."
   - "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md."
   - "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md."
-  - "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact."
+  - "This revision incorporates the frozen Product wire semantics at repository commit f9678d64 and Architecture boundary at a52d23ce; it does not approve either role-owned artifact."
   - "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607."
   - "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."

--- a/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
+++ b/data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml
@@ -29,8 +29,9 @@ accepted_interpretation: >
   schedule, terrain-access, symptom, and recent-history gates fail closed.
   Unknown grade, ordinary course footing, environment, support, or fueling
   context can limit only their named module after all core gates pass. Five
-  signed-grade basis-point buckets, six unordered footing flags, exact footing
-  set containment, and bounded optional context are reversible Praxys
+  signed-grade basis-point buckets, six unordered footing flags, known-or-
+  unknown boolean hazard fields, exact footing set containment, bounded
+  schedule capacity, and bounded optional context are reversible Praxys
   operational guardrails, not validated difficulty scores, training doses,
   equivalence formulas, predictions, or safety thresholds. No route, GPS,
   free-text planning, provider payload, activity-average power, road fallback,
@@ -45,8 +46,9 @@ decision_review:
     I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as
     strict revision-bound Trail planning envelopes: explicit known or unknown
     fields, server-owned provenance, separate ascent and descent, descriptive
-    signed-grade shares, closed footing and hazard vocabularies, exact footing
-    containment, bounded optional context, and fail-closed core materiality. I
+    signed-grade shares, closed footing and known-or-unknown boolean hazard
+    fields, exact footing containment, bounded schedule and optional context,
+    and fail-closed core materiality. I
     approve the exact DTO values only as reversible Praxys operational
     guardrails, not as published biological findings, difficulty or safety
     scores, doses, equivalences, or predictions. This approval authorizes only
@@ -102,8 +104,8 @@ decision_review:
       disposition: approve
       question: >
         Should v2 use the exact five signed-grade share buckets, six unordered
-        footing flags, two tri-state hazard gates, and weekday/uphill/downhill/
-        footing access fields?
+        footing flags, two known-or-unknown boolean hazard fields, and bounded
+        schedule plus uphill/downhill/footing access fields?
       proposed_decision: >
         Accept these closed DTOs and exact set-containment rules as
         deterministic descriptions, not as technicality scores or doses.
@@ -218,18 +220,21 @@ model_parameters:
           type: integer
           unit: meters
           minimum: 1
+          maximum: 49999
           envelope: known_or_unknown
           materiality: core
         total_ascent_m:
           type: integer
           unit: meters
           minimum: 0
+          maximum: 20000
           envelope: known_or_unknown
           materiality: core
         total_descent_m:
           type: integer
           unit: meters
           minimum: 0
+          maximum: 20000
           envelope: known_or_unknown
           materiality: core
         planning_duration_range:
@@ -263,12 +268,12 @@ model_parameters:
           materiality: limited_with_core_matching_when_known
           limited_module: technical_terrain
         hands_assist:
-          type: tri_state
-          allowed: ["yes", "no", unknown]
+          type: strict_boolean
+          envelope: known_or_unknown
           materiality: core
         fixed_rope:
-          type: tri_state
-          allowed: ["yes", "no", unknown]
+          type: strict_boolean
+          envelope: known_or_unknown
           materiality: core
         environment_and_altitude:
           type: bounded_object
@@ -342,7 +347,9 @@ model_parameters:
     value:
       field: planning_duration_range
       unit: integer_minutes
-      minimum_value: 1
+      minimum_and_maximum_each:
+        minimum: 1
+        maximum: 1440
       minimum_strictly_less_than_maximum: true
       athlete_confirmed: true
       purpose: planning_context
@@ -429,15 +436,17 @@ model_parameters:
         difficulty_score: false
       hazard_gates:
         hands_assist:
-          allowed: ["yes", "no", unknown]
-          unknown_result: clarification_required
-          yes_result: policy_unavailable.technical_features_outside_v2
-          eligible_value: "no"
+          envelope: known_or_unknown
+          known_value_type: strict_boolean
+          unknown_result: clarification_required.material_course_demand_unknown
+          known_true_result: policy_unavailable.technical_features_outside_v2
+          eligible_value: known_false
         fixed_rope:
-          allowed: ["yes", "no", unknown]
-          unknown_result: clarification_required
-          yes_result: policy_unavailable.technical_features_outside_v2
-          eligible_value: "no"
+          envelope: known_or_unknown
+          known_value_type: strict_boolean
+          unknown_result: clarification_required.material_course_demand_unknown
+          known_true_result: policy_unavailable.technical_features_outside_v2
+          eligible_value: known_false
         reducible_to_ordinary_footing: false
         technical_skill_or_safety_score: false
     classification: guardrail
@@ -456,20 +465,52 @@ model_parameters:
         available_weekdays:
           type: unique_unordered_set
           allowed_iso_weekdays: [1, 2, 3, 4, 5, 6, 7]
+          minimum_members: 1
           envelope: known_or_unknown
           materiality: core
           unknown_result: clarification_required.training_constraints_missing
-        nontechnical_continuous_three_minute_uphill_accessible:
+        weekly_time_limit_min:
+          type: integer
+          minimum: 1
+          maximum: 10080
+          envelope: known_or_unknown
+          materiality: core
+          unknown_result: clarification_required.training_constraints_missing
+        maximum_session_duration_min:
+          type: integer
+          minimum: 1
+          maximum: 1440
+          not_greater_than: weekly_time_limit_min
+          envelope: known_or_unknown
+          materiality: core
+          unknown_result: clarification_required.training_constraints_missing
+        unavailable_dates:
+          type: sorted_unique_iso_date_set
+          maximum_members: 14
+          all_dates_within_requested_14_day_horizon: true
+          empty_known_set_allowed: true
+          envelope: known_or_unknown
+          materiality: core
+          unknown_result: clarification_required.training_constraints_missing
+        preferred_longest_weekday:
+          type: optional_iso_weekday
+          allowed: [1, 2, 3, 4, 5, 6, 7]
+          omitted_means_no_preference: true
+          when_present_must_be_in: available_weekdays
+          conflict_result: clarification_required.contradictory_input
+        nontechnical_three_minute_uphill_access:
           type: strict_boolean
           envelope: known_or_unknown
           materiality: core
-          false_or_unknown_result: readiness_blocked.insufficient_terrain_access
-        controlled_downhill_terrain_accessible:
+          unknown_result: clarification_required.training_constraints_missing
+          false_result: readiness_blocked.insufficient_terrain_access
+        controlled_downhill_access:
           type: strict_boolean
           envelope: known_or_unknown
           materiality: core
           duration_distance_grade_speed_or_repeat_fields_allowed: false
-          false_or_unknown_result: readiness_blocked.insufficient_terrain_access
+          unknown_result: clarification_required.training_constraints_missing
+          false_result: readiness_blocked.insufficient_terrain_access
         accessible_footing:
           type: nonempty_unordered_closed_set
           vocabulary: trail_footing_and_hazard_contract.ordinary_footing.allowed
@@ -478,21 +519,25 @@ model_parameters:
           missing_required_member_result: readiness_blocked.insufficient_terrain_access
         adult_nonclinical_scope_confirmed:
           type: strict_boolean
+          envelope: known_or_unknown
           required_value_for_eligibility: true
           materiality: core
-          false_or_unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+          unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+          false_result: policy_unavailable.unsupported_population_or_intent
         performance_intent_confirmed:
           type: strict_boolean
+          envelope: known_or_unknown
           required_value_for_eligibility: true
           materiality: core
-          false_or_unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+          unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+          false_result: policy_unavailable.unsupported_population_or_intent
         current_symptom_stop:
-          type: tri_state_boolean
+          type: strict_boolean
           envelope: known_or_unknown
           stop_value: true
           materiality: core
           true_result: readiness_blocked.current_symptom_stop
-          unknown_result: clarification_required.adult_scope_or_constraints_unconfirmed
+          unknown_result: clarification_required.training_constraints_missing
       server_derived_history_fields:
         - recent_running_continuity
         - recent_ascent_exposure
@@ -618,8 +663,12 @@ model_parameters:
         - performance_intent_confirmed
         - current_symptom_stop
         - available_weekdays
-        - nontechnical_continuous_three_minute_uphill_accessible
-        - controlled_downhill_terrain_accessible
+        - weekly_time_limit_min
+        - maximum_session_duration_min
+        - unavailable_dates
+        - preferred_longest_weekday_consistency_when_present
+        - nontechnical_three_minute_uphill_access
+        - controlled_downhill_access
         - accessible_footing_when_course_footing_known
         - recent_running_continuity
         - recent_ascent_exposure
@@ -763,6 +812,8 @@ model_parameters:
       footing_vocabulary: descriptive_operational_guardrail_only
       core_and_limited_materiality: operational_guardrail_only
       planning_duration_range_shape: operational_guardrail_only
+      course_domain_bounds: product_scope_and_operability_guardrail_only
+      schedule_capacity_bounds: product_scope_and_operability_guardrail_only
       optional_context_bounds: operational_guardrail_only
       technicality_score: not_accepted
       route_or_provider_inference: not_accepted
@@ -866,5 +917,8 @@ decision_notes:
   - "The accepted evidence remains sufficient only because every new exact value is classified as a reversible operational guardrail rather than a published biological rule."
   - "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md."
   - "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md."
+  - "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md."
+  - "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md."
+  - "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact."
   - "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607."
   - "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."

--- a/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v1.json
+++ b/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v1.json
@@ -3,9 +3,9 @@
     "inactive non-ultra trail deterministic early-block policy and generator",
     "trail course-demand and history snapshot matching"
   ],
-  "contract_digest": "sha256:472c895bc4c3d467eac4a59dbacaeaaf665ddee462fdc76bba4cdf772df8e42b",
+  "contract_digest": "sha256:2035f855cea2c1c117bd092796615148e98e59f1536013f86fb2bba1cab73ce2",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v1",
-  "decision_status": "accepted",
+  "decision_status": "superseded",
   "decision_version": 1,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
+++ b/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
@@ -4,7 +4,7 @@
     "v2 Trail validation, readiness, and complete reason receipt",
     "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
   ],
-  "contract_digest": "sha256:afb120c2ef58543751b60d68bbe738698395c9c62e4f42a908f8efcbf9b8ff41",
+  "contract_digest": "sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -443,6 +443,13 @@
             }
           },
           {
+            "condition": "unrecognized_event_format_distance_family_or_planning_intent_literal",
+            "result": {
+              "detail_reason": "invalid_field_value",
+              "status": "validation_failed"
+            }
+          },
+          {
             "condition": "course_or_constraint_schema_id_is_not_exact_v2",
             "result": {
               "detail_reason": "schema_version_mismatch",
@@ -467,6 +474,13 @@
             "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
             "result": {
               "detail_reason": "material_course_demand_unknown",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "recognized_event_format_distance_family_or_planning_intent_unknown",
+            "result": {
+              "detail_reason": "adult_scope_or_constraints_unconfirmed",
               "status": "clarification_required"
             }
           },
@@ -576,14 +590,14 @@
             }
           },
           {
-            "condition": "event_ultra_distance_or_multiday",
+            "condition": "recognized_event_format_multi_day_or_distance_family_ultra",
             "result": {
               "detail_reason": "unsupported_ultra_or_multiday",
               "status": "policy_unavailable"
             }
           },
           {
-            "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+            "condition": "unsupported_population_or_clinical_state_or_recognized_first_completion_or_return_to_consistency_intent",
             "result": {
               "detail_reason": "unsupported_population_or_intent",
               "status": "policy_unavailable"
@@ -637,6 +651,7 @@
             "deterministic_invariant_failed"
           ]
         },
+        "eligible_proposal_detail_reason": null,
         "goal_remains_recorded": true,
         "limited_modules": {
           "allowed_sorted_order": [
@@ -676,14 +691,15 @@
             "available",
             "limited"
           ],
+          "arbitrary_reason_selection_allowed": false,
           "authoritative": true,
           "limited_reason_targets": {
             "environment_altitude": [
-              "course.environment_and_altitude"
+              "course.optional_context.environment"
             ],
             "fueling": [
-              "course.aid_and_support",
-              "course.fueling_and_gastrointestinal_context"
+              "course.optional_context.support",
+              "course.optional_context.fueling"
             ],
             "grade_specificity": [
               "course.grade_distribution"
@@ -692,27 +708,33 @@
               "course.course_footing"
             ]
           },
+          "multiple_matching_reasons_choose_primary_by": [
+            "status_precedence",
+            "detail_reason_catalog_order"
+          ],
+          "non_eligible_status_evaluates_individual_modules": false,
           "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
-          "required_keys_in_sorted_order": [
-            "environment_altitude",
-            "fueling",
+          "required_keys_in_fixed_order": [
             "grade_specificity",
-            "technical_terrain"
+            "technical_terrain",
+            "environment_altitude",
+            "fueling"
           ],
           "state_rules": {
             "available": {
               "guarantees_proposal_inclusion": false,
               "reason_target": null,
-              "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+              "when": "top_level_status_is_eligible_proposal_and_module_inputs_and_science_boundary_permit_consideration"
             },
             "limited": {
               "may_be_included_in_proposal": false,
               "reason_target": "closed_first_party_field_or_section_target",
-              "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+              "when": "top_level_status_is_eligible_proposal_and_accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
             },
             "not_evaluated": {
-              "reason_target": "one_applicable_namespaced_matching_reason",
-              "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+              "all_four_modules_use_same_reason_target": true,
+              "reason_target": "top_level_primary_namespaced_reason",
+              "when": "top_level_status_is_not_eligible_proposal"
             }
           },
           "value_exact_keys": [
@@ -721,6 +743,7 @@
           ]
         },
         "namespaced_reason_identity": "<status>.<detail_reason>",
+        "primary_namespaced_reason": "deterministic_top_level_status_dot_detail_reason",
         "road_fallback": false,
         "status_precedence": [
           "validation_failed",
@@ -790,5 +813,5 @@
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56"
+  "source_decision_digest": "sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe"
 }

--- a/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
+++ b/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
@@ -1,0 +1,516 @@
+{
+  "affected_models": [
+    "inactive non-ultra Trail deterministic early-block policy v2",
+    "v2 Trail validation, readiness, and complete reason receipt",
+    "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
+  ],
+  "contract_digest": "sha256:2fb5776b13453937708a77f54c273c81f81f4ca265932e4e0eb0a7ac0da2064b",
+  "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
+  "decision_status": "draft",
+  "decision_version": 2,
+  "evidence_claim_ids": [
+    "trail-ontology.course-demand-is-multidimensional",
+    "trail-ontology.uphill-downhill-demands-differ",
+    "trail-ontology.technicality-and-downhill-vary-performance",
+    "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+    "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose",
+    "non-ultra-trail.course-specific-policy-required",
+    "non-ultra-trail.uphill-downhill-require-distinct-handling",
+    "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+    "non-ultra-trail.training-specificity-promising-not-prescriptive",
+    "non-ultra-trail.injury-fatigue-no-safe-dose",
+    "non-ultra-trail.observed-load-does-not-prove-prescription",
+    "non-ultra-trail.taper-direction-indirect",
+    "non-ultra-trail.fueling-duration-and-practice-context",
+    "eligibility.recent-history-anchor-without-universal-threshold",
+    "eligibility.fixed-progression-and-acwr-not-safety-laws",
+    "eligibility.goal-relevant-current-capability-task-specific",
+    "eligibility.current-symptoms-support-stop-not-clearance"
+  ],
+  "evidence_review_ids": [
+    "evidence-trail-running-goal-ontology-v1",
+    "evidence-non-ultra-trail-plan-generation-policy-v1",
+    "evidence-plan-generation-eligibility-safety-v1"
+  ],
+  "linked_evidence_digests": {
+    "evidence-non-ultra-trail-plan-generation-policy-v1": "sha256:51e9349704d969b6524b947311a04e585477cffd7071254a9d2859690d87d78e",
+    "evidence-plan-generation-eligibility-safety-v1": "sha256:e884907d33783edc6cdb16fd5504f7f10b6d68f968bfe7cf87e3f024b5bda773",
+    "evidence-trail-running-goal-ontology-v1": "sha256:60f0e785e4fc2b4226fed3bb30750191195cffbb0236b4a81d34431c0002c87a"
+  },
+  "model_version": "non-ultra-trail-plan-generation-policy-v2",
+  "parameters": {
+    "trail_policy_course_exposure_caps": {
+      "applies_to": "early-block terrain and vertical exposure",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws"
+      ],
+      "value": {
+        "automatic_vertical_progression": false,
+        "high_speed_or_maximal_downhill_repeats": false,
+        "road_or_flat_substitution_claimed_equivalent": false,
+        "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
+        "session_descent_hard_cap": "recent_maximum_completed_session_descent",
+        "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
+        "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+        "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
+        "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
+        "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
+        "weekly_descent_target": "no_more_than_recent_median_usable_weekly_descent"
+      }
+    },
+    "trail_policy_deferred_scope": {
+      "applies_to": "scope outside the early rolling block",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "value": {
+        "back_to_back_sessions": "not_accepted",
+        "fueling_amount_or_frequency": "not_accepted",
+        "hiking_threshold_or_dose": "not_accepted",
+        "hr_pace_power_or_rpe_targets": "not_accepted",
+        "outcome_window_or_meaningful_change": "not_accepted",
+        "progression_above_recent_typical_load": "not_accepted",
+        "recovery_interval": "not_accepted",
+        "strength_frequency_or_dose": "not_accepted",
+        "taper_duration_and_reduction": "not_accepted",
+        "technical_terrain_dose": "not_accepted",
+        "vertical_or_downhill_progression_above_recent_history": "not_accepted"
+      }
+    },
+    "trail_policy_event_and_taper": {
+      "applies_to": "dated Trail goals",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.taper-direction-indirect"
+      ],
+      "value": {
+        "event_day_generated_as_training_workout": false,
+        "event_or_race_counts_as_quality_and_load": true,
+        "imported_event_must_be_athlete_confirmed": true,
+        "taper_implementation": "not_accepted",
+        "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
+        "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+      }
+    },
+    "trail_policy_evidence_use": {
+      "applies_to": "module selection and ScienceNote claims",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "non-ultra-trail.observed-load-does-not-prove-prescription",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "value": {
+        "fueling": "expected_duration_and_practice_context_only",
+        "hiking": "conditional_candidate_module",
+        "injury_and_fatigue_findings": "safety_context_only",
+        "observed_load_associations": "descriptive_only",
+        "strength_and_multimodal": "conditional_candidate_module",
+        "taper": "indirect_direction_only",
+        "trail_specificity": "conditional_candidate_module"
+      }
+    },
+    "trail_policy_execution_and_reassessment": {
+      "applies_to": "early non-ultra Trail rolling proposals",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.recent-history-anchor-without-universal-threshold",
+        "non-ultra-trail.course-specific-policy-required"
+      ],
+      "value": {
+        "advisory_reassessment_after_completed_days": 7,
+        "automatic_overwrite_of_adopted_future_days": false,
+        "automatic_successor_adoption": false,
+        "biological_optimum_claim": false,
+        "calendar_schedule_unit_days": 7,
+        "committed_proposal_days": 14,
+        "continued_goal_horizon_requires_successor": true,
+        "each_successor_requires_fresh_history_course_and_constraints": true,
+        "proposal_end_inclusive": true
+      }
+    },
+    "trail_policy_hard_boundaries": {
+      "applies_to": "all future policy and implementation surfaces",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws",
+        "eligibility.current-symptoms-support-stop-not-clearance"
+      ],
+      "value": {
+        "activity_average_power_valid_for_intensity": false,
+        "canonical_adoption_requires_explicit_athlete_action": true,
+        "diagnosis_or_clearance": false,
+        "heart_rate_or_level_pace_may_be_sole_hilly_controller": false,
+        "missed_work_may_create_catch_up": false,
+        "performance_injury_or_safety_guarantee": false,
+        "personal_finish_probability": false,
+        "provider_delivery_requires_separate_explicit_consent": true,
+        "road_policy_fallback": false,
+        "target_gap_may_raise_dose": false,
+        "universal_ascent_descent_equivalence": false,
+        "universal_distance_vertical_conversion": false,
+        "valid_intensity_sources": [
+          "activity_splits",
+          "activity_samples"
+        ]
+      }
+    },
+    "trail_policy_history_guardrails": {
+      "applies_to": "owner-scoped readiness history",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.recent-history-anchor-without-universal-threshold",
+        "non-ultra-trail.course-specific-policy-required",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling"
+      ],
+      "value": {
+        "comparable_hilly_or_trail_sessions_within_completed_days": {
+          "count": 2,
+          "window": 42
+        },
+        "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
+        "latest_run_within_completed_days": 10,
+        "minimum_running_sessions_per_usable_week": 3,
+        "minimum_usable_completed_weeks": 4,
+        "qualifying_activity_requires": [
+          "outdoor_running_or_trail_running",
+          "positive_duration_and_distance",
+          "usable_elevation_gain_and_loss_or_explicit_unknown",
+          "source_timestamp"
+        ],
+        "recent_history_lookback_completed_weeks": 8,
+        "sparse_or_stale_result": "insufficient_comparable_trail_history",
+        "thresholds_are_published_biological_laws": false,
+        "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
+      }
+    },
+    "trail_policy_intensity_and_spacing": {
+      "applies_to": "all planned running minutes",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive"
+      ],
+      "value": {
+        "activity_average_power_allowed": false,
+        "consecutive_quality_running_days_allowed": false,
+        "historical_intensity_source_priority": [
+          "activity_splits",
+          "activity_samples"
+        ],
+        "low_intensity_fraction_is_optimum_claim": false,
+        "maximum_quality_exposures_per_7_day_unit": 1,
+        "minimum_intervening_easy_rest_or_non_running_days": 1,
+        "minimum_planned_low_intensity_running_minutes_fraction": 0.75,
+        "missed_quality_makeup_allowed": false,
+        "quality_exposures_include": [
+          "controlled_quality_template",
+          "confirmed_race_or_maximal_effort"
+        ],
+        "reduce_or_remove_quality_before_adding_minutes": true
+      }
+    },
+    "trail_policy_modular_structure": {
+      "applies_to": "future deterministic generator envelope",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "value": {
+        "module_requires_matching_input": true,
+        "modules": [
+          "readiness_and_history",
+          "easy_and_aerobic",
+          "ascent_specificity",
+          "descent_and_neuromuscular_exposure",
+          "technical_terrain",
+          "hiking",
+          "strength",
+          "longest_session_and_fueling_practice",
+          "taper",
+          "environment_and_altitude",
+          "reassessment_and_outcome"
+        ],
+        "unavailable_module_may_be_silently_replaced": false
+      }
+    },
+    "trail_policy_non_science_authority": {
+      "applies_to": "work outside Science authority",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "deployment": "not_accepted",
+        "implementation_review": "required",
+        "lifecycle_supersession": "not_accepted",
+        "owner_only_pilot": "not_accepted",
+        "product_visibility_or_catalog": "not_accepted",
+        "production_data_use": "not_accepted",
+        "provider_mapping_or_delivery": "not_accepted",
+        "runtime_activation": "not_accepted"
+      }
+    },
+    "trail_policy_required_inputs": {
+      "applies_to": "v2 capability matching and readiness",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.course-specific-policy-required",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "eligibility.recent-history-anchor-without-universal-threshold"
+      ],
+      "value": {
+        "client_supplied_history_allowed": false,
+        "conditional": [
+          "grade_distribution",
+          "course_footing",
+          "altitude_and_environment_context",
+          "aid_and_support_context",
+          "fueling_practice_experience"
+        ],
+        "material_unknown_behavior": "canonical_status_or_named_limited_module",
+        "required": [
+          "athlete_confirmed_trail_course_demand_v2",
+          "athlete_confirmed_non_ultra_trail_constraints_v2",
+          "stable_recent_running_history",
+          "comparable_recent_ascent_exposure",
+          "comparable_recent_descent_exposure",
+          "available_training_days_and_limits",
+          "accessible_training_terrain",
+          "current_symptom_stop"
+        ],
+        "server_derived": [
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing"
+        ]
+      }
+    },
+    "trail_policy_runtime_evaluation": {
+      "applies_to": "inactive dry run and separately authorized owner pilot",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws"
+      ],
+      "value": {
+        "dry_run": {
+          "deterministic_invariant_breach_tolerance": 0,
+          "replay_mismatch_tolerance": 0,
+          "unsupported_or_material_unknown_plan_tolerance": 0
+        },
+        "efficacy_or_safety_claim_from_process_pilot": false,
+        "owner_only_pilot": {
+          "major_edit_definition": "session_duration_or_vertical_change_over_twenty_percent_or_two_scheduled_days_changed",
+          "maximum_major_edit_fraction": 0.3,
+          "serious_plausibly_related_report_pause_threshold": 1
+        },
+        "pause_or_revise_when_threshold_crossed": true
+      }
+    },
+    "trail_policy_schedule_construction": {
+      "applies_to": "deterministic early-block schedule",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.fixed-progression-and-acwr-not-safety-laws",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive"
+      ],
+      "value": {
+        "below_minimum_result": "no_schedule_within_envelope",
+        "easy_and_longest_easy_allocation": {
+          "automatic_longest_easy_increase": false,
+          "preferred_longest_easy_day_used_when_available": true,
+          "quality_minutes_allocated_first": true,
+          "remaining_minutes_distributed_across_non_quality_days": true
+        },
+        "no_schedule_result": "no_schedule_within_envelope",
+        "non_taper_progression_above_recent_median": false,
+        "quality_sessions_per_7_day_unit": 1,
+        "requested_above_maximum_result": "clarification_required",
+        "selected_running_days_per_7_day_unit": {
+          "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
+          "maximum": 6,
+          "minimum": 3
+        },
+        "session_duration_hard_cap": "minimum_of_recent_maximum_completed_session_and_athlete_limit",
+        "target_time_gap_may_raise_load": false,
+        "weekly_running_minutes_hard_cap": "minimum_of_recent_maximum_usable_weekly_minutes_and_athlete_limit",
+        "weekly_running_minutes_target": "minimum_of_recent_median_usable_weekly_minutes_and_athlete_limit"
+      }
+    },
+    "trail_policy_scope_and_dependencies": {
+      "applies_to": "non-ultra-trail-plan-generation-policy-v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.course-specific-policy-required",
+        "eligibility.goal-relevant-current-capability-task-specific"
+      ],
+      "value": {
+        "clinical_or_return_to_sport": false,
+        "distance_family": "non_ultra",
+        "event_format": "single_day",
+        "intent": "performance",
+        "minimum_age_years": 18,
+        "requires_accepted_ontology": "sdr-trail-running-goal-ontology-v2",
+        "requires_confirmed_constraint_revision": true,
+        "requires_confirmed_course_revision": true,
+        "requires_constraint_schema": "non_ultra_trail_constraints_v2",
+        "requires_course_demand_schema": "trail_course_demand_v2",
+        "requires_server_derived_history_revision": true,
+        "suggestion_only": true
+      }
+    },
+    "trail_policy_typed_outcomes": {
+      "applies_to": "v2 validation, policy availability, readiness, and proposal eligibility receipts",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "eligibility.recent-history-anchor-without-universal-threshold"
+      ],
+      "value": {
+        "authorization_failures_occur_before_product_receipt": true,
+        "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
+        "detail_reason_catalog": {
+          "clarification_required": [
+            "material_course_demand_unknown",
+            "assumption_confirmation_required",
+            "adult_scope_or_constraints_unconfirmed",
+            "training_constraints_missing",
+            "contradictory_input"
+          ],
+          "eligible_proposal": [],
+          "policy_unavailable": [
+            "policy_inactive",
+            "event_inside_unapproved_taper_window",
+            "unsupported_ultra_or_multiday",
+            "unsupported_population_or_intent",
+            "technical_features_outside_v2"
+          ],
+          "readiness_blocked": [
+            "insufficient_recent_running_history",
+            "insufficient_comparable_trail_history",
+            "insufficient_descent_history",
+            "insufficient_terrain_access",
+            "current_symptom_stop",
+            "no_schedule_within_envelope"
+          ],
+          "validation_failed": [
+            "invalid_field_value",
+            "schema_version_mismatch",
+            "deterministic_invariant_failed"
+          ]
+        },
+        "goal_remains_recorded": true,
+        "limited_modules": {
+          "allowed_sorted_order": [
+            "environment_altitude",
+            "fueling",
+            "grade_specificity",
+            "technical_terrain"
+          ],
+          "changes_top_level_status": false,
+          "empty_means_eligible": false,
+          "generic_or_road_replacement_allowed": false,
+          "hides_matching_reason": false,
+          "serialize_sorted": true,
+          "set_semantics": true
+        },
+        "matching_reasons": {
+          "de_duplicate": true,
+          "include_every_independently_and_safely_evaluable_match": true,
+          "independently_evaluable_lower_precedence_reasons_preserved": true,
+          "malformed_value_may_be_dereferenced_to_find_more_reasons": false,
+          "order_by": [
+            "status_precedence",
+            "detail_reason_catalog_order"
+          ],
+          "pair_fields": [
+            "status",
+            "detail_reason"
+          ]
+        },
+        "namespaced_reason_identity": "<status>.<detail_reason>",
+        "road_fallback": false,
+        "status_precedence": [
+          "validation_failed",
+          "policy_unavailable",
+          "readiness_blocked",
+          "clarification_required",
+          "eligible_proposal"
+        ],
+        "top_level_status": "highest_precedence_matching_status"
+      }
+    },
+    "trail_policy_workout_templates": {
+      "applies_to": "eligible early-block quality session",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling"
+      ],
+      "value": {
+        "controlled_quality": {
+          "steps": [
+            {
+              "duration_minutes": 10,
+              "intended_intensity": "low",
+              "kind": "step",
+              "phase": "warmup"
+            },
+            {
+              "kind": "repeat",
+              "repetitions": 4,
+              "steps": [
+                {
+                  "duration_minutes": 3,
+                  "intended_intensity": "controlled_uphill_effort",
+                  "kind": "step",
+                  "phase": "work"
+                },
+                {
+                  "duration_minutes": 2,
+                  "intended_intensity": "low",
+                  "kind": "step",
+                  "phase": "recovery"
+                }
+              ]
+            },
+            {
+              "duration_minutes": 8,
+              "intended_intensity": "low",
+              "kind": "step",
+              "phase": "cooldown"
+            }
+          ],
+          "template_id": "trail-controlled-uphill-quality-v1",
+          "total_planned_minutes": 38
+        },
+        "downhill_recovery_may_be_prescribed": false,
+        "easy": "duration_only_with_optional_accessible_terrain_category",
+        "exact_hr_pace_power_or_rpe_target": false,
+        "longest_easy": "duration_only_with_observed_duration_and_course_exposure_caps",
+        "target_expression": "duration_phase_and_effort_label_only",
+        "template_must_fit_history_constraint_and_exposure_caps": true,
+        "template_optimum_claim": false,
+        "work_step_requires_accessible_non_technical_uphill": true
+      }
+    }
+  },
+  "runtime_state": "inactive",
+  "schema_version": 1,
+  "source_decision_digest": "sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40"
+}

--- a/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
+++ b/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
@@ -4,9 +4,9 @@
     "v2 Trail validation, readiness, and complete reason receipt",
     "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
   ],
-  "contract_digest": "sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d",
+  "contract_digest": "sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
-  "decision_status": "draft",
+  "decision_status": "accepted",
   "decision_version": 2,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
+++ b/data/science/generated/contracts/sdr-non-ultra-trail-plan-generation-policy-v2.json
@@ -4,7 +4,7 @@
     "v2 Trail validation, readiness, and complete reason receipt",
     "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
   ],
-  "contract_digest": "sha256:2fb5776b13453937708a77f54c273c81f81f4ca265932e4e0eb0a7ac0da2064b",
+  "contract_digest": "sha256:afb120c2ef58543751b60d68bbe738698395c9c62e4f42a908f8efcbf9b8ff41",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -54,7 +54,11 @@
         "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
         "session_descent_hard_cap": "recent_maximum_completed_session_descent",
         "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
-        "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+        "unknown_course_footing_module_state": "limited",
+        "unknown_descent_result": {
+          "detail_reason": "material_course_demand_unknown",
+          "status": "clarification_required"
+        },
         "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
         "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
         "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
@@ -95,8 +99,11 @@
         "event_or_race_counts_as_quality_and_load": true,
         "imported_event_must_be_athlete_confirmed": true,
         "taper_implementation": "not_accepted",
-        "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
-        "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+        "target_more_than_14_days_after_start_adds_reason": false,
+        "target_within_14_days_of_start_result": {
+          "detail_reason": "event_inside_unapproved_taper_window",
+          "status": "policy_unavailable"
+        }
       }
     },
     "trail_policy_evidence_use": {
@@ -111,11 +118,11 @@
       ],
       "value": {
         "fueling": "expected_duration_and_practice_context_only",
-        "hiking": "conditional_candidate_module",
+        "hiking": "disabled_deferred_no_accepted_v2_input_or_dose",
         "injury_and_fatigue_findings": "safety_context_only",
         "observed_load_associations": "descriptive_only",
-        "strength_and_multimodal": "conditional_candidate_module",
-        "taper": "indirect_direction_only",
+        "strength_and_multimodal": "disabled_deferred_no_accepted_v2_input_or_dose",
+        "taper": "disabled_deferred_no_accepted_v2_input_or_dose",
         "trail_specificity": "conditional_candidate_module"
       }
     },
@@ -179,6 +186,22 @@
           "count": 2,
           "window": 42
         },
+        "insufficient_ascent_or_trail_result": {
+          "detail_reason": "insufficient_comparable_trail_history",
+          "status": "readiness_blocked"
+        },
+        "insufficient_recent_descent_result": {
+          "detail_reason": "insufficient_descent_history",
+          "status": "readiness_blocked"
+        },
+        "insufficient_recent_running_result": {
+          "detail_reason": "insufficient_recent_running_history",
+          "status": "readiness_blocked"
+        },
+        "known_course_footing_not_observed_result": {
+          "detail_reason": "insufficient_comparable_trail_history",
+          "status": "readiness_blocked"
+        },
         "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
         "latest_run_within_completed_days": 10,
         "minimum_running_sessions_per_usable_week": 3,
@@ -190,7 +213,6 @@
           "source_timestamp"
         ],
         "recent_history_lookback_completed_weeks": 8,
-        "sparse_or_stale_result": "insufficient_comparable_trail_history",
         "thresholds_are_published_biological_laws": false,
         "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
       }
@@ -231,20 +253,33 @@
         "non-ultra-trail.fueling-duration-and-practice-context"
       ],
       "value": {
-        "module_requires_matching_input": true,
-        "modules": [
+        "candidate_modules": [
           "readiness_and_history",
           "easy_and_aerobic",
           "ascent_specificity",
           "descent_and_neuromuscular_exposure",
           "technical_terrain",
-          "hiking",
-          "strength",
           "longest_session_and_fueling_practice",
-          "taper",
           "environment_and_altitude",
           "reassessment_and_outcome"
         ],
+        "disabled_deferred_modules": {
+          "hiking": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          },
+          "strength": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          },
+          "taper": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          }
+        },
+        "disabled_modules_are_module_availability_keys": false,
+        "disabled_modules_may_be_included_in_v2_proposal": false,
+        "module_requires_matching_input": true,
         "unavailable_module_may_be_silently_replaced": false
       }
     },
@@ -287,8 +322,16 @@
           "stable_recent_running_history",
           "comparable_recent_ascent_exposure",
           "comparable_recent_descent_exposure",
-          "available_training_days_and_limits",
-          "accessible_training_terrain",
+          "available_weekdays",
+          "weekly_time_limit_min",
+          "maximum_session_duration_min",
+          "unavailable_dates_within_14_day_horizon",
+          "optional_preferred_longest_weekday_when_supplied",
+          "nontechnical_three_minute_uphill_access",
+          "controlled_downhill_access",
+          "accessible_footing",
+          "adult_nonclinical_scope_confirmation",
+          "performance_intent_confirmation",
           "current_symptom_stop"
         ],
         "server_derived": [
@@ -329,17 +372,26 @@
         "non-ultra-trail.training-specificity-promising-not-prescriptive"
       ],
       "value": {
-        "below_minimum_result": "no_schedule_within_envelope",
+        "below_minimum_result": {
+          "detail_reason": "no_schedule_within_envelope",
+          "status": "readiness_blocked"
+        },
         "easy_and_longest_easy_allocation": {
           "automatic_longest_easy_increase": false,
           "preferred_longest_easy_day_used_when_available": true,
           "quality_minutes_allocated_first": true,
           "remaining_minutes_distributed_across_non_quality_days": true
         },
-        "no_schedule_result": "no_schedule_within_envelope",
+        "explicit_request_above_history_envelope_result": {
+          "detail_reason": "training_constraints_outside_history_envelope",
+          "status": "clarification_required"
+        },
+        "no_schedule_result": {
+          "detail_reason": "no_schedule_within_envelope",
+          "status": "readiness_blocked"
+        },
         "non_taper_progression_above_recent_median": false,
         "quality_sessions_per_7_day_unit": 1,
-        "requested_above_maximum_result": "clarification_required",
         "selected_running_days_per_7_day_unit": {
           "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
           "maximum": 6,
@@ -382,6 +434,176 @@
       ],
       "value": {
         "authorization_failures_occur_before_product_receipt": true,
+        "condition_reason_mapping": [
+          {
+            "condition": "invalid_type_nonfinite_out_of_domain_duplicate_forbidden_or_internally_inconsistent_value",
+            "result": {
+              "detail_reason": "invalid_field_value",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "course_or_constraint_schema_id_is_not_exact_v2",
+            "result": {
+              "detail_reason": "schema_version_mismatch",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "canonical_replay_receipt_proposal_or_other_invariant_fails",
+            "result": {
+              "detail_reason": "deterministic_invariant_failed",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "required_ontology_policy_or_specialist_dependency_missing_mismatched_inactive_or_not_runtime_authorized",
+            "result": {
+              "detail_reason": "policy_inactive",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
+            "result": {
+              "detail_reason": "material_course_demand_unknown",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "explicit_assumption_not_confirmed_at_exact_revision",
+            "result": {
+              "detail_reason": "assumption_confirmation_required",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "adult_nonclinical_or_performance_scope_confirmation_missing_or_unknown",
+            "result": {
+              "detail_reason": "adult_scope_or_constraints_unconfirmed",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "schedule_capacity_unavailable_dates_access_footing_or_symptom_input_missing_or_unknown",
+            "result": {
+              "detail_reason": "training_constraints_missing",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "explicit_requested_workload_or_proposal_edit_above_server_history_envelope",
+            "result": {
+              "detail_reason": "training_constraints_outside_history_envelope",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "required_confirmation_course_constraint_or_history_source_revision_stale",
+            "result": {
+              "detail_reason": "stale_confirmation_or_source_revision",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "individually_valid_values_conflict_including_preferred_weekday_outside_available_set",
+            "result": {
+              "detail_reason": "contradictory_input",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "server_derived_recent_running_continuity_insufficient",
+            "result": {
+              "detail_reason": "insufficient_recent_running_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "server_derived_recent_ascent_or_trail_exposure_insufficient",
+            "result": {
+              "detail_reason": "insufficient_comparable_trail_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_course_footing_not_subset_of_recently_observed_footing",
+            "result": {
+              "detail_reason": "insufficient_comparable_trail_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "server_derived_recent_descent_exposure_insufficient",
+            "result": {
+              "detail_reason": "insufficient_descent_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_uphill_or_downhill_access_false",
+            "result": {
+              "detail_reason": "insufficient_terrain_access",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_course_footing_not_subset_of_accessible_footing",
+            "result": {
+              "detail_reason": "insufficient_terrain_access",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "current_symptom_stop_known_true",
+            "result": {
+              "detail_reason": "current_symptom_stop",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "complete_valid_constraints_history_caps_and_spacing_leave_no_14_day_schedule",
+            "result": {
+              "detail_reason": "no_schedule_within_envelope",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "event_within_unapproved_14_day_taper_window",
+            "result": {
+              "detail_reason": "event_inside_unapproved_taper_window",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "event_ultra_distance_or_multiday",
+            "result": {
+              "detail_reason": "unsupported_ultra_or_multiday",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+            "result": {
+              "detail_reason": "unsupported_population_or_intent",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "hands_assist_or_fixed_rope_known_true",
+            "result": {
+              "detail_reason": "technical_features_outside_v2",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "no_higher_precedence_reason_matches",
+            "result": {
+              "detail_reason": null,
+              "status": "eligible_proposal"
+            }
+          }
+        ],
         "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
         "detail_reason_catalog": {
           "clarification_required": [
@@ -389,6 +611,8 @@
             "assumption_confirmation_required",
             "adult_scope_or_constraints_unconfirmed",
             "training_constraints_missing",
+            "training_constraints_outside_history_envelope",
+            "stale_confirmation_or_source_revision",
             "contradictory_input"
           ],
           "eligible_proposal": [],
@@ -423,10 +647,13 @@
           ],
           "changes_top_level_status": false,
           "empty_means_eligible": false,
+          "empty_means_included": false,
           "generic_or_road_replacement_allowed": false,
           "hides_matching_reason": false,
+          "projection_of": "module_availability_state_limited",
           "serialize_sorted": true,
-          "set_semantics": true
+          "set_semantics": true,
+          "source_of_truth": false
         },
         "matching_reasons": {
           "de_duplicate": true,
@@ -440,6 +667,57 @@
           "pair_fields": [
             "status",
             "detail_reason"
+          ]
+        },
+        "module_availability": {
+          "actual_included_or_omitted_state_exists_only_in_immutable_proposal": true,
+          "allowed_states": [
+            "not_evaluated",
+            "available",
+            "limited"
+          ],
+          "authoritative": true,
+          "limited_reason_targets": {
+            "environment_altitude": [
+              "course.environment_and_altitude"
+            ],
+            "fueling": [
+              "course.aid_and_support",
+              "course.fueling_and_gastrointestinal_context"
+            ],
+            "grade_specificity": [
+              "course.grade_distribution"
+            ],
+            "technical_terrain": [
+              "course.course_footing"
+            ]
+          },
+          "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
+          "required_keys_in_sorted_order": [
+            "environment_altitude",
+            "fueling",
+            "grade_specificity",
+            "technical_terrain"
+          ],
+          "state_rules": {
+            "available": {
+              "guarantees_proposal_inclusion": false,
+              "reason_target": null,
+              "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+            },
+            "limited": {
+              "may_be_included_in_proposal": false,
+              "reason_target": "closed_first_party_field_or_section_target",
+              "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+            },
+            "not_evaluated": {
+              "reason_target": "one_applicable_namespaced_matching_reason",
+              "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+            }
+          },
+          "value_exact_keys": [
+            "state",
+            "reason_target"
           ]
         },
         "namespaced_reason_identity": "<status>.<detail_reason>",
@@ -512,5 +790,5 @@
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40"
+  "source_decision_digest": "sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56"
 }

--- a/data/science/generated/contracts/sdr-trail-running-goal-ontology-v1.json
+++ b/data/science/generated/contracts/sdr-trail-running-goal-ontology-v1.json
@@ -3,9 +3,9 @@
     "trail_course_demand_v1 ontology",
     "trail capability matching contract"
   ],
-  "contract_digest": "sha256:5bf6b47ede65af84af85fb364d148bffa38c1ea330272a3e71553d091a8695dc",
+  "contract_digest": "sha256:e341c379d8f60a27ee5919beab4800721c96b79458c861237d6e14800cdcd752",
   "decision_id": "sdr-trail-running-goal-ontology-v1",
-  "decision_status": "accepted",
+  "decision_status": "superseded",
   "decision_version": 1,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
+++ b/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
@@ -4,7 +4,7 @@
     "non_ultra_trail_constraints_v2 input and confirmation envelope",
     "future v2 Trail capability matching contract"
   ],
-  "contract_digest": "sha256:12c107e9d19f6c5e7204f09ef680ab5c4517a4f9385179d72822630a61df1c96",
+  "contract_digest": "sha256:1297f713b992822335978dac92cfaa9b968b092d4ff6869ad73baa3d94ee2e7a",
   "decision_id": "sdr-trail-running-goal-ontology-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -63,6 +63,7 @@
           "distance_meters": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 49999,
             "minimum": 1,
             "type": "integer",
             "unit": "meters"
@@ -87,13 +88,9 @@
             "type": "closed_enum"
           },
           "fixed_rope": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
+            "envelope": "known_or_unknown",
             "materiality": "core",
-            "type": "tri_state"
+            "type": "strict_boolean"
           },
           "fueling_and_gastrointestinal_context": {
             "envelope": "known_or_unknown",
@@ -108,13 +105,9 @@
             "type": "five_bucket_basis_point_object"
           },
           "hands_assist": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
+            "envelope": "known_or_unknown",
             "materiality": "core",
-            "type": "tri_state"
+            "type": "strict_boolean"
           },
           "planning_duration_range": {
             "envelope": "known_or_unknown",
@@ -133,6 +126,7 @@
           "total_ascent_m": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 20000,
             "minimum": 0,
             "type": "integer",
             "unit": "meters"
@@ -140,6 +134,7 @@
           "total_descent_m": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 20000,
             "minimum": 0,
             "type": "integer",
             "unit": "meters"
@@ -188,6 +183,7 @@
       ],
       "value": {
         "core_and_limited_materiality": "operational_guardrail_only",
+        "course_domain_bounds": "product_scope_and_operability_guardrail_only",
         "distance_vertical_conversion": "not_accepted",
         "downhill_progression": "not_accepted",
         "environment_or_altitude_dose": "not_accepted",
@@ -198,6 +194,7 @@
         "planning_duration_range_shape": "operational_guardrail_only",
         "road_trail_equivalence": "not_accepted",
         "route_or_provider_inference": "not_accepted",
+        "schedule_capacity_bounds": "product_scope_and_operability_guardrail_only",
         "signed_grade_buckets": "descriptive_operational_guardrail_only",
         "technical_terrain_dose": "not_accepted",
         "technicality_score": "not_accepted",
@@ -275,24 +272,18 @@
       "value": {
         "hazard_gates": {
           "fixed_rope": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
-            "eligible_value": "no",
-            "unknown_result": "clarification_required",
-            "yes_result": "policy_unavailable.technical_features_outside_v2"
+            "eligible_value": "known_false",
+            "envelope": "known_or_unknown",
+            "known_true_result": "policy_unavailable.technical_features_outside_v2",
+            "known_value_type": "strict_boolean",
+            "unknown_result": "clarification_required.material_course_demand_unknown"
           },
           "hands_assist": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
-            "eligible_value": "no",
-            "unknown_result": "clarification_required",
-            "yes_result": "policy_unavailable.technical_features_outside_v2"
+            "eligible_value": "known_false",
+            "envelope": "known_or_unknown",
+            "known_true_result": "policy_unavailable.technical_features_outside_v2",
+            "known_value_type": "strict_boolean",
+            "unknown_result": "clarification_required.material_course_demand_unknown"
           },
           "reducible_to_ordinary_footing": false,
           "technical_skill_or_safety_score": false
@@ -545,8 +536,11 @@
         "feasibility_verdict": false,
         "field": "planning_duration_range",
         "finish_time_prediction": false,
+        "minimum_and_maximum_each": {
+          "maximum": 1440,
+          "minimum": 1
+        },
         "minimum_strictly_less_than_maximum": true,
-        "minimum_value": 1,
         "performance_promise": false,
         "purpose": "planning_context",
         "unit": "integer_minutes"
@@ -650,10 +644,12 @@
             "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
           },
           "adult_nonclinical_scope_confirmed": {
-            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "envelope": "known_or_unknown",
+            "false_result": "policy_unavailable.unsupported_population_or_intent",
             "materiality": "core",
             "required_value_for_eligibility": true,
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
           },
           "available_weekdays": {
             "allowed_iso_weekdays": [
@@ -667,35 +663,81 @@
             ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "minimum_members": 1,
             "type": "unique_unordered_set",
             "unknown_result": "clarification_required.training_constraints_missing"
           },
-          "controlled_downhill_terrain_accessible": {
+          "controlled_downhill_access": {
             "duration_distance_grade_speed_or_repeat_fields_allowed": false,
             "envelope": "known_or_unknown",
-            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "false_result": "readiness_blocked.insufficient_terrain_access",
             "materiality": "core",
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
           "current_symptom_stop": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "stop_value": true,
             "true_result": "readiness_blocked.current_symptom_stop",
-            "type": "tri_state_boolean",
-            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
-          "nontechnical_continuous_three_minute_uphill_accessible": {
+          "maximum_session_duration_min": {
             "envelope": "known_or_unknown",
-            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
             "materiality": "core",
-            "type": "strict_boolean"
+            "maximum": 1440,
+            "minimum": 1,
+            "not_greater_than": "weekly_time_limit_min",
+            "type": "integer",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "nontechnical_three_minute_uphill_access": {
+            "envelope": "known_or_unknown",
+            "false_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
           "performance_intent_confirmed": {
-            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "envelope": "known_or_unknown",
+            "false_result": "policy_unavailable.unsupported_population_or_intent",
             "materiality": "core",
             "required_value_for_eligibility": true,
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+          },
+          "preferred_longest_weekday": {
+            "allowed": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ],
+            "conflict_result": "clarification_required.contradictory_input",
+            "omitted_means_no_preference": true,
+            "type": "optional_iso_weekday",
+            "when_present_must_be_in": "available_weekdays"
+          },
+          "unavailable_dates": {
+            "all_dates_within_requested_14_day_horizon": true,
+            "empty_known_set_allowed": true,
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "maximum_members": 14,
+            "type": "sorted_unique_iso_date_set",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "weekly_time_limit_min": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "maximum": 10080,
+            "minimum": 1,
+            "type": "integer",
+            "unknown_result": "clarification_required.training_constraints_missing"
           }
         },
         "history_provenance": "history_observed",
@@ -733,8 +775,12 @@
           "performance_intent_confirmed",
           "current_symptom_stop",
           "available_weekdays",
-          "nontechnical_continuous_three_minute_uphill_accessible",
-          "controlled_downhill_terrain_accessible",
+          "weekly_time_limit_min",
+          "maximum_session_duration_min",
+          "unavailable_dates",
+          "preferred_longest_weekday_consistency_when_present",
+          "nontechnical_three_minute_uphill_access",
+          "controlled_downhill_access",
           "accessible_footing_when_course_footing_known",
           "recent_running_continuity",
           "recent_ascent_exposure",
@@ -769,5 +815,5 @@
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b"
+  "source_decision_digest": "sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c"
 }

--- a/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
+++ b/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
@@ -4,9 +4,9 @@
     "non_ultra_trail_constraints_v2 input and confirmation envelope",
     "future v2 Trail capability matching contract"
   ],
-  "contract_digest": "sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617",
+  "contract_digest": "sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c",
   "decision_id": "sdr-trail-running-goal-ontology-v2",
-  "decision_status": "draft",
+  "decision_status": "accepted",
   "decision_version": 2,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
+++ b/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
@@ -1,0 +1,773 @@
+{
+  "affected_models": [
+    "trail_course_demand_v2 ontology",
+    "non_ultra_trail_constraints_v2 input and confirmation envelope",
+    "future v2 Trail capability matching contract"
+  ],
+  "contract_digest": "sha256:12c107e9d19f6c5e7204f09ef680ab5c4517a4f9385179d72822630a61df1c96",
+  "decision_id": "sdr-trail-running-goal-ontology-v2",
+  "decision_status": "draft",
+  "decision_version": 2,
+  "evidence_claim_ids": [
+    "trail-ontology.course-demand-is-multidimensional",
+    "trail-ontology.uphill-downhill-demands-differ",
+    "trail-ontology.technicality-and-downhill-vary-performance",
+    "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+    "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose",
+    "trail-ontology.environment-and-altitude-are-distinct-context",
+    "trail-ontology.duration-and-fueling-practice-are-context"
+  ],
+  "evidence_review_ids": [
+    "evidence-trail-running-goal-ontology-v1"
+  ],
+  "linked_evidence_digests": {
+    "evidence-trail-running-goal-ontology-v1": "sha256:60f0e785e4fc2b4226fed3bb30750191195cffbb0236b4a81d34431c0002c87a"
+  },
+  "model_version": "trail-course-demand-v2",
+  "parameters": {
+    "trail_course_demand_schema": {
+      "applies_to": "trail_course_demand_v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.uphill-downhill-demands-differ"
+      ],
+      "value": {
+        "event_identity": {
+          "client_writable": false,
+          "field": "event_id",
+          "materiality": "core",
+          "type": "server_owned_identifier"
+        },
+        "fields": {
+          "aid_and_support": {
+            "envelope": "known_or_unknown",
+            "limited_module": "fueling",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "course_footing": {
+            "envelope": "known_or_unknown",
+            "limited_module": "technical_terrain",
+            "materiality": "limited_with_core_matching_when_known",
+            "type": "nonempty_unordered_closed_set"
+          },
+          "distance_family": {
+            "allowed": [
+              "non_ultra"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "distance_meters": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 1,
+            "type": "integer",
+            "unit": "meters"
+          },
+          "environment_and_altitude": {
+            "envelope": "known_or_unknown",
+            "limited_module": "environment_altitude",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "event_date": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "iso_date"
+          },
+          "event_format": {
+            "allowed": [
+              "single_day"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "fixed_rope": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "materiality": "core",
+            "type": "tri_state"
+          },
+          "fueling_and_gastrointestinal_context": {
+            "envelope": "known_or_unknown",
+            "limited_module": "fueling",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "grade_distribution": {
+            "envelope": "known_or_unknown",
+            "limited_module": "grade_specificity",
+            "materiality": "limited",
+            "type": "five_bucket_basis_point_object"
+          },
+          "hands_assist": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "materiality": "core",
+            "type": "tri_state"
+          },
+          "planning_duration_range": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "integer_range",
+            "unit": "minutes"
+          },
+          "planning_intent": {
+            "allowed": [
+              "performance"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "total_ascent_m": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 0,
+            "type": "integer",
+            "unit": "meters"
+          },
+          "total_descent_m": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 0,
+            "type": "integer",
+            "unit": "meters"
+          }
+        },
+        "schema_id": "trail_course_demand_v2",
+        "strict_unknown_fields_rejected": true
+      }
+    },
+    "trail_distinct_demand_invariants": {
+      "applies_to": "v2 course, access, history, and intensity boundaries",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.technicality-and-downhill-vary-performance",
+        "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone"
+      ],
+      "value": {
+        "activity_average_power_allowed": false,
+        "ascent_and_descent_separate": true,
+        "downhill_history_required_when_descent_material": true,
+        "footing_set_containment": {
+          "access_failure_reason": "readiness_blocked.insufficient_terrain_access",
+          "access_requirement": "C subset_of A",
+          "accessible_set_symbol": "A",
+          "applies_only_when_course_footing_known": true,
+          "course_set_symbol": "C",
+          "history_failure_reason": "readiness_blocked.insufficient_comparable_trail_history",
+          "history_requirement": "C subset_of H",
+          "observed_history_set_symbol": "H",
+          "similarity_synonyms_or_model_inference_allowed": false
+        },
+        "grade_distribution_descriptive_only": true,
+        "heart_rate_alone_sufficient_for_hilly_intensity": false,
+        "level_pace_alone_sufficient_for_hilly_intensity": false,
+        "technicality_score_allowed": false,
+        "universal_distance_vertical_equivalence": false
+      }
+    },
+    "trail_exact_values": {
+      "applies_to": "unresolved ontology and prescription values",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "core_and_limited_materiality": "operational_guardrail_only",
+        "distance_vertical_conversion": "not_accepted",
+        "downhill_progression": "not_accepted",
+        "environment_or_altitude_dose": "not_accepted",
+        "finish_time_prediction": "not_accepted",
+        "footing_vocabulary": "descriptive_operational_guardrail_only",
+        "fueling_amount_or_frequency": "not_accepted",
+        "optional_context_bounds": "operational_guardrail_only",
+        "planning_duration_range_shape": "operational_guardrail_only",
+        "road_trail_equivalence": "not_accepted",
+        "route_or_provider_inference": "not_accepted",
+        "signed_grade_buckets": "descriptive_operational_guardrail_only",
+        "technical_terrain_dose": "not_accepted",
+        "technicality_score": "not_accepted",
+        "vertical_progression": "not_accepted"
+      }
+    },
+    "trail_field_provenance": {
+      "applies_to": "every reviewable v2 course, constraint, and history field",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "assumption_requires_revision_bound_confirmation": true,
+        "client_may_submit_history_hash": false,
+        "client_may_submit_model_version": false,
+        "client_may_submit_provenance": false,
+        "client_may_submit_source_revision": false,
+        "client_may_submit_source_timestamp": false,
+        "field_restrictions": {
+          "athlete_assumption_conditions": [
+            "explicit_assumption"
+          ],
+          "event_id": "server_owned",
+          "grade_distribution": [
+            "athlete_stated",
+            "course_verified",
+            "unknown"
+          ],
+          "recent_history": [
+            "history_observed"
+          ]
+        },
+        "inferred_requires_server_model_version": true,
+        "request_envelope": {
+          "arbitrary_object_invalid": true,
+          "empty_string_invalid": true,
+          "guessed_zero_invalid": true,
+          "known": {
+            "exact_keys": [
+              "state",
+              "value"
+            ],
+            "schema_valid_value_required": true,
+            "state_literal": "known"
+          },
+          "missing_state_invalid": true,
+          "null_invalid_except_explicit_aid_gap_case": true,
+          "numeric_values_must_be_finite": true,
+          "sentinel_number_invalid": true,
+          "unknown": {
+            "exact_keys": [
+              "state"
+            ],
+            "state_literal": "unknown",
+            "value_forbidden": true
+          }
+        },
+        "server_stamped_provenance_allowed": [
+          "athlete_stated",
+          "course_verified",
+          "history_observed",
+          "model_inferred",
+          "explicit_assumption",
+          "unknown"
+        ],
+        "unknown_is_preserved": true
+      }
+    },
+    "trail_footing_and_hazard_contract": {
+      "applies_to": "course, access, and observed-history footing plus v2 hazard gates",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.technicality-and-downhill-vary-performance",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "hazard_gates": {
+          "fixed_rope": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "eligible_value": "no",
+            "unknown_result": "clarification_required",
+            "yes_result": "policy_unavailable.technical_features_outside_v2"
+          },
+          "hands_assist": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "eligible_value": "no",
+            "unknown_result": "clarification_required",
+            "yes_result": "policy_unavailable.technical_features_outside_v2"
+          },
+          "reducible_to_ordinary_footing": false,
+          "technical_skill_or_safety_score": false
+        },
+        "ordinary_footing": {
+          "allowed": [
+            "firm_smooth",
+            "loose_gravel",
+            "mud",
+            "rocks_or_roots",
+            "built_steps",
+            "water_crossing"
+          ],
+          "difficulty_score": false,
+          "duplicates_invalid": true,
+          "free_text_allowed": false,
+          "other_value_allowed": false,
+          "type": "nonempty_unordered_set",
+          "unknown_members_invalid": true
+        }
+      }
+    },
+    "trail_grade_distribution": {
+      "applies_to": "known grade_distribution in trail_course_demand_v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ"
+      ],
+      "value": {
+        "allowed_provenance": [
+          "athlete_stated",
+          "course_verified"
+        ],
+        "buckets": {
+          "below_neg_10": {
+            "interval": "g < -10%",
+            "upper_bound_percent": -10,
+            "upper_inclusive": false
+          },
+          "neg_10_to_below_neg_3": {
+            "interval": "-10% <= g < -3%",
+            "lower_bound_percent": -10,
+            "lower_inclusive": true,
+            "upper_bound_percent": -3,
+            "upper_inclusive": false
+          },
+          "neg_3_to_below_pos_3": {
+            "interval": "-3% <= g < 3%",
+            "lower_bound_percent": -3,
+            "lower_inclusive": true,
+            "upper_bound_percent": 3,
+            "upper_inclusive": false
+          },
+          "pos_10_and_above": {
+            "interval": "g >= 10%",
+            "lower_bound_percent": 10,
+            "lower_inclusive": true
+          },
+          "pos_3_to_below_pos_10": {
+            "interval": "3% <= g < 10%",
+            "lower_bound_percent": 3,
+            "lower_inclusive": true,
+            "upper_bound_percent": 10,
+            "upper_inclusive": false
+          }
+        },
+        "descriptive_only": true,
+        "difficulty_score": false,
+        "each_share_minimum": 0,
+        "each_share_type": "integer",
+        "equivalence_or_prediction_input": false,
+        "exact_sum": 10000,
+        "known_value_exact_keys": [
+          "below_neg_10",
+          "neg_10_to_below_neg_3",
+          "neg_3_to_below_pos_3",
+          "pos_3_to_below_pos_10",
+          "pos_10_and_above"
+        ],
+        "ordering_semantic": false,
+        "route_or_model_inference": false,
+        "safety_threshold": false,
+        "unit": "basis_points_of_course_distance",
+        "workout_dose_input": false
+      }
+    },
+    "trail_non_science_authority_boundary": {
+      "applies_to": "all work outside the Science role",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "deployment": "not_accepted",
+        "implementation_review": "required",
+        "lifecycle_supersession": "not_accepted",
+        "owner_only_dogfood": "not_accepted",
+        "product_and_experience_dependency": "human_acceptance_required",
+        "product_visibility_or_catalog": "not_accepted",
+        "production_data_use": "not_accepted",
+        "provider_mapping_or_delivery": "not_accepted",
+        "runtime_activation": "not_accepted",
+        "science_authority": [
+          "evidence",
+          "applicability",
+          "uncertainty",
+          "claim_limits",
+          "safety_scope"
+        ]
+      }
+    },
+    "trail_optional_context_shapes": {
+      "applies_to": "optional v2 course context only",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.environment-and-altitude-are-distinct-context",
+        "trail-ontology.duration-and-fueling-practice-are-context"
+      ],
+      "value": {
+        "aid_and_support": {
+          "aid_station_count": {
+            "maximum": 50,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "aid_support_mode": {
+            "known_allowed": [
+              "organized_aid",
+              "mixed",
+              "self_supported"
+            ]
+          },
+          "food_availability": {
+            "known_allowed": [
+              "none",
+              "some_stations",
+              "all_stations"
+            ],
+            "unknown_uses_field_envelope": true
+          },
+          "mandatory_gear": {
+            "allowed": [
+              "water_carry",
+              "food_carry",
+              "weather_shell",
+              "lighting",
+              "navigation_device",
+              "other_required"
+            ],
+            "other_required_has_no_label_or_free_text": true,
+            "type": "unordered_closed_set"
+          },
+          "max_aid_station_gap_km": {
+            "maximum": 50,
+            "minimum": 0.1,
+            "null_allowed_only_for": "no_applicable_gap",
+            "type": "finite_number"
+          },
+          "water_availability": {
+            "known_allowed": [
+              "none",
+              "some_stations",
+              "all_stations"
+            ],
+            "unknown_uses_field_envelope": true
+          }
+        },
+        "environment_and_altitude": {
+          "conditions_basis": {
+            "athlete_assumption_provenance": "explicit_assumption",
+            "athlete_assumption_requires_confirmation": true,
+            "known_allowed": [
+              "organizer_information",
+              "seasonal_expectation",
+              "athlete_assumption"
+            ]
+          },
+          "humidity_range_pct": {
+            "maximum": 100,
+            "minimum": 0,
+            "minimum_may_equal_maximum": true,
+            "type": "finite_number_range"
+          },
+          "maximum_altitude_m": {
+            "maximum": 9000,
+            "minimum": -500,
+            "type": "integer"
+          },
+          "sun_exposure": {
+            "known_allowed": [
+              "low",
+              "mixed",
+              "high"
+            ],
+            "unknown_uses_field_envelope": true
+          },
+          "temperature_range_c": {
+            "maximum": 55,
+            "minimum": -30,
+            "minimum_may_equal_maximum": true,
+            "type": "finite_number_range"
+          },
+          "wind_exposure": {
+            "known_allowed": [
+              "sheltered",
+              "mixed",
+              "exposed"
+            ],
+            "unknown_uses_field_envelope": true
+          }
+        },
+        "fixed_prescription_from_known_context": false,
+        "fueling_and_gastrointestinal_context": {
+          "gastrointestinal_experience": {
+            "known_allowed": [
+              "no_plan_altering_issue",
+              "plan_altering_issue"
+            ],
+            "non_diagnostic": true,
+            "unknown_uses_field_envelope": true
+          },
+          "intake_form": {
+            "known_allowed": [
+              "none",
+              "fluids_only",
+              "carbohydrate_drink",
+              "mixed_food_and_drink"
+            ]
+          },
+          "longest_practiced_duration_min": {
+            "maximum": 1440,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "practice_sessions_last_42_days": {
+            "maximum": 84,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+      }
+    },
+    "trail_planning_duration_range": {
+      "applies_to": "trail_course_demand_v2 core confirmation",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.duration-and-fueling-practice-are-context"
+      ],
+      "value": {
+        "athlete_confirmed": true,
+        "feasibility_verdict": false,
+        "field": "planning_duration_range",
+        "finish_time_prediction": false,
+        "minimum_strictly_less_than_maximum": true,
+        "minimum_value": 1,
+        "performance_promise": false,
+        "purpose": "planning_context",
+        "unit": "integer_minutes"
+      }
+    },
+    "trail_revision_and_confirmation": {
+      "applies_to": "every v2 mutation, readiness receipt, and later proposal",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "confirm_all_allowed": false,
+        "confirmation_invalidated_by": [
+          "value_change",
+          "known_unknown_state_change",
+          "server_stamped_source_change",
+          "source_revision_change"
+        ],
+        "confirmation_is_truth_safety_or_eligibility_attestation": false,
+        "confirmation_scope": "exact_visible_field_or_section_revision",
+        "mutation_creates_new_immutable_revision": true,
+        "proposal_binds_same_exact_revisions": true,
+        "readiness_binds_exact_revisions": [
+          "goal",
+          "course",
+          "constraints",
+          "history_snapshot",
+          "policy",
+          "generator"
+        ],
+        "stale_confirmation_rebound_allowed": false,
+        "stale_source_revision_rebound_allowed": false
+      }
+    },
+    "trail_science_safety_and_privacy_boundary": {
+      "applies_to": "all v2 science, storage, API, client, audit, and deletion surfaces",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "activity_average_power_valid_for_intensity": false,
+        "authenticated_owner_scoped_reset_export_and_deletion_required": true,
+        "diagnosis_treatment_clearance_or_return_to_sport": false,
+        "forbidden_collection_or_persistence": [
+          "gps_points",
+          "route_files",
+          "polylines",
+          "maps",
+          "inferred_course_geometry",
+          "course_source_urls",
+          "scraped_course_content",
+          "provider_request_or_response_payloads",
+          "provider_account_activity_or_workout_ids",
+          "device_identifiers",
+          "free_text_health_symptom_fueling_surface_or_course_narratives",
+          "diagnoses_or_medical_clearance",
+          "injury_probability",
+          "activity_average_power",
+          "road_equivalent_distance_pace_or_load"
+        ],
+        "generic_audit_or_telemetry_may_copy_sensitive_payloads": false,
+        "inferred_and_athlete_stated_fields_correctable_and_deletable": true,
+        "minimum_age_years": 18,
+        "minimum_normalized_storage_only": true,
+        "nonclinical_only": true,
+        "performance_injury_or_safety_guarantee": false,
+        "permitted_persisted_categories": [
+          "canonical_field_values_and_unknown_states",
+          "server_stamped_provenance",
+          "source_and_field_or_section_revisions",
+          "confirmations",
+          "owner_scoped_history_snapshot_reference_and_hash",
+          "readiness_and_proposal_binding_digests"
+        ],
+        "personal_finish_probability": false,
+        "suggestion_only": true,
+        "symptom_stop_required": true,
+        "valid_intensity_sources": [
+          "activity_splits",
+          "activity_samples"
+        ]
+      }
+    },
+    "trail_training_constraints_schema": {
+      "applies_to": "non_ultra_trail_constraints_v2 and owner-scoped readiness",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "client_may_submit_or_attest_history": false,
+        "client_reviewable_fields": {
+          "accessible_footing": {
+            "envelope": "known_or_unknown",
+            "materiality": "core_when_course_footing_known",
+            "missing_required_member_result": "readiness_blocked.insufficient_terrain_access",
+            "type": "nonempty_unordered_closed_set",
+            "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
+          },
+          "adult_nonclinical_scope_confirmed": {
+            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "materiality": "core",
+            "required_value_for_eligibility": true,
+            "type": "strict_boolean"
+          },
+          "available_weekdays": {
+            "allowed_iso_weekdays": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "unique_unordered_set",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "controlled_downhill_terrain_accessible": {
+            "duration_distance_grade_speed_or_repeat_fields_allowed": false,
+            "envelope": "known_or_unknown",
+            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean"
+          },
+          "current_symptom_stop": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "stop_value": true,
+            "true_result": "readiness_blocked.current_symptom_stop",
+            "type": "tri_state_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+          },
+          "nontechnical_continuous_three_minute_uphill_accessible": {
+            "envelope": "known_or_unknown",
+            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean"
+          },
+          "performance_intent_confirmed": {
+            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "materiality": "core",
+            "required_value_for_eligibility": true,
+            "type": "strict_boolean"
+          }
+        },
+        "history_provenance": "history_observed",
+        "schema_id": "non_ultra_trail_constraints_v2",
+        "server_derived_history_fields": [
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing"
+        ]
+      }
+    },
+    "trail_unknown_and_materiality_policy": {
+      "applies_to": "v2 capability matching and readiness receipts",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.technicality-and-downhill-vary-performance"
+      ],
+      "value": {
+        "bounded_alternative_requires_separate_review": true,
+        "core_fields": [
+          "event_id",
+          "event_date",
+          "distance_meters",
+          "total_ascent_m",
+          "total_descent_m",
+          "planning_duration_range",
+          "event_format",
+          "distance_family",
+          "planning_intent",
+          "hands_assist",
+          "fixed_rope",
+          "adult_nonclinical_scope_confirmed",
+          "performance_intent_confirmed",
+          "current_symptom_stop",
+          "available_weekdays",
+          "nontechnical_continuous_three_minute_uphill_accessible",
+          "controlled_downhill_terrain_accessible",
+          "accessible_footing_when_course_footing_known",
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing_when_course_footing_known"
+        ],
+        "known_value_automatically_enables_module": false,
+        "limited_module_may_substitute_generic_or_road_behavior": false,
+        "limited_modules_sorted_allowed": [
+          "environment_altitude",
+          "fueling",
+          "grade_specificity",
+          "technical_terrain"
+        ],
+        "limited_unknown_mapping": {
+          "aid_and_support": "fueling",
+          "course_footing": "technical_terrain",
+          "environment_and_altitude": "environment_altitude",
+          "fueling_and_gastrointestinal_context": "fueling",
+          "grade_distribution": "grade_specificity"
+        },
+        "material_unknown_result": [
+          "clarification_required",
+          "policy_unavailable"
+        ],
+        "unknown_defaults_to_easy": false,
+        "unknown_defaults_to_nontechnical": false,
+        "unknown_defaults_to_road": false,
+        "unknown_defaults_to_zero": false
+      }
+    }
+  },
+  "runtime_state": "inactive",
+  "schema_version": 1,
+  "source_decision_digest": "sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b"
+}

--- a/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
+++ b/data/science/generated/contracts/sdr-trail-running-goal-ontology-v2.json
@@ -4,7 +4,7 @@
     "non_ultra_trail_constraints_v2 input and confirmation envelope",
     "future v2 Trail capability matching contract"
   ],
-  "contract_digest": "sha256:1297f713b992822335978dac92cfaa9b968b092d4ff6869ad73baa3d94ee2e7a",
+  "contract_digest": "sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617",
   "decision_id": "sdr-trail-running-goal-ontology-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -40,12 +40,6 @@
           "type": "server_owned_identifier"
         },
         "fields": {
-          "aid_and_support": {
-            "envelope": "known_or_unknown",
-            "limited_module": "fueling",
-            "materiality": "limited",
-            "type": "bounded_object"
-          },
           "course_footing": {
             "envelope": "known_or_unknown",
             "limited_module": "technical_terrain",
@@ -53,11 +47,13 @@
             "type": "nonempty_unordered_closed_set"
           },
           "distance_family": {
-            "allowed": [
-              "non_ultra"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "non_ultra",
+              "ultra"
+            ],
+            "supported_value": "non_ultra",
             "type": "closed_enum"
           },
           "distance_meters": {
@@ -68,35 +64,25 @@
             "type": "integer",
             "unit": "meters"
           },
-          "environment_and_altitude": {
-            "envelope": "known_or_unknown",
-            "limited_module": "environment_altitude",
-            "materiality": "limited",
-            "type": "bounded_object"
-          },
           "event_date": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "type": "iso_date"
           },
           "event_format": {
-            "allowed": [
-              "single_day"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "single_day",
+              "multi_day"
+            ],
+            "supported_value": "single_day",
             "type": "closed_enum"
           },
           "fixed_rope": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "type": "strict_boolean"
-          },
-          "fueling_and_gastrointestinal_context": {
-            "envelope": "known_or_unknown",
-            "limited_module": "fueling",
-            "materiality": "limited",
-            "type": "bounded_object"
           },
           "grade_distribution": {
             "envelope": "known_or_unknown",
@@ -109,6 +95,18 @@
             "materiality": "core",
             "type": "strict_boolean"
           },
+          "optional_context": {
+            "every_declared_leaf_required": true,
+            "every_leaf_envelope": "known_or_unknown",
+            "exact_groups": [
+              "environment",
+              "support",
+              "fueling"
+            ],
+            "group_envelope_allowed": false,
+            "materiality": "limited_by_leaf",
+            "type": "strict_fixed_key_object"
+          },
           "planning_duration_range": {
             "envelope": "known_or_unknown",
             "materiality": "core",
@@ -116,11 +114,14 @@
             "unit": "minutes"
           },
           "planning_intent": {
-            "allowed": [
-              "performance"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "performance",
+              "first_completion",
+              "return_to_consistency"
+            ],
+            "supported_value": "performance",
             "type": "closed_enum"
           },
           "total_ascent_m": {
@@ -141,6 +142,24 @@
           }
         },
         "schema_id": "trail_course_demand_v2",
+        "scope_enum_results": {
+          "recognized_multi_day_or_ultra": {
+            "detail_reason": "unsupported_ultra_or_multiday",
+            "status": "policy_unavailable"
+          },
+          "recognized_non_performance_intent": {
+            "detail_reason": "unsupported_population_or_intent",
+            "status": "policy_unavailable"
+          },
+          "unknown_recognized_scope": {
+            "detail_reason": "adult_scope_or_constraints_unconfirmed",
+            "status": "clarification_required"
+          },
+          "unrecognized_literal": {
+            "detail_reason": "invalid_field_value",
+            "status": "validation_failed"
+          }
+        },
         "strict_unknown_fields_rejected": true
       }
     },
@@ -401,13 +420,121 @@
         "trail-ontology.duration-and-fueling-practice-are-context"
       ],
       "value": {
-        "aid_and_support": {
+        "common_leaf_envelope": "known_or_unknown",
+        "enum_unknown_literals_allowed": false,
+        "environment": {
+          "conditions_basis": {
+            "athlete_assumption_provenance": "explicit_assumption",
+            "athlete_assumption_requires_confirmation": true,
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "organizer_information",
+              "seasonal_expectation",
+              "athlete_assumption"
+            ]
+          },
+          "cross_field_rules": {
+            "humidity_order_when_both_known": "humidity_min_pct_lte_humidity_max_pct",
+            "one_unknown_leaf_remains_unknown_without_inventing_other_bound": true,
+            "temperature_order_when_both_known": "temperature_min_c_lte_temperature_max_c"
+          },
+          "humidity_max_pct": {
+            "envelope": "known_or_unknown",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "finite_number"
+          },
+          "humidity_min_pct": {
+            "envelope": "known_or_unknown",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "finite_number"
+          },
+          "maximum_altitude_m": {
+            "envelope": "known_or_unknown",
+            "maximum": 9000,
+            "minimum": -500,
+            "type": "integer"
+          },
+          "sun_exposure": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "low",
+              "mixed",
+              "high"
+            ]
+          },
+          "temperature_max_c": {
+            "envelope": "known_or_unknown",
+            "maximum": 55,
+            "minimum": -30,
+            "type": "finite_number"
+          },
+          "temperature_min_c": {
+            "envelope": "known_or_unknown",
+            "maximum": 55,
+            "minimum": -30,
+            "type": "finite_number"
+          },
+          "wind_exposure": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "sheltered",
+              "mixed",
+              "exposed"
+            ]
+          }
+        },
+        "every_declared_leaf_required": true,
+        "exact_groups": [
+          "environment",
+          "support",
+          "fueling"
+        ],
+        "fixed_prescription_from_known_context": false,
+        "fueling": {
+          "gastrointestinal_experience": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "no_plan_altering_issue",
+              "plan_altering_issue"
+            ],
+            "non_diagnostic": true
+          },
+          "intake_form": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "none",
+              "fluids_only",
+              "carbohydrate_drink",
+              "mixed_food_and_drink"
+            ]
+          },
+          "longest_practiced_duration_min": {
+            "envelope": "known_or_unknown",
+            "maximum": 1440,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "practice_sessions_last_42_days": {
+            "envelope": "known_or_unknown",
+            "maximum": 84,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "group_envelope_allowed": false,
+        "group_unknown_control_is_leaf_batch_action_only": true,
+        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false,
+        "support": {
           "aid_station_count": {
+            "envelope": "known_or_unknown",
             "maximum": 50,
             "minimum": 0,
             "type": "integer"
           },
           "aid_support_mode": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "organized_aid",
               "mixed",
@@ -415,12 +542,12 @@
             ]
           },
           "food_availability": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "none",
               "some_stations",
               "all_stations"
-            ],
-            "unknown_uses_field_envelope": true
+            ]
           },
           "mandatory_gear": {
             "allowed": [
@@ -431,98 +558,28 @@
               "navigation_device",
               "other_required"
             ],
+            "envelope": "known_or_unknown",
             "other_required_has_no_label_or_free_text": true,
             "type": "unordered_closed_set"
           },
-          "max_aid_station_gap_km": {
-            "maximum": 50,
-            "minimum": 0.1,
-            "null_allowed_only_for": "no_applicable_gap",
-            "type": "finite_number"
+          "max_aid_station_gap_m": {
+            "envelope": "known_or_unknown",
+            "integer_maximum": 50000,
+            "integer_minimum": 100,
+            "kilometer_wire_or_storage_field_allowed": false,
+            "known_null_meaning": "not_applicable",
+            "known_value_type": "integer_or_explicit_null"
           },
           "water_availability": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "none",
               "some_stations",
               "all_stations"
-            ],
-            "unknown_uses_field_envelope": true
-          }
-        },
-        "environment_and_altitude": {
-          "conditions_basis": {
-            "athlete_assumption_provenance": "explicit_assumption",
-            "athlete_assumption_requires_confirmation": true,
-            "known_allowed": [
-              "organizer_information",
-              "seasonal_expectation",
-              "athlete_assumption"
             ]
-          },
-          "humidity_range_pct": {
-            "maximum": 100,
-            "minimum": 0,
-            "minimum_may_equal_maximum": true,
-            "type": "finite_number_range"
-          },
-          "maximum_altitude_m": {
-            "maximum": 9000,
-            "minimum": -500,
-            "type": "integer"
-          },
-          "sun_exposure": {
-            "known_allowed": [
-              "low",
-              "mixed",
-              "high"
-            ],
-            "unknown_uses_field_envelope": true
-          },
-          "temperature_range_c": {
-            "maximum": 55,
-            "minimum": -30,
-            "minimum_may_equal_maximum": true,
-            "type": "finite_number_range"
-          },
-          "wind_exposure": {
-            "known_allowed": [
-              "sheltered",
-              "mixed",
-              "exposed"
-            ],
-            "unknown_uses_field_envelope": true
           }
         },
-        "fixed_prescription_from_known_context": false,
-        "fueling_and_gastrointestinal_context": {
-          "gastrointestinal_experience": {
-            "known_allowed": [
-              "no_plan_altering_issue",
-              "plan_altering_issue"
-            ],
-            "non_diagnostic": true,
-            "unknown_uses_field_envelope": true
-          },
-          "intake_form": {
-            "known_allowed": [
-              "none",
-              "fluids_only",
-              "carbohydrate_drink",
-              "mixed_food_and_drink"
-            ]
-          },
-          "longest_practiced_duration_min": {
-            "maximum": 1440,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "practice_sessions_last_42_days": {
-            "maximum": 84,
-            "minimum": 0,
-            "type": "integer"
-          }
-        },
-        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+        "type": "strict_fixed_key_object"
       }
     },
     "trail_planning_duration_range": {
@@ -560,7 +617,11 @@
         ],
         "confirmation_is_truth_safety_or_eligibility_attestation": false,
         "confirmation_scope": "exact_visible_field_or_section_revision",
-        "mutation_creates_new_immutable_revision": true,
+        "current_unproposed_draft_revision_is_mutable_state": true,
+        "immutable_snapshot_begins_only_with_proposal": true,
+        "pre_proposal_immutable_edit_or_confirmation_history": false,
+        "prior_draft_value_retained": false,
+        "prior_revision_token_retained": false,
         "proposal_binds_same_exact_revisions": true,
         "readiness_binds_exact_revisions": [
           "goal",
@@ -571,7 +632,12 @@
           "generator"
         ],
         "stale_confirmation_rebound_allowed": false,
-        "stale_source_revision_rebound_allowed": false
+        "stale_source_revision_rebound_allowed": false,
+        "successful_edit_atomically_overwrites": [
+          "current_draft_value",
+          "current_revision_token",
+          "invalidated_confirmation_state"
+        ]
       }
     },
     "trail_science_safety_and_privacy_boundary": {
@@ -611,10 +677,11 @@
         "permitted_persisted_categories": [
           "canonical_field_values_and_unknown_states",
           "server_stamped_provenance",
-          "source_and_field_or_section_revisions",
-          "confirmations",
+          "current_source_and_field_or_section_revisions",
+          "current_confirmations",
           "owner_scoped_history_snapshot_reference_and_hash",
-          "readiness_and_proposal_binding_digests"
+          "readiness_and_proposal_binding_digests",
+          "immutable_snapshot_only_after_proposal_creation"
         ],
         "personal_finish_probability": false,
         "suggestion_only": true,
@@ -796,11 +863,11 @@
           "technical_terrain"
         ],
         "limited_unknown_mapping": {
-          "aid_and_support": "fueling",
           "course_footing": "technical_terrain",
-          "environment_and_altitude": "environment_altitude",
-          "fueling_and_gastrointestinal_context": "fueling",
-          "grade_distribution": "grade_specificity"
+          "grade_distribution": "grade_specificity",
+          "optional_context.environment.*": "environment_altitude",
+          "optional_context.fueling.*": "fueling",
+          "optional_context.support.*": "fueling"
         },
         "material_unknown_result": [
           "clarification_required",
@@ -815,5 +882,5 @@
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c"
+  "source_decision_digest": "sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1"
 }

--- a/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v1.md
+++ b/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v1.md
@@ -3,11 +3,11 @@
 > Start with the decision sheet. The audit appendix preserves every code-consumed field, but it is not the reviewer's primary task.
 
 - **Record:** `sdr-non-ultra-trail-plan-generation-policy-v1`
-- **Lifecycle:** `accepted`
+- **Lifecycle:** `superseded`
 - **Model version:** `non-ultra-trail-plan-generation-policy-v1`
 - **Runtime state:** `inactive`
 - **Decision digest:** `sha256:afc9fecefd55c699a8fdf3d3ab885968c7f7981fadbcba7bf09494fdfcdcd606`
-- **Contract digest:** `sha256:472c895bc4c3d467eac4a59dbacaeaaf665ddee462fdc76bba4cdf772df8e42b`
+- **Contract digest:** `sha256:2035f855cea2c1c117bd092796615148e98e59f1536013f86fb2bba1cab73ce2`
 - **Required decision role:** `decision_approver`
 - **Decision approval:** `github:dddtc2005` on `2026-09-03` ([source](https://github.com/praxys-run/praxys/pull/759#issuecomment-5527639393))
 - **Required activation role:** `implementation_reviewer`
@@ -818,9 +818,9 @@ Post-hoc validation cannot make unsupported assumptions or values accepted and c
     "inactive non-ultra trail deterministic early-block policy and generator",
     "trail course-demand and history snapshot matching"
   ],
-  "contract_digest": "sha256:472c895bc4c3d467eac4a59dbacaeaaf665ddee462fdc76bba4cdf772df8e42b",
+  "contract_digest": "sha256:2035f855cea2c1c117bd092796615148e98e59f1536013f86fb2bba1cab73ce2",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v1",
-  "decision_status": "accepted",
+  "decision_status": "superseded",
   "decision_version": 1,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
+++ b/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
@@ -1,0 +1,2193 @@
+# Science decision review packet: Bind the non-ultra Trail policy to the strict v2 readiness receipt
+
+> Start with the decision sheet. The audit appendix preserves every code-consumed field, but it is not the reviewer's primary task.
+
+- **Record:** `sdr-non-ultra-trail-plan-generation-policy-v2`
+- **Lifecycle:** `draft`
+- **Model version:** `non-ultra-trail-plan-generation-policy-v2`
+- **Runtime state:** `inactive`
+- **Decision digest:** `sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40`
+- **Contract digest:** `sha256:2fb5776b13453937708a77f54c273c81f81f4ca265932e4e0eb0a7ac0da2064b`
+- **Required decision role:** `decision_approver`
+- **Decision approval:** _Pending_
+- **Required activation role:** `implementation_reviewer`
+- **Implementation approval:** _Pending_
+
+## Your task
+
+Decide whether the six proposed v2 actions preserve every accepted v1 policy guardrail while replacing ambiguous readiness input and output with strict v2 dependencies and a deterministic complete receipt. Approve the sheet as a unit or request changes by item ID.
+
+Choose one outcome:
+
+1. **Approve the decision sheet as a unit.** This accepts both the proposed decisions and the explicit deferrals below.
+2. **Request changes by item ID.** Do this when any proposal, effect, or non-authorization is unclear or wrong.
+
+Do not approve merely because the audit appendix looks reasonable or because you found no obvious problem while skimming it.
+
+## Decision sheet
+
+### Proposed decisions to approve
+
+#### `v2-scope-dependencies-and-modules` — Bind the narrow accepted policy to the two strict v2 schemas
+
+- **Question:** Should the history-rich adult non-ultra performance policy require the accepted v2 ontology, confirmed v2 course and constraint revisions, server-derived history, and the same conditional module structure?
+- **Proposed decision:** Update only the dependency and schema identities while preserving the accepted scope, evidence use, and modular scientific interpretation.
+- **Approval means:**
+  - A future inactive evaluator can require exact v2 inputs without widening the eligible population.
+  - Known or unknown context cannot silently enable a module.
+- **This does not authorize:**
+  - A broader population, first-completion plan, ultra plan, fixed module dose, or runtime use.
+
+<details><summary>Traceability: 4 contract groups, 3 evidence claims</summary>
+
+- **Contract groups covered:** `trail_policy_scope_and_dependencies`, `trail_policy_required_inputs`, `trail_policy_modular_structure`, `trail_policy_evidence_use`
+- **Evidence claims:** `non-ultra-trail.course-specific-policy-required`, `non-ultra-trail.uphill-downhill-require-distinct-handling`, `non-ultra-trail.training-specificity-promising-not-prescriptive`
+
+</details>
+
+#### `unchanged-early-block-construction` — Carry the accepted early-block construction forward unchanged
+
+- **Question:** Should v2 retain every accepted execution, reassessment, history, schedule, and workout-template value exactly as v1?
+- **Proposed decision:** Preserve the exact fourteen-day, seven-day, history qualification, no-progression scheduling, and targetless 38-minute uphill-template guardrails without presenting them as biological optima.
+- **Approval means:**
+  - The successor changes readiness semantics without silently changing the generated training envelope.
+- **This does not authorize:**
+  - Load progression, a new template, fixed target zones, or a claim of optimality or safety.
+
+<details><summary>Traceability: 4 contract groups, 3 evidence claims</summary>
+
+- **Contract groups covered:** `trail_policy_execution_and_reassessment`, `trail_policy_history_guardrails`, `trail_policy_schedule_construction`, `trail_policy_workout_templates`
+- **Evidence claims:** `eligibility.recent-history-anchor-without-universal-threshold`, `eligibility.fixed-progression-and-acwr-not-safety-laws`, `non-ultra-trail.training-specificity-promising-not-prescriptive`
+
+</details>
+
+#### `unchanged-intensity-exposure-event-and-safety` — Carry the accepted intensity, exposure, event, and hard boundaries forward
+
+- **Question:** Should v2 keep the 75-percent low-intensity floor, one-quality ceiling, spacing, separate history caps, event-window behavior, and all hard Science prohibitions unchanged?
+- **Proposed decision:** Preserve those exact v1 guardrails and keep ascent, descent, terrain, symptoms, athlete action, and intensity provenance separate.
+- **Approval means:**
+  - A new receipt cannot weaken the generated-plan invariants or claim boundaries.
+- **This does not authorize:**
+  - Taper dose, catch-up, target-gap escalation, road substitution, medical advice, or personal guarantees.
+
+<details><summary>Traceability: 4 contract groups, 3 evidence claims</summary>
+
+- **Contract groups covered:** `trail_policy_intensity_and_spacing`, `trail_policy_course_exposure_caps`, `trail_policy_event_and_taper`, `trail_policy_hard_boundaries`
+- **Evidence claims:** `non-ultra-trail.hr-and-road-pace-not-sole-targets`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `eligibility.current-symptoms-support-stop-not-clearance`
+
+</details>
+
+#### `deterministic-complete-v2-receipt` — Adopt the five-status exhaustive deterministic receipt
+
+- **Question:** Should every safely classified evaluation return one status by fixed precedence, the first cataloged primary detail, every matching reason, and a separate sorted limited-module set?
+- **Proposed decision:** Accept the exact status, detail, namespacing, de-duplication, ordering, independent-evaluation, and module serialization rules from Product v2 as reversible operational guardrails.
+- **Approval means:**
+  - Clients receive one next-action status without losing simultaneous lower-precedence findings.
+  - Malformed fields are never dereferenced merely to fill the receipt.
+- **This does not authorize:**
+  - A biological readiness score, risk rank, hidden reason, client-created reason, or eligibility from an empty module list.
+
+<details><summary>Traceability: 1 contract group, 2 evidence claims</summary>
+
+- **Contract groups covered:** `trail_policy_typed_outcomes`
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `eligibility.recent-history-anchor-without-universal-threshold`
+
+</details>
+
+#### `inactive-evaluation-and-role-boundary` — Preserve dry-run checks and require separate authority for all exposure
+
+- **Question:** Should deterministic zero-tolerance dry-run checks remain available while every owner, provider, deployment, and runtime action stays under separate Product, Trust, Quality, Operations, and human authority?
+- **Proposed decision:** Carry the accepted evaluation thresholds and non-Science boundary forward without starting observation, pilot, delivery, or activation.
+- **Approval means:**
+  - Inactive verification can detect invariant or replay failures before any exposure.
+- **This does not authorize:**
+  - Collecting value telemetry, starting owner dogfood, sending workouts, deploying, or activating.
+
+<details><summary>Traceability: 2 contract groups, 2 evidence claims</summary>
+
+- **Contract groups covered:** `trail_policy_runtime_evaluation`, `trail_policy_non_science_authority`
+- **Evidence claims:** `non-ultra-trail.injury-fatigue-no-safe-dose`, `eligibility.fixed-progression-and-acwr-not-safety-laws`
+
+</details>
+
+### Decisions explicitly deferred
+
+#### `unresolved-dose-and-scope-stays-deferred` — Keep taper, progression, fixed dose, and wider authority unaccepted
+
+- **Question:** Should every literal not_accepted value in the event, deferred-scope, and non-Science authority groups remain unavailable?
+- **Proposed decision:** Retain all existing deferrals and require a future evidence-consistent successor plus role-scoped review before any expansion.
+- **Approval means:**
+  - The v2 receipt cannot turn descriptive context into a prescription or activation path.
+- **This does not authorize:**
+  - Taper, progression, fixed dose, broader scope, provider behavior, deployment, or activation.
+
+<details><summary>Traceability: 3 contract groups, 4 evidence claims</summary>
+
+- **Contract groups covered:** `trail_policy_event_and_taper`, `trail_policy_deferred_scope`, `trail_policy_non_science_authority`
+- **Evidence claims:** `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
+
+</details>
+
+## Approval statement
+
+A decision approval bound to the displayed digest attests:
+
+> I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt and sorted limited modules as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+
+- **Decision approval:** _Pending_
+
+### Decision approval
+
+Approve in this GitHub comment format or in an authenticated agent session. For session approval, the agent mirrors this exact statement to the human-authenticated PR comment before automation records the YAML and lifecycle transition.
+
+```markdown
+Praxys science approval — **APPROVE**
+
+- Role: `decision_approver`
+- Subject: `sdr-non-ultra-trail-plan-generation-policy-v2`
+- Digest: `sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40`
+
+> I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt and sorted limited modules as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+
+<!-- praxys-science-approval:v1
+{"role":"decision_approver","subject_digest":"sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40","subject_id":"sdr-non-ultra-trail-plan-generation-policy-v2","subject_kind":"science_decision"}
+-->
+```
+
+## Audit appendix
+
+<details><summary>Evidence, parameters, alternatives, limits, and validation</summary>
+
+### Accepted interpretation
+
+If separately accepted after the ontology successor, this record would bind the accepted history-rich adult non-ultra Trail policy to trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing any accepted v1 execution, history, schedule, workout-template, intensity, exposure, event-window, taper deferral, or hard scientific boundary. The fourteen-day proposal, seven-day reassessment, eight-week history window, four usable weeks, three-run usable-week floor, ten-day recent-run check, 42/21-day comparable-history checks, no-initial-progression schedule, targetless 38-minute controlled-uphill template, 75-percent low-intensity floor, one nonconsecutive quality exposure, and separate history-anchored ascent/descent caps remain reversible Praxys guardrails rather than published optima or safety laws. A deterministic v2 receipt returns exactly one of five statuses, one cataloged primary detail when applicable, every independently safe matching reason, and sorted limited modules. It never hides a lower-precedence reason, interprets malformed data to manufacture more reasons, selects a road fallback, uses activity-average power, or authorizes a provider or runtime behavior. Taper, progression above history, fixed fueling, strength, hiking, technical-terrain or recovery dose, back-to-back sessions, universal targets, and personal performance or safety predictions remain unaccepted.
+
+### Linked evidence
+
+#### `trail-ontology.course-demand-is-multidimensional` — moderate
+
+Trail-running performance and exposure are course-specific and multifactorial. Distance alone does not preserve elevation, grade, surface, technicality, altitude, environment, event format, or support.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `scheer-2020-off-road-definition`, `de-waal-2021-performance-review`, `pastor-2022-distance-determinants`, `scheer-2019-threshold-prediction`
+- **Limitations:** The literature does not provide one validated machine-readable schema.; Performance associations do not establish individual plan dose.
+
+#### `trail-ontology.uphill-downhill-demands-differ` — moderate
+
+Uphill and downhill running impose different metabolic, biomechanical, and neuromuscular demands; total elevation gain cannot stand in for descent exposure or grade distribution.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `minetti-2002`, `bjorklund-2019-short-trail`, `lemire-2021-downhill-fatigue`, `lemire-2022-slope-energy-cost`
+- **Limitations:** Studies use small, selected samples and specific grades.; Results do not validate a universal vertical conversion or progression rate.
+
+#### `trail-ontology.technicality-and-downhill-vary-performance` — low
+
+Technical terrain and downhill sections can materially change between- runner performance and mechanical exposure, so technicality and descent cannot be inferred safely from distance and gain alone.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `bjorklund-2019-short-trail`, `de-waal-2021-performance-review`, `genitrini-2024-race-stage`
+- **Limitations:** Technicality measurement is inconsistent across studies.; The evidence does not establish an exact technical-terrain training dose.
+
+#### `trail-ontology.heart-rate-and-road-pace-are-insufficient-alone` — low
+
+Rapidly changing slope can decouple heart rate and level-running pace from the metabolic and mechanical demands of hilly running; neither is a sufficient sole representation of course demand or training intensity.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `born-2017-hilly-intensity`, `lemire-2022-slope-energy-cost`
+- **Limitations:** Small studies do not invalidate athlete-specific heart-rate or pace context in all settings.; NIRS findings do not authorize a consumer prescription.
+
+#### `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose` — low
+
+Direct trail-training evidence is small, and trail-injury evidence is heterogeneous and substantially observational. Neither establishes a universal safe downhill, vertical, technical-terrain, or weekly progression dose, an individualized injury probability, or an injury-prevention guarantee.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `drum-2023-trail-road-rct`, `viljoen-2022-risk-factors`
+- **Limitations:** The randomized study found no significant group-by-time interactions.; Observational injury associations do not establish causal prevention rules.; This absence of a validated universal dose does not show that every exposure is equally appropriate.
+
+#### `non-ultra-trail.course-specific-policy-required` — moderate
+
+Trail performance and training demand are course-specific and multifactorial. A policy must match an explicit course-demand vector and comparable exposure rather than distance, level pace, or one physiological marker alone.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `de-waal-2021-performance-review`, `pastor-2022-distance-determinants`, `bjorklund-2019-short-trail`
+- **Limitations:** Associations and prediction models do not establish causal training dose.; The reviewed courses and populations are heterogeneous.
+
+#### `non-ultra-trail.uphill-downhill-require-distinct-handling` — moderate
+
+Uphill and downhill running have materially different metabolic, mechanical, cardiovascular, and neuromuscular profiles. Training history and proposed exposure should therefore preserve ascent, descent, grade, and technical context separately.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `bjorklund-2019-short-trail`, `lemire-2021-downhill-fatigue`, `lemire-2022-slope-energy-cost`
+- **Limitations:** Small studies at specific grades do not establish universal progression.; Comparable oxygen uptake does not imply comparable mechanical cost.
+
+#### `non-ultra-trail.hr-and-road-pace-not-sole-targets` — low
+
+Heart rate can lag or fail to reflect rapid slope-dependent changes, and level-running pace does not preserve trail mechanical demand. Neither should be the sole driver of a hilly or technical prescription.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `born-2017-hilly-intensity`, `lemire-2022-slope-energy-cost`
+- **Limitations:** This does not prohibit contextual athlete-specific HR or pace use.; No reviewed evidence validates one universal trail RPE, power, HR, or pace equivalence.
+
+#### `non-ultra-trail.training-specificity-promising-not-prescriptive` — low
+
+Trail-specific and multimodal training can be plausible modules, but the reviewed interventions are too small and heterogeneous to establish a universal session mix, weekly frequency, vertical dose, or superiority over road training.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `drum-2023-trail-road-rct`, `panthong-2026-masters-training`
+- **Limitations:** The trail-versus-road study found no significant group-by-time interactions.; The masters trial does not define a universal plan or transfer to every age and course.
+
+#### `non-ultra-trail.injury-fatigue-no-safe-dose` — low
+
+Trail racing is associated with heterogeneous injury, illness, muscular, and neuromuscular stress observations, but current evidence does not establish a universal injury-preventive plan, safe downhill dose, recovery interval, or progression percentage.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `viljoen-2022-risk-factors`, `garcia-valiente-2026-damage-review`
+- **Limitations:** Associations do not establish causality or individual safety.; Race biomarkers cannot be converted into medical clearance or training readiness.
+
+#### `non-ultra-trail.observed-load-does-not-prove-prescription` — very_low
+
+Observed trail workload and pacing associations may inform descriptive context, but they do not validate ACWR zones, fixed taper behavior, activity-average-power intensity, or an individual causal prescription.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `matos-2020-load-profiles`
+- **Limitations:** Small observational male sample and heterogeneous events.; Correlation and group averages do not select individual dose.
+
+#### `non-ultra-trail.taper-direction-indirect` — moderate
+
+Broader endurance evidence supports a pre-event reduction in training volume while generally retaining intensity and frequency, but it does not validate one trail-specific taper duration, reduction percentage, or personal performance gain.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `wang-2023`
+- **Limitations:** Mixed sports and protocols rather than direct non-ultra trail trials.; Subgroup estimates cannot be treated as an individual optimum.
+
+#### `non-ultra-trail.fueling-duration-and-practice-context` — moderate
+
+During-exercise carbohydrate strategy depends on expected duration and tolerance, and practice can reduce gastrointestinal problems in some endurance contexts. Distance alone does not select a fueling prescription.
+
+- **Evidence Review:** `evidence-non-ultra-trail-plan-generation-policy-v1`
+- **Sources:** `burke-2011`, `martinez-2023`
+- **Limitations:** Numeric guidance is not trail-course specific.; Practice does not guarantee tolerance or performance for an individual.
+
+#### `eligibility.recent-history-anchor-without-universal-threshold` — moderate
+
+Abrupt weekly or single-session distance increases are associated with higher running-related injury rates, while the reviewed evidence is heterogeneous and does not establish one universal safe increase. Recent consistency and recent longest-session history are therefore relevant eligibility dimensions, not validated prescription cutoffs.
+
+- **Evidence Review:** `evidence-plan-generation-eligibility-safety-v1`
+- **Sources:** `damsted-2019`, `frandsen-2025`, `correia-2024`
+- **Limitations:** These studies do not establish causation or an individual safety threshold.; The weekly association was significant at 21 days but not later follow-up points.; The single-session cohort used self-reported injury outcomes and did not validate an automatic plan rule.; The umbrella review found only critically low or low-quality systematic reviews.
+
+#### `eligibility.fixed-progression-and-acwr-not-safety-laws` — moderate
+
+A novice-running program based on the 10 percent rule did not reduce running-related injury compared with a standard program, and acute-to- chronic workload-ratio zones lack established causal support for individual training recommendations. Neither should be used as a universal plan-generation safety law.
+
+- **Evidence Review:** `evidence-plan-generation-eligibility-safety-v1`
+- **Sources:** `buist-2008`, `impellizzeri-2020`
+- **Limitations:** The trial does not show that every faster progression is safe.; Injury outcomes do not determine an optimal performance progression.; The critique does not make recent training history irrelevant or validate a replacement threshold.
+
+#### `eligibility.goal-relevant-current-capability-task-specific` — moderate
+
+Current performance evidence is most interpretable when the task and protocol match the intended outcome. Fixed-distance time trials are generally more reliable than time-to-exhaustion tests, supporting an explicit goal-relevant current-capability axis rather than automatic substitution from a different test protocol.
+
+- **Evidence Review:** `evidence-plan-generation-eligibility-safety-v1`
+- **Sources:** `currell-2008`, `laursen-2007`
+- **Limitations:** The sources do not make solo time trials and races automatically interchangeable.; They do not validate a universal baseline freshness cutoff.; They do not define Praxys capability-state labels or a cross-distance conversion.
+
+#### `eligibility.current-symptoms-support-stop-not-clearance` — low
+
+Current signs and symptoms are relevant before vigorous exercise. This supports a conservative, non-medical fail-closed stop before a vigorous plan or maximal field-test path, but does not support diagnosis, treatment, clearance, or return-to-sport advice.
+
+- **Evidence Review:** `evidence-plan-generation-eligibility-safety-v1`
+- **Sources:** `riebe-2015`
+- **Limitations:** The source is not a validation study of Praxys symptom wording or automatic generation.; Absence of a reported symptom does not establish that vigorous exercise is risk-free.; The policy cannot infer a medical state from training behavior.
+
+### Reviewed parameters
+
+#### `trail_policy_scope_and_dependencies` — guardrail
+
+- **Applies to:** non-ultra-trail-plan-generation-policy-v2
+- **Evidence claims:** `non-ultra-trail.course-specific-policy-required`, `eligibility.goal-relevant-current-capability-task-specific`
+- **Rationale:** Only dependency and schema identities change. The narrow v1 population and intent remain unchanged; exact revisions are operational replay guardrails rather than published eligibility thresholds.
+- **Exact value:**
+
+```json
+{
+  "clinical_or_return_to_sport": false,
+  "distance_family": "non_ultra",
+  "event_format": "single_day",
+  "intent": "performance",
+  "minimum_age_years": 18,
+  "requires_accepted_ontology": "sdr-trail-running-goal-ontology-v2",
+  "requires_confirmed_constraint_revision": true,
+  "requires_confirmed_course_revision": true,
+  "requires_constraint_schema": "non_ultra_trail_constraints_v2",
+  "requires_course_demand_schema": "trail_course_demand_v2",
+  "requires_server_derived_history_revision": true,
+  "suggestion_only": true
+}
+```
+
+#### `trail_policy_required_inputs` — guardrail
+
+- **Applies to:** v2 capability matching and readiness
+- **Evidence claims:** `non-ultra-trail.course-specific-policy-required`, `non-ultra-trail.uphill-downhill-require-distinct-handling`, `eligibility.recent-history-anchor-without-universal-threshold`
+- **Rationale:** The v2 names make the accepted course, access, and history boundary explicit without changing history thresholds or inventing a dose.
+- **Exact value:**
+
+```json
+{
+  "client_supplied_history_allowed": false,
+  "conditional": [
+    "grade_distribution",
+    "course_footing",
+    "altitude_and_environment_context",
+    "aid_and_support_context",
+    "fueling_practice_experience"
+  ],
+  "material_unknown_behavior": "canonical_status_or_named_limited_module",
+  "required": [
+    "athlete_confirmed_trail_course_demand_v2",
+    "athlete_confirmed_non_ultra_trail_constraints_v2",
+    "stable_recent_running_history",
+    "comparable_recent_ascent_exposure",
+    "comparable_recent_descent_exposure",
+    "available_training_days_and_limits",
+    "accessible_training_terrain",
+    "current_symptom_stop"
+  ],
+  "server_derived": [
+    "recent_running_continuity",
+    "recent_ascent_exposure",
+    "recent_descent_exposure",
+    "recently_observed_footing"
+  ]
+}
+```
+
+#### `trail_policy_execution_and_reassessment` — guardrail
+
+- **Applies to:** early non-ultra Trail rolling proposals
+- **Evidence claims:** `eligibility.recent-history-anchor-without-universal-threshold`, `non-ultra-trail.course-specific-policy-required`
+- **Rationale:** Carried unchanged from accepted v1. Fourteen days is the Product-selected minimum complete two-unit experience and seven days is an advisory review point; neither is a biological optimum.
+- **Exact value:**
+
+```json
+{
+  "advisory_reassessment_after_completed_days": 7,
+  "automatic_overwrite_of_adopted_future_days": false,
+  "automatic_successor_adoption": false,
+  "biological_optimum_claim": false,
+  "calendar_schedule_unit_days": 7,
+  "committed_proposal_days": 14,
+  "continued_goal_horizon_requires_successor": true,
+  "each_successor_requires_fresh_history_course_and_constraints": true,
+  "proposal_end_inclusive": true
+}
+```
+
+#### `trail_policy_history_guardrails` — guardrail
+
+- **Applies to:** owner-scoped readiness history
+- **Evidence claims:** `eligibility.recent-history-anchor-without-universal-threshold`, `non-ultra-trail.course-specific-policy-required`, `non-ultra-trail.uphill-downhill-require-distinct-handling`
+- **Rationale:** Carried unchanged from accepted v1. The counts prevent extrapolation from sparse records and remain conservative qualifications, not safety, adaptation, or readiness laws.
+- **Exact value:**
+
+```json
+{
+  "comparable_hilly_or_trail_sessions_within_completed_days": {
+    "count": 2,
+    "window": 42
+  },
+  "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
+  "latest_run_within_completed_days": 10,
+  "minimum_running_sessions_per_usable_week": 3,
+  "minimum_usable_completed_weeks": 4,
+  "qualifying_activity_requires": [
+    "outdoor_running_or_trail_running",
+    "positive_duration_and_distance",
+    "usable_elevation_gain_and_loss_or_explicit_unknown",
+    "source_timestamp"
+  ],
+  "recent_history_lookback_completed_weeks": 8,
+  "sparse_or_stale_result": "insufficient_comparable_trail_history",
+  "thresholds_are_published_biological_laws": false,
+  "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
+}
+```
+
+#### `trail_policy_schedule_construction` — guardrail
+
+- **Applies to:** deterministic early-block schedule
+- **Evidence claims:** `eligibility.fixed-progression-and-acwr-not-safety-laws`, `non-ultra-trail.training-specificity-promising-not-prescriptive`
+- **Rationale:** Carried unchanged from accepted v1. Median, maximum, and athlete caps organize existing exposure without automatic progression; one quality session is a conservative Product choice, not a universal optimum.
+- **Exact value:**
+
+```json
+{
+  "below_minimum_result": "no_schedule_within_envelope",
+  "easy_and_longest_easy_allocation": {
+    "automatic_longest_easy_increase": false,
+    "preferred_longest_easy_day_used_when_available": true,
+    "quality_minutes_allocated_first": true,
+    "remaining_minutes_distributed_across_non_quality_days": true
+  },
+  "no_schedule_result": "no_schedule_within_envelope",
+  "non_taper_progression_above_recent_median": false,
+  "quality_sessions_per_7_day_unit": 1,
+  "requested_above_maximum_result": "clarification_required",
+  "selected_running_days_per_7_day_unit": {
+    "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
+    "maximum": 6,
+    "minimum": 3
+  },
+  "session_duration_hard_cap": "minimum_of_recent_maximum_completed_session_and_athlete_limit",
+  "target_time_gap_may_raise_load": false,
+  "weekly_running_minutes_hard_cap": "minimum_of_recent_maximum_usable_weekly_minutes_and_athlete_limit",
+  "weekly_running_minutes_target": "minimum_of_recent_median_usable_weekly_minutes_and_athlete_limit"
+}
+```
+
+#### `trail_policy_workout_templates` — guardrail
+
+- **Applies to:** eligible early-block quality session
+- **Evidence claims:** `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.hr-and-road-pace-not-sole-targets`, `non-ultra-trail.uphill-downhill-require-distinct-handling`
+- **Rationale:** Carried unchanged from accepted v1. The targetless uphill template is a transparent reversible Product guardrail and prescribes no downhill speed or universal target zone.
+- **Exact value:**
+
+```json
+{
+  "controlled_quality": {
+    "steps": [
+      {
+        "duration_minutes": 10,
+        "intended_intensity": "low",
+        "kind": "step",
+        "phase": "warmup"
+      },
+      {
+        "kind": "repeat",
+        "repetitions": 4,
+        "steps": [
+          {
+            "duration_minutes": 3,
+            "intended_intensity": "controlled_uphill_effort",
+            "kind": "step",
+            "phase": "work"
+          },
+          {
+            "duration_minutes": 2,
+            "intended_intensity": "low",
+            "kind": "step",
+            "phase": "recovery"
+          }
+        ]
+      },
+      {
+        "duration_minutes": 8,
+        "intended_intensity": "low",
+        "kind": "step",
+        "phase": "cooldown"
+      }
+    ],
+    "template_id": "trail-controlled-uphill-quality-v1",
+    "total_planned_minutes": 38
+  },
+  "downhill_recovery_may_be_prescribed": false,
+  "easy": "duration_only_with_optional_accessible_terrain_category",
+  "exact_hr_pace_power_or_rpe_target": false,
+  "longest_easy": "duration_only_with_observed_duration_and_course_exposure_caps",
+  "target_expression": "duration_phase_and_effort_label_only",
+  "template_must_fit_history_constraint_and_exposure_caps": true,
+  "template_optimum_claim": false,
+  "work_step_requires_accessible_non_technical_uphill": true
+}
+```
+
+#### `trail_policy_intensity_and_spacing` — guardrail
+
+- **Applies to:** all planned running minutes
+- **Evidence claims:** `non-ultra-trail.hr-and-road-pace-not-sole-targets`, `non-ultra-trail.training-specificity-promising-not-prescriptive`
+- **Rationale:** Carried unchanged from accepted v1. The floor, ceiling, and spacing are conservative no-progression guardrails, not published universal values.
+- **Exact value:**
+
+```json
+{
+  "activity_average_power_allowed": false,
+  "consecutive_quality_running_days_allowed": false,
+  "historical_intensity_source_priority": [
+    "activity_splits",
+    "activity_samples"
+  ],
+  "low_intensity_fraction_is_optimum_claim": false,
+  "maximum_quality_exposures_per_7_day_unit": 1,
+  "minimum_intervening_easy_rest_or_non_running_days": 1,
+  "minimum_planned_low_intensity_running_minutes_fraction": 0.75,
+  "missed_quality_makeup_allowed": false,
+  "quality_exposures_include": [
+    "controlled_quality_template",
+    "confirmed_race_or_maximal_effort"
+  ],
+  "reduce_or_remove_quality_before_adding_minutes": true
+}
+```
+
+#### `trail_policy_course_exposure_caps` — guardrail
+
+- **Applies to:** early-block terrain and vertical exposure
+- **Evidence claims:** `non-ultra-trail.uphill-downhill-require-distinct-handling`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `eligibility.fixed-progression-and-acwr-not-safety-laws`
+- **Rationale:** Carried unchanged from accepted v1. Separate observed ascent, descent, and terrain caps avoid inventing a conversion, dose, or progression.
+- **Exact value:**
+
+```json
+{
+  "automatic_vertical_progression": false,
+  "high_speed_or_maximal_downhill_repeats": false,
+  "road_or_flat_substitution_claimed_equivalent": false,
+  "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
+  "session_descent_hard_cap": "recent_maximum_completed_session_descent",
+  "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
+  "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+  "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
+  "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
+  "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
+  "weekly_descent_target": "no_more_than_recent_median_usable_weekly_descent"
+}
+```
+
+#### `trail_policy_event_and_taper` — guardrail
+
+- **Applies to:** dated Trail goals
+- **Evidence claims:** `non-ultra-trail.taper-direction-indirect`
+- **Rationale:** Carried unchanged from accepted v1. General endurance evidence remains insufficient to select a Trail-specific taper; the event-near path fails closed pending a successor decision.
+- **Exact value:**
+
+```json
+{
+  "event_day_generated_as_training_workout": false,
+  "event_or_race_counts_as_quality_and_load": true,
+  "imported_event_must_be_athlete_confirmed": true,
+  "taper_implementation": "not_accepted",
+  "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
+  "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+}
+```
+
+#### `trail_policy_typed_outcomes` — guardrail
+
+- **Applies to:** v2 validation, policy availability, readiness, and proposal eligibility receipts
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `eligibility.recent-history-anchor-without-universal-threshold`
+- **Rationale:** The evidence supports explicit missingness and bounded applicability, but the five statuses, exact reason catalog, precedence, and serialization are reversible Product-selected operational guardrails rather than a biological readiness or risk model.
+- **Exact value:**
+
+```json
+{
+  "authorization_failures_occur_before_product_receipt": true,
+  "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
+  "detail_reason_catalog": {
+    "clarification_required": [
+      "material_course_demand_unknown",
+      "assumption_confirmation_required",
+      "adult_scope_or_constraints_unconfirmed",
+      "training_constraints_missing",
+      "contradictory_input"
+    ],
+    "eligible_proposal": [],
+    "policy_unavailable": [
+      "policy_inactive",
+      "event_inside_unapproved_taper_window",
+      "unsupported_ultra_or_multiday",
+      "unsupported_population_or_intent",
+      "technical_features_outside_v2"
+    ],
+    "readiness_blocked": [
+      "insufficient_recent_running_history",
+      "insufficient_comparable_trail_history",
+      "insufficient_descent_history",
+      "insufficient_terrain_access",
+      "current_symptom_stop",
+      "no_schedule_within_envelope"
+    ],
+    "validation_failed": [
+      "invalid_field_value",
+      "schema_version_mismatch",
+      "deterministic_invariant_failed"
+    ]
+  },
+  "goal_remains_recorded": true,
+  "limited_modules": {
+    "allowed_sorted_order": [
+      "environment_altitude",
+      "fueling",
+      "grade_specificity",
+      "technical_terrain"
+    ],
+    "changes_top_level_status": false,
+    "empty_means_eligible": false,
+    "generic_or_road_replacement_allowed": false,
+    "hides_matching_reason": false,
+    "serialize_sorted": true,
+    "set_semantics": true
+  },
+  "matching_reasons": {
+    "de_duplicate": true,
+    "include_every_independently_and_safely_evaluable_match": true,
+    "independently_evaluable_lower_precedence_reasons_preserved": true,
+    "malformed_value_may_be_dereferenced_to_find_more_reasons": false,
+    "order_by": [
+      "status_precedence",
+      "detail_reason_catalog_order"
+    ],
+    "pair_fields": [
+      "status",
+      "detail_reason"
+    ]
+  },
+  "namespaced_reason_identity": "<status>.<detail_reason>",
+  "road_fallback": false,
+  "status_precedence": [
+    "validation_failed",
+    "policy_unavailable",
+    "readiness_blocked",
+    "clarification_required",
+    "eligible_proposal"
+  ],
+  "top_level_status": "highest_precedence_matching_status"
+}
+```
+
+#### `trail_policy_modular_structure` — guardrail
+
+- **Applies to:** future deterministic generator envelope
+- **Evidence claims:** `non-ultra-trail.uphill-downhill-require-distinct-handling`, `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
+- **Rationale:** Carried unchanged from accepted v1. Modular handling preserves distinct demands and uncertainty without claiming one universal Trail schedule.
+- **Exact value:**
+
+```json
+{
+  "module_requires_matching_input": true,
+  "modules": [
+    "readiness_and_history",
+    "easy_and_aerobic",
+    "ascent_specificity",
+    "descent_and_neuromuscular_exposure",
+    "technical_terrain",
+    "hiking",
+    "strength",
+    "longest_session_and_fueling_practice",
+    "taper",
+    "environment_and_altitude",
+    "reassessment_and_outcome"
+  ],
+  "unavailable_module_may_be_silently_replaced": false
+}
+```
+
+#### `trail_policy_evidence_use` — guardrail
+
+- **Applies to:** module selection and ScienceNote claims
+- **Evidence claims:** `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `non-ultra-trail.observed-load-does-not-prove-prescription`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
+- **Rationale:** Carried unchanged from accepted v1. This keeps evidence-supported directions separate from exact prescriptions the sources do not establish.
+- **Exact value:**
+
+```json
+{
+  "fueling": "expected_duration_and_practice_context_only",
+  "hiking": "conditional_candidate_module",
+  "injury_and_fatigue_findings": "safety_context_only",
+  "observed_load_associations": "descriptive_only",
+  "strength_and_multimodal": "conditional_candidate_module",
+  "taper": "indirect_direction_only",
+  "trail_specificity": "conditional_candidate_module"
+}
+```
+
+#### `trail_policy_hard_boundaries` — guardrail
+
+- **Applies to:** all future policy and implementation surfaces
+- **Evidence claims:** `non-ultra-trail.hr-and-road-pace-not-sole-targets`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `eligibility.fixed-progression-and-acwr-not-safety-laws`, `eligibility.current-symptoms-support-stop-not-clearance`
+- **Rationale:** Carried unchanged from accepted v1. These boundaries prevent unsupported inference, hidden load escalation, medical claims, and authority expansion.
+- **Exact value:**
+
+```json
+{
+  "activity_average_power_valid_for_intensity": false,
+  "canonical_adoption_requires_explicit_athlete_action": true,
+  "diagnosis_or_clearance": false,
+  "heart_rate_or_level_pace_may_be_sole_hilly_controller": false,
+  "missed_work_may_create_catch_up": false,
+  "performance_injury_or_safety_guarantee": false,
+  "personal_finish_probability": false,
+  "provider_delivery_requires_separate_explicit_consent": true,
+  "road_policy_fallback": false,
+  "target_gap_may_raise_dose": false,
+  "universal_ascent_descent_equivalence": false,
+  "universal_distance_vertical_conversion": false,
+  "valid_intensity_sources": [
+    "activity_splits",
+    "activity_samples"
+  ]
+}
+```
+
+#### `trail_policy_deferred_scope` — guardrail
+
+- **Applies to:** scope outside the early rolling block
+- **Evidence claims:** `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
+- **Rationale:** Carried unchanged from accepted v1. These higher-load, event-near, fixed-dose, and target-specific behaviors need a future decision.
+- **Exact value:**
+
+```json
+{
+  "back_to_back_sessions": "not_accepted",
+  "fueling_amount_or_frequency": "not_accepted",
+  "hiking_threshold_or_dose": "not_accepted",
+  "hr_pace_power_or_rpe_targets": "not_accepted",
+  "outcome_window_or_meaningful_change": "not_accepted",
+  "progression_above_recent_typical_load": "not_accepted",
+  "recovery_interval": "not_accepted",
+  "strength_frequency_or_dose": "not_accepted",
+  "taper_duration_and_reduction": "not_accepted",
+  "technical_terrain_dose": "not_accepted",
+  "vertical_or_downhill_progression_above_recent_history": "not_accepted"
+}
+```
+
+#### `trail_policy_runtime_evaluation` — guardrail
+
+- **Applies to:** inactive dry run and separately authorized owner pilot
+- **Evidence claims:** `non-ultra-trail.injury-fatigue-no-safe-dose`, `eligibility.fixed-progression-and-acwr-not-safety-laws`
+- **Rationale:** Carried unchanged from accepted v1. These are evaluation guardrails for inactive verification or a separately authorized future pilot; this successor authorizes neither exposure nor value telemetry.
+- **Exact value:**
+
+```json
+{
+  "dry_run": {
+    "deterministic_invariant_breach_tolerance": 0,
+    "replay_mismatch_tolerance": 0,
+    "unsupported_or_material_unknown_plan_tolerance": 0
+  },
+  "efficacy_or_safety_claim_from_process_pilot": false,
+  "owner_only_pilot": {
+    "major_edit_definition": "session_duration_or_vertical_change_over_twenty_percent_or_two_scheduled_days_changed",
+    "maximum_major_edit_fraction": 0.3,
+    "serious_plausibly_related_report_pause_threshold": 1
+  },
+  "pause_or_revise_when_threshold_crossed": true
+}
+```
+
+#### `trail_policy_non_science_authority` — guardrail
+
+- **Applies to:** work outside Science authority
+- **Evidence claims:** _None; product rationale only_
+- **Rationale:** Science cannot originate or widen Product, Design, Engineering, Trust, Quality, Operations, provider, rollout, or activation authority.
+- **Exact value:**
+
+```json
+{
+  "deployment": "not_accepted",
+  "implementation_review": "required",
+  "lifecycle_supersession": "not_accepted",
+  "owner_only_pilot": "not_accepted",
+  "product_visibility_or_catalog": "not_accepted",
+  "production_data_use": "not_accepted",
+  "provider_mapping_or_delivery": "not_accepted",
+  "runtime_activation": "not_accepted"
+}
+```
+
+### Rejected alternatives
+
+#### Change the readiness receipt while also tuning the training schedule
+
+That would confound an input/output contract repair with unreviewed dose and make the v1-to-v2 training envelope impossible to audit.
+
+#### Return only the highest-precedence reason
+
+One reason would hide other safely evaluable actions and make the receipt unstable as fields are corrected.
+
+#### Let clients invent reason strings or infer eligibility from module limits
+
+Client-specific interpretation would break replay and could transform an omitted module into a false readiness claim.
+
+#### Use a road policy, route inference, provider payload, or AI output to complete missing Trail input
+
+Those inputs and fallbacks are outside the accepted evidence and privacy boundary and cannot manufacture an exact capability match.
+
+### Applicability
+
+- Adults with stable recent comparable running, ascent, descent, and Trail exposure
+- Single-day non-ultra Trail performance intent
+- Complete confirmed trail_course_demand_v2 and non_ultra_trail_constraints_v2 revisions
+- Server-derived owner-scoped recent-history snapshot
+- Suggestion-only plan proposals and scientific claim limits
+
+### User-facing claim limits
+
+- Do not present the five statuses, reason order, module list, DTO values, or exact v1 guardrails as a biological readiness score, validated safe dose, or scientific optimum.
+- Do not present the policy as a road plan adjusted for elevation or infer route, grade, footing, or course demand from provider data.
+- Do not claim one universal vertical, descent, technicality, hiking, strength, long-session, taper, fueling, recovery, HR, pace, power, or RPE dose.
+- Do not use heart rate, road pace, ACWR, or activity-average power as a sole or safety-validating controller.
+- Do not show a personal finish probability, target guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance.
+
+### Safety implications
+
+- Current symptoms stop performance optimization and route outside this nonclinical policy without creating a diagnosis.
+- Missing core course demand, history, schedule, hazard, or terrain access fails closed; only ontology-approved non-core unknowns can limit a named module.
+- No catch-up, target-gap load escalation, fixed progression law, road fallback, route inference, or provider completion is allowed.
+- Downhill and technical exposure stay within the accepted separate history-anchored bounds.
+- A complete reason receipt does not weaken the highest-precedence status or permit unsafe dereferencing of malformed fields.
+
+### Privacy implications
+
+- Consume only normalized confirmed v2 course/constraint revisions and owner-scoped aggregate history snapshots required for deterministic replay.
+- Do not copy raw activities, samples, GPS, routes, free text, provider payloads or identifiers, device identifiers, or target values into generic audit or telemetry.
+- Activity-average power is neither collected nor used as readiness or intensity evidence.
+- Owner-scoped goal, readiness, proposal, adoption, reset, export, deletion, and account-deletion controls remain mandatory.
+
+### Validation plan
+
+- Prove every execution, history, schedule, template, intensity, exposure, event, and hard-boundary value is structurally equal to the accepted v1 contract except the named v2 dependency and receipt groups.
+- Exhaustively exercise every status and detail reason, every pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, and sorted limited modules.
+- Verify malformed values are not dereferenced while all independently safe policy, history, schedule, and missingness reasons remain present.
+- Unit-test history qualification, schedule allocation, targetless template steps, low-intensity fraction, quality spacing, and separate ascent/descent/terrain caps against immutable owner-scoped snapshots.
+- Verify no proposal is returned from an inactive contract, a core unknown, a failed gate, a stale revision, route/provider input, or any road fallback.
+- Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests.
+
+### Falsification conditions
+
+- Any accepted v1 execution, history, schedule, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency and receipt groups.
+- Status selection, primary detail, matching-reason ordering, de-duplication, or limited-module sorting is nondeterministic or loses a safely evaluable reason.
+- A malformed field is interpreted to manufacture a reason, or a core unknown or failed gate produces eligible_proposal.
+- An exact value outside the accepted early-block guardrails is inferred despite literal not_accepted status.
+- Uphill and downhill collapse, terrain or history access is ignored, or an unsupported module is silently substituted.
+- Activity-average power, ACWR, road pace, or heart rate becomes a safe sole controller, or a personal performance, safety, injury, diagnosis, or clearance claim appears.
+- The generated contract becomes active or any provider/runtime behavior appears without separate role-scoped authority.
+
+### Decision notes
+
+- Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim.
+- Proposed predecessor transition: after separate digest-bound human approval and coordinated lifecycle review, this record may replace sdr-non-ultra-trail-plan-generation-policy-v1; no supersession link is active in this draft.
+- It depends on separate acceptance and coordinated lifecycle handling of sdr-trail-running-goal-ontology-v2.
+- Every exact value outside the v2 dependency and receipt groups is carried unchanged from accepted v1 and remains classified as a reversible Praxys guardrail.
+- Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.
+- Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.
+- Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.
+- Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168.
+
+</details>
+
+<details><summary>Exact machine contract — code consumption audit</summary>
+
+```json
+{
+  "affected_models": [
+    "inactive non-ultra Trail deterministic early-block policy v2",
+    "v2 Trail validation, readiness, and complete reason receipt",
+    "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
+  ],
+  "contract_digest": "sha256:2fb5776b13453937708a77f54c273c81f81f4ca265932e4e0eb0a7ac0da2064b",
+  "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
+  "decision_status": "draft",
+  "decision_version": 2,
+  "evidence_claim_ids": [
+    "trail-ontology.course-demand-is-multidimensional",
+    "trail-ontology.uphill-downhill-demands-differ",
+    "trail-ontology.technicality-and-downhill-vary-performance",
+    "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+    "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose",
+    "non-ultra-trail.course-specific-policy-required",
+    "non-ultra-trail.uphill-downhill-require-distinct-handling",
+    "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+    "non-ultra-trail.training-specificity-promising-not-prescriptive",
+    "non-ultra-trail.injury-fatigue-no-safe-dose",
+    "non-ultra-trail.observed-load-does-not-prove-prescription",
+    "non-ultra-trail.taper-direction-indirect",
+    "non-ultra-trail.fueling-duration-and-practice-context",
+    "eligibility.recent-history-anchor-without-universal-threshold",
+    "eligibility.fixed-progression-and-acwr-not-safety-laws",
+    "eligibility.goal-relevant-current-capability-task-specific",
+    "eligibility.current-symptoms-support-stop-not-clearance"
+  ],
+  "evidence_review_ids": [
+    "evidence-trail-running-goal-ontology-v1",
+    "evidence-non-ultra-trail-plan-generation-policy-v1",
+    "evidence-plan-generation-eligibility-safety-v1"
+  ],
+  "linked_evidence_digests": {
+    "evidence-non-ultra-trail-plan-generation-policy-v1": "sha256:51e9349704d969b6524b947311a04e585477cffd7071254a9d2859690d87d78e",
+    "evidence-plan-generation-eligibility-safety-v1": "sha256:e884907d33783edc6cdb16fd5504f7f10b6d68f968bfe7cf87e3f024b5bda773",
+    "evidence-trail-running-goal-ontology-v1": "sha256:60f0e785e4fc2b4226fed3bb30750191195cffbb0236b4a81d34431c0002c87a"
+  },
+  "model_version": "non-ultra-trail-plan-generation-policy-v2",
+  "parameters": {
+    "trail_policy_course_exposure_caps": {
+      "applies_to": "early-block terrain and vertical exposure",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws"
+      ],
+      "value": {
+        "automatic_vertical_progression": false,
+        "high_speed_or_maximal_downhill_repeats": false,
+        "road_or_flat_substitution_claimed_equivalent": false,
+        "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
+        "session_descent_hard_cap": "recent_maximum_completed_session_descent",
+        "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
+        "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+        "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
+        "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
+        "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
+        "weekly_descent_target": "no_more_than_recent_median_usable_weekly_descent"
+      }
+    },
+    "trail_policy_deferred_scope": {
+      "applies_to": "scope outside the early rolling block",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "value": {
+        "back_to_back_sessions": "not_accepted",
+        "fueling_amount_or_frequency": "not_accepted",
+        "hiking_threshold_or_dose": "not_accepted",
+        "hr_pace_power_or_rpe_targets": "not_accepted",
+        "outcome_window_or_meaningful_change": "not_accepted",
+        "progression_above_recent_typical_load": "not_accepted",
+        "recovery_interval": "not_accepted",
+        "strength_frequency_or_dose": "not_accepted",
+        "taper_duration_and_reduction": "not_accepted",
+        "technical_terrain_dose": "not_accepted",
+        "vertical_or_downhill_progression_above_recent_history": "not_accepted"
+      }
+    },
+    "trail_policy_event_and_taper": {
+      "applies_to": "dated Trail goals",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.taper-direction-indirect"
+      ],
+      "value": {
+        "event_day_generated_as_training_workout": false,
+        "event_or_race_counts_as_quality_and_load": true,
+        "imported_event_must_be_athlete_confirmed": true,
+        "taper_implementation": "not_accepted",
+        "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
+        "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+      }
+    },
+    "trail_policy_evidence_use": {
+      "applies_to": "module selection and ScienceNote claims",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "non-ultra-trail.observed-load-does-not-prove-prescription",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "value": {
+        "fueling": "expected_duration_and_practice_context_only",
+        "hiking": "conditional_candidate_module",
+        "injury_and_fatigue_findings": "safety_context_only",
+        "observed_load_associations": "descriptive_only",
+        "strength_and_multimodal": "conditional_candidate_module",
+        "taper": "indirect_direction_only",
+        "trail_specificity": "conditional_candidate_module"
+      }
+    },
+    "trail_policy_execution_and_reassessment": {
+      "applies_to": "early non-ultra Trail rolling proposals",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.recent-history-anchor-without-universal-threshold",
+        "non-ultra-trail.course-specific-policy-required"
+      ],
+      "value": {
+        "advisory_reassessment_after_completed_days": 7,
+        "automatic_overwrite_of_adopted_future_days": false,
+        "automatic_successor_adoption": false,
+        "biological_optimum_claim": false,
+        "calendar_schedule_unit_days": 7,
+        "committed_proposal_days": 14,
+        "continued_goal_horizon_requires_successor": true,
+        "each_successor_requires_fresh_history_course_and_constraints": true,
+        "proposal_end_inclusive": true
+      }
+    },
+    "trail_policy_hard_boundaries": {
+      "applies_to": "all future policy and implementation surfaces",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws",
+        "eligibility.current-symptoms-support-stop-not-clearance"
+      ],
+      "value": {
+        "activity_average_power_valid_for_intensity": false,
+        "canonical_adoption_requires_explicit_athlete_action": true,
+        "diagnosis_or_clearance": false,
+        "heart_rate_or_level_pace_may_be_sole_hilly_controller": false,
+        "missed_work_may_create_catch_up": false,
+        "performance_injury_or_safety_guarantee": false,
+        "personal_finish_probability": false,
+        "provider_delivery_requires_separate_explicit_consent": true,
+        "road_policy_fallback": false,
+        "target_gap_may_raise_dose": false,
+        "universal_ascent_descent_equivalence": false,
+        "universal_distance_vertical_conversion": false,
+        "valid_intensity_sources": [
+          "activity_splits",
+          "activity_samples"
+        ]
+      }
+    },
+    "trail_policy_history_guardrails": {
+      "applies_to": "owner-scoped readiness history",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.recent-history-anchor-without-universal-threshold",
+        "non-ultra-trail.course-specific-policy-required",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling"
+      ],
+      "value": {
+        "comparable_hilly_or_trail_sessions_within_completed_days": {
+          "count": 2,
+          "window": 42
+        },
+        "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
+        "latest_run_within_completed_days": 10,
+        "minimum_running_sessions_per_usable_week": 3,
+        "minimum_usable_completed_weeks": 4,
+        "qualifying_activity_requires": [
+          "outdoor_running_or_trail_running",
+          "positive_duration_and_distance",
+          "usable_elevation_gain_and_loss_or_explicit_unknown",
+          "source_timestamp"
+        ],
+        "recent_history_lookback_completed_weeks": 8,
+        "sparse_or_stale_result": "insufficient_comparable_trail_history",
+        "thresholds_are_published_biological_laws": false,
+        "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
+      }
+    },
+    "trail_policy_intensity_and_spacing": {
+      "applies_to": "all planned running minutes",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive"
+      ],
+      "value": {
+        "activity_average_power_allowed": false,
+        "consecutive_quality_running_days_allowed": false,
+        "historical_intensity_source_priority": [
+          "activity_splits",
+          "activity_samples"
+        ],
+        "low_intensity_fraction_is_optimum_claim": false,
+        "maximum_quality_exposures_per_7_day_unit": 1,
+        "minimum_intervening_easy_rest_or_non_running_days": 1,
+        "minimum_planned_low_intensity_running_minutes_fraction": 0.75,
+        "missed_quality_makeup_allowed": false,
+        "quality_exposures_include": [
+          "controlled_quality_template",
+          "confirmed_race_or_maximal_effort"
+        ],
+        "reduce_or_remove_quality_before_adding_minutes": true
+      }
+    },
+    "trail_policy_modular_structure": {
+      "applies_to": "future deterministic generator envelope",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "value": {
+        "module_requires_matching_input": true,
+        "modules": [
+          "readiness_and_history",
+          "easy_and_aerobic",
+          "ascent_specificity",
+          "descent_and_neuromuscular_exposure",
+          "technical_terrain",
+          "hiking",
+          "strength",
+          "longest_session_and_fueling_practice",
+          "taper",
+          "environment_and_altitude",
+          "reassessment_and_outcome"
+        ],
+        "unavailable_module_may_be_silently_replaced": false
+      }
+    },
+    "trail_policy_non_science_authority": {
+      "applies_to": "work outside Science authority",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "deployment": "not_accepted",
+        "implementation_review": "required",
+        "lifecycle_supersession": "not_accepted",
+        "owner_only_pilot": "not_accepted",
+        "product_visibility_or_catalog": "not_accepted",
+        "production_data_use": "not_accepted",
+        "provider_mapping_or_delivery": "not_accepted",
+        "runtime_activation": "not_accepted"
+      }
+    },
+    "trail_policy_required_inputs": {
+      "applies_to": "v2 capability matching and readiness",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.course-specific-policy-required",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "eligibility.recent-history-anchor-without-universal-threshold"
+      ],
+      "value": {
+        "client_supplied_history_allowed": false,
+        "conditional": [
+          "grade_distribution",
+          "course_footing",
+          "altitude_and_environment_context",
+          "aid_and_support_context",
+          "fueling_practice_experience"
+        ],
+        "material_unknown_behavior": "canonical_status_or_named_limited_module",
+        "required": [
+          "athlete_confirmed_trail_course_demand_v2",
+          "athlete_confirmed_non_ultra_trail_constraints_v2",
+          "stable_recent_running_history",
+          "comparable_recent_ascent_exposure",
+          "comparable_recent_descent_exposure",
+          "available_training_days_and_limits",
+          "accessible_training_terrain",
+          "current_symptom_stop"
+        ],
+        "server_derived": [
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing"
+        ]
+      }
+    },
+    "trail_policy_runtime_evaluation": {
+      "applies_to": "inactive dry run and separately authorized owner pilot",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws"
+      ],
+      "value": {
+        "dry_run": {
+          "deterministic_invariant_breach_tolerance": 0,
+          "replay_mismatch_tolerance": 0,
+          "unsupported_or_material_unknown_plan_tolerance": 0
+        },
+        "efficacy_or_safety_claim_from_process_pilot": false,
+        "owner_only_pilot": {
+          "major_edit_definition": "session_duration_or_vertical_change_over_twenty_percent_or_two_scheduled_days_changed",
+          "maximum_major_edit_fraction": 0.3,
+          "serious_plausibly_related_report_pause_threshold": 1
+        },
+        "pause_or_revise_when_threshold_crossed": true
+      }
+    },
+    "trail_policy_schedule_construction": {
+      "applies_to": "deterministic early-block schedule",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.fixed-progression-and-acwr-not-safety-laws",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive"
+      ],
+      "value": {
+        "below_minimum_result": "no_schedule_within_envelope",
+        "easy_and_longest_easy_allocation": {
+          "automatic_longest_easy_increase": false,
+          "preferred_longest_easy_day_used_when_available": true,
+          "quality_minutes_allocated_first": true,
+          "remaining_minutes_distributed_across_non_quality_days": true
+        },
+        "no_schedule_result": "no_schedule_within_envelope",
+        "non_taper_progression_above_recent_median": false,
+        "quality_sessions_per_7_day_unit": 1,
+        "requested_above_maximum_result": "clarification_required",
+        "selected_running_days_per_7_day_unit": {
+          "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
+          "maximum": 6,
+          "minimum": 3
+        },
+        "session_duration_hard_cap": "minimum_of_recent_maximum_completed_session_and_athlete_limit",
+        "target_time_gap_may_raise_load": false,
+        "weekly_running_minutes_hard_cap": "minimum_of_recent_maximum_usable_weekly_minutes_and_athlete_limit",
+        "weekly_running_minutes_target": "minimum_of_recent_median_usable_weekly_minutes_and_athlete_limit"
+      }
+    },
+    "trail_policy_scope_and_dependencies": {
+      "applies_to": "non-ultra-trail-plan-generation-policy-v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.course-specific-policy-required",
+        "eligibility.goal-relevant-current-capability-task-specific"
+      ],
+      "value": {
+        "clinical_or_return_to_sport": false,
+        "distance_family": "non_ultra",
+        "event_format": "single_day",
+        "intent": "performance",
+        "minimum_age_years": 18,
+        "requires_accepted_ontology": "sdr-trail-running-goal-ontology-v2",
+        "requires_confirmed_constraint_revision": true,
+        "requires_confirmed_course_revision": true,
+        "requires_constraint_schema": "non_ultra_trail_constraints_v2",
+        "requires_course_demand_schema": "trail_course_demand_v2",
+        "requires_server_derived_history_revision": true,
+        "suggestion_only": true
+      }
+    },
+    "trail_policy_typed_outcomes": {
+      "applies_to": "v2 validation, policy availability, readiness, and proposal eligibility receipts",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "eligibility.recent-history-anchor-without-universal-threshold"
+      ],
+      "value": {
+        "authorization_failures_occur_before_product_receipt": true,
+        "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
+        "detail_reason_catalog": {
+          "clarification_required": [
+            "material_course_demand_unknown",
+            "assumption_confirmation_required",
+            "adult_scope_or_constraints_unconfirmed",
+            "training_constraints_missing",
+            "contradictory_input"
+          ],
+          "eligible_proposal": [],
+          "policy_unavailable": [
+            "policy_inactive",
+            "event_inside_unapproved_taper_window",
+            "unsupported_ultra_or_multiday",
+            "unsupported_population_or_intent",
+            "technical_features_outside_v2"
+          ],
+          "readiness_blocked": [
+            "insufficient_recent_running_history",
+            "insufficient_comparable_trail_history",
+            "insufficient_descent_history",
+            "insufficient_terrain_access",
+            "current_symptom_stop",
+            "no_schedule_within_envelope"
+          ],
+          "validation_failed": [
+            "invalid_field_value",
+            "schema_version_mismatch",
+            "deterministic_invariant_failed"
+          ]
+        },
+        "goal_remains_recorded": true,
+        "limited_modules": {
+          "allowed_sorted_order": [
+            "environment_altitude",
+            "fueling",
+            "grade_specificity",
+            "technical_terrain"
+          ],
+          "changes_top_level_status": false,
+          "empty_means_eligible": false,
+          "generic_or_road_replacement_allowed": false,
+          "hides_matching_reason": false,
+          "serialize_sorted": true,
+          "set_semantics": true
+        },
+        "matching_reasons": {
+          "de_duplicate": true,
+          "include_every_independently_and_safely_evaluable_match": true,
+          "independently_evaluable_lower_precedence_reasons_preserved": true,
+          "malformed_value_may_be_dereferenced_to_find_more_reasons": false,
+          "order_by": [
+            "status_precedence",
+            "detail_reason_catalog_order"
+          ],
+          "pair_fields": [
+            "status",
+            "detail_reason"
+          ]
+        },
+        "namespaced_reason_identity": "<status>.<detail_reason>",
+        "road_fallback": false,
+        "status_precedence": [
+          "validation_failed",
+          "policy_unavailable",
+          "readiness_blocked",
+          "clarification_required",
+          "eligible_proposal"
+        ],
+        "top_level_status": "highest_precedence_matching_status"
+      }
+    },
+    "trail_policy_workout_templates": {
+      "applies_to": "eligible early-block quality session",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling"
+      ],
+      "value": {
+        "controlled_quality": {
+          "steps": [
+            {
+              "duration_minutes": 10,
+              "intended_intensity": "low",
+              "kind": "step",
+              "phase": "warmup"
+            },
+            {
+              "kind": "repeat",
+              "repetitions": 4,
+              "steps": [
+                {
+                  "duration_minutes": 3,
+                  "intended_intensity": "controlled_uphill_effort",
+                  "kind": "step",
+                  "phase": "work"
+                },
+                {
+                  "duration_minutes": 2,
+                  "intended_intensity": "low",
+                  "kind": "step",
+                  "phase": "recovery"
+                }
+              ]
+            },
+            {
+              "duration_minutes": 8,
+              "intended_intensity": "low",
+              "kind": "step",
+              "phase": "cooldown"
+            }
+          ],
+          "template_id": "trail-controlled-uphill-quality-v1",
+          "total_planned_minutes": 38
+        },
+        "downhill_recovery_may_be_prescribed": false,
+        "easy": "duration_only_with_optional_accessible_terrain_category",
+        "exact_hr_pace_power_or_rpe_target": false,
+        "longest_easy": "duration_only_with_observed_duration_and_course_exposure_caps",
+        "target_expression": "duration_phase_and_effort_label_only",
+        "template_must_fit_history_constraint_and_exposure_caps": true,
+        "template_optimum_claim": false,
+        "work_step_requires_accessible_non_technical_uphill": true
+      }
+    }
+  },
+  "runtime_state": "inactive",
+  "schema_version": 1,
+  "source_decision_digest": "sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40"
+}
+```
+
+</details>
+
+<details><summary>Implementation approval — not part of decision approval</summary>
+
+Runtime activation remains fail-closed until implementation approval can bind both the active contract digest and the exact reviewed code diff/validation evidence. Evidence or decision approval cannot fill this role.
+
+</details>
+
+<details><summary>Exact reviewed decision payload</summary>
+
+```json
+{
+  "accepted_interpretation": "If separately accepted after the ontology successor, this record would bind the accepted history-rich adult non-ultra Trail policy to trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing any accepted v1 execution, history, schedule, workout-template, intensity, exposure, event-window, taper deferral, or hard scientific boundary. The fourteen-day proposal, seven-day reassessment, eight-week history window, four usable weeks, three-run usable-week floor, ten-day recent-run check, 42/21-day comparable-history checks, no-initial-progression schedule, targetless 38-minute controlled-uphill template, 75-percent low-intensity floor, one nonconsecutive quality exposure, and separate history-anchored ascent/descent caps remain reversible Praxys guardrails rather than published optima or safety laws. A deterministic v2 receipt returns exactly one of five statuses, one cataloged primary detail when applicable, every independently safe matching reason, and sorted limited modules. It never hides a lower-precedence reason, interprets malformed data to manufacture more reasons, selects a road fallback, uses activity-average power, or authorizes a provider or runtime behavior. Taper, progression above history, fixed fueling, strength, hiking, technical-terrain or recovery dose, back-to-back sessions, universal targets, and personal performance or safety predictions remain unaccepted.",
+  "affected_surfaces": {
+    "apis": [
+      "future inactive v2 Trail readiness and proposal contracts"
+    ],
+    "clients": [
+      "future inactive Praxys Web Trail course-ledger and readiness receipt",
+      "future unavailable miniapp Trail setup handoff"
+    ],
+    "models": [
+      "inactive non-ultra Trail deterministic early-block policy v2",
+      "v2 Trail validation, readiness, and complete reason receipt",
+      "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
+    ],
+    "science_notes": [
+      "Why Trail plans match course demand rather than distance alone",
+      "Why exact schedule values are reversible guardrails rather than safe-dose claims",
+      "Why a complete deterministic receipt is not a biological readiness score"
+    ]
+  },
+  "applicability": [
+    "Adults with stable recent comparable running, ascent, descent, and Trail exposure",
+    "Single-day non-ultra Trail performance intent",
+    "Complete confirmed trail_course_demand_v2 and non_ultra_trail_constraints_v2 revisions",
+    "Server-derived owner-scoped recent-history snapshot",
+    "Suggestion-only plan proposals and scientific claim limits"
+  ],
+  "artifact_policy": {
+    "runtime_state": "inactive"
+  },
+  "decision_date": "2026-09-04",
+  "decision_notes": [
+    "Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim.",
+    "Proposed predecessor transition: after separate digest-bound human approval and coordinated lifecycle review, this record may replace sdr-non-ultra-trail-plan-generation-policy-v1; no supersession link is active in this draft.",
+    "It depends on separate acceptance and coordinated lifecycle handling of sdr-trail-running-goal-ontology-v2.",
+    "Every exact value outside the v2 dependency and receipt groups is carried unchanged from accepted v1 and remains classified as a reversible Praxys guardrail.",
+    "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.",
+    "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.",
+    "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.",
+    "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."
+  ],
+  "decision_review": {
+    "approval_statement": "I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt and sorted limited modules as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.",
+    "items": [
+      {
+        "approval_effect": [
+          "A future inactive evaluator can require exact v2 inputs without widening the eligible population.",
+          "Known or unknown context cannot silently enable a module."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "A broader population, first-completion plan, ultra plan, fixed module dose, or runtime use."
+        ],
+        "evidence_claim_ids": [
+          "non-ultra-trail.course-specific-policy-required",
+          "non-ultra-trail.uphill-downhill-require-distinct-handling",
+          "non-ultra-trail.training-specificity-promising-not-prescriptive"
+        ],
+        "id": "v2-scope-dependencies-and-modules",
+        "parameter_names": [
+          "trail_policy_scope_and_dependencies",
+          "trail_policy_required_inputs",
+          "trail_policy_modular_structure",
+          "trail_policy_evidence_use"
+        ],
+        "proposed_decision": "Update only the dependency and schema identities while preserving the accepted scope, evidence use, and modular scientific interpretation.",
+        "question": "Should the history-rich adult non-ultra performance policy require the accepted v2 ontology, confirmed v2 course and constraint revisions, server-derived history, and the same conditional module structure?",
+        "title": "Bind the narrow accepted policy to the two strict v2 schemas"
+      },
+      {
+        "approval_effect": [
+          "The successor changes readiness semantics without silently changing the generated training envelope."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "Load progression, a new template, fixed target zones, or a claim of optimality or safety."
+        ],
+        "evidence_claim_ids": [
+          "eligibility.recent-history-anchor-without-universal-threshold",
+          "eligibility.fixed-progression-and-acwr-not-safety-laws",
+          "non-ultra-trail.training-specificity-promising-not-prescriptive"
+        ],
+        "id": "unchanged-early-block-construction",
+        "parameter_names": [
+          "trail_policy_execution_and_reassessment",
+          "trail_policy_history_guardrails",
+          "trail_policy_schedule_construction",
+          "trail_policy_workout_templates"
+        ],
+        "proposed_decision": "Preserve the exact fourteen-day, seven-day, history qualification, no-progression scheduling, and targetless 38-minute uphill-template guardrails without presenting them as biological optima.",
+        "question": "Should v2 retain every accepted execution, reassessment, history, schedule, and workout-template value exactly as v1?",
+        "title": "Carry the accepted early-block construction forward unchanged"
+      },
+      {
+        "approval_effect": [
+          "A new receipt cannot weaken the generated-plan invariants or claim boundaries."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "Taper dose, catch-up, target-gap escalation, road substitution, medical advice, or personal guarantees."
+        ],
+        "evidence_claim_ids": [
+          "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+          "non-ultra-trail.injury-fatigue-no-safe-dose",
+          "eligibility.current-symptoms-support-stop-not-clearance"
+        ],
+        "id": "unchanged-intensity-exposure-event-and-safety",
+        "parameter_names": [
+          "trail_policy_intensity_and_spacing",
+          "trail_policy_course_exposure_caps",
+          "trail_policy_event_and_taper",
+          "trail_policy_hard_boundaries"
+        ],
+        "proposed_decision": "Preserve those exact v1 guardrails and keep ascent, descent, terrain, symptoms, athlete action, and intensity provenance separate.",
+        "question": "Should v2 keep the 75-percent low-intensity floor, one-quality ceiling, spacing, separate history caps, event-window behavior, and all hard Science prohibitions unchanged?",
+        "title": "Carry the accepted intensity, exposure, event, and hard boundaries forward"
+      },
+      {
+        "approval_effect": [
+          "Clients receive one next-action status without losing simultaneous lower-precedence findings.",
+          "Malformed fields are never dereferenced merely to fill the receipt."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "A biological readiness score, risk rank, hidden reason, client-created reason, or eligibility from an empty module list."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.course-demand-is-multidimensional",
+          "eligibility.recent-history-anchor-without-universal-threshold"
+        ],
+        "id": "deterministic-complete-v2-receipt",
+        "parameter_names": [
+          "trail_policy_typed_outcomes"
+        ],
+        "proposed_decision": "Accept the exact status, detail, namespacing, de-duplication, ordering, independent-evaluation, and module serialization rules from Product v2 as reversible operational guardrails.",
+        "question": "Should every safely classified evaluation return one status by fixed precedence, the first cataloged primary detail, every matching reason, and a separate sorted limited-module set?",
+        "title": "Adopt the five-status exhaustive deterministic receipt"
+      },
+      {
+        "approval_effect": [
+          "The v2 receipt cannot turn descriptive context into a prescription or activation path."
+        ],
+        "disposition": "defer",
+        "does_not_authorize": [
+          "Taper, progression, fixed dose, broader scope, provider behavior, deployment, or activation."
+        ],
+        "evidence_claim_ids": [
+          "non-ultra-trail.training-specificity-promising-not-prescriptive",
+          "non-ultra-trail.injury-fatigue-no-safe-dose",
+          "non-ultra-trail.taper-direction-indirect",
+          "non-ultra-trail.fueling-duration-and-practice-context"
+        ],
+        "id": "unresolved-dose-and-scope-stays-deferred",
+        "parameter_names": [
+          "trail_policy_event_and_taper",
+          "trail_policy_deferred_scope",
+          "trail_policy_non_science_authority"
+        ],
+        "proposed_decision": "Retain all existing deferrals and require a future evidence-consistent successor plus role-scoped review before any expansion.",
+        "question": "Should every literal not_accepted value in the event, deferred-scope, and non-Science authority groups remain unavailable?",
+        "title": "Keep taper, progression, fixed dose, and wider authority unaccepted"
+      },
+      {
+        "approval_effect": [
+          "Inactive verification can detect invariant or replay failures before any exposure."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "Collecting value telemetry, starting owner dogfood, sending workouts, deploying, or activating."
+        ],
+        "evidence_claim_ids": [
+          "non-ultra-trail.injury-fatigue-no-safe-dose",
+          "eligibility.fixed-progression-and-acwr-not-safety-laws"
+        ],
+        "id": "inactive-evaluation-and-role-boundary",
+        "parameter_names": [
+          "trail_policy_runtime_evaluation",
+          "trail_policy_non_science_authority"
+        ],
+        "proposed_decision": "Carry the accepted evaluation thresholds and non-Science boundary forward without starting observation, pilot, delivery, or activation.",
+        "question": "Should deterministic zero-tolerance dry-run checks remain available while every owner, provider, deployment, and runtime action stays under separate Product, Trust, Quality, Operations, and human authority?",
+        "title": "Preserve dry-run checks and require separate authority for all exposure"
+      }
+    ],
+    "reviewer_task": "Decide whether the six proposed v2 actions preserve every accepted v1 policy guardrail while replacing ambiguous readiness input and output with strict v2 dependencies and a deterministic complete receipt. Approve the sheet as a unit or request changes by item ID."
+  },
+  "evidence_claim_ids": [
+    "trail-ontology.course-demand-is-multidimensional",
+    "trail-ontology.uphill-downhill-demands-differ",
+    "trail-ontology.technicality-and-downhill-vary-performance",
+    "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+    "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose",
+    "non-ultra-trail.course-specific-policy-required",
+    "non-ultra-trail.uphill-downhill-require-distinct-handling",
+    "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+    "non-ultra-trail.training-specificity-promising-not-prescriptive",
+    "non-ultra-trail.injury-fatigue-no-safe-dose",
+    "non-ultra-trail.observed-load-does-not-prove-prescription",
+    "non-ultra-trail.taper-direction-indirect",
+    "non-ultra-trail.fueling-duration-and-practice-context",
+    "eligibility.recent-history-anchor-without-universal-threshold",
+    "eligibility.fixed-progression-and-acwr-not-safety-laws",
+    "eligibility.goal-relevant-current-capability-task-specific",
+    "eligibility.current-symptoms-support-stop-not-clearance"
+  ],
+  "evidence_review_ids": [
+    "evidence-trail-running-goal-ontology-v1",
+    "evidence-non-ultra-trail-plan-generation-policy-v1",
+    "evidence-plan-generation-eligibility-safety-v1"
+  ],
+  "falsification_conditions": [
+    "Any accepted v1 execution, history, schedule, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency and receipt groups.",
+    "Status selection, primary detail, matching-reason ordering, de-duplication, or limited-module sorting is nondeterministic or loses a safely evaluable reason.",
+    "A malformed field is interpreted to manufacture a reason, or a core unknown or failed gate produces eligible_proposal.",
+    "An exact value outside the accepted early-block guardrails is inferred despite literal not_accepted status.",
+    "Uphill and downhill collapse, terrain or history access is ignored, or an unsupported module is silently substituted.",
+    "Activity-average power, ACWR, road pace, or heart rate becomes a safe sole controller, or a personal performance, safety, injury, diagnosis, or clearance claim appears.",
+    "The generated contract becomes active or any provider/runtime behavior appears without separate role-scoped authority."
+  ],
+  "id": "sdr-non-ultra-trail-plan-generation-policy-v2",
+  "model_parameters": [
+    {
+      "applies_to": "non-ultra-trail-plan-generation-policy-v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.course-specific-policy-required",
+        "eligibility.goal-relevant-current-capability-task-specific"
+      ],
+      "name": "trail_policy_scope_and_dependencies",
+      "rationale": "Only dependency and schema identities change. The narrow v1 population and intent remain unchanged; exact revisions are operational replay guardrails rather than published eligibility thresholds.",
+      "value": {
+        "clinical_or_return_to_sport": false,
+        "distance_family": "non_ultra",
+        "event_format": "single_day",
+        "intent": "performance",
+        "minimum_age_years": 18,
+        "requires_accepted_ontology": "sdr-trail-running-goal-ontology-v2",
+        "requires_confirmed_constraint_revision": true,
+        "requires_confirmed_course_revision": true,
+        "requires_constraint_schema": "non_ultra_trail_constraints_v2",
+        "requires_course_demand_schema": "trail_course_demand_v2",
+        "requires_server_derived_history_revision": true,
+        "suggestion_only": true
+      }
+    },
+    {
+      "applies_to": "v2 capability matching and readiness",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.course-specific-policy-required",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "eligibility.recent-history-anchor-without-universal-threshold"
+      ],
+      "name": "trail_policy_required_inputs",
+      "rationale": "The v2 names make the accepted course, access, and history boundary explicit without changing history thresholds or inventing a dose.",
+      "value": {
+        "client_supplied_history_allowed": false,
+        "conditional": [
+          "grade_distribution",
+          "course_footing",
+          "altitude_and_environment_context",
+          "aid_and_support_context",
+          "fueling_practice_experience"
+        ],
+        "material_unknown_behavior": "canonical_status_or_named_limited_module",
+        "required": [
+          "athlete_confirmed_trail_course_demand_v2",
+          "athlete_confirmed_non_ultra_trail_constraints_v2",
+          "stable_recent_running_history",
+          "comparable_recent_ascent_exposure",
+          "comparable_recent_descent_exposure",
+          "available_training_days_and_limits",
+          "accessible_training_terrain",
+          "current_symptom_stop"
+        ],
+        "server_derived": [
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing"
+        ]
+      }
+    },
+    {
+      "applies_to": "early non-ultra Trail rolling proposals",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.recent-history-anchor-without-universal-threshold",
+        "non-ultra-trail.course-specific-policy-required"
+      ],
+      "name": "trail_policy_execution_and_reassessment",
+      "rationale": "Carried unchanged from accepted v1. Fourteen days is the Product-selected minimum complete two-unit experience and seven days is an advisory review point; neither is a biological optimum.",
+      "value": {
+        "advisory_reassessment_after_completed_days": 7,
+        "automatic_overwrite_of_adopted_future_days": false,
+        "automatic_successor_adoption": false,
+        "biological_optimum_claim": false,
+        "calendar_schedule_unit_days": 7,
+        "committed_proposal_days": 14,
+        "continued_goal_horizon_requires_successor": true,
+        "each_successor_requires_fresh_history_course_and_constraints": true,
+        "proposal_end_inclusive": true
+      }
+    },
+    {
+      "applies_to": "owner-scoped readiness history",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.recent-history-anchor-without-universal-threshold",
+        "non-ultra-trail.course-specific-policy-required",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling"
+      ],
+      "name": "trail_policy_history_guardrails",
+      "rationale": "Carried unchanged from accepted v1. The counts prevent extrapolation from sparse records and remain conservative qualifications, not safety, adaptation, or readiness laws.",
+      "value": {
+        "comparable_hilly_or_trail_sessions_within_completed_days": {
+          "count": 2,
+          "window": 42
+        },
+        "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
+        "latest_run_within_completed_days": 10,
+        "minimum_running_sessions_per_usable_week": 3,
+        "minimum_usable_completed_weeks": 4,
+        "qualifying_activity_requires": [
+          "outdoor_running_or_trail_running",
+          "positive_duration_and_distance",
+          "usable_elevation_gain_and_loss_or_explicit_unknown",
+          "source_timestamp"
+        ],
+        "recent_history_lookback_completed_weeks": 8,
+        "sparse_or_stale_result": "insufficient_comparable_trail_history",
+        "thresholds_are_published_biological_laws": false,
+        "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
+      }
+    },
+    {
+      "applies_to": "deterministic early-block schedule",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "eligibility.fixed-progression-and-acwr-not-safety-laws",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive"
+      ],
+      "name": "trail_policy_schedule_construction",
+      "rationale": "Carried unchanged from accepted v1. Median, maximum, and athlete caps organize existing exposure without automatic progression; one quality session is a conservative Product choice, not a universal optimum.",
+      "value": {
+        "below_minimum_result": "no_schedule_within_envelope",
+        "easy_and_longest_easy_allocation": {
+          "automatic_longest_easy_increase": false,
+          "preferred_longest_easy_day_used_when_available": true,
+          "quality_minutes_allocated_first": true,
+          "remaining_minutes_distributed_across_non_quality_days": true
+        },
+        "no_schedule_result": "no_schedule_within_envelope",
+        "non_taper_progression_above_recent_median": false,
+        "quality_sessions_per_7_day_unit": 1,
+        "requested_above_maximum_result": "clarification_required",
+        "selected_running_days_per_7_day_unit": {
+          "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
+          "maximum": 6,
+          "minimum": 3
+        },
+        "session_duration_hard_cap": "minimum_of_recent_maximum_completed_session_and_athlete_limit",
+        "target_time_gap_may_raise_load": false,
+        "weekly_running_minutes_hard_cap": "minimum_of_recent_maximum_usable_weekly_minutes_and_athlete_limit",
+        "weekly_running_minutes_target": "minimum_of_recent_median_usable_weekly_minutes_and_athlete_limit"
+      }
+    },
+    {
+      "applies_to": "eligible early-block quality session",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.uphill-downhill-require-distinct-handling"
+      ],
+      "name": "trail_policy_workout_templates",
+      "rationale": "Carried unchanged from accepted v1. The targetless uphill template is a transparent reversible Product guardrail and prescribes no downhill speed or universal target zone.",
+      "value": {
+        "controlled_quality": {
+          "steps": [
+            {
+              "duration_minutes": 10,
+              "intended_intensity": "low",
+              "kind": "step",
+              "phase": "warmup"
+            },
+            {
+              "kind": "repeat",
+              "repetitions": 4,
+              "steps": [
+                {
+                  "duration_minutes": 3,
+                  "intended_intensity": "controlled_uphill_effort",
+                  "kind": "step",
+                  "phase": "work"
+                },
+                {
+                  "duration_minutes": 2,
+                  "intended_intensity": "low",
+                  "kind": "step",
+                  "phase": "recovery"
+                }
+              ]
+            },
+            {
+              "duration_minutes": 8,
+              "intended_intensity": "low",
+              "kind": "step",
+              "phase": "cooldown"
+            }
+          ],
+          "template_id": "trail-controlled-uphill-quality-v1",
+          "total_planned_minutes": 38
+        },
+        "downhill_recovery_may_be_prescribed": false,
+        "easy": "duration_only_with_optional_accessible_terrain_category",
+        "exact_hr_pace_power_or_rpe_target": false,
+        "longest_easy": "duration_only_with_observed_duration_and_course_exposure_caps",
+        "target_expression": "duration_phase_and_effort_label_only",
+        "template_must_fit_history_constraint_and_exposure_caps": true,
+        "template_optimum_claim": false,
+        "work_step_requires_accessible_non_technical_uphill": true
+      }
+    },
+    {
+      "applies_to": "all planned running minutes",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive"
+      ],
+      "name": "trail_policy_intensity_and_spacing",
+      "rationale": "Carried unchanged from accepted v1. The floor, ceiling, and spacing are conservative no-progression guardrails, not published universal values.",
+      "value": {
+        "activity_average_power_allowed": false,
+        "consecutive_quality_running_days_allowed": false,
+        "historical_intensity_source_priority": [
+          "activity_splits",
+          "activity_samples"
+        ],
+        "low_intensity_fraction_is_optimum_claim": false,
+        "maximum_quality_exposures_per_7_day_unit": 1,
+        "minimum_intervening_easy_rest_or_non_running_days": 1,
+        "minimum_planned_low_intensity_running_minutes_fraction": 0.75,
+        "missed_quality_makeup_allowed": false,
+        "quality_exposures_include": [
+          "controlled_quality_template",
+          "confirmed_race_or_maximal_effort"
+        ],
+        "reduce_or_remove_quality_before_adding_minutes": true
+      }
+    },
+    {
+      "applies_to": "early-block terrain and vertical exposure",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws"
+      ],
+      "name": "trail_policy_course_exposure_caps",
+      "rationale": "Carried unchanged from accepted v1. Separate observed ascent, descent, and terrain caps avoid inventing a conversion, dose, or progression.",
+      "value": {
+        "automatic_vertical_progression": false,
+        "high_speed_or_maximal_downhill_repeats": false,
+        "road_or_flat_substitution_claimed_equivalent": false,
+        "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
+        "session_descent_hard_cap": "recent_maximum_completed_session_descent",
+        "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
+        "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+        "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
+        "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
+        "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
+        "weekly_descent_target": "no_more_than_recent_median_usable_weekly_descent"
+      }
+    },
+    {
+      "applies_to": "dated Trail goals",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.taper-direction-indirect"
+      ],
+      "name": "trail_policy_event_and_taper",
+      "rationale": "Carried unchanged from accepted v1. General endurance evidence remains insufficient to select a Trail-specific taper; the event-near path fails closed pending a successor decision.",
+      "value": {
+        "event_day_generated_as_training_workout": false,
+        "event_or_race_counts_as_quality_and_load": true,
+        "imported_event_must_be_athlete_confirmed": true,
+        "taper_implementation": "not_accepted",
+        "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
+        "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+      }
+    },
+    {
+      "applies_to": "v2 validation, policy availability, readiness, and proposal eligibility receipts",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "eligibility.recent-history-anchor-without-universal-threshold"
+      ],
+      "name": "trail_policy_typed_outcomes",
+      "rationale": "The evidence supports explicit missingness and bounded applicability, but the five statuses, exact reason catalog, precedence, and serialization are reversible Product-selected operational guardrails rather than a biological readiness or risk model.",
+      "value": {
+        "authorization_failures_occur_before_product_receipt": true,
+        "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
+        "detail_reason_catalog": {
+          "clarification_required": [
+            "material_course_demand_unknown",
+            "assumption_confirmation_required",
+            "adult_scope_or_constraints_unconfirmed",
+            "training_constraints_missing",
+            "contradictory_input"
+          ],
+          "eligible_proposal": [],
+          "policy_unavailable": [
+            "policy_inactive",
+            "event_inside_unapproved_taper_window",
+            "unsupported_ultra_or_multiday",
+            "unsupported_population_or_intent",
+            "technical_features_outside_v2"
+          ],
+          "readiness_blocked": [
+            "insufficient_recent_running_history",
+            "insufficient_comparable_trail_history",
+            "insufficient_descent_history",
+            "insufficient_terrain_access",
+            "current_symptom_stop",
+            "no_schedule_within_envelope"
+          ],
+          "validation_failed": [
+            "invalid_field_value",
+            "schema_version_mismatch",
+            "deterministic_invariant_failed"
+          ]
+        },
+        "goal_remains_recorded": true,
+        "limited_modules": {
+          "allowed_sorted_order": [
+            "environment_altitude",
+            "fueling",
+            "grade_specificity",
+            "technical_terrain"
+          ],
+          "changes_top_level_status": false,
+          "empty_means_eligible": false,
+          "generic_or_road_replacement_allowed": false,
+          "hides_matching_reason": false,
+          "serialize_sorted": true,
+          "set_semantics": true
+        },
+        "matching_reasons": {
+          "de_duplicate": true,
+          "include_every_independently_and_safely_evaluable_match": true,
+          "independently_evaluable_lower_precedence_reasons_preserved": true,
+          "malformed_value_may_be_dereferenced_to_find_more_reasons": false,
+          "order_by": [
+            "status_precedence",
+            "detail_reason_catalog_order"
+          ],
+          "pair_fields": [
+            "status",
+            "detail_reason"
+          ]
+        },
+        "namespaced_reason_identity": "<status>.<detail_reason>",
+        "road_fallback": false,
+        "status_precedence": [
+          "validation_failed",
+          "policy_unavailable",
+          "readiness_blocked",
+          "clarification_required",
+          "eligible_proposal"
+        ],
+        "top_level_status": "highest_precedence_matching_status"
+      }
+    },
+    {
+      "applies_to": "future deterministic generator envelope",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.uphill-downhill-require-distinct-handling",
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "name": "trail_policy_modular_structure",
+      "rationale": "Carried unchanged from accepted v1. Modular handling preserves distinct demands and uncertainty without claiming one universal Trail schedule.",
+      "value": {
+        "module_requires_matching_input": true,
+        "modules": [
+          "readiness_and_history",
+          "easy_and_aerobic",
+          "ascent_specificity",
+          "descent_and_neuromuscular_exposure",
+          "technical_terrain",
+          "hiking",
+          "strength",
+          "longest_session_and_fueling_practice",
+          "taper",
+          "environment_and_altitude",
+          "reassessment_and_outcome"
+        ],
+        "unavailable_module_may_be_silently_replaced": false
+      }
+    },
+    {
+      "applies_to": "module selection and ScienceNote claims",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "non-ultra-trail.observed-load-does-not-prove-prescription",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "name": "trail_policy_evidence_use",
+      "rationale": "Carried unchanged from accepted v1. This keeps evidence-supported directions separate from exact prescriptions the sources do not establish.",
+      "value": {
+        "fueling": "expected_duration_and_practice_context_only",
+        "hiking": "conditional_candidate_module",
+        "injury_and_fatigue_findings": "safety_context_only",
+        "observed_load_associations": "descriptive_only",
+        "strength_and_multimodal": "conditional_candidate_module",
+        "taper": "indirect_direction_only",
+        "trail_specificity": "conditional_candidate_module"
+      }
+    },
+    {
+      "applies_to": "all future policy and implementation surfaces",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.hr-and-road-pace-not-sole-targets",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws",
+        "eligibility.current-symptoms-support-stop-not-clearance"
+      ],
+      "name": "trail_policy_hard_boundaries",
+      "rationale": "Carried unchanged from accepted v1. These boundaries prevent unsupported inference, hidden load escalation, medical claims, and authority expansion.",
+      "value": {
+        "activity_average_power_valid_for_intensity": false,
+        "canonical_adoption_requires_explicit_athlete_action": true,
+        "diagnosis_or_clearance": false,
+        "heart_rate_or_level_pace_may_be_sole_hilly_controller": false,
+        "missed_work_may_create_catch_up": false,
+        "performance_injury_or_safety_guarantee": false,
+        "personal_finish_probability": false,
+        "provider_delivery_requires_separate_explicit_consent": true,
+        "road_policy_fallback": false,
+        "target_gap_may_raise_dose": false,
+        "universal_ascent_descent_equivalence": false,
+        "universal_distance_vertical_conversion": false,
+        "valid_intensity_sources": [
+          "activity_splits",
+          "activity_samples"
+        ]
+      }
+    },
+    {
+      "applies_to": "scope outside the early rolling block",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.training-specificity-promising-not-prescriptive",
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "non-ultra-trail.taper-direction-indirect",
+        "non-ultra-trail.fueling-duration-and-practice-context"
+      ],
+      "name": "trail_policy_deferred_scope",
+      "rationale": "Carried unchanged from accepted v1. These higher-load, event-near, fixed-dose, and target-specific behaviors need a future decision.",
+      "value": {
+        "back_to_back_sessions": "not_accepted",
+        "fueling_amount_or_frequency": "not_accepted",
+        "hiking_threshold_or_dose": "not_accepted",
+        "hr_pace_power_or_rpe_targets": "not_accepted",
+        "outcome_window_or_meaningful_change": "not_accepted",
+        "progression_above_recent_typical_load": "not_accepted",
+        "recovery_interval": "not_accepted",
+        "strength_frequency_or_dose": "not_accepted",
+        "taper_duration_and_reduction": "not_accepted",
+        "technical_terrain_dose": "not_accepted",
+        "vertical_or_downhill_progression_above_recent_history": "not_accepted"
+      }
+    },
+    {
+      "applies_to": "inactive dry run and separately authorized owner pilot",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "non-ultra-trail.injury-fatigue-no-safe-dose",
+        "eligibility.fixed-progression-and-acwr-not-safety-laws"
+      ],
+      "name": "trail_policy_runtime_evaluation",
+      "rationale": "Carried unchanged from accepted v1. These are evaluation guardrails for inactive verification or a separately authorized future pilot; this successor authorizes neither exposure nor value telemetry.",
+      "value": {
+        "dry_run": {
+          "deterministic_invariant_breach_tolerance": 0,
+          "replay_mismatch_tolerance": 0,
+          "unsupported_or_material_unknown_plan_tolerance": 0
+        },
+        "efficacy_or_safety_claim_from_process_pilot": false,
+        "owner_only_pilot": {
+          "major_edit_definition": "session_duration_or_vertical_change_over_twenty_percent_or_two_scheduled_days_changed",
+          "maximum_major_edit_fraction": 0.3,
+          "serious_plausibly_related_report_pause_threshold": 1
+        },
+        "pause_or_revise_when_threshold_crossed": true
+      }
+    },
+    {
+      "applies_to": "work outside Science authority",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "name": "trail_policy_non_science_authority",
+      "rationale": "Science cannot originate or widen Product, Design, Engineering, Trust, Quality, Operations, provider, rollout, or activation authority.",
+      "value": {
+        "deployment": "not_accepted",
+        "implementation_review": "required",
+        "lifecycle_supersession": "not_accepted",
+        "owner_only_pilot": "not_accepted",
+        "product_visibility_or_catalog": "not_accepted",
+        "production_data_use": "not_accepted",
+        "provider_mapping_or_delivery": "not_accepted",
+        "runtime_activation": "not_accepted"
+      }
+    }
+  ],
+  "model_version": "non-ultra-trail-plan-generation-policy-v2",
+  "owners": [
+    "team:praxys"
+  ],
+  "privacy_implications": [
+    "Consume only normalized confirmed v2 course/constraint revisions and owner-scoped aggregate history snapshots required for deterministic replay.",
+    "Do not copy raw activities, samples, GPS, routes, free text, provider payloads or identifiers, device identifiers, or target values into generic audit or telemetry.",
+    "Activity-average power is neither collected nor used as readiness or intensity evidence.",
+    "Owner-scoped goal, readiness, proposal, adoption, reset, export, deletion, and account-deletion controls remain mandatory."
+  ],
+  "rejected_alternatives": [
+    {
+      "alternative": "Change the readiness receipt while also tuning the training schedule",
+      "rationale": "That would confound an input/output contract repair with unreviewed dose and make the v1-to-v2 training envelope impossible to audit."
+    },
+    {
+      "alternative": "Return only the highest-precedence reason",
+      "rationale": "One reason would hide other safely evaluable actions and make the receipt unstable as fields are corrected."
+    },
+    {
+      "alternative": "Let clients invent reason strings or infer eligibility from module limits",
+      "rationale": "Client-specific interpretation would break replay and could transform an omitted module into a false readiness claim."
+    },
+    {
+      "alternative": "Use a road policy, route inference, provider payload, or AI output to complete missing Trail input",
+      "rationale": "Those inputs and fallbacks are outside the accepted evidence and privacy boundary and cannot manufacture an exact capability match."
+    }
+  ],
+  "safety_implications": [
+    "Current symptoms stop performance optimization and route outside this nonclinical policy without creating a diagnosis.",
+    "Missing core course demand, history, schedule, hazard, or terrain access fails closed; only ontology-approved non-core unknowns can limit a named module.",
+    "No catch-up, target-gap load escalation, fixed progression law, road fallback, route inference, or provider completion is allowed.",
+    "Downhill and technical exposure stay within the accepted separate history-anchored bounds.",
+    "A complete reason receipt does not weaken the highest-precedence status or permit unsafe dereferencing of malformed fields."
+  ],
+  "schema_version": 1,
+  "supersedes": [],
+  "title": "Bind the non-ultra Trail policy to the strict v2 readiness receipt",
+  "user_facing_claim_limits": [
+    "Do not present the five statuses, reason order, module list, DTO values, or exact v1 guardrails as a biological readiness score, validated safe dose, or scientific optimum.",
+    "Do not present the policy as a road plan adjusted for elevation or infer route, grade, footing, or course demand from provider data.",
+    "Do not claim one universal vertical, descent, technicality, hiking, strength, long-session, taper, fueling, recovery, HR, pace, power, or RPE dose.",
+    "Do not use heart rate, road pace, ACWR, or activity-average power as a sole or safety-validating controller.",
+    "Do not show a personal finish probability, target guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance."
+  ],
+  "validation_plan": [
+    "Prove every execution, history, schedule, template, intensity, exposure, event, and hard-boundary value is structurally equal to the accepted v1 contract except the named v2 dependency and receipt groups.",
+    "Exhaustively exercise every status and detail reason, every pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, and sorted limited modules.",
+    "Verify malformed values are not dereferenced while all independently safe policy, history, schedule, and missingness reasons remain present.",
+    "Unit-test history qualification, schedule allocation, targetless template steps, low-intensity fraction, quality spacing, and separate ascent/descent/terrain caps against immutable owner-scoped snapshots.",
+    "Verify no proposal is returned from an inactive contract, a core unknown, a failed gate, a stale revision, route/provider input, or any road fallback.",
+    "Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests."
+  ],
+  "version": 2
+}
+```
+
+</details>

--- a/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
+++ b/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
@@ -6,8 +6,8 @@
 - **Lifecycle:** `draft`
 - **Model version:** `non-ultra-trail-plan-generation-policy-v2`
 - **Runtime state:** `inactive`
-- **Decision digest:** `sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56`
-- **Contract digest:** `sha256:afb120c2ef58543751b60d68bbe738698395c9c62e4f42a908f8efcbf9b8ff41`
+- **Decision digest:** `sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe`
+- **Contract digest:** `sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d`
 - **Required decision role:** `decision_approver`
 - **Decision approval:** _Pending_
 - **Required activation role:** `implementation_reviewer`
@@ -145,12 +145,12 @@ Praxys science approval — **APPROVE**
 
 - Role: `decision_approver`
 - Subject: `sdr-non-ultra-trail-plan-generation-policy-v2`
-- Digest: `sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56`
+- Digest: `sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe`
 
 > I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt, authoritative four-module availability, and redundant sorted limitation projection as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. Hiking, strength, and taper remain disabled because v2 has no accepted input and dose contract for them. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
 <!-- praxys-science-approval:v1
-{"role":"decision_approver","subject_digest":"sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56","subject_id":"sdr-non-ultra-trail-plan-generation-policy-v2","subject_kind":"science_decision"}
+{"role":"decision_approver","subject_digest":"sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe","subject_id":"sdr-non-ultra-trail-plan-generation-policy-v2","subject_kind":"science_decision"}
 -->
 ```
 
@@ -629,6 +629,13 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
       }
     },
     {
+      "condition": "unrecognized_event_format_distance_family_or_planning_intent_literal",
+      "result": {
+        "detail_reason": "invalid_field_value",
+        "status": "validation_failed"
+      }
+    },
+    {
       "condition": "course_or_constraint_schema_id_is_not_exact_v2",
       "result": {
         "detail_reason": "schema_version_mismatch",
@@ -653,6 +660,13 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
       "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
       "result": {
         "detail_reason": "material_course_demand_unknown",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "recognized_event_format_distance_family_or_planning_intent_unknown",
+      "result": {
+        "detail_reason": "adult_scope_or_constraints_unconfirmed",
         "status": "clarification_required"
       }
     },
@@ -762,14 +776,14 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
       }
     },
     {
-      "condition": "event_ultra_distance_or_multiday",
+      "condition": "recognized_event_format_multi_day_or_distance_family_ultra",
       "result": {
         "detail_reason": "unsupported_ultra_or_multiday",
         "status": "policy_unavailable"
       }
     },
     {
-      "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+      "condition": "unsupported_population_or_clinical_state_or_recognized_first_completion_or_return_to_consistency_intent",
       "result": {
         "detail_reason": "unsupported_population_or_intent",
         "status": "policy_unavailable"
@@ -823,6 +837,7 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
       "deterministic_invariant_failed"
     ]
   },
+  "eligible_proposal_detail_reason": null,
   "goal_remains_recorded": true,
   "limited_modules": {
     "allowed_sorted_order": [
@@ -862,14 +877,15 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
       "available",
       "limited"
     ],
+    "arbitrary_reason_selection_allowed": false,
     "authoritative": true,
     "limited_reason_targets": {
       "environment_altitude": [
-        "course.environment_and_altitude"
+        "course.optional_context.environment"
       ],
       "fueling": [
-        "course.aid_and_support",
-        "course.fueling_and_gastrointestinal_context"
+        "course.optional_context.support",
+        "course.optional_context.fueling"
       ],
       "grade_specificity": [
         "course.grade_distribution"
@@ -878,27 +894,33 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
         "course.course_footing"
       ]
     },
+    "multiple_matching_reasons_choose_primary_by": [
+      "status_precedence",
+      "detail_reason_catalog_order"
+    ],
+    "non_eligible_status_evaluates_individual_modules": false,
     "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
-    "required_keys_in_sorted_order": [
-      "environment_altitude",
-      "fueling",
+    "required_keys_in_fixed_order": [
       "grade_specificity",
-      "technical_terrain"
+      "technical_terrain",
+      "environment_altitude",
+      "fueling"
     ],
     "state_rules": {
       "available": {
         "guarantees_proposal_inclusion": false,
         "reason_target": null,
-        "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+        "when": "top_level_status_is_eligible_proposal_and_module_inputs_and_science_boundary_permit_consideration"
       },
       "limited": {
         "may_be_included_in_proposal": false,
         "reason_target": "closed_first_party_field_or_section_target",
-        "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+        "when": "top_level_status_is_eligible_proposal_and_accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
       },
       "not_evaluated": {
-        "reason_target": "one_applicable_namespaced_matching_reason",
-        "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+        "all_four_modules_use_same_reason_target": true,
+        "reason_target": "top_level_primary_namespaced_reason",
+        "when": "top_level_status_is_not_eligible_proposal"
       }
     },
     "value_exact_keys": [
@@ -907,6 +929,7 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
     ]
   },
   "namespaced_reason_identity": "<status>.<detail_reason>",
+  "primary_namespaced_reason": "deterministic_top_level_status_dot_detail_reason",
   "road_fallback": false,
   "status_precedence": [
     "validation_failed",
@@ -1151,7 +1174,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
 - Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.
 - Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.
 - Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.
-- This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.
+- This revision incorporates the frozen Product wire semantics at repository commit f9678d64 and Architecture boundary at a52d23ce; it does not approve either role-owned artifact.
 - Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.
 - Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168.
 
@@ -1166,7 +1189,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
     "v2 Trail validation, readiness, and complete reason receipt",
     "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
   ],
-  "contract_digest": "sha256:afb120c2ef58543751b60d68bbe738698395c9c62e4f42a908f8efcbf9b8ff41",
+  "contract_digest": "sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -1605,6 +1628,13 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
             }
           },
           {
+            "condition": "unrecognized_event_format_distance_family_or_planning_intent_literal",
+            "result": {
+              "detail_reason": "invalid_field_value",
+              "status": "validation_failed"
+            }
+          },
+          {
             "condition": "course_or_constraint_schema_id_is_not_exact_v2",
             "result": {
               "detail_reason": "schema_version_mismatch",
@@ -1629,6 +1659,13 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
             "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
             "result": {
               "detail_reason": "material_course_demand_unknown",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "recognized_event_format_distance_family_or_planning_intent_unknown",
+            "result": {
+              "detail_reason": "adult_scope_or_constraints_unconfirmed",
               "status": "clarification_required"
             }
           },
@@ -1738,14 +1775,14 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
             }
           },
           {
-            "condition": "event_ultra_distance_or_multiday",
+            "condition": "recognized_event_format_multi_day_or_distance_family_ultra",
             "result": {
               "detail_reason": "unsupported_ultra_or_multiday",
               "status": "policy_unavailable"
             }
           },
           {
-            "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+            "condition": "unsupported_population_or_clinical_state_or_recognized_first_completion_or_return_to_consistency_intent",
             "result": {
               "detail_reason": "unsupported_population_or_intent",
               "status": "policy_unavailable"
@@ -1799,6 +1836,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
             "deterministic_invariant_failed"
           ]
         },
+        "eligible_proposal_detail_reason": null,
         "goal_remains_recorded": true,
         "limited_modules": {
           "allowed_sorted_order": [
@@ -1838,14 +1876,15 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
             "available",
             "limited"
           ],
+          "arbitrary_reason_selection_allowed": false,
           "authoritative": true,
           "limited_reason_targets": {
             "environment_altitude": [
-              "course.environment_and_altitude"
+              "course.optional_context.environment"
             ],
             "fueling": [
-              "course.aid_and_support",
-              "course.fueling_and_gastrointestinal_context"
+              "course.optional_context.support",
+              "course.optional_context.fueling"
             ],
             "grade_specificity": [
               "course.grade_distribution"
@@ -1854,27 +1893,33 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
               "course.course_footing"
             ]
           },
+          "multiple_matching_reasons_choose_primary_by": [
+            "status_precedence",
+            "detail_reason_catalog_order"
+          ],
+          "non_eligible_status_evaluates_individual_modules": false,
           "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
-          "required_keys_in_sorted_order": [
-            "environment_altitude",
-            "fueling",
+          "required_keys_in_fixed_order": [
             "grade_specificity",
-            "technical_terrain"
+            "technical_terrain",
+            "environment_altitude",
+            "fueling"
           ],
           "state_rules": {
             "available": {
               "guarantees_proposal_inclusion": false,
               "reason_target": null,
-              "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+              "when": "top_level_status_is_eligible_proposal_and_module_inputs_and_science_boundary_permit_consideration"
             },
             "limited": {
               "may_be_included_in_proposal": false,
               "reason_target": "closed_first_party_field_or_section_target",
-              "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+              "when": "top_level_status_is_eligible_proposal_and_accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
             },
             "not_evaluated": {
-              "reason_target": "one_applicable_namespaced_matching_reason",
-              "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+              "all_four_modules_use_same_reason_target": true,
+              "reason_target": "top_level_primary_namespaced_reason",
+              "when": "top_level_status_is_not_eligible_proposal"
             }
           },
           "value_exact_keys": [
@@ -1883,6 +1928,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
           ]
         },
         "namespaced_reason_identity": "<status>.<detail_reason>",
+        "primary_namespaced_reason": "deterministic_top_level_status_dot_detail_reason",
         "road_fallback": false,
         "status_precedence": [
           "validation_failed",
@@ -1952,7 +1998,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56"
+  "source_decision_digest": "sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe"
 }
 ```
 
@@ -2008,7 +2054,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
     "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.",
     "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.",
     "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.",
-    "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.",
+    "This revision incorporates the frozen Product wire semantics at repository commit f9678d64 and Architecture boundary at a52d23ce; it does not approve either role-owned artifact.",
     "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.",
     "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."
   ],
@@ -2525,6 +2571,13 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             }
           },
           {
+            "condition": "unrecognized_event_format_distance_family_or_planning_intent_literal",
+            "result": {
+              "detail_reason": "invalid_field_value",
+              "status": "validation_failed"
+            }
+          },
+          {
             "condition": "course_or_constraint_schema_id_is_not_exact_v2",
             "result": {
               "detail_reason": "schema_version_mismatch",
@@ -2549,6 +2602,13 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
             "result": {
               "detail_reason": "material_course_demand_unknown",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "recognized_event_format_distance_family_or_planning_intent_unknown",
+            "result": {
+              "detail_reason": "adult_scope_or_constraints_unconfirmed",
               "status": "clarification_required"
             }
           },
@@ -2658,14 +2718,14 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             }
           },
           {
-            "condition": "event_ultra_distance_or_multiday",
+            "condition": "recognized_event_format_multi_day_or_distance_family_ultra",
             "result": {
               "detail_reason": "unsupported_ultra_or_multiday",
               "status": "policy_unavailable"
             }
           },
           {
-            "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+            "condition": "unsupported_population_or_clinical_state_or_recognized_first_completion_or_return_to_consistency_intent",
             "result": {
               "detail_reason": "unsupported_population_or_intent",
               "status": "policy_unavailable"
@@ -2719,6 +2779,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "deterministic_invariant_failed"
           ]
         },
+        "eligible_proposal_detail_reason": null,
         "goal_remains_recorded": true,
         "limited_modules": {
           "allowed_sorted_order": [
@@ -2758,14 +2819,15 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "available",
             "limited"
           ],
+          "arbitrary_reason_selection_allowed": false,
           "authoritative": true,
           "limited_reason_targets": {
             "environment_altitude": [
-              "course.environment_and_altitude"
+              "course.optional_context.environment"
             ],
             "fueling": [
-              "course.aid_and_support",
-              "course.fueling_and_gastrointestinal_context"
+              "course.optional_context.support",
+              "course.optional_context.fueling"
             ],
             "grade_specificity": [
               "course.grade_distribution"
@@ -2774,27 +2836,33 @@ Runtime activation remains fail-closed until implementation approval can bind bo
               "course.course_footing"
             ]
           },
+          "multiple_matching_reasons_choose_primary_by": [
+            "status_precedence",
+            "detail_reason_catalog_order"
+          ],
+          "non_eligible_status_evaluates_individual_modules": false,
           "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
-          "required_keys_in_sorted_order": [
-            "environment_altitude",
-            "fueling",
+          "required_keys_in_fixed_order": [
             "grade_specificity",
-            "technical_terrain"
+            "technical_terrain",
+            "environment_altitude",
+            "fueling"
           ],
           "state_rules": {
             "available": {
               "guarantees_proposal_inclusion": false,
               "reason_target": null,
-              "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+              "when": "top_level_status_is_eligible_proposal_and_module_inputs_and_science_boundary_permit_consideration"
             },
             "limited": {
               "may_be_included_in_proposal": false,
               "reason_target": "closed_first_party_field_or_section_target",
-              "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+              "when": "top_level_status_is_eligible_proposal_and_accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
             },
             "not_evaluated": {
-              "reason_target": "one_applicable_namespaced_matching_reason",
-              "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+              "all_four_modules_use_same_reason_target": true,
+              "reason_target": "top_level_primary_namespaced_reason",
+              "when": "top_level_status_is_not_eligible_proposal"
             }
           },
           "value_exact_keys": [
@@ -2803,6 +2871,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           ]
         },
         "namespaced_reason_identity": "<status>.<detail_reason>",
+        "primary_namespaced_reason": "deterministic_top_level_status_dot_detail_reason",
         "road_fallback": false,
         "status_precedence": [
           "validation_failed",

--- a/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
+++ b/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
@@ -3,13 +3,13 @@
 > Start with the decision sheet. The audit appendix preserves every code-consumed field, but it is not the reviewer's primary task.
 
 - **Record:** `sdr-non-ultra-trail-plan-generation-policy-v2`
-- **Lifecycle:** `draft`
+- **Lifecycle:** `accepted`
 - **Model version:** `non-ultra-trail-plan-generation-policy-v2`
 - **Runtime state:** `inactive`
 - **Decision digest:** `sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe`
-- **Contract digest:** `sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d`
+- **Contract digest:** `sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9`
 - **Required decision role:** `decision_approver`
-- **Decision approval:** _Pending_
+- **Decision approval:** `github:dddtc2005` on `2026-09-04` ([source](https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653739))
 - **Required activation role:** `implementation_reviewer`
 - **Implementation approval:** _Pending_
 
@@ -134,7 +134,7 @@ A decision approval bound to the displayed digest attests:
 
 > I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt, authoritative four-module availability, and redundant sorted limitation projection as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. Hiking, strength, and taper remain disabled because v2 has no accepted input and dose contract for them. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
-- **Decision approval:** _Pending_
+- **Decision approval:** `github:dddtc2005` on `2026-09-04` ([source](https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653739))
 
 ### Decision approval
 
@@ -1189,9 +1189,9 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
     "v2 Trail validation, readiness, and complete reason receipt",
     "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
   ],
-  "contract_digest": "sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d",
+  "contract_digest": "sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
-  "decision_status": "draft",
+  "decision_status": "accepted",
   "decision_version": 2,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
+++ b/data/science/generated/review-packets/sdr-non-ultra-trail-plan-generation-policy-v2.md
@@ -6,8 +6,8 @@
 - **Lifecycle:** `draft`
 - **Model version:** `non-ultra-trail-plan-generation-policy-v2`
 - **Runtime state:** `inactive`
-- **Decision digest:** `sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40`
-- **Contract digest:** `sha256:2fb5776b13453937708a77f54c273c81f81f4ca265932e4e0eb0a7ac0da2064b`
+- **Decision digest:** `sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56`
+- **Contract digest:** `sha256:afb120c2ef58543751b60d68bbe738698395c9c62e4f42a908f8efcbf9b8ff41`
 - **Required decision role:** `decision_approver`
 - **Decision approval:** _Pending_
 - **Required activation role:** `implementation_reviewer`
@@ -30,8 +30,8 @@ Do not approve merely because the audit appendix looks reasonable or because you
 
 #### `v2-scope-dependencies-and-modules` — Bind the narrow accepted policy to the two strict v2 schemas
 
-- **Question:** Should the history-rich adult non-ultra performance policy require the accepted v2 ontology, confirmed v2 course and constraint revisions, server-derived history, and the same conditional module structure?
-- **Proposed decision:** Update only the dependency and schema identities while preserving the accepted scope, evidence use, and modular scientific interpretation.
+- **Question:** Should the history-rich adult non-ultra performance policy require the accepted v2 ontology, confirmed v2 course and full schedule-constraint revisions, server-derived history, and an explicitly bounded module structure?
+- **Proposed decision:** Update the dependency and schema identities, preserve the accepted scope and evidence interpretation, and explicitly disable hiking, strength, and taper until accepted inputs and doses exist.
 - **Approval means:**
   - A future inactive evaluator can require exact v2 inputs without widening the eligible population.
   - Known or unknown context cannot silently enable a module.
@@ -47,8 +47,8 @@ Do not approve merely because the audit appendix looks reasonable or because you
 
 #### `unchanged-early-block-construction` — Carry the accepted early-block construction forward unchanged
 
-- **Question:** Should v2 retain every accepted execution, reassessment, history, schedule, and workout-template value exactly as v1?
-- **Proposed decision:** Preserve the exact fourteen-day, seven-day, history qualification, no-progression scheduling, and targetless 38-minute uphill-template guardrails without presenting them as biological optima.
+- **Question:** Should v2 retain every accepted execution, reassessment, history threshold, schedule construction, and workout-template value from v1, while normalizing bare results to cataloged status/detail pairs?
+- **Proposed decision:** Preserve the exact fourteen-day, seven-day, history qualification, no-progression scheduling, and targetless 38-minute uphill-template guardrails without presenting them as biological optima; change only their receipt representation where a pair is required.
 - **Approval means:**
   - The successor changes readiness semantics without silently changing the generated training envelope.
 - **This does not authorize:**
@@ -79,8 +79,8 @@ Do not approve merely because the audit appendix looks reasonable or because you
 
 #### `deterministic-complete-v2-receipt` — Adopt the five-status exhaustive deterministic receipt
 
-- **Question:** Should every safely classified evaluation return one status by fixed precedence, the first cataloged primary detail, every matching reason, and a separate sorted limited-module set?
-- **Proposed decision:** Accept the exact status, detail, namespacing, de-duplication, ordering, independent-evaluation, and module serialization rules from Product v2 as reversible operational guardrails.
+- **Question:** Should every safely classified evaluation return one status by fixed precedence, the first cataloged primary detail, every matching reason, authoritative state for all four modules, and a redundant sorted limited-module projection?
+- **Proposed decision:** Accept the exact status, detail, namespacing, de-duplication, ordering, independent-evaluation, condition mapping, module-availability, and projection rules from Product v2 as reversible operational guardrails.
 - **Approval means:**
   - Clients receive one next-action status without losing simultaneous lower-precedence findings.
   - Malformed fields are never dereferenced merely to fill the receipt.
@@ -121,9 +121,9 @@ Do not approve merely because the audit appendix looks reasonable or because you
 - **This does not authorize:**
   - Taper, progression, fixed dose, broader scope, provider behavior, deployment, or activation.
 
-<details><summary>Traceability: 3 contract groups, 4 evidence claims</summary>
+<details><summary>Traceability: 5 contract groups, 4 evidence claims</summary>
 
-- **Contract groups covered:** `trail_policy_event_and_taper`, `trail_policy_deferred_scope`, `trail_policy_non_science_authority`
+- **Contract groups covered:** `trail_policy_event_and_taper`, `trail_policy_modular_structure`, `trail_policy_evidence_use`, `trail_policy_deferred_scope`, `trail_policy_non_science_authority`
 - **Evidence claims:** `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
 
 </details>
@@ -132,7 +132,7 @@ Do not approve merely because the audit appendix looks reasonable or because you
 
 A decision approval bound to the displayed digest attests:
 
-> I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt and sorted limited modules as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+> I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt, authoritative four-module availability, and redundant sorted limitation projection as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. Hiking, strength, and taper remain disabled because v2 has no accepted input and dose contract for them. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
 - **Decision approval:** _Pending_
 
@@ -145,12 +145,12 @@ Praxys science approval — **APPROVE**
 
 - Role: `decision_approver`
 - Subject: `sdr-non-ultra-trail-plan-generation-policy-v2`
-- Digest: `sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40`
+- Digest: `sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56`
 
-> I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt and sorted limited modules as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+> I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt, authoritative four-module availability, and redundant sorted limitation projection as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. Hiking, strength, and taper remain disabled because v2 has no accepted input and dose contract for them. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
 <!-- praxys-science-approval:v1
-{"role":"decision_approver","subject_digest":"sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40","subject_id":"sdr-non-ultra-trail-plan-generation-policy-v2","subject_kind":"science_decision"}
+{"role":"decision_approver","subject_digest":"sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56","subject_id":"sdr-non-ultra-trail-plan-generation-policy-v2","subject_kind":"science_decision"}
 -->
 ```
 
@@ -160,7 +160,7 @@ Praxys science approval — **APPROVE**
 
 ### Accepted interpretation
 
-If separately accepted after the ontology successor, this record would bind the accepted history-rich adult non-ultra Trail policy to trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing any accepted v1 execution, history, schedule, workout-template, intensity, exposure, event-window, taper deferral, or hard scientific boundary. The fourteen-day proposal, seven-day reassessment, eight-week history window, four usable weeks, three-run usable-week floor, ten-day recent-run check, 42/21-day comparable-history checks, no-initial-progression schedule, targetless 38-minute controlled-uphill template, 75-percent low-intensity floor, one nonconsecutive quality exposure, and separate history-anchored ascent/descent caps remain reversible Praxys guardrails rather than published optima or safety laws. A deterministic v2 receipt returns exactly one of five statuses, one cataloged primary detail when applicable, every independently safe matching reason, and sorted limited modules. It never hides a lower-precedence reason, interprets malformed data to manufacture more reasons, selects a road fallback, uses activity-average power, or authorizes a provider or runtime behavior. Taper, progression above history, fixed fueling, strength, hiking, technical-terrain or recovery dose, back-to-back sessions, universal targets, and personal performance or safety predictions remain unaccepted.
+If separately accepted after the ontology successor, this record would bind the accepted history-rich adult non-ultra Trail policy to trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing any accepted v1 execution, history, schedule, workout-template, intensity, exposure, event-window, taper deferral, or hard scientific boundary. The fourteen-day proposal, seven-day reassessment, eight-week history window, four usable weeks, three-run usable-week floor, ten-day recent-run check, 42/21-day comparable-history checks, no-initial-progression schedule, targetless 38-minute controlled-uphill template, 75-percent low-intensity floor, one nonconsecutive quality exposure, and separate history-anchored ascent/descent caps remain reversible Praxys guardrails rather than published optima or safety laws. A deterministic v2 receipt returns exactly one of five statuses, one cataloged primary detail when applicable, every independently safe matching reason, authoritative availability for four modules, and a redundant sorted limited-module projection. It never hides a lower-precedence reason, interprets malformed data to manufacture more reasons, selects a road fallback, uses activity-average power, or authorizes a provider or runtime behavior. Taper, progression above history, fixed fueling, strength, hiking, taper, technical-terrain or recovery dose, back-to-back sessions, universal targets, and personal performance or safety predictions remain unaccepted.
 
 ### Linked evidence
 
@@ -350,8 +350,16 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
     "stable_recent_running_history",
     "comparable_recent_ascent_exposure",
     "comparable_recent_descent_exposure",
-    "available_training_days_and_limits",
-    "accessible_training_terrain",
+    "available_weekdays",
+    "weekly_time_limit_min",
+    "maximum_session_duration_min",
+    "unavailable_dates_within_14_day_horizon",
+    "optional_preferred_longest_weekday_when_supplied",
+    "nontechnical_three_minute_uphill_access",
+    "controlled_downhill_access",
+    "accessible_footing",
+    "adult_nonclinical_scope_confirmation",
+    "performance_intent_confirmation",
     "current_symptom_stop"
   ],
   "server_derived": [
@@ -388,7 +396,7 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
 
 - **Applies to:** owner-scoped readiness history
 - **Evidence claims:** `eligibility.recent-history-anchor-without-universal-threshold`, `non-ultra-trail.course-specific-policy-required`, `non-ultra-trail.uphill-downhill-require-distinct-handling`
-- **Rationale:** Carried unchanged from accepted v1. The counts prevent extrapolation from sparse records and remain conservative qualifications, not safety, adaptation, or readiness laws.
+- **Rationale:** The accepted v1 counts and windows are unchanged. Only bare outcomes are normalized to cataloged status/detail pairs; the qualifications remain conservative guardrails, not safety, adaptation, or readiness laws.
 - **Exact value:**
 
 ```json
@@ -396,6 +404,22 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
   "comparable_hilly_or_trail_sessions_within_completed_days": {
     "count": 2,
     "window": 42
+  },
+  "insufficient_ascent_or_trail_result": {
+    "detail_reason": "insufficient_comparable_trail_history",
+    "status": "readiness_blocked"
+  },
+  "insufficient_recent_descent_result": {
+    "detail_reason": "insufficient_descent_history",
+    "status": "readiness_blocked"
+  },
+  "insufficient_recent_running_result": {
+    "detail_reason": "insufficient_recent_running_history",
+    "status": "readiness_blocked"
+  },
+  "known_course_footing_not_observed_result": {
+    "detail_reason": "insufficient_comparable_trail_history",
+    "status": "readiness_blocked"
   },
   "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
   "latest_run_within_completed_days": 10,
@@ -408,7 +432,6 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
     "source_timestamp"
   ],
   "recent_history_lookback_completed_weeks": 8,
-  "sparse_or_stale_result": "insufficient_comparable_trail_history",
   "thresholds_are_published_biological_laws": false,
   "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
 }
@@ -418,22 +441,31 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
 
 - **Applies to:** deterministic early-block schedule
 - **Evidence claims:** `eligibility.fixed-progression-and-acwr-not-safety-laws`, `non-ultra-trail.training-specificity-promising-not-prescriptive`
-- **Rationale:** Carried unchanged from accepted v1. Median, maximum, and athlete caps organize existing exposure without automatic progression; one quality session is a conservative Product choice, not a universal optimum.
+- **Rationale:** The accepted v1 construction values are unchanged. Only bare outcomes are normalized to cataloged status/detail pairs. Median, maximum, and athlete caps organize existing exposure without automatic progression.
 - **Exact value:**
 
 ```json
 {
-  "below_minimum_result": "no_schedule_within_envelope",
+  "below_minimum_result": {
+    "detail_reason": "no_schedule_within_envelope",
+    "status": "readiness_blocked"
+  },
   "easy_and_longest_easy_allocation": {
     "automatic_longest_easy_increase": false,
     "preferred_longest_easy_day_used_when_available": true,
     "quality_minutes_allocated_first": true,
     "remaining_minutes_distributed_across_non_quality_days": true
   },
-  "no_schedule_result": "no_schedule_within_envelope",
+  "explicit_request_above_history_envelope_result": {
+    "detail_reason": "training_constraints_outside_history_envelope",
+    "status": "clarification_required"
+  },
+  "no_schedule_result": {
+    "detail_reason": "no_schedule_within_envelope",
+    "status": "readiness_blocked"
+  },
   "non_taper_progression_above_recent_median": false,
   "quality_sessions_per_7_day_unit": 1,
-  "requested_above_maximum_result": "clarification_required",
   "selected_running_days_per_7_day_unit": {
     "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
     "maximum": 6,
@@ -545,7 +577,11 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
   "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
   "session_descent_hard_cap": "recent_maximum_completed_session_descent",
   "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
-  "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+  "unknown_course_footing_module_state": "limited",
+  "unknown_descent_result": {
+    "detail_reason": "material_course_demand_unknown",
+    "status": "clarification_required"
+  },
   "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
   "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
   "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
@@ -557,7 +593,7 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
 
 - **Applies to:** dated Trail goals
 - **Evidence claims:** `non-ultra-trail.taper-direction-indirect`
-- **Rationale:** Carried unchanged from accepted v1. General endurance evidence remains insufficient to select a Trail-specific taper; the event-near path fails closed pending a successor decision.
+- **Rationale:** The accepted v1 event-window behavior is unchanged and its bare outcome is normalized to a cataloged pair. General endurance evidence remains insufficient to select a Trail-specific taper.
 - **Exact value:**
 
 ```json
@@ -566,8 +602,11 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
   "event_or_race_counts_as_quality_and_load": true,
   "imported_event_must_be_athlete_confirmed": true,
   "taper_implementation": "not_accepted",
-  "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
-  "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+  "target_more_than_14_days_after_start_adds_reason": false,
+  "target_within_14_days_of_start_result": {
+    "detail_reason": "event_inside_unapproved_taper_window",
+    "status": "policy_unavailable"
+  }
 }
 ```
 
@@ -581,6 +620,176 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
 ```json
 {
   "authorization_failures_occur_before_product_receipt": true,
+  "condition_reason_mapping": [
+    {
+      "condition": "invalid_type_nonfinite_out_of_domain_duplicate_forbidden_or_internally_inconsistent_value",
+      "result": {
+        "detail_reason": "invalid_field_value",
+        "status": "validation_failed"
+      }
+    },
+    {
+      "condition": "course_or_constraint_schema_id_is_not_exact_v2",
+      "result": {
+        "detail_reason": "schema_version_mismatch",
+        "status": "validation_failed"
+      }
+    },
+    {
+      "condition": "canonical_replay_receipt_proposal_or_other_invariant_fails",
+      "result": {
+        "detail_reason": "deterministic_invariant_failed",
+        "status": "validation_failed"
+      }
+    },
+    {
+      "condition": "required_ontology_policy_or_specialist_dependency_missing_mismatched_inactive_or_not_runtime_authorized",
+      "result": {
+        "detail_reason": "policy_inactive",
+        "status": "policy_unavailable"
+      }
+    },
+    {
+      "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
+      "result": {
+        "detail_reason": "material_course_demand_unknown",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "explicit_assumption_not_confirmed_at_exact_revision",
+      "result": {
+        "detail_reason": "assumption_confirmation_required",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "adult_nonclinical_or_performance_scope_confirmation_missing_or_unknown",
+      "result": {
+        "detail_reason": "adult_scope_or_constraints_unconfirmed",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "schedule_capacity_unavailable_dates_access_footing_or_symptom_input_missing_or_unknown",
+      "result": {
+        "detail_reason": "training_constraints_missing",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "explicit_requested_workload_or_proposal_edit_above_server_history_envelope",
+      "result": {
+        "detail_reason": "training_constraints_outside_history_envelope",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "required_confirmation_course_constraint_or_history_source_revision_stale",
+      "result": {
+        "detail_reason": "stale_confirmation_or_source_revision",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "individually_valid_values_conflict_including_preferred_weekday_outside_available_set",
+      "result": {
+        "detail_reason": "contradictory_input",
+        "status": "clarification_required"
+      }
+    },
+    {
+      "condition": "server_derived_recent_running_continuity_insufficient",
+      "result": {
+        "detail_reason": "insufficient_recent_running_history",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "server_derived_recent_ascent_or_trail_exposure_insufficient",
+      "result": {
+        "detail_reason": "insufficient_comparable_trail_history",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "known_course_footing_not_subset_of_recently_observed_footing",
+      "result": {
+        "detail_reason": "insufficient_comparable_trail_history",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "server_derived_recent_descent_exposure_insufficient",
+      "result": {
+        "detail_reason": "insufficient_descent_history",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "known_uphill_or_downhill_access_false",
+      "result": {
+        "detail_reason": "insufficient_terrain_access",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "known_course_footing_not_subset_of_accessible_footing",
+      "result": {
+        "detail_reason": "insufficient_terrain_access",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "current_symptom_stop_known_true",
+      "result": {
+        "detail_reason": "current_symptom_stop",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "complete_valid_constraints_history_caps_and_spacing_leave_no_14_day_schedule",
+      "result": {
+        "detail_reason": "no_schedule_within_envelope",
+        "status": "readiness_blocked"
+      }
+    },
+    {
+      "condition": "event_within_unapproved_14_day_taper_window",
+      "result": {
+        "detail_reason": "event_inside_unapproved_taper_window",
+        "status": "policy_unavailable"
+      }
+    },
+    {
+      "condition": "event_ultra_distance_or_multiday",
+      "result": {
+        "detail_reason": "unsupported_ultra_or_multiday",
+        "status": "policy_unavailable"
+      }
+    },
+    {
+      "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+      "result": {
+        "detail_reason": "unsupported_population_or_intent",
+        "status": "policy_unavailable"
+      }
+    },
+    {
+      "condition": "hands_assist_or_fixed_rope_known_true",
+      "result": {
+        "detail_reason": "technical_features_outside_v2",
+        "status": "policy_unavailable"
+      }
+    },
+    {
+      "condition": "no_higher_precedence_reason_matches",
+      "result": {
+        "detail_reason": null,
+        "status": "eligible_proposal"
+      }
+    }
+  ],
   "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
   "detail_reason_catalog": {
     "clarification_required": [
@@ -588,6 +797,8 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
       "assumption_confirmation_required",
       "adult_scope_or_constraints_unconfirmed",
       "training_constraints_missing",
+      "training_constraints_outside_history_envelope",
+      "stale_confirmation_or_source_revision",
       "contradictory_input"
     ],
     "eligible_proposal": [],
@@ -622,10 +833,13 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
     ],
     "changes_top_level_status": false,
     "empty_means_eligible": false,
+    "empty_means_included": false,
     "generic_or_road_replacement_allowed": false,
     "hides_matching_reason": false,
+    "projection_of": "module_availability_state_limited",
     "serialize_sorted": true,
-    "set_semantics": true
+    "set_semantics": true,
+    "source_of_truth": false
   },
   "matching_reasons": {
     "de_duplicate": true,
@@ -639,6 +853,57 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
     "pair_fields": [
       "status",
       "detail_reason"
+    ]
+  },
+  "module_availability": {
+    "actual_included_or_omitted_state_exists_only_in_immutable_proposal": true,
+    "allowed_states": [
+      "not_evaluated",
+      "available",
+      "limited"
+    ],
+    "authoritative": true,
+    "limited_reason_targets": {
+      "environment_altitude": [
+        "course.environment_and_altitude"
+      ],
+      "fueling": [
+        "course.aid_and_support",
+        "course.fueling_and_gastrointestinal_context"
+      ],
+      "grade_specificity": [
+        "course.grade_distribution"
+      ],
+      "technical_terrain": [
+        "course.course_footing"
+      ]
+    },
+    "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
+    "required_keys_in_sorted_order": [
+      "environment_altitude",
+      "fueling",
+      "grade_specificity",
+      "technical_terrain"
+    ],
+    "state_rules": {
+      "available": {
+        "guarantees_proposal_inclusion": false,
+        "reason_target": null,
+        "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+      },
+      "limited": {
+        "may_be_included_in_proposal": false,
+        "reason_target": "closed_first_party_field_or_section_target",
+        "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+      },
+      "not_evaluated": {
+        "reason_target": "one_applicable_namespaced_matching_reason",
+        "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+      }
+    },
+    "value_exact_keys": [
+      "state",
+      "reason_target"
     ]
   },
   "namespaced_reason_identity": "<status>.<detail_reason>",
@@ -658,25 +923,38 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
 
 - **Applies to:** future deterministic generator envelope
 - **Evidence claims:** `non-ultra-trail.uphill-downhill-require-distinct-handling`, `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
-- **Rationale:** Carried unchanged from accepted v1. Modular handling preserves distinct demands and uncertainty without claiming one universal Trail schedule.
+- **Rationale:** V2 preserves distinct demand handling but explicitly disables hiking, strength, and taper because no accepted v2 input and dose contract exists. This is a deferral, not evidence that those modules lack value.
 - **Exact value:**
 
 ```json
 {
-  "module_requires_matching_input": true,
-  "modules": [
+  "candidate_modules": [
     "readiness_and_history",
     "easy_and_aerobic",
     "ascent_specificity",
     "descent_and_neuromuscular_exposure",
     "technical_terrain",
-    "hiking",
-    "strength",
     "longest_session_and_fueling_practice",
-    "taper",
     "environment_and_altitude",
     "reassessment_and_outcome"
   ],
+  "disabled_deferred_modules": {
+    "hiking": {
+      "reason": "no_accepted_v2_input_and_dose_contract",
+      "state": "not_accepted"
+    },
+    "strength": {
+      "reason": "no_accepted_v2_input_and_dose_contract",
+      "state": "not_accepted"
+    },
+    "taper": {
+      "reason": "no_accepted_v2_input_and_dose_contract",
+      "state": "not_accepted"
+    }
+  },
+  "disabled_modules_are_module_availability_keys": false,
+  "disabled_modules_may_be_included_in_v2_proposal": false,
+  "module_requires_matching_input": true,
   "unavailable_module_may_be_silently_replaced": false
 }
 ```
@@ -685,17 +963,17 @@ Current signs and symptoms are relevant before vigorous exercise. This supports 
 
 - **Applies to:** module selection and ScienceNote claims
 - **Evidence claims:** `non-ultra-trail.training-specificity-promising-not-prescriptive`, `non-ultra-trail.injury-fatigue-no-safe-dose`, `non-ultra-trail.observed-load-does-not-prove-prescription`, `non-ultra-trail.taper-direction-indirect`, `non-ultra-trail.fueling-duration-and-practice-context`
-- **Rationale:** Carried unchanged from accepted v1. This keeps evidence-supported directions separate from exact prescriptions the sources do not establish.
+- **Rationale:** Evidence-supported directions remain distinct from exact prescriptions; v2 disables modules whose required inputs and dose are not accepted.
 - **Exact value:**
 
 ```json
 {
   "fueling": "expected_duration_and_practice_context_only",
-  "hiking": "conditional_candidate_module",
+  "hiking": "disabled_deferred_no_accepted_v2_input_or_dose",
   "injury_and_fatigue_findings": "safety_context_only",
   "observed_load_associations": "descriptive_only",
-  "strength_and_multimodal": "conditional_candidate_module",
-  "taper": "indirect_direction_only",
+  "strength_and_multimodal": "disabled_deferred_no_accepted_v2_input_or_dose",
+  "taper": "disabled_deferred_no_accepted_v2_input_or_dose",
   "trail_specificity": "conditional_candidate_module"
 }
 ```
@@ -846,8 +1124,8 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
 
 ### Validation plan
 
-- Prove every execution, history, schedule, template, intensity, exposure, event, and hard-boundary value is structurally equal to the accepted v1 contract except the named v2 dependency and receipt groups.
-- Exhaustively exercise every status and detail reason, every pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, and sorted limited modules.
+- Prove every behavior-driving execution, history threshold, schedule construction, template, intensity, exposure, event-window, and hard-boundary value equals accepted v1; allow only the named dependency, pair-normalization, receipt, and disabled-module changes.
+- Exhaustively exercise every status and detail reason, every condition mapping, pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, authoritative four-module state, and sorted redundant limited-module projection.
 - Verify malformed values are not dereferenced while all independently safe policy, history, schedule, and missingness reasons remain present.
 - Unit-test history qualification, schedule allocation, targetless template steps, low-intensity fraction, quality spacing, and separate ascent/descent/terrain caps against immutable owner-scoped snapshots.
 - Verify no proposal is returned from an inactive contract, a core unknown, a failed gate, a stale revision, route/provider input, or any road fallback.
@@ -855,8 +1133,8 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
 
 ### Falsification conditions
 
-- Any accepted v1 execution, history, schedule, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency and receipt groups.
-- Status selection, primary detail, matching-reason ordering, de-duplication, or limited-module sorting is nondeterministic or loses a safely evaluable reason.
+- Any accepted v1 behavior-driving execution, history threshold, schedule construction, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency, pair-normalization, receipt, and disabled-module groups.
+- Status selection, condition mapping, primary detail, matching-reason ordering, de-duplication, module availability, or limited-module projection is nondeterministic or loses a safely evaluable reason.
 - A malformed field is interpreted to manufacture a reason, or a core unknown or failed gate produces eligible_proposal.
 - An exact value outside the accepted early-block guardrails is inferred despite literal not_accepted status.
 - Uphill and downhill collapse, terrain or history access is ignored, or an unsupported module is silently substituted.
@@ -871,6 +1149,9 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
 - Every exact value outside the v2 dependency and receipt groups is carried unchanged from accepted v1 and remains classified as a reversible Praxys guardrail.
 - Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.
 - Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.
+- Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.
+- Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.
+- This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.
 - Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.
 - Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168.
 
@@ -885,7 +1166,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
     "v2 Trail validation, readiness, and complete reason receipt",
     "trail_course_demand_v2 and non_ultra_trail_constraints_v2 matching"
   ],
-  "contract_digest": "sha256:2fb5776b13453937708a77f54c273c81f81f4ca265932e4e0eb0a7ac0da2064b",
+  "contract_digest": "sha256:afb120c2ef58543751b60d68bbe738698395c9c62e4f42a908f8efcbf9b8ff41",
   "decision_id": "sdr-non-ultra-trail-plan-generation-policy-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -935,7 +1216,11 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
         "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
         "session_descent_hard_cap": "recent_maximum_completed_session_descent",
         "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
-        "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+        "unknown_course_footing_module_state": "limited",
+        "unknown_descent_result": {
+          "detail_reason": "material_course_demand_unknown",
+          "status": "clarification_required"
+        },
         "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
         "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
         "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
@@ -976,8 +1261,11 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
         "event_or_race_counts_as_quality_and_load": true,
         "imported_event_must_be_athlete_confirmed": true,
         "taper_implementation": "not_accepted",
-        "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
-        "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+        "target_more_than_14_days_after_start_adds_reason": false,
+        "target_within_14_days_of_start_result": {
+          "detail_reason": "event_inside_unapproved_taper_window",
+          "status": "policy_unavailable"
+        }
       }
     },
     "trail_policy_evidence_use": {
@@ -992,11 +1280,11 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
       ],
       "value": {
         "fueling": "expected_duration_and_practice_context_only",
-        "hiking": "conditional_candidate_module",
+        "hiking": "disabled_deferred_no_accepted_v2_input_or_dose",
         "injury_and_fatigue_findings": "safety_context_only",
         "observed_load_associations": "descriptive_only",
-        "strength_and_multimodal": "conditional_candidate_module",
-        "taper": "indirect_direction_only",
+        "strength_and_multimodal": "disabled_deferred_no_accepted_v2_input_or_dose",
+        "taper": "disabled_deferred_no_accepted_v2_input_or_dose",
         "trail_specificity": "conditional_candidate_module"
       }
     },
@@ -1060,6 +1348,22 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
           "count": 2,
           "window": 42
         },
+        "insufficient_ascent_or_trail_result": {
+          "detail_reason": "insufficient_comparable_trail_history",
+          "status": "readiness_blocked"
+        },
+        "insufficient_recent_descent_result": {
+          "detail_reason": "insufficient_descent_history",
+          "status": "readiness_blocked"
+        },
+        "insufficient_recent_running_result": {
+          "detail_reason": "insufficient_recent_running_history",
+          "status": "readiness_blocked"
+        },
+        "known_course_footing_not_observed_result": {
+          "detail_reason": "insufficient_comparable_trail_history",
+          "status": "readiness_blocked"
+        },
         "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
         "latest_run_within_completed_days": 10,
         "minimum_running_sessions_per_usable_week": 3,
@@ -1071,7 +1375,6 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
           "source_timestamp"
         ],
         "recent_history_lookback_completed_weeks": 8,
-        "sparse_or_stale_result": "insufficient_comparable_trail_history",
         "thresholds_are_published_biological_laws": false,
         "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
       }
@@ -1112,20 +1415,33 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
         "non-ultra-trail.fueling-duration-and-practice-context"
       ],
       "value": {
-        "module_requires_matching_input": true,
-        "modules": [
+        "candidate_modules": [
           "readiness_and_history",
           "easy_and_aerobic",
           "ascent_specificity",
           "descent_and_neuromuscular_exposure",
           "technical_terrain",
-          "hiking",
-          "strength",
           "longest_session_and_fueling_practice",
-          "taper",
           "environment_and_altitude",
           "reassessment_and_outcome"
         ],
+        "disabled_deferred_modules": {
+          "hiking": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          },
+          "strength": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          },
+          "taper": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          }
+        },
+        "disabled_modules_are_module_availability_keys": false,
+        "disabled_modules_may_be_included_in_v2_proposal": false,
+        "module_requires_matching_input": true,
         "unavailable_module_may_be_silently_replaced": false
       }
     },
@@ -1168,8 +1484,16 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
           "stable_recent_running_history",
           "comparable_recent_ascent_exposure",
           "comparable_recent_descent_exposure",
-          "available_training_days_and_limits",
-          "accessible_training_terrain",
+          "available_weekdays",
+          "weekly_time_limit_min",
+          "maximum_session_duration_min",
+          "unavailable_dates_within_14_day_horizon",
+          "optional_preferred_longest_weekday_when_supplied",
+          "nontechnical_three_minute_uphill_access",
+          "controlled_downhill_access",
+          "accessible_footing",
+          "adult_nonclinical_scope_confirmation",
+          "performance_intent_confirmation",
           "current_symptom_stop"
         ],
         "server_derived": [
@@ -1210,17 +1534,26 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
         "non-ultra-trail.training-specificity-promising-not-prescriptive"
       ],
       "value": {
-        "below_minimum_result": "no_schedule_within_envelope",
+        "below_minimum_result": {
+          "detail_reason": "no_schedule_within_envelope",
+          "status": "readiness_blocked"
+        },
         "easy_and_longest_easy_allocation": {
           "automatic_longest_easy_increase": false,
           "preferred_longest_easy_day_used_when_available": true,
           "quality_minutes_allocated_first": true,
           "remaining_minutes_distributed_across_non_quality_days": true
         },
-        "no_schedule_result": "no_schedule_within_envelope",
+        "explicit_request_above_history_envelope_result": {
+          "detail_reason": "training_constraints_outside_history_envelope",
+          "status": "clarification_required"
+        },
+        "no_schedule_result": {
+          "detail_reason": "no_schedule_within_envelope",
+          "status": "readiness_blocked"
+        },
         "non_taper_progression_above_recent_median": false,
         "quality_sessions_per_7_day_unit": 1,
-        "requested_above_maximum_result": "clarification_required",
         "selected_running_days_per_7_day_unit": {
           "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
           "maximum": 6,
@@ -1263,6 +1596,176 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
       ],
       "value": {
         "authorization_failures_occur_before_product_receipt": true,
+        "condition_reason_mapping": [
+          {
+            "condition": "invalid_type_nonfinite_out_of_domain_duplicate_forbidden_or_internally_inconsistent_value",
+            "result": {
+              "detail_reason": "invalid_field_value",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "course_or_constraint_schema_id_is_not_exact_v2",
+            "result": {
+              "detail_reason": "schema_version_mismatch",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "canonical_replay_receipt_proposal_or_other_invariant_fails",
+            "result": {
+              "detail_reason": "deterministic_invariant_failed",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "required_ontology_policy_or_specialist_dependency_missing_mismatched_inactive_or_not_runtime_authorized",
+            "result": {
+              "detail_reason": "policy_inactive",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
+            "result": {
+              "detail_reason": "material_course_demand_unknown",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "explicit_assumption_not_confirmed_at_exact_revision",
+            "result": {
+              "detail_reason": "assumption_confirmation_required",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "adult_nonclinical_or_performance_scope_confirmation_missing_or_unknown",
+            "result": {
+              "detail_reason": "adult_scope_or_constraints_unconfirmed",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "schedule_capacity_unavailable_dates_access_footing_or_symptom_input_missing_or_unknown",
+            "result": {
+              "detail_reason": "training_constraints_missing",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "explicit_requested_workload_or_proposal_edit_above_server_history_envelope",
+            "result": {
+              "detail_reason": "training_constraints_outside_history_envelope",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "required_confirmation_course_constraint_or_history_source_revision_stale",
+            "result": {
+              "detail_reason": "stale_confirmation_or_source_revision",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "individually_valid_values_conflict_including_preferred_weekday_outside_available_set",
+            "result": {
+              "detail_reason": "contradictory_input",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "server_derived_recent_running_continuity_insufficient",
+            "result": {
+              "detail_reason": "insufficient_recent_running_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "server_derived_recent_ascent_or_trail_exposure_insufficient",
+            "result": {
+              "detail_reason": "insufficient_comparable_trail_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_course_footing_not_subset_of_recently_observed_footing",
+            "result": {
+              "detail_reason": "insufficient_comparable_trail_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "server_derived_recent_descent_exposure_insufficient",
+            "result": {
+              "detail_reason": "insufficient_descent_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_uphill_or_downhill_access_false",
+            "result": {
+              "detail_reason": "insufficient_terrain_access",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_course_footing_not_subset_of_accessible_footing",
+            "result": {
+              "detail_reason": "insufficient_terrain_access",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "current_symptom_stop_known_true",
+            "result": {
+              "detail_reason": "current_symptom_stop",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "complete_valid_constraints_history_caps_and_spacing_leave_no_14_day_schedule",
+            "result": {
+              "detail_reason": "no_schedule_within_envelope",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "event_within_unapproved_14_day_taper_window",
+            "result": {
+              "detail_reason": "event_inside_unapproved_taper_window",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "event_ultra_distance_or_multiday",
+            "result": {
+              "detail_reason": "unsupported_ultra_or_multiday",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+            "result": {
+              "detail_reason": "unsupported_population_or_intent",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "hands_assist_or_fixed_rope_known_true",
+            "result": {
+              "detail_reason": "technical_features_outside_v2",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "no_higher_precedence_reason_matches",
+            "result": {
+              "detail_reason": null,
+              "status": "eligible_proposal"
+            }
+          }
+        ],
         "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
         "detail_reason_catalog": {
           "clarification_required": [
@@ -1270,6 +1773,8 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
             "assumption_confirmation_required",
             "adult_scope_or_constraints_unconfirmed",
             "training_constraints_missing",
+            "training_constraints_outside_history_envelope",
+            "stale_confirmation_or_source_revision",
             "contradictory_input"
           ],
           "eligible_proposal": [],
@@ -1304,10 +1809,13 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
           ],
           "changes_top_level_status": false,
           "empty_means_eligible": false,
+          "empty_means_included": false,
           "generic_or_road_replacement_allowed": false,
           "hides_matching_reason": false,
+          "projection_of": "module_availability_state_limited",
           "serialize_sorted": true,
-          "set_semantics": true
+          "set_semantics": true,
+          "source_of_truth": false
         },
         "matching_reasons": {
           "de_duplicate": true,
@@ -1321,6 +1829,57 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
           "pair_fields": [
             "status",
             "detail_reason"
+          ]
+        },
+        "module_availability": {
+          "actual_included_or_omitted_state_exists_only_in_immutable_proposal": true,
+          "allowed_states": [
+            "not_evaluated",
+            "available",
+            "limited"
+          ],
+          "authoritative": true,
+          "limited_reason_targets": {
+            "environment_altitude": [
+              "course.environment_and_altitude"
+            ],
+            "fueling": [
+              "course.aid_and_support",
+              "course.fueling_and_gastrointestinal_context"
+            ],
+            "grade_specificity": [
+              "course.grade_distribution"
+            ],
+            "technical_terrain": [
+              "course.course_footing"
+            ]
+          },
+          "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
+          "required_keys_in_sorted_order": [
+            "environment_altitude",
+            "fueling",
+            "grade_specificity",
+            "technical_terrain"
+          ],
+          "state_rules": {
+            "available": {
+              "guarantees_proposal_inclusion": false,
+              "reason_target": null,
+              "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+            },
+            "limited": {
+              "may_be_included_in_proposal": false,
+              "reason_target": "closed_first_party_field_or_section_target",
+              "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+            },
+            "not_evaluated": {
+              "reason_target": "one_applicable_namespaced_matching_reason",
+              "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+            }
+          },
+          "value_exact_keys": [
+            "state",
+            "reason_target"
           ]
         },
         "namespaced_reason_identity": "<status>.<detail_reason>",
@@ -1393,7 +1952,7 @@ Those inputs and fallbacks are outside the accepted evidence and privacy boundar
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:a52d3e7e79f5783453ff5f19cc7ac13f2a7152f756c82c819e94b363704fdf40"
+  "source_decision_digest": "sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56"
 }
 ```
 
@@ -1409,7 +1968,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
 
 ```json
 {
-  "accepted_interpretation": "If separately accepted after the ontology successor, this record would bind the accepted history-rich adult non-ultra Trail policy to trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing any accepted v1 execution, history, schedule, workout-template, intensity, exposure, event-window, taper deferral, or hard scientific boundary. The fourteen-day proposal, seven-day reassessment, eight-week history window, four usable weeks, three-run usable-week floor, ten-day recent-run check, 42/21-day comparable-history checks, no-initial-progression schedule, targetless 38-minute controlled-uphill template, 75-percent low-intensity floor, one nonconsecutive quality exposure, and separate history-anchored ascent/descent caps remain reversible Praxys guardrails rather than published optima or safety laws. A deterministic v2 receipt returns exactly one of five statuses, one cataloged primary detail when applicable, every independently safe matching reason, and sorted limited modules. It never hides a lower-precedence reason, interprets malformed data to manufacture more reasons, selects a road fallback, uses activity-average power, or authorizes a provider or runtime behavior. Taper, progression above history, fixed fueling, strength, hiking, technical-terrain or recovery dose, back-to-back sessions, universal targets, and personal performance or safety predictions remain unaccepted.",
+  "accepted_interpretation": "If separately accepted after the ontology successor, this record would bind the accepted history-rich adult non-ultra Trail policy to trail_course_demand_v2 and non_ultra_trail_constraints_v2 without changing any accepted v1 execution, history, schedule, workout-template, intensity, exposure, event-window, taper deferral, or hard scientific boundary. The fourteen-day proposal, seven-day reassessment, eight-week history window, four usable weeks, three-run usable-week floor, ten-day recent-run check, 42/21-day comparable-history checks, no-initial-progression schedule, targetless 38-minute controlled-uphill template, 75-percent low-intensity floor, one nonconsecutive quality exposure, and separate history-anchored ascent/descent caps remain reversible Praxys guardrails rather than published optima or safety laws. A deterministic v2 receipt returns exactly one of five statuses, one cataloged primary detail when applicable, every independently safe matching reason, authoritative availability for four modules, and a redundant sorted limited-module projection. It never hides a lower-precedence reason, interprets malformed data to manufacture more reasons, selects a road fallback, uses activity-average power, or authorizes a provider or runtime behavior. Taper, progression above history, fixed fueling, strength, hiking, taper, technical-terrain or recovery dose, back-to-back sessions, universal targets, and personal performance or safety predictions remain unaccepted.",
   "affected_surfaces": {
     "apis": [
       "future inactive v2 Trail readiness and proposal contracts"
@@ -1447,11 +2006,14 @@ Runtime activation remains fail-closed until implementation approval can bind bo
     "Every exact value outside the v2 dependency and receipt groups is carried unchanged from accepted v1 and remains classified as a reversible Praxys guardrail.",
     "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.",
     "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.",
+    "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.",
+    "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.",
+    "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.",
     "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.",
     "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."
   ],
   "decision_review": {
-    "approval_statement": "I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt and sorted limited modules as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.",
+    "approval_statement": "I approve the non-ultra Trail policy v2 as a strict successor candidate bound to trail_course_demand_v2 and non_ultra_trail_constraints_v2. I approve carrying forward unchanged the accepted v1 fourteen-day execution, seven-day reassessment, history qualification, no-initial-progression schedule, targetless controlled-uphill template, intensity spacing, separate ascent and descent caps, event-window behavior, and hard Science boundaries. I approve the five-status exhaustive reason receipt, authoritative four-module availability, and redundant sorted limitation projection as reversible Praxys operational guardrails, not as published biological rules, validated safe doses, equivalences, or predictions. Hiking, strength, and taper remain disabled because v2 has no accepted input and dose contract for them. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.",
     "items": [
       {
         "approval_effect": [
@@ -1474,8 +2036,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "trail_policy_modular_structure",
           "trail_policy_evidence_use"
         ],
-        "proposed_decision": "Update only the dependency and schema identities while preserving the accepted scope, evidence use, and modular scientific interpretation.",
-        "question": "Should the history-rich adult non-ultra performance policy require the accepted v2 ontology, confirmed v2 course and constraint revisions, server-derived history, and the same conditional module structure?",
+        "proposed_decision": "Update the dependency and schema identities, preserve the accepted scope and evidence interpretation, and explicitly disable hiking, strength, and taper until accepted inputs and doses exist.",
+        "question": "Should the history-rich adult non-ultra performance policy require the accepted v2 ontology, confirmed v2 course and full schedule-constraint revisions, server-derived history, and an explicitly bounded module structure?",
         "title": "Bind the narrow accepted policy to the two strict v2 schemas"
       },
       {
@@ -1498,8 +2060,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "trail_policy_schedule_construction",
           "trail_policy_workout_templates"
         ],
-        "proposed_decision": "Preserve the exact fourteen-day, seven-day, history qualification, no-progression scheduling, and targetless 38-minute uphill-template guardrails without presenting them as biological optima.",
-        "question": "Should v2 retain every accepted execution, reassessment, history, schedule, and workout-template value exactly as v1?",
+        "proposed_decision": "Preserve the exact fourteen-day, seven-day, history qualification, no-progression scheduling, and targetless 38-minute uphill-template guardrails without presenting them as biological optima; change only their receipt representation where a pair is required.",
+        "question": "Should v2 retain every accepted execution, reassessment, history threshold, schedule construction, and workout-template value from v1, while normalizing bare results to cataloged status/detail pairs?",
         "title": "Carry the accepted early-block construction forward unchanged"
       },
       {
@@ -1543,8 +2105,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "parameter_names": [
           "trail_policy_typed_outcomes"
         ],
-        "proposed_decision": "Accept the exact status, detail, namespacing, de-duplication, ordering, independent-evaluation, and module serialization rules from Product v2 as reversible operational guardrails.",
-        "question": "Should every safely classified evaluation return one status by fixed precedence, the first cataloged primary detail, every matching reason, and a separate sorted limited-module set?",
+        "proposed_decision": "Accept the exact status, detail, namespacing, de-duplication, ordering, independent-evaluation, condition mapping, module-availability, and projection rules from Product v2 as reversible operational guardrails.",
+        "question": "Should every safely classified evaluation return one status by fixed precedence, the first cataloged primary detail, every matching reason, authoritative state for all four modules, and a redundant sorted limited-module projection?",
         "title": "Adopt the five-status exhaustive deterministic receipt"
       },
       {
@@ -1564,6 +2126,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "id": "unresolved-dose-and-scope-stays-deferred",
         "parameter_names": [
           "trail_policy_event_and_taper",
+          "trail_policy_modular_structure",
+          "trail_policy_evidence_use",
           "trail_policy_deferred_scope",
           "trail_policy_non_science_authority"
         ],
@@ -1620,8 +2184,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
     "evidence-plan-generation-eligibility-safety-v1"
   ],
   "falsification_conditions": [
-    "Any accepted v1 execution, history, schedule, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency and receipt groups.",
-    "Status selection, primary detail, matching-reason ordering, de-duplication, or limited-module sorting is nondeterministic or loses a safely evaluable reason.",
+    "Any accepted v1 behavior-driving execution, history threshold, schedule construction, template, intensity, exposure, event-window, taper deferral, or hard boundary changes outside the named dependency, pair-normalization, receipt, and disabled-module groups.",
+    "Status selection, condition mapping, primary detail, matching-reason ordering, de-duplication, module availability, or limited-module projection is nondeterministic or loses a safely evaluable reason.",
     "A malformed field is interpreted to manufacture a reason, or a core unknown or failed gate produces eligible_proposal.",
     "An exact value outside the accepted early-block guardrails is inferred despite literal not_accepted status.",
     "Uphill and downhill collapse, terrain or history access is ignored, or an unsupported module is silently substituted.",
@@ -1680,8 +2244,16 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "stable_recent_running_history",
           "comparable_recent_ascent_exposure",
           "comparable_recent_descent_exposure",
-          "available_training_days_and_limits",
-          "accessible_training_terrain",
+          "available_weekdays",
+          "weekly_time_limit_min",
+          "maximum_session_duration_min",
+          "unavailable_dates_within_14_day_horizon",
+          "optional_preferred_longest_weekday_when_supplied",
+          "nontechnical_three_minute_uphill_access",
+          "controlled_downhill_access",
+          "accessible_footing",
+          "adult_nonclinical_scope_confirmation",
+          "performance_intent_confirmation",
           "current_symptom_stop"
         ],
         "server_derived": [
@@ -1722,11 +2294,27 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "non-ultra-trail.uphill-downhill-require-distinct-handling"
       ],
       "name": "trail_policy_history_guardrails",
-      "rationale": "Carried unchanged from accepted v1. The counts prevent extrapolation from sparse records and remain conservative qualifications, not safety, adaptation, or readiness laws.",
+      "rationale": "The accepted v1 counts and windows are unchanged. Only bare outcomes are normalized to cataloged status/detail pairs; the qualifications remain conservative guardrails, not safety, adaptation, or readiness laws.",
       "value": {
         "comparable_hilly_or_trail_sessions_within_completed_days": {
           "count": 2,
           "window": 42
+        },
+        "insufficient_ascent_or_trail_result": {
+          "detail_reason": "insufficient_comparable_trail_history",
+          "status": "readiness_blocked"
+        },
+        "insufficient_recent_descent_result": {
+          "detail_reason": "insufficient_descent_history",
+          "status": "readiness_blocked"
+        },
+        "insufficient_recent_running_result": {
+          "detail_reason": "insufficient_recent_running_history",
+          "status": "readiness_blocked"
+        },
+        "known_course_footing_not_observed_result": {
+          "detail_reason": "insufficient_comparable_trail_history",
+          "status": "readiness_blocked"
         },
         "latest_comparable_hilly_or_trail_session_within_completed_days": 21,
         "latest_run_within_completed_days": 10,
@@ -1739,7 +2327,6 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "source_timestamp"
         ],
         "recent_history_lookback_completed_weeks": 8,
-        "sparse_or_stale_result": "insufficient_comparable_trail_history",
         "thresholds_are_published_biological_laws": false,
         "unknown_descent_or_terrain_cannot_satisfy_comparable_exposure": true
       }
@@ -1752,19 +2339,28 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "non-ultra-trail.training-specificity-promising-not-prescriptive"
       ],
       "name": "trail_policy_schedule_construction",
-      "rationale": "Carried unchanged from accepted v1. Median, maximum, and athlete caps organize existing exposure without automatic progression; one quality session is a conservative Product choice, not a universal optimum.",
+      "rationale": "The accepted v1 construction values are unchanged. Only bare outcomes are normalized to cataloged status/detail pairs. Median, maximum, and athlete caps organize existing exposure without automatic progression.",
       "value": {
-        "below_minimum_result": "no_schedule_within_envelope",
+        "below_minimum_result": {
+          "detail_reason": "no_schedule_within_envelope",
+          "status": "readiness_blocked"
+        },
         "easy_and_longest_easy_allocation": {
           "automatic_longest_easy_increase": false,
           "preferred_longest_easy_day_used_when_available": true,
           "quality_minutes_allocated_first": true,
           "remaining_minutes_distributed_across_non_quality_days": true
         },
-        "no_schedule_result": "no_schedule_within_envelope",
+        "explicit_request_above_history_envelope_result": {
+          "detail_reason": "training_constraints_outside_history_envelope",
+          "status": "clarification_required"
+        },
+        "no_schedule_result": {
+          "detail_reason": "no_schedule_within_envelope",
+          "status": "readiness_blocked"
+        },
         "non_taper_progression_above_recent_median": false,
         "quality_sessions_per_7_day_unit": 1,
-        "requested_above_maximum_result": "clarification_required",
         "selected_running_days_per_7_day_unit": {
           "deterministic_value": "minimum_of_available_days_recent_modal_days_and_policy_maximum",
           "maximum": 6,
@@ -1878,7 +2474,11 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "session_ascent_hard_cap": "recent_maximum_completed_session_ascent",
         "session_descent_hard_cap": "recent_maximum_completed_session_descent",
         "technicality": "no_more_difficult_than_recently_observed_and_currently_accessible_category",
-        "unknown_descent_or_technicality_result": "clarification_or_limited_module",
+        "unknown_course_footing_module_state": "limited",
+        "unknown_descent_result": {
+          "detail_reason": "material_course_demand_unknown",
+          "status": "clarification_required"
+        },
         "weekly_ascent_hard_cap": "recent_maximum_usable_weekly_ascent",
         "weekly_ascent_target": "no_more_than_recent_median_usable_weekly_ascent",
         "weekly_descent_hard_cap": "recent_maximum_usable_weekly_descent",
@@ -1892,14 +2492,17 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "non-ultra-trail.taper-direction-indirect"
       ],
       "name": "trail_policy_event_and_taper",
-      "rationale": "Carried unchanged from accepted v1. General endurance evidence remains insufficient to select a Trail-specific taper; the event-near path fails closed pending a successor decision.",
+      "rationale": "The accepted v1 event-window behavior is unchanged and its bare outcome is normalized to a cataloged pair. General endurance evidence remains insufficient to select a Trail-specific taper.",
       "value": {
         "event_day_generated_as_training_workout": false,
         "event_or_race_counts_as_quality_and_load": true,
         "imported_event_must_be_athlete_confirmed": true,
         "taper_implementation": "not_accepted",
-        "target_more_than_14_days_after_start": "normal_14_day_rolling_proposal",
-        "target_within_14_days_of_start": "event_inside_unapproved_taper_window"
+        "target_more_than_14_days_after_start_adds_reason": false,
+        "target_within_14_days_of_start_result": {
+          "detail_reason": "event_inside_unapproved_taper_window",
+          "status": "policy_unavailable"
+        }
       }
     },
     {
@@ -1913,6 +2516,176 @@ Runtime activation remains fail-closed until implementation approval can bind bo
       "rationale": "The evidence supports explicit missingness and bounded applicability, but the five statuses, exact reason catalog, precedence, and serialization are reversible Product-selected operational guardrails rather than a biological readiness or risk model.",
       "value": {
         "authorization_failures_occur_before_product_receipt": true,
+        "condition_reason_mapping": [
+          {
+            "condition": "invalid_type_nonfinite_out_of_domain_duplicate_forbidden_or_internally_inconsistent_value",
+            "result": {
+              "detail_reason": "invalid_field_value",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "course_or_constraint_schema_id_is_not_exact_v2",
+            "result": {
+              "detail_reason": "schema_version_mismatch",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "canonical_replay_receipt_proposal_or_other_invariant_fails",
+            "result": {
+              "detail_reason": "deterministic_invariant_failed",
+              "status": "validation_failed"
+            }
+          },
+          {
+            "condition": "required_ontology_policy_or_specialist_dependency_missing_mismatched_inactive_or_not_runtime_authorized",
+            "result": {
+              "detail_reason": "policy_inactive",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "event_identity_date_distance_ascent_descent_planning_duration_or_hazard_unknown",
+            "result": {
+              "detail_reason": "material_course_demand_unknown",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "explicit_assumption_not_confirmed_at_exact_revision",
+            "result": {
+              "detail_reason": "assumption_confirmation_required",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "adult_nonclinical_or_performance_scope_confirmation_missing_or_unknown",
+            "result": {
+              "detail_reason": "adult_scope_or_constraints_unconfirmed",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "schedule_capacity_unavailable_dates_access_footing_or_symptom_input_missing_or_unknown",
+            "result": {
+              "detail_reason": "training_constraints_missing",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "explicit_requested_workload_or_proposal_edit_above_server_history_envelope",
+            "result": {
+              "detail_reason": "training_constraints_outside_history_envelope",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "required_confirmation_course_constraint_or_history_source_revision_stale",
+            "result": {
+              "detail_reason": "stale_confirmation_or_source_revision",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "individually_valid_values_conflict_including_preferred_weekday_outside_available_set",
+            "result": {
+              "detail_reason": "contradictory_input",
+              "status": "clarification_required"
+            }
+          },
+          {
+            "condition": "server_derived_recent_running_continuity_insufficient",
+            "result": {
+              "detail_reason": "insufficient_recent_running_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "server_derived_recent_ascent_or_trail_exposure_insufficient",
+            "result": {
+              "detail_reason": "insufficient_comparable_trail_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_course_footing_not_subset_of_recently_observed_footing",
+            "result": {
+              "detail_reason": "insufficient_comparable_trail_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "server_derived_recent_descent_exposure_insufficient",
+            "result": {
+              "detail_reason": "insufficient_descent_history",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_uphill_or_downhill_access_false",
+            "result": {
+              "detail_reason": "insufficient_terrain_access",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "known_course_footing_not_subset_of_accessible_footing",
+            "result": {
+              "detail_reason": "insufficient_terrain_access",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "current_symptom_stop_known_true",
+            "result": {
+              "detail_reason": "current_symptom_stop",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "complete_valid_constraints_history_caps_and_spacing_leave_no_14_day_schedule",
+            "result": {
+              "detail_reason": "no_schedule_within_envelope",
+              "status": "readiness_blocked"
+            }
+          },
+          {
+            "condition": "event_within_unapproved_14_day_taper_window",
+            "result": {
+              "detail_reason": "event_inside_unapproved_taper_window",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "event_ultra_distance_or_multiday",
+            "result": {
+              "detail_reason": "unsupported_ultra_or_multiday",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "population_clinical_return_to_sport_or_intent_outside_scope",
+            "result": {
+              "detail_reason": "unsupported_population_or_intent",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "hands_assist_or_fixed_rope_known_true",
+            "result": {
+              "detail_reason": "technical_features_outside_v2",
+              "status": "policy_unavailable"
+            }
+          },
+          {
+            "condition": "no_higher_precedence_reason_matches",
+            "result": {
+              "detail_reason": null,
+              "status": "eligible_proposal"
+            }
+          }
+        ],
         "detail_reason": "first_matching_reason_in_selected_status_catalog_order",
         "detail_reason_catalog": {
           "clarification_required": [
@@ -1920,6 +2693,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "assumption_confirmation_required",
             "adult_scope_or_constraints_unconfirmed",
             "training_constraints_missing",
+            "training_constraints_outside_history_envelope",
+            "stale_confirmation_or_source_revision",
             "contradictory_input"
           ],
           "eligible_proposal": [],
@@ -1954,10 +2729,13 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           ],
           "changes_top_level_status": false,
           "empty_means_eligible": false,
+          "empty_means_included": false,
           "generic_or_road_replacement_allowed": false,
           "hides_matching_reason": false,
+          "projection_of": "module_availability_state_limited",
           "serialize_sorted": true,
-          "set_semantics": true
+          "set_semantics": true,
+          "source_of_truth": false
         },
         "matching_reasons": {
           "de_duplicate": true,
@@ -1971,6 +2749,57 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "pair_fields": [
             "status",
             "detail_reason"
+          ]
+        },
+        "module_availability": {
+          "actual_included_or_omitted_state_exists_only_in_immutable_proposal": true,
+          "allowed_states": [
+            "not_evaluated",
+            "available",
+            "limited"
+          ],
+          "authoritative": true,
+          "limited_reason_targets": {
+            "environment_altitude": [
+              "course.environment_and_altitude"
+            ],
+            "fueling": [
+              "course.aid_and_support",
+              "course.fueling_and_gastrointestinal_context"
+            ],
+            "grade_specificity": [
+              "course.grade_distribution"
+            ],
+            "technical_terrain": [
+              "course.course_footing"
+            ]
+          },
+          "reason_target_may_be_url_fragment_value_identifier_or_client_string": false,
+          "required_keys_in_sorted_order": [
+            "environment_altitude",
+            "fueling",
+            "grade_specificity",
+            "technical_terrain"
+          ],
+          "state_rules": {
+            "available": {
+              "guarantees_proposal_inclusion": false,
+              "reason_target": null,
+              "when": "module_inputs_and_science_boundary_permit_generation_to_consider_the_module"
+            },
+            "limited": {
+              "may_be_included_in_proposal": false,
+              "reason_target": "closed_first_party_field_or_section_target",
+              "when": "accepted_non_core_unknown_requires_omission_or_descriptive_only_handling"
+            },
+            "not_evaluated": {
+              "reason_target": "one_applicable_namespaced_matching_reason",
+              "when": "validation_policy_clarification_or_core_readiness_prevents_safe_module_decision"
+            }
+          },
+          "value_exact_keys": [
+            "state",
+            "reason_target"
           ]
         },
         "namespaced_reason_identity": "<status>.<detail_reason>",
@@ -1995,22 +2824,35 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "non-ultra-trail.fueling-duration-and-practice-context"
       ],
       "name": "trail_policy_modular_structure",
-      "rationale": "Carried unchanged from accepted v1. Modular handling preserves distinct demands and uncertainty without claiming one universal Trail schedule.",
+      "rationale": "V2 preserves distinct demand handling but explicitly disables hiking, strength, and taper because no accepted v2 input and dose contract exists. This is a deferral, not evidence that those modules lack value.",
       "value": {
-        "module_requires_matching_input": true,
-        "modules": [
+        "candidate_modules": [
           "readiness_and_history",
           "easy_and_aerobic",
           "ascent_specificity",
           "descent_and_neuromuscular_exposure",
           "technical_terrain",
-          "hiking",
-          "strength",
           "longest_session_and_fueling_practice",
-          "taper",
           "environment_and_altitude",
           "reassessment_and_outcome"
         ],
+        "disabled_deferred_modules": {
+          "hiking": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          },
+          "strength": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          },
+          "taper": {
+            "reason": "no_accepted_v2_input_and_dose_contract",
+            "state": "not_accepted"
+          }
+        },
+        "disabled_modules_are_module_availability_keys": false,
+        "disabled_modules_may_be_included_in_v2_proposal": false,
+        "module_requires_matching_input": true,
         "unavailable_module_may_be_silently_replaced": false
       }
     },
@@ -2025,14 +2867,14 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "non-ultra-trail.fueling-duration-and-practice-context"
       ],
       "name": "trail_policy_evidence_use",
-      "rationale": "Carried unchanged from accepted v1. This keeps evidence-supported directions separate from exact prescriptions the sources do not establish.",
+      "rationale": "Evidence-supported directions remain distinct from exact prescriptions; v2 disables modules whose required inputs and dose are not accepted.",
       "value": {
         "fueling": "expected_duration_and_practice_context_only",
-        "hiking": "conditional_candidate_module",
+        "hiking": "disabled_deferred_no_accepted_v2_input_or_dose",
         "injury_and_fatigue_findings": "safety_context_only",
         "observed_load_associations": "descriptive_only",
-        "strength_and_multimodal": "conditional_candidate_module",
-        "taper": "indirect_direction_only",
+        "strength_and_multimodal": "disabled_deferred_no_accepted_v2_input_or_dose",
+        "taper": "disabled_deferred_no_accepted_v2_input_or_dose",
         "trail_specificity": "conditional_candidate_module"
       }
     },
@@ -2179,8 +3021,8 @@ Runtime activation remains fail-closed until implementation approval can bind bo
     "Do not show a personal finish probability, target guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance."
   ],
   "validation_plan": [
-    "Prove every execution, history, schedule, template, intensity, exposure, event, and hard-boundary value is structurally equal to the accepted v1 contract except the named v2 dependency and receipt groups.",
-    "Exhaustively exercise every status and detail reason, every pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, and sorted limited modules.",
+    "Prove every behavior-driving execution, history threshold, schedule construction, template, intensity, exposure, event-window, and hard-boundary value equals accepted v1; allow only the named dependency, pair-normalization, receipt, and disabled-module changes.",
+    "Exhaustively exercise every status and detail reason, every condition mapping, pairwise and representative multi-reason combination, fixed precedence, catalog order, de-duplication, authoritative four-module state, and sorted redundant limited-module projection.",
     "Verify malformed values are not dereferenced while all independently safe policy, history, schedule, and missingness reasons remain present.",
     "Unit-test history qualification, schedule allocation, targetless template steps, low-intensity fraction, quality spacing, and separate ascent/descent/terrain caps against immutable owner-scoped snapshots.",
     "Verify no proposal is returned from an inactive contract, a core unknown, a failed gate, a stale revision, route/provider input, or any road fallback.",

--- a/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v1.md
+++ b/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v1.md
@@ -3,11 +3,11 @@
 > Start with the decision sheet. The audit appendix preserves every code-consumed field, but it is not the reviewer's primary task.
 
 - **Record:** `sdr-trail-running-goal-ontology-v1`
-- **Lifecycle:** `accepted`
+- **Lifecycle:** `superseded`
 - **Model version:** `trail-course-demand-v1`
 - **Runtime state:** `inactive`
 - **Decision digest:** `sha256:cb53936289927d0f5f73268b5b6468e17a5b771532e2eaeee5c5c8781e541774`
-- **Contract digest:** `sha256:5bf6b47ede65af84af85fb364d148bffa38c1ea330272a3e71553d091a8695dc`
+- **Contract digest:** `sha256:e341c379d8f60a27ee5919beab4800721c96b79458c861237d6e14800cdcd752`
 - **Required decision role:** `decision_approver`
 - **Decision approval:** `github:dddtc2005` on `2026-09-03` ([source](https://github.com/praxys-run/praxys/pull/759#issuecomment-5527639012))
 - **Required activation role:** `implementation_reviewer`
@@ -514,9 +514,9 @@ Generated assumptions cannot replace athlete confirmation or a verified course s
     "trail_course_demand_v1 ontology",
     "trail capability matching contract"
   ],
-  "contract_digest": "sha256:5bf6b47ede65af84af85fb364d148bffa38c1ea330272a3e71553d091a8695dc",
+  "contract_digest": "sha256:e341c379d8f60a27ee5919beab4800721c96b79458c861237d6e14800cdcd752",
   "decision_id": "sdr-trail-running-goal-ontology-v1",
-  "decision_status": "accepted",
+  "decision_status": "superseded",
   "decision_version": 1,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
+++ b/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
@@ -6,8 +6,8 @@
 - **Lifecycle:** `draft`
 - **Model version:** `trail-course-demand-v2`
 - **Runtime state:** `inactive`
-- **Decision digest:** `sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c`
-- **Contract digest:** `sha256:1297f713b992822335978dac92cfaa9b968b092d4ff6869ad73baa3d94ee2e7a`
+- **Decision digest:** `sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1`
+- **Contract digest:** `sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617`
 - **Required decision role:** `decision_approver`
 - **Decision approval:** _Pending_
 - **Required activation role:** `implementation_reviewer`
@@ -31,7 +31,7 @@ Do not approve merely because the audit appendix looks reasonable or because you
 #### `strict-value-provenance-envelope` — Adopt explicit field states and server-owned provenance
 
 - **Question:** Should every reviewable v2 field use an exact known-or-unknown envelope while provenance, source metadata, and history hashes remain server-owned and revision-bound?
-- **Proposed decision:** Accept the closed envelope, provenance categories, field-specific provenance restrictions, immutable revisions, and confirmation invalidation rules as operational guardrails.
+- **Proposed decision:** Accept the closed envelope, provenance categories, field-specific provenance restrictions, replaceable current revision tokens, proposal-time immutable snapshots, and confirmation invalidation rules as operational guardrails.
 - **Approval means:**
   - Missing values cannot be represented as zero, empty text, or a client-selected source.
   - Readiness and proposals can bind the exact confirmed source revisions used.
@@ -148,12 +148,12 @@ Praxys science approval — **APPROVE**
 
 - Role: `decision_approver`
 - Subject: `sdr-trail-running-goal-ontology-v2`
-- Digest: `sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c`
+- Digest: `sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1`
 
 > I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and known-or-unknown boolean hazard fields, exact footing containment, bounded schedule and optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
 <!-- praxys-science-approval:v1
-{"role":"decision_approver","subject_digest":"sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c","subject_id":"sdr-trail-running-goal-ontology-v2","subject_kind":"science_decision"}
+{"role":"decision_approver","subject_digest":"sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1","subject_id":"sdr-trail-running-goal-ontology-v2","subject_kind":"science_decision"}
 -->
 ```
 
@@ -241,12 +241,6 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "type": "server_owned_identifier"
   },
   "fields": {
-    "aid_and_support": {
-      "envelope": "known_or_unknown",
-      "limited_module": "fueling",
-      "materiality": "limited",
-      "type": "bounded_object"
-    },
     "course_footing": {
       "envelope": "known_or_unknown",
       "limited_module": "technical_terrain",
@@ -254,11 +248,13 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "type": "nonempty_unordered_closed_set"
     },
     "distance_family": {
-      "allowed": [
-        "non_ultra"
-      ],
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "recognized": [
+        "non_ultra",
+        "ultra"
+      ],
+      "supported_value": "non_ultra",
       "type": "closed_enum"
     },
     "distance_meters": {
@@ -269,35 +265,25 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "type": "integer",
       "unit": "meters"
     },
-    "environment_and_altitude": {
-      "envelope": "known_or_unknown",
-      "limited_module": "environment_altitude",
-      "materiality": "limited",
-      "type": "bounded_object"
-    },
     "event_date": {
       "envelope": "known_or_unknown",
       "materiality": "core",
       "type": "iso_date"
     },
     "event_format": {
-      "allowed": [
-        "single_day"
-      ],
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "recognized": [
+        "single_day",
+        "multi_day"
+      ],
+      "supported_value": "single_day",
       "type": "closed_enum"
     },
     "fixed_rope": {
       "envelope": "known_or_unknown",
       "materiality": "core",
       "type": "strict_boolean"
-    },
-    "fueling_and_gastrointestinal_context": {
-      "envelope": "known_or_unknown",
-      "limited_module": "fueling",
-      "materiality": "limited",
-      "type": "bounded_object"
     },
     "grade_distribution": {
       "envelope": "known_or_unknown",
@@ -310,6 +296,18 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "materiality": "core",
       "type": "strict_boolean"
     },
+    "optional_context": {
+      "every_declared_leaf_required": true,
+      "every_leaf_envelope": "known_or_unknown",
+      "exact_groups": [
+        "environment",
+        "support",
+        "fueling"
+      ],
+      "group_envelope_allowed": false,
+      "materiality": "limited_by_leaf",
+      "type": "strict_fixed_key_object"
+    },
     "planning_duration_range": {
       "envelope": "known_or_unknown",
       "materiality": "core",
@@ -317,11 +315,14 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "unit": "minutes"
     },
     "planning_intent": {
-      "allowed": [
-        "performance"
-      ],
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "recognized": [
+        "performance",
+        "first_completion",
+        "return_to_consistency"
+      ],
+      "supported_value": "performance",
       "type": "closed_enum"
     },
     "total_ascent_m": {
@@ -342,6 +343,24 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     }
   },
   "schema_id": "trail_course_demand_v2",
+  "scope_enum_results": {
+    "recognized_multi_day_or_ultra": {
+      "detail_reason": "unsupported_ultra_or_multiday",
+      "status": "policy_unavailable"
+    },
+    "recognized_non_performance_intent": {
+      "detail_reason": "unsupported_population_or_intent",
+      "status": "policy_unavailable"
+    },
+    "unknown_recognized_scope": {
+      "detail_reason": "adult_scope_or_constraints_unconfirmed",
+      "status": "clarification_required"
+    },
+    "unrecognized_literal": {
+      "detail_reason": "invalid_field_value",
+      "status": "validation_failed"
+    }
+  },
   "strict_unknown_fields_rejected": true
 }
 ```
@@ -684,13 +703,121 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
 
 ```json
 {
-  "aid_and_support": {
+  "common_leaf_envelope": "known_or_unknown",
+  "enum_unknown_literals_allowed": false,
+  "environment": {
+    "conditions_basis": {
+      "athlete_assumption_provenance": "explicit_assumption",
+      "athlete_assumption_requires_confirmation": true,
+      "envelope": "known_or_unknown",
+      "known_allowed": [
+        "organizer_information",
+        "seasonal_expectation",
+        "athlete_assumption"
+      ]
+    },
+    "cross_field_rules": {
+      "humidity_order_when_both_known": "humidity_min_pct_lte_humidity_max_pct",
+      "one_unknown_leaf_remains_unknown_without_inventing_other_bound": true,
+      "temperature_order_when_both_known": "temperature_min_c_lte_temperature_max_c"
+    },
+    "humidity_max_pct": {
+      "envelope": "known_or_unknown",
+      "maximum": 100,
+      "minimum": 0,
+      "type": "finite_number"
+    },
+    "humidity_min_pct": {
+      "envelope": "known_or_unknown",
+      "maximum": 100,
+      "minimum": 0,
+      "type": "finite_number"
+    },
+    "maximum_altitude_m": {
+      "envelope": "known_or_unknown",
+      "maximum": 9000,
+      "minimum": -500,
+      "type": "integer"
+    },
+    "sun_exposure": {
+      "envelope": "known_or_unknown",
+      "known_allowed": [
+        "low",
+        "mixed",
+        "high"
+      ]
+    },
+    "temperature_max_c": {
+      "envelope": "known_or_unknown",
+      "maximum": 55,
+      "minimum": -30,
+      "type": "finite_number"
+    },
+    "temperature_min_c": {
+      "envelope": "known_or_unknown",
+      "maximum": 55,
+      "minimum": -30,
+      "type": "finite_number"
+    },
+    "wind_exposure": {
+      "envelope": "known_or_unknown",
+      "known_allowed": [
+        "sheltered",
+        "mixed",
+        "exposed"
+      ]
+    }
+  },
+  "every_declared_leaf_required": true,
+  "exact_groups": [
+    "environment",
+    "support",
+    "fueling"
+  ],
+  "fixed_prescription_from_known_context": false,
+  "fueling": {
+    "gastrointestinal_experience": {
+      "envelope": "known_or_unknown",
+      "known_allowed": [
+        "no_plan_altering_issue",
+        "plan_altering_issue"
+      ],
+      "non_diagnostic": true
+    },
+    "intake_form": {
+      "envelope": "known_or_unknown",
+      "known_allowed": [
+        "none",
+        "fluids_only",
+        "carbohydrate_drink",
+        "mixed_food_and_drink"
+      ]
+    },
+    "longest_practiced_duration_min": {
+      "envelope": "known_or_unknown",
+      "maximum": 1440,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "practice_sessions_last_42_days": {
+      "envelope": "known_or_unknown",
+      "maximum": 84,
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "group_envelope_allowed": false,
+  "group_unknown_control_is_leaf_batch_action_only": true,
+  "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false,
+  "support": {
     "aid_station_count": {
+      "envelope": "known_or_unknown",
       "maximum": 50,
       "minimum": 0,
       "type": "integer"
     },
     "aid_support_mode": {
+      "envelope": "known_or_unknown",
       "known_allowed": [
         "organized_aid",
         "mixed",
@@ -698,12 +825,12 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       ]
     },
     "food_availability": {
+      "envelope": "known_or_unknown",
       "known_allowed": [
         "none",
         "some_stations",
         "all_stations"
-      ],
-      "unknown_uses_field_envelope": true
+      ]
     },
     "mandatory_gear": {
       "allowed": [
@@ -714,98 +841,28 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
         "navigation_device",
         "other_required"
       ],
+      "envelope": "known_or_unknown",
       "other_required_has_no_label_or_free_text": true,
       "type": "unordered_closed_set"
     },
-    "max_aid_station_gap_km": {
-      "maximum": 50,
-      "minimum": 0.1,
-      "null_allowed_only_for": "no_applicable_gap",
-      "type": "finite_number"
+    "max_aid_station_gap_m": {
+      "envelope": "known_or_unknown",
+      "integer_maximum": 50000,
+      "integer_minimum": 100,
+      "kilometer_wire_or_storage_field_allowed": false,
+      "known_null_meaning": "not_applicable",
+      "known_value_type": "integer_or_explicit_null"
     },
     "water_availability": {
+      "envelope": "known_or_unknown",
       "known_allowed": [
         "none",
         "some_stations",
         "all_stations"
-      ],
-      "unknown_uses_field_envelope": true
-    }
-  },
-  "environment_and_altitude": {
-    "conditions_basis": {
-      "athlete_assumption_provenance": "explicit_assumption",
-      "athlete_assumption_requires_confirmation": true,
-      "known_allowed": [
-        "organizer_information",
-        "seasonal_expectation",
-        "athlete_assumption"
       ]
-    },
-    "humidity_range_pct": {
-      "maximum": 100,
-      "minimum": 0,
-      "minimum_may_equal_maximum": true,
-      "type": "finite_number_range"
-    },
-    "maximum_altitude_m": {
-      "maximum": 9000,
-      "minimum": -500,
-      "type": "integer"
-    },
-    "sun_exposure": {
-      "known_allowed": [
-        "low",
-        "mixed",
-        "high"
-      ],
-      "unknown_uses_field_envelope": true
-    },
-    "temperature_range_c": {
-      "maximum": 55,
-      "minimum": -30,
-      "minimum_may_equal_maximum": true,
-      "type": "finite_number_range"
-    },
-    "wind_exposure": {
-      "known_allowed": [
-        "sheltered",
-        "mixed",
-        "exposed"
-      ],
-      "unknown_uses_field_envelope": true
     }
   },
-  "fixed_prescription_from_known_context": false,
-  "fueling_and_gastrointestinal_context": {
-    "gastrointestinal_experience": {
-      "known_allowed": [
-        "no_plan_altering_issue",
-        "plan_altering_issue"
-      ],
-      "non_diagnostic": true,
-      "unknown_uses_field_envelope": true
-    },
-    "intake_form": {
-      "known_allowed": [
-        "none",
-        "fluids_only",
-        "carbohydrate_drink",
-        "mixed_food_and_drink"
-      ]
-    },
-    "longest_practiced_duration_min": {
-      "maximum": 1440,
-      "minimum": 0,
-      "type": "integer"
-    },
-    "practice_sessions_last_42_days": {
-      "maximum": 84,
-      "minimum": 0,
-      "type": "integer"
-    }
-  },
-  "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+  "type": "strict_fixed_key_object"
 }
 ```
 
@@ -856,11 +913,11 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "technical_terrain"
   ],
   "limited_unknown_mapping": {
-    "aid_and_support": "fueling",
     "course_footing": "technical_terrain",
-    "environment_and_altitude": "environment_altitude",
-    "fueling_and_gastrointestinal_context": "fueling",
-    "grade_distribution": "grade_specificity"
+    "grade_distribution": "grade_specificity",
+    "optional_context.environment.*": "environment_altitude",
+    "optional_context.fueling.*": "fueling",
+    "optional_context.support.*": "fueling"
   },
   "material_unknown_result": [
     "clarification_required",
@@ -922,7 +979,11 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
   ],
   "confirmation_is_truth_safety_or_eligibility_attestation": false,
   "confirmation_scope": "exact_visible_field_or_section_revision",
-  "mutation_creates_new_immutable_revision": true,
+  "current_unproposed_draft_revision_is_mutable_state": true,
+  "immutable_snapshot_begins_only_with_proposal": true,
+  "pre_proposal_immutable_edit_or_confirmation_history": false,
+  "prior_draft_value_retained": false,
+  "prior_revision_token_retained": false,
   "proposal_binds_same_exact_revisions": true,
   "readiness_binds_exact_revisions": [
     "goal",
@@ -933,7 +994,12 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "generator"
   ],
   "stale_confirmation_rebound_allowed": false,
-  "stale_source_revision_rebound_allowed": false
+  "stale_source_revision_rebound_allowed": false,
+  "successful_edit_atomically_overwrites": [
+    "current_draft_value",
+    "current_revision_token",
+    "invalidated_confirmation_state"
+  ]
 }
 ```
 
@@ -975,10 +1041,11 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
   "permitted_persisted_categories": [
     "canonical_field_values_and_unknown_states",
     "server_stamped_provenance",
-    "source_and_field_or_section_revisions",
-    "confirmations",
+    "current_source_and_field_or_section_revisions",
+    "current_confirmations",
     "owner_scoped_history_snapshot_reference_and_hash",
-    "readiness_and_proposal_binding_digests"
+    "readiness_and_proposal_binding_digests",
+    "immutable_snapshot_only_after_proposal_creation"
   ],
   "personal_finish_probability": false,
   "suggestion_only": true,
@@ -1123,7 +1190,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
 - Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.
 - Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.
 - Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.
-- This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.
+- This revision incorporates the frozen Product wire semantics at repository commit f9678d64 and Architecture boundary at a52d23ce; it does not approve either role-owned artifact.
 - Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.
 - Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168.
 
@@ -1138,7 +1205,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
     "non_ultra_trail_constraints_v2 input and confirmation envelope",
     "future v2 Trail capability matching contract"
   ],
-  "contract_digest": "sha256:1297f713b992822335978dac92cfaa9b968b092d4ff6869ad73baa3d94ee2e7a",
+  "contract_digest": "sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617",
   "decision_id": "sdr-trail-running-goal-ontology-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -1174,12 +1241,6 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "type": "server_owned_identifier"
         },
         "fields": {
-          "aid_and_support": {
-            "envelope": "known_or_unknown",
-            "limited_module": "fueling",
-            "materiality": "limited",
-            "type": "bounded_object"
-          },
           "course_footing": {
             "envelope": "known_or_unknown",
             "limited_module": "technical_terrain",
@@ -1187,11 +1248,13 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "type": "nonempty_unordered_closed_set"
           },
           "distance_family": {
-            "allowed": [
-              "non_ultra"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "non_ultra",
+              "ultra"
+            ],
+            "supported_value": "non_ultra",
             "type": "closed_enum"
           },
           "distance_meters": {
@@ -1202,35 +1265,25 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "type": "integer",
             "unit": "meters"
           },
-          "environment_and_altitude": {
-            "envelope": "known_or_unknown",
-            "limited_module": "environment_altitude",
-            "materiality": "limited",
-            "type": "bounded_object"
-          },
           "event_date": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "type": "iso_date"
           },
           "event_format": {
-            "allowed": [
-              "single_day"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "single_day",
+              "multi_day"
+            ],
+            "supported_value": "single_day",
             "type": "closed_enum"
           },
           "fixed_rope": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "type": "strict_boolean"
-          },
-          "fueling_and_gastrointestinal_context": {
-            "envelope": "known_or_unknown",
-            "limited_module": "fueling",
-            "materiality": "limited",
-            "type": "bounded_object"
           },
           "grade_distribution": {
             "envelope": "known_or_unknown",
@@ -1243,6 +1296,18 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "materiality": "core",
             "type": "strict_boolean"
           },
+          "optional_context": {
+            "every_declared_leaf_required": true,
+            "every_leaf_envelope": "known_or_unknown",
+            "exact_groups": [
+              "environment",
+              "support",
+              "fueling"
+            ],
+            "group_envelope_allowed": false,
+            "materiality": "limited_by_leaf",
+            "type": "strict_fixed_key_object"
+          },
           "planning_duration_range": {
             "envelope": "known_or_unknown",
             "materiality": "core",
@@ -1250,11 +1315,14 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "unit": "minutes"
           },
           "planning_intent": {
-            "allowed": [
-              "performance"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "performance",
+              "first_completion",
+              "return_to_consistency"
+            ],
+            "supported_value": "performance",
             "type": "closed_enum"
           },
           "total_ascent_m": {
@@ -1275,6 +1343,24 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           }
         },
         "schema_id": "trail_course_demand_v2",
+        "scope_enum_results": {
+          "recognized_multi_day_or_ultra": {
+            "detail_reason": "unsupported_ultra_or_multiday",
+            "status": "policy_unavailable"
+          },
+          "recognized_non_performance_intent": {
+            "detail_reason": "unsupported_population_or_intent",
+            "status": "policy_unavailable"
+          },
+          "unknown_recognized_scope": {
+            "detail_reason": "adult_scope_or_constraints_unconfirmed",
+            "status": "clarification_required"
+          },
+          "unrecognized_literal": {
+            "detail_reason": "invalid_field_value",
+            "status": "validation_failed"
+          }
+        },
         "strict_unknown_fields_rejected": true
       }
     },
@@ -1535,13 +1621,121 @@ That would erase course-specific demand and violate the accepted no-road- fallba
         "trail-ontology.duration-and-fueling-practice-are-context"
       ],
       "value": {
-        "aid_and_support": {
+        "common_leaf_envelope": "known_or_unknown",
+        "enum_unknown_literals_allowed": false,
+        "environment": {
+          "conditions_basis": {
+            "athlete_assumption_provenance": "explicit_assumption",
+            "athlete_assumption_requires_confirmation": true,
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "organizer_information",
+              "seasonal_expectation",
+              "athlete_assumption"
+            ]
+          },
+          "cross_field_rules": {
+            "humidity_order_when_both_known": "humidity_min_pct_lte_humidity_max_pct",
+            "one_unknown_leaf_remains_unknown_without_inventing_other_bound": true,
+            "temperature_order_when_both_known": "temperature_min_c_lte_temperature_max_c"
+          },
+          "humidity_max_pct": {
+            "envelope": "known_or_unknown",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "finite_number"
+          },
+          "humidity_min_pct": {
+            "envelope": "known_or_unknown",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "finite_number"
+          },
+          "maximum_altitude_m": {
+            "envelope": "known_or_unknown",
+            "maximum": 9000,
+            "minimum": -500,
+            "type": "integer"
+          },
+          "sun_exposure": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "low",
+              "mixed",
+              "high"
+            ]
+          },
+          "temperature_max_c": {
+            "envelope": "known_or_unknown",
+            "maximum": 55,
+            "minimum": -30,
+            "type": "finite_number"
+          },
+          "temperature_min_c": {
+            "envelope": "known_or_unknown",
+            "maximum": 55,
+            "minimum": -30,
+            "type": "finite_number"
+          },
+          "wind_exposure": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "sheltered",
+              "mixed",
+              "exposed"
+            ]
+          }
+        },
+        "every_declared_leaf_required": true,
+        "exact_groups": [
+          "environment",
+          "support",
+          "fueling"
+        ],
+        "fixed_prescription_from_known_context": false,
+        "fueling": {
+          "gastrointestinal_experience": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "no_plan_altering_issue",
+              "plan_altering_issue"
+            ],
+            "non_diagnostic": true
+          },
+          "intake_form": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "none",
+              "fluids_only",
+              "carbohydrate_drink",
+              "mixed_food_and_drink"
+            ]
+          },
+          "longest_practiced_duration_min": {
+            "envelope": "known_or_unknown",
+            "maximum": 1440,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "practice_sessions_last_42_days": {
+            "envelope": "known_or_unknown",
+            "maximum": 84,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "group_envelope_allowed": false,
+        "group_unknown_control_is_leaf_batch_action_only": true,
+        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false,
+        "support": {
           "aid_station_count": {
+            "envelope": "known_or_unknown",
             "maximum": 50,
             "minimum": 0,
             "type": "integer"
           },
           "aid_support_mode": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "organized_aid",
               "mixed",
@@ -1549,12 +1743,12 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             ]
           },
           "food_availability": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "none",
               "some_stations",
               "all_stations"
-            ],
-            "unknown_uses_field_envelope": true
+            ]
           },
           "mandatory_gear": {
             "allowed": [
@@ -1565,98 +1759,28 @@ That would erase course-specific demand and violate the accepted no-road- fallba
               "navigation_device",
               "other_required"
             ],
+            "envelope": "known_or_unknown",
             "other_required_has_no_label_or_free_text": true,
             "type": "unordered_closed_set"
           },
-          "max_aid_station_gap_km": {
-            "maximum": 50,
-            "minimum": 0.1,
-            "null_allowed_only_for": "no_applicable_gap",
-            "type": "finite_number"
+          "max_aid_station_gap_m": {
+            "envelope": "known_or_unknown",
+            "integer_maximum": 50000,
+            "integer_minimum": 100,
+            "kilometer_wire_or_storage_field_allowed": false,
+            "known_null_meaning": "not_applicable",
+            "known_value_type": "integer_or_explicit_null"
           },
           "water_availability": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "none",
               "some_stations",
               "all_stations"
-            ],
-            "unknown_uses_field_envelope": true
-          }
-        },
-        "environment_and_altitude": {
-          "conditions_basis": {
-            "athlete_assumption_provenance": "explicit_assumption",
-            "athlete_assumption_requires_confirmation": true,
-            "known_allowed": [
-              "organizer_information",
-              "seasonal_expectation",
-              "athlete_assumption"
             ]
-          },
-          "humidity_range_pct": {
-            "maximum": 100,
-            "minimum": 0,
-            "minimum_may_equal_maximum": true,
-            "type": "finite_number_range"
-          },
-          "maximum_altitude_m": {
-            "maximum": 9000,
-            "minimum": -500,
-            "type": "integer"
-          },
-          "sun_exposure": {
-            "known_allowed": [
-              "low",
-              "mixed",
-              "high"
-            ],
-            "unknown_uses_field_envelope": true
-          },
-          "temperature_range_c": {
-            "maximum": 55,
-            "minimum": -30,
-            "minimum_may_equal_maximum": true,
-            "type": "finite_number_range"
-          },
-          "wind_exposure": {
-            "known_allowed": [
-              "sheltered",
-              "mixed",
-              "exposed"
-            ],
-            "unknown_uses_field_envelope": true
           }
         },
-        "fixed_prescription_from_known_context": false,
-        "fueling_and_gastrointestinal_context": {
-          "gastrointestinal_experience": {
-            "known_allowed": [
-              "no_plan_altering_issue",
-              "plan_altering_issue"
-            ],
-            "non_diagnostic": true,
-            "unknown_uses_field_envelope": true
-          },
-          "intake_form": {
-            "known_allowed": [
-              "none",
-              "fluids_only",
-              "carbohydrate_drink",
-              "mixed_food_and_drink"
-            ]
-          },
-          "longest_practiced_duration_min": {
-            "maximum": 1440,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "practice_sessions_last_42_days": {
-            "maximum": 84,
-            "minimum": 0,
-            "type": "integer"
-          }
-        },
-        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+        "type": "strict_fixed_key_object"
       }
     },
     "trail_planning_duration_range": {
@@ -1694,7 +1818,11 @@ That would erase course-specific demand and violate the accepted no-road- fallba
         ],
         "confirmation_is_truth_safety_or_eligibility_attestation": false,
         "confirmation_scope": "exact_visible_field_or_section_revision",
-        "mutation_creates_new_immutable_revision": true,
+        "current_unproposed_draft_revision_is_mutable_state": true,
+        "immutable_snapshot_begins_only_with_proposal": true,
+        "pre_proposal_immutable_edit_or_confirmation_history": false,
+        "prior_draft_value_retained": false,
+        "prior_revision_token_retained": false,
         "proposal_binds_same_exact_revisions": true,
         "readiness_binds_exact_revisions": [
           "goal",
@@ -1705,7 +1833,12 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "generator"
         ],
         "stale_confirmation_rebound_allowed": false,
-        "stale_source_revision_rebound_allowed": false
+        "stale_source_revision_rebound_allowed": false,
+        "successful_edit_atomically_overwrites": [
+          "current_draft_value",
+          "current_revision_token",
+          "invalidated_confirmation_state"
+        ]
       }
     },
     "trail_science_safety_and_privacy_boundary": {
@@ -1745,10 +1878,11 @@ That would erase course-specific demand and violate the accepted no-road- fallba
         "permitted_persisted_categories": [
           "canonical_field_values_and_unknown_states",
           "server_stamped_provenance",
-          "source_and_field_or_section_revisions",
-          "confirmations",
+          "current_source_and_field_or_section_revisions",
+          "current_confirmations",
           "owner_scoped_history_snapshot_reference_and_hash",
-          "readiness_and_proposal_binding_digests"
+          "readiness_and_proposal_binding_digests",
+          "immutable_snapshot_only_after_proposal_creation"
         ],
         "personal_finish_probability": false,
         "suggestion_only": true,
@@ -1930,11 +2064,11 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "technical_terrain"
         ],
         "limited_unknown_mapping": {
-          "aid_and_support": "fueling",
           "course_footing": "technical_terrain",
-          "environment_and_altitude": "environment_altitude",
-          "fueling_and_gastrointestinal_context": "fueling",
-          "grade_distribution": "grade_specificity"
+          "grade_distribution": "grade_specificity",
+          "optional_context.environment.*": "environment_altitude",
+          "optional_context.fueling.*": "fueling",
+          "optional_context.support.*": "fueling"
         },
         "material_unknown_result": [
           "clarification_required",
@@ -1949,7 +2083,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c"
+  "source_decision_digest": "sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1"
 }
 ```
 
@@ -2003,7 +2137,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
     "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.",
     "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.",
     "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.",
-    "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.",
+    "This revision incorporates the frozen Product wire semantics at repository commit f9678d64 and Architecture boundary at a52d23ce; it does not approve either role-owned artifact.",
     "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.",
     "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."
   ],
@@ -2027,7 +2161,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "trail_field_provenance",
           "trail_revision_and_confirmation"
         ],
-        "proposed_decision": "Accept the closed envelope, provenance categories, field-specific provenance restrictions, immutable revisions, and confirmation invalidation rules as operational guardrails.",
+        "proposed_decision": "Accept the closed envelope, provenance categories, field-specific provenance restrictions, replaceable current revision tokens, proposal-time immutable snapshots, and confirmation invalidation rules as operational guardrails.",
         "question": "Should every reviewable v2 field use an exact known-or-unknown envelope while provenance, source metadata, and history hashes remain server-owned and revision-bound?",
         "title": "Adopt explicit field states and server-owned provenance"
       },
@@ -2184,12 +2318,6 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "type": "server_owned_identifier"
         },
         "fields": {
-          "aid_and_support": {
-            "envelope": "known_or_unknown",
-            "limited_module": "fueling",
-            "materiality": "limited",
-            "type": "bounded_object"
-          },
           "course_footing": {
             "envelope": "known_or_unknown",
             "limited_module": "technical_terrain",
@@ -2197,11 +2325,13 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "type": "nonempty_unordered_closed_set"
           },
           "distance_family": {
-            "allowed": [
-              "non_ultra"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "non_ultra",
+              "ultra"
+            ],
+            "supported_value": "non_ultra",
             "type": "closed_enum"
           },
           "distance_meters": {
@@ -2212,35 +2342,25 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "type": "integer",
             "unit": "meters"
           },
-          "environment_and_altitude": {
-            "envelope": "known_or_unknown",
-            "limited_module": "environment_altitude",
-            "materiality": "limited",
-            "type": "bounded_object"
-          },
           "event_date": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "type": "iso_date"
           },
           "event_format": {
-            "allowed": [
-              "single_day"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "single_day",
+              "multi_day"
+            ],
+            "supported_value": "single_day",
             "type": "closed_enum"
           },
           "fixed_rope": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "type": "strict_boolean"
-          },
-          "fueling_and_gastrointestinal_context": {
-            "envelope": "known_or_unknown",
-            "limited_module": "fueling",
-            "materiality": "limited",
-            "type": "bounded_object"
           },
           "grade_distribution": {
             "envelope": "known_or_unknown",
@@ -2253,6 +2373,18 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "materiality": "core",
             "type": "strict_boolean"
           },
+          "optional_context": {
+            "every_declared_leaf_required": true,
+            "every_leaf_envelope": "known_or_unknown",
+            "exact_groups": [
+              "environment",
+              "support",
+              "fueling"
+            ],
+            "group_envelope_allowed": false,
+            "materiality": "limited_by_leaf",
+            "type": "strict_fixed_key_object"
+          },
           "planning_duration_range": {
             "envelope": "known_or_unknown",
             "materiality": "core",
@@ -2260,11 +2392,14 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "unit": "minutes"
           },
           "planning_intent": {
-            "allowed": [
-              "performance"
-            ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "recognized": [
+              "performance",
+              "first_completion",
+              "return_to_consistency"
+            ],
+            "supported_value": "performance",
             "type": "closed_enum"
           },
           "total_ascent_m": {
@@ -2285,6 +2420,24 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           }
         },
         "schema_id": "trail_course_demand_v2",
+        "scope_enum_results": {
+          "recognized_multi_day_or_ultra": {
+            "detail_reason": "unsupported_ultra_or_multiday",
+            "status": "policy_unavailable"
+          },
+          "recognized_non_performance_intent": {
+            "detail_reason": "unsupported_population_or_intent",
+            "status": "policy_unavailable"
+          },
+          "unknown_recognized_scope": {
+            "detail_reason": "adult_scope_or_constraints_unconfirmed",
+            "status": "clarification_required"
+          },
+          "unrecognized_literal": {
+            "detail_reason": "invalid_field_value",
+            "status": "validation_failed"
+          }
+        },
         "strict_unknown_fields_rejected": true
       }
     },
@@ -2623,13 +2776,121 @@ Runtime activation remains fail-closed until implementation approval can bind bo
       "name": "trail_optional_context_shapes",
       "rationale": "Environment and fueling are relevant context, while every exact bound and enum is a reversible minimization and validation choice. None establishes an exposure, equipment, fueling, gastrointestinal, or safety prescription.",
       "value": {
-        "aid_and_support": {
+        "common_leaf_envelope": "known_or_unknown",
+        "enum_unknown_literals_allowed": false,
+        "environment": {
+          "conditions_basis": {
+            "athlete_assumption_provenance": "explicit_assumption",
+            "athlete_assumption_requires_confirmation": true,
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "organizer_information",
+              "seasonal_expectation",
+              "athlete_assumption"
+            ]
+          },
+          "cross_field_rules": {
+            "humidity_order_when_both_known": "humidity_min_pct_lte_humidity_max_pct",
+            "one_unknown_leaf_remains_unknown_without_inventing_other_bound": true,
+            "temperature_order_when_both_known": "temperature_min_c_lte_temperature_max_c"
+          },
+          "humidity_max_pct": {
+            "envelope": "known_or_unknown",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "finite_number"
+          },
+          "humidity_min_pct": {
+            "envelope": "known_or_unknown",
+            "maximum": 100,
+            "minimum": 0,
+            "type": "finite_number"
+          },
+          "maximum_altitude_m": {
+            "envelope": "known_or_unknown",
+            "maximum": 9000,
+            "minimum": -500,
+            "type": "integer"
+          },
+          "sun_exposure": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "low",
+              "mixed",
+              "high"
+            ]
+          },
+          "temperature_max_c": {
+            "envelope": "known_or_unknown",
+            "maximum": 55,
+            "minimum": -30,
+            "type": "finite_number"
+          },
+          "temperature_min_c": {
+            "envelope": "known_or_unknown",
+            "maximum": 55,
+            "minimum": -30,
+            "type": "finite_number"
+          },
+          "wind_exposure": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "sheltered",
+              "mixed",
+              "exposed"
+            ]
+          }
+        },
+        "every_declared_leaf_required": true,
+        "exact_groups": [
+          "environment",
+          "support",
+          "fueling"
+        ],
+        "fixed_prescription_from_known_context": false,
+        "fueling": {
+          "gastrointestinal_experience": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "no_plan_altering_issue",
+              "plan_altering_issue"
+            ],
+            "non_diagnostic": true
+          },
+          "intake_form": {
+            "envelope": "known_or_unknown",
+            "known_allowed": [
+              "none",
+              "fluids_only",
+              "carbohydrate_drink",
+              "mixed_food_and_drink"
+            ]
+          },
+          "longest_practiced_duration_min": {
+            "envelope": "known_or_unknown",
+            "maximum": 1440,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "practice_sessions_last_42_days": {
+            "envelope": "known_or_unknown",
+            "maximum": 84,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "group_envelope_allowed": false,
+        "group_unknown_control_is_leaf_batch_action_only": true,
+        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false,
+        "support": {
           "aid_station_count": {
+            "envelope": "known_or_unknown",
             "maximum": 50,
             "minimum": 0,
             "type": "integer"
           },
           "aid_support_mode": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "organized_aid",
               "mixed",
@@ -2637,12 +2898,12 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             ]
           },
           "food_availability": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "none",
               "some_stations",
               "all_stations"
-            ],
-            "unknown_uses_field_envelope": true
+            ]
           },
           "mandatory_gear": {
             "allowed": [
@@ -2653,98 +2914,28 @@ Runtime activation remains fail-closed until implementation approval can bind bo
               "navigation_device",
               "other_required"
             ],
+            "envelope": "known_or_unknown",
             "other_required_has_no_label_or_free_text": true,
             "type": "unordered_closed_set"
           },
-          "max_aid_station_gap_km": {
-            "maximum": 50,
-            "minimum": 0.1,
-            "null_allowed_only_for": "no_applicable_gap",
-            "type": "finite_number"
+          "max_aid_station_gap_m": {
+            "envelope": "known_or_unknown",
+            "integer_maximum": 50000,
+            "integer_minimum": 100,
+            "kilometer_wire_or_storage_field_allowed": false,
+            "known_null_meaning": "not_applicable",
+            "known_value_type": "integer_or_explicit_null"
           },
           "water_availability": {
+            "envelope": "known_or_unknown",
             "known_allowed": [
               "none",
               "some_stations",
               "all_stations"
-            ],
-            "unknown_uses_field_envelope": true
-          }
-        },
-        "environment_and_altitude": {
-          "conditions_basis": {
-            "athlete_assumption_provenance": "explicit_assumption",
-            "athlete_assumption_requires_confirmation": true,
-            "known_allowed": [
-              "organizer_information",
-              "seasonal_expectation",
-              "athlete_assumption"
             ]
-          },
-          "humidity_range_pct": {
-            "maximum": 100,
-            "minimum": 0,
-            "minimum_may_equal_maximum": true,
-            "type": "finite_number_range"
-          },
-          "maximum_altitude_m": {
-            "maximum": 9000,
-            "minimum": -500,
-            "type": "integer"
-          },
-          "sun_exposure": {
-            "known_allowed": [
-              "low",
-              "mixed",
-              "high"
-            ],
-            "unknown_uses_field_envelope": true
-          },
-          "temperature_range_c": {
-            "maximum": 55,
-            "minimum": -30,
-            "minimum_may_equal_maximum": true,
-            "type": "finite_number_range"
-          },
-          "wind_exposure": {
-            "known_allowed": [
-              "sheltered",
-              "mixed",
-              "exposed"
-            ],
-            "unknown_uses_field_envelope": true
           }
         },
-        "fixed_prescription_from_known_context": false,
-        "fueling_and_gastrointestinal_context": {
-          "gastrointestinal_experience": {
-            "known_allowed": [
-              "no_plan_altering_issue",
-              "plan_altering_issue"
-            ],
-            "non_diagnostic": true,
-            "unknown_uses_field_envelope": true
-          },
-          "intake_form": {
-            "known_allowed": [
-              "none",
-              "fluids_only",
-              "carbohydrate_drink",
-              "mixed_food_and_drink"
-            ]
-          },
-          "longest_practiced_duration_min": {
-            "maximum": 1440,
-            "minimum": 0,
-            "type": "integer"
-          },
-          "practice_sessions_last_42_days": {
-            "maximum": 84,
-            "minimum": 0,
-            "type": "integer"
-          }
-        },
-        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+        "type": "strict_fixed_key_object"
       }
     },
     {
@@ -2795,11 +2986,11 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "technical_terrain"
         ],
         "limited_unknown_mapping": {
-          "aid_and_support": "fueling",
           "course_footing": "technical_terrain",
-          "environment_and_altitude": "environment_altitude",
-          "fueling_and_gastrointestinal_context": "fueling",
-          "grade_distribution": "grade_specificity"
+          "grade_distribution": "grade_specificity",
+          "optional_context.environment.*": "environment_altitude",
+          "optional_context.fueling.*": "fueling",
+          "optional_context.support.*": "fueling"
         },
         "material_unknown_result": [
           "clarification_required",
@@ -2859,7 +3050,11 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         ],
         "confirmation_is_truth_safety_or_eligibility_attestation": false,
         "confirmation_scope": "exact_visible_field_or_section_revision",
-        "mutation_creates_new_immutable_revision": true,
+        "current_unproposed_draft_revision_is_mutable_state": true,
+        "immutable_snapshot_begins_only_with_proposal": true,
+        "pre_proposal_immutable_edit_or_confirmation_history": false,
+        "prior_draft_value_retained": false,
+        "prior_revision_token_retained": false,
         "proposal_binds_same_exact_revisions": true,
         "readiness_binds_exact_revisions": [
           "goal",
@@ -2870,7 +3065,12 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "generator"
         ],
         "stale_confirmation_rebound_allowed": false,
-        "stale_source_revision_rebound_allowed": false
+        "stale_source_revision_rebound_allowed": false,
+        "successful_edit_atomically_overwrites": [
+          "current_draft_value",
+          "current_revision_token",
+          "invalidated_confirmation_state"
+        ]
       }
     },
     {
@@ -2912,10 +3112,11 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "permitted_persisted_categories": [
           "canonical_field_values_and_unknown_states",
           "server_stamped_provenance",
-          "source_and_field_or_section_revisions",
-          "confirmations",
+          "current_source_and_field_or_section_revisions",
+          "current_confirmations",
           "owner_scoped_history_snapshot_reference_and_hash",
-          "readiness_and_proposal_binding_digests"
+          "readiness_and_proposal_binding_digests",
+          "immutable_snapshot_only_after_proposal_creation"
         ],
         "personal_finish_probability": false,
         "suggestion_only": true,

--- a/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
+++ b/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
@@ -3,13 +3,13 @@
 > Start with the decision sheet. The audit appendix preserves every code-consumed field, but it is not the reviewer's primary task.
 
 - **Record:** `sdr-trail-running-goal-ontology-v2`
-- **Lifecycle:** `draft`
+- **Lifecycle:** `accepted`
 - **Model version:** `trail-course-demand-v2`
 - **Runtime state:** `inactive`
 - **Decision digest:** `sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1`
-- **Contract digest:** `sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617`
+- **Contract digest:** `sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c`
 - **Required decision role:** `decision_approver`
-- **Decision approval:** _Pending_
+- **Decision approval:** `github:dddtc2005` on `2026-09-04` ([source](https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653482))
 - **Required activation role:** `implementation_reviewer`
 - **Implementation approval:** _Pending_
 
@@ -137,7 +137,7 @@ A decision approval bound to the displayed digest attests:
 
 > I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and known-or-unknown boolean hazard fields, exact footing containment, bounded schedule and optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
-- **Decision approval:** _Pending_
+- **Decision approval:** `github:dddtc2005` on `2026-09-04` ([source](https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653482))
 
 ### Decision approval
 
@@ -1205,9 +1205,9 @@ That would erase course-specific demand and violate the accepted no-road- fallba
     "non_ultra_trail_constraints_v2 input and confirmation envelope",
     "future v2 Trail capability matching contract"
   ],
-  "contract_digest": "sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617",
+  "contract_digest": "sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c",
   "decision_id": "sdr-trail-running-goal-ontology-v2",
-  "decision_status": "draft",
+  "decision_status": "accepted",
   "decision_version": 2,
   "evidence_claim_ids": [
     "trail-ontology.course-demand-is-multidimensional",

--- a/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
+++ b/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
@@ -1,0 +1,2898 @@
+# Science decision review packet: Define the strict v2 Trail course-demand and constraint envelope
+
+> Start with the decision sheet. The audit appendix preserves every code-consumed field, but it is not the reviewer's primary task.
+
+- **Record:** `sdr-trail-running-goal-ontology-v2`
+- **Lifecycle:** `draft`
+- **Model version:** `trail-course-demand-v2`
+- **Runtime state:** `inactive`
+- **Decision digest:** `sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b`
+- **Contract digest:** `sha256:12c107e9d19f6c5e7204f09ef680ab5c4517a4f9385179d72822630a61df1c96`
+- **Required decision role:** `decision_approver`
+- **Decision approval:** _Pending_
+- **Required activation role:** `implementation_reviewer`
+- **Implementation approval:** _Pending_
+
+## Your task
+
+Decide whether the six proposed v2 ontology actions preserve the accepted v1 evidence, uncertainty, safety, and privacy boundaries while making the inactive input contract deterministic enough to implement. Approve the sheet as a unit or request changes by item ID.
+
+Choose one outcome:
+
+1. **Approve the decision sheet as a unit.** This accepts both the proposed decisions and the explicit deferrals below.
+2. **Request changes by item ID.** Do this when any proposal, effect, or non-authorization is unclear or wrong.
+
+Do not approve merely because the audit appendix looks reasonable or because you found no obvious problem while skimming it.
+
+## Decision sheet
+
+### Proposed decisions to approve
+
+#### `strict-value-provenance-envelope` — Adopt explicit field states and server-owned provenance
+
+- **Question:** Should every reviewable v2 field use an exact known-or-unknown envelope while provenance, source metadata, and history hashes remain server-owned and revision-bound?
+- **Proposed decision:** Accept the closed envelope, provenance categories, field-specific provenance restrictions, immutable revisions, and confirmation invalidation rules as operational guardrails.
+- **Approval means:**
+  - Missing values cannot be represented as zero, empty text, or a client-selected source.
+  - Readiness and proposals can bind the exact confirmed source revisions used.
+- **This does not authorize:**
+  - Source scraping, route inference, model truth claims, or automatic confirmation.
+
+<details><summary>Traceability: 2 contract groups, 1 evidence claim</summary>
+
+- **Contract groups covered:** `trail_field_provenance`, `trail_revision_and_confirmation`
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`
+
+</details>
+
+#### `core-course-and-planning-context` — Adopt the v2 core course tuple and planning-duration range
+
+- **Question:** Should event identity, date, distance, ascent, descent, scope, intent, hazard gates, and a confirmed planning-duration range be core inputs?
+- **Proposed decision:** Require those typed fields and treat planning duration only as athlete-confirmed planning context, never as a finish-time prediction.
+- **Approval means:**
+  - Distance and ascent alone cannot select a Trail policy.
+  - A material core unknown prevents an eligible proposal.
+- **This does not authorize:**
+  - A finish-time estimate, feasibility verdict, performance promise, or course equivalence.
+
+<details><summary>Traceability: 2 contract groups, 3 evidence claims</summary>
+
+- **Contract groups covered:** `trail_course_demand_schema`, `trail_planning_duration_range`
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `trail-ontology.uphill-downhill-demands-differ`, `trail-ontology.duration-and-fueling-practice-are-context`
+
+</details>
+
+#### `descriptive-course-and-access-vocabularies` — Adopt descriptive grade, footing, hazard, and terrain-access DTOs
+
+- **Question:** Should v2 use the exact five signed-grade share buckets, six unordered footing flags, two tri-state hazard gates, and weekday/uphill/downhill/ footing access fields?
+- **Proposed decision:** Accept these closed DTOs and exact set-containment rules as deterministic descriptions, not as technicality scores or doses.
+- **Approval means:**
+  - Grade boundaries and footing matching replay identically.
+  - Course footing cannot be approximated by synonyms or a road category.
+- **This does not authorize:**
+  - Route-derived grade, a technical score, downhill dose, or terrain equivalence.
+
+<details><summary>Traceability: 3 contract groups, 2 evidence claims</summary>
+
+- **Contract groups covered:** `trail_grade_distribution`, `trail_footing_and_hazard_contract`, `trail_training_constraints_schema`
+- **Evidence claims:** `trail-ontology.uphill-downhill-demands-differ`, `trail-ontology.technicality-and-downhill-vary-performance`
+
+</details>
+
+#### `bounded-context-and-materiality` — Adopt bounded optional context and exact block-versus-limit rules
+
+- **Question:** Should environment, altitude, aid, equipment, fueling, and gastrointestinal context use closed bounded shapes, with only named non-core unknowns limiting dependent modules?
+- **Proposed decision:** Accept the bounded shapes, exact core/limited mapping, sorted module vocabulary, and course-footing containment against access and observed history.
+- **Approval means:**
+  - Optional unknowns remain visible without becoming hidden defaults.
+  - A known mismatch still blocks the affected core access or history gate.
+- **This does not authorize:**
+  - An environment, altitude, equipment, fueling, gastrointestinal, or safety prescription.
+
+<details><summary>Traceability: 3 contract groups, 3 evidence claims</summary>
+
+- **Contract groups covered:** `trail_optional_context_shapes`, `trail_unknown_and_materiality_policy`, `trail_distinct_demand_invariants`
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `trail-ontology.environment-and-altitude-are-distinct-context`, `trail-ontology.duration-and-fueling-practice-are-context`
+
+</details>
+
+#### `science-safety-and-privacy-boundary` — Preserve the accepted nonclinical, intensity, claim, and privacy limits
+
+- **Question:** Should v2 preserve the adult nonclinical scope, symptom stop, split/sample intensity provenance, minimum normalized storage, and all prohibitions on personal guarantees and sensitive planning payloads?
+- **Proposed decision:** Carry the accepted v1 boundaries forward unchanged and apply them to every v2 field, receipt, and later implementation surface.
+- **Approval means:**
+  - Activity-average power cannot satisfy intensity provenance.
+  - Route, GPS, free-text, diagnosis, and provider payloads remain outside the contract.
+- **This does not authorize:**
+  - Diagnosis, clearance, treatment, injury prevention, safety assurance, or personal performance prediction.
+
+<details><summary>Traceability: 1 contract group, 2 evidence claims</summary>
+
+- **Contract groups covered:** `trail_science_safety_and_privacy_boundary`
+- **Evidence claims:** `trail-ontology.heart-rate-and-road-pace-are-insufficient-alone`, `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose`
+
+</details>
+
+### Decisions explicitly deferred
+
+#### `unresolved-values-and-authority-deferred` — Keep dose, scoring, equivalence, provider, and activation decisions deferred
+
+- **Question:** Should every technicality score, route inference, dose, progression, equivalence, prediction, provider, rollout, and activation behavior remain unaccepted?
+- **Proposed decision:** Preserve literal not_accepted values and the inactive role boundary until separate specialist and human review authorizes a successor.
+- **Approval means:**
+  - Exact DTO validation cannot silently become scientific prescription or runtime authority.
+- **This does not authorize:**
+  - Any behavior listed as not_accepted or any lifecycle transition for v1.
+
+<details><summary>Traceability: 2 contract groups, 1 evidence claim</summary>
+
+- **Contract groups covered:** `trail_exact_values`, `trail_non_science_authority_boundary`
+- **Evidence claims:** `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose`
+
+</details>
+
+## Approval statement
+
+A decision approval bound to the displayed digest attests:
+
+> I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and hazard vocabularies, exact footing containment, bounded optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+
+- **Decision approval:** _Pending_
+
+### Decision approval
+
+Approve in this GitHub comment format or in an authenticated agent session. For session approval, the agent mirrors this exact statement to the human-authenticated PR comment before automation records the YAML and lifecycle transition.
+
+```markdown
+Praxys science approval — **APPROVE**
+
+- Role: `decision_approver`
+- Subject: `sdr-trail-running-goal-ontology-v2`
+- Digest: `sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b`
+
+> I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and hazard vocabularies, exact footing containment, bounded optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+
+<!-- praxys-science-approval:v1
+{"role":"decision_approver","subject_digest":"sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b","subject_id":"sdr-trail-running-goal-ontology-v2","subject_kind":"science_decision"}
+-->
+```
+
+## Audit appendix
+
+<details><summary>Evidence, parameters, alternatives, limits, and validation</summary>
+
+### Accepted interpretation
+
+If separately accepted by the decision approver, this successor would keep every accepted v1 science and safety boundary while defining trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict, provider-neutral, revision-bound data contracts. Reviewable fields carry an explicit known value or explicit unknown state; the server, never the client, stamps provenance and source revisions. Core course, scope, hazard, schedule, terrain-access, symptom, and recent-history gates fail closed. Unknown grade, ordinary course footing, environment, support, or fueling context can limit only their named module after all core gates pass. Five signed-grade basis-point buckets, six unordered footing flags, exact footing set containment, and bounded optional context are reversible Praxys operational guardrails, not validated difficulty scores, training doses, equivalence formulas, predictions, or safety thresholds. No route, GPS, free-text planning, provider payload, activity-average power, road fallback, personal performance prediction, or runtime behavior is accepted.
+
+### Linked evidence
+
+#### `trail-ontology.course-demand-is-multidimensional` — moderate
+
+Trail-running performance and exposure are course-specific and multifactorial. Distance alone does not preserve elevation, grade, surface, technicality, altitude, environment, event format, or support.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `scheer-2020-off-road-definition`, `de-waal-2021-performance-review`, `pastor-2022-distance-determinants`, `scheer-2019-threshold-prediction`
+- **Limitations:** The literature does not provide one validated machine-readable schema.; Performance associations do not establish individual plan dose.
+
+#### `trail-ontology.uphill-downhill-demands-differ` — moderate
+
+Uphill and downhill running impose different metabolic, biomechanical, and neuromuscular demands; total elevation gain cannot stand in for descent exposure or grade distribution.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `minetti-2002`, `bjorklund-2019-short-trail`, `lemire-2021-downhill-fatigue`, `lemire-2022-slope-energy-cost`
+- **Limitations:** Studies use small, selected samples and specific grades.; Results do not validate a universal vertical conversion or progression rate.
+
+#### `trail-ontology.technicality-and-downhill-vary-performance` — low
+
+Technical terrain and downhill sections can materially change between- runner performance and mechanical exposure, so technicality and descent cannot be inferred safely from distance and gain alone.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `bjorklund-2019-short-trail`, `de-waal-2021-performance-review`, `genitrini-2024-race-stage`
+- **Limitations:** Technicality measurement is inconsistent across studies.; The evidence does not establish an exact technical-terrain training dose.
+
+#### `trail-ontology.heart-rate-and-road-pace-are-insufficient-alone` — low
+
+Rapidly changing slope can decouple heart rate and level-running pace from the metabolic and mechanical demands of hilly running; neither is a sufficient sole representation of course demand or training intensity.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `born-2017-hilly-intensity`, `lemire-2022-slope-energy-cost`
+- **Limitations:** Small studies do not invalidate athlete-specific heart-rate or pace context in all settings.; NIRS findings do not authorize a consumer prescription.
+
+#### `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose` — low
+
+Direct trail-training evidence is small, and trail-injury evidence is heterogeneous and substantially observational. Neither establishes a universal safe downhill, vertical, technical-terrain, or weekly progression dose, an individualized injury probability, or an injury-prevention guarantee.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `drum-2023-trail-road-rct`, `viljoen-2022-risk-factors`
+- **Limitations:** The randomized study found no significant group-by-time interactions.; Observational injury associations do not establish causal prevention rules.; This absence of a validated universal dose does not show that every exposure is equally appropriate.
+
+#### `trail-ontology.environment-and-altitude-are-distinct-context` — low
+
+Heat exposure depends on multiple environmental and athlete factors, while acute altitude can reduce aerobic capacity in controlled endurance protocols. Expected environment and maximum altitude are therefore distinct context dimensions; the evidence does not validate a personal trail pace correction, acclimation schedule, or safety threshold.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `periard-2021`, `wehrlin-2006-altitude`
+- **Limitations:** The evidence is not a direct validation of a trail-course matching schema.; Controlled acute-altitude findings do not establish self-paced trail performance effects.; Heat response varies with metabolic rate, clothing, wind, solar load, acclimation, and individual context.
+
+#### `trail-ontology.duration-and-fueling-practice-are-context` — moderate
+
+Endurance carbohydrate strategy varies with expected exercise duration, feeding opportunity, and prior tolerance. Repeated feeding practice may reduce gastrointestinal problems in some protocols, but distance alone does not establish a personal fueling amount, timing rule, tolerance, or performance benefit.
+
+- **Evidence Review:** `evidence-trail-running-goal-ontology-v1`
+- **Sources:** `burke-2011`, `martinez-2023`
+- **Limitations:** The evidence is broader endurance evidence rather than a trail-course ontology validation.; Reviewed protocols, carbohydrate forms, event durations, and populations vary.; Practice does not guarantee individual gastrointestinal tolerance or performance.
+
+### Reviewed parameters
+
+#### `trail_course_demand_schema` — guardrail
+
+- **Applies to:** trail_course_demand_v2
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `trail-ontology.uphill-downhill-demands-differ`
+- **Rationale:** The evidence supports explicit distinct dimensions; field names, types, units, and the core/limited representation are reversible Praxys DTO choices selected to make missingness and replay unambiguous.
+- **Exact value:**
+
+```json
+{
+  "event_identity": {
+    "client_writable": false,
+    "field": "event_id",
+    "materiality": "core",
+    "type": "server_owned_identifier"
+  },
+  "fields": {
+    "aid_and_support": {
+      "envelope": "known_or_unknown",
+      "limited_module": "fueling",
+      "materiality": "limited",
+      "type": "bounded_object"
+    },
+    "course_footing": {
+      "envelope": "known_or_unknown",
+      "limited_module": "technical_terrain",
+      "materiality": "limited_with_core_matching_when_known",
+      "type": "nonempty_unordered_closed_set"
+    },
+    "distance_family": {
+      "allowed": [
+        "non_ultra"
+      ],
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "type": "closed_enum"
+    },
+    "distance_meters": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "minimum": 1,
+      "type": "integer",
+      "unit": "meters"
+    },
+    "environment_and_altitude": {
+      "envelope": "known_or_unknown",
+      "limited_module": "environment_altitude",
+      "materiality": "limited",
+      "type": "bounded_object"
+    },
+    "event_date": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "type": "iso_date"
+    },
+    "event_format": {
+      "allowed": [
+        "single_day"
+      ],
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "type": "closed_enum"
+    },
+    "fixed_rope": {
+      "allowed": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "materiality": "core",
+      "type": "tri_state"
+    },
+    "fueling_and_gastrointestinal_context": {
+      "envelope": "known_or_unknown",
+      "limited_module": "fueling",
+      "materiality": "limited",
+      "type": "bounded_object"
+    },
+    "grade_distribution": {
+      "envelope": "known_or_unknown",
+      "limited_module": "grade_specificity",
+      "materiality": "limited",
+      "type": "five_bucket_basis_point_object"
+    },
+    "hands_assist": {
+      "allowed": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "materiality": "core",
+      "type": "tri_state"
+    },
+    "planning_duration_range": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "type": "integer_range",
+      "unit": "minutes"
+    },
+    "planning_intent": {
+      "allowed": [
+        "performance"
+      ],
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "type": "closed_enum"
+    },
+    "total_ascent_m": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "minimum": 0,
+      "type": "integer",
+      "unit": "meters"
+    },
+    "total_descent_m": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "minimum": 0,
+      "type": "integer",
+      "unit": "meters"
+    }
+  },
+  "schema_id": "trail_course_demand_v2",
+  "strict_unknown_fields_rejected": true
+}
+```
+
+#### `trail_field_provenance` — guardrail
+
+- **Applies to:** every reviewable v2 course, constraint, and history field
+- **Evidence claims:** _None; product rationale only_
+- **Rationale:** A strict server-owned provenance envelope prevents client-selected trust, hidden defaults, and stale source metadata. These are operational integrity controls, not published scientific values.
+- **Exact value:**
+
+```json
+{
+  "assumption_requires_revision_bound_confirmation": true,
+  "client_may_submit_history_hash": false,
+  "client_may_submit_model_version": false,
+  "client_may_submit_provenance": false,
+  "client_may_submit_source_revision": false,
+  "client_may_submit_source_timestamp": false,
+  "field_restrictions": {
+    "athlete_assumption_conditions": [
+      "explicit_assumption"
+    ],
+    "event_id": "server_owned",
+    "grade_distribution": [
+      "athlete_stated",
+      "course_verified",
+      "unknown"
+    ],
+    "recent_history": [
+      "history_observed"
+    ]
+  },
+  "inferred_requires_server_model_version": true,
+  "request_envelope": {
+    "arbitrary_object_invalid": true,
+    "empty_string_invalid": true,
+    "guessed_zero_invalid": true,
+    "known": {
+      "exact_keys": [
+        "state",
+        "value"
+      ],
+      "schema_valid_value_required": true,
+      "state_literal": "known"
+    },
+    "missing_state_invalid": true,
+    "null_invalid_except_explicit_aid_gap_case": true,
+    "numeric_values_must_be_finite": true,
+    "sentinel_number_invalid": true,
+    "unknown": {
+      "exact_keys": [
+        "state"
+      ],
+      "state_literal": "unknown",
+      "value_forbidden": true
+    }
+  },
+  "server_stamped_provenance_allowed": [
+    "athlete_stated",
+    "course_verified",
+    "history_observed",
+    "model_inferred",
+    "explicit_assumption",
+    "unknown"
+  ],
+  "unknown_is_preserved": true
+}
+```
+
+#### `trail_planning_duration_range` — guardrail
+
+- **Applies to:** trail_course_demand_v2 core confirmation
+- **Evidence claims:** `trail-ontology.duration-and-fueling-practice-are-context`
+- **Rationale:** Expected duration is relevant context, while the exact range shape is a reversible Product DTO and cannot be presented as a prediction.
+- **Exact value:**
+
+```json
+{
+  "athlete_confirmed": true,
+  "feasibility_verdict": false,
+  "field": "planning_duration_range",
+  "finish_time_prediction": false,
+  "minimum_strictly_less_than_maximum": true,
+  "minimum_value": 1,
+  "performance_promise": false,
+  "purpose": "planning_context",
+  "unit": "integer_minutes"
+}
+```
+
+#### `trail_grade_distribution` — guardrail
+
+- **Applies to:** known grade_distribution in trail_course_demand_v2
+- **Evidence claims:** `trail-ontology.uphill-downhill-demands-differ`
+- **Rationale:** Literature supports keeping signed grade demand explicit but does not validate these exact bins. The half-open intervals and basis-point sum are reversible deterministic description guardrails only.
+- **Exact value:**
+
+```json
+{
+  "allowed_provenance": [
+    "athlete_stated",
+    "course_verified"
+  ],
+  "buckets": {
+    "below_neg_10": {
+      "interval": "g < -10%",
+      "upper_bound_percent": -10,
+      "upper_inclusive": false
+    },
+    "neg_10_to_below_neg_3": {
+      "interval": "-10% <= g < -3%",
+      "lower_bound_percent": -10,
+      "lower_inclusive": true,
+      "upper_bound_percent": -3,
+      "upper_inclusive": false
+    },
+    "neg_3_to_below_pos_3": {
+      "interval": "-3% <= g < 3%",
+      "lower_bound_percent": -3,
+      "lower_inclusive": true,
+      "upper_bound_percent": 3,
+      "upper_inclusive": false
+    },
+    "pos_10_and_above": {
+      "interval": "g >= 10%",
+      "lower_bound_percent": 10,
+      "lower_inclusive": true
+    },
+    "pos_3_to_below_pos_10": {
+      "interval": "3% <= g < 10%",
+      "lower_bound_percent": 3,
+      "lower_inclusive": true,
+      "upper_bound_percent": 10,
+      "upper_inclusive": false
+    }
+  },
+  "descriptive_only": true,
+  "difficulty_score": false,
+  "each_share_minimum": 0,
+  "each_share_type": "integer",
+  "equivalence_or_prediction_input": false,
+  "exact_sum": 10000,
+  "known_value_exact_keys": [
+    "below_neg_10",
+    "neg_10_to_below_neg_3",
+    "neg_3_to_below_pos_3",
+    "pos_3_to_below_pos_10",
+    "pos_10_and_above"
+  ],
+  "ordering_semantic": false,
+  "route_or_model_inference": false,
+  "safety_threshold": false,
+  "unit": "basis_points_of_course_distance",
+  "workout_dose_input": false
+}
+```
+
+#### `trail_footing_and_hazard_contract` — guardrail
+
+- **Applies to:** course, access, and observed-history footing plus v2 hazard gates
+- **Evidence claims:** `trail-ontology.technicality-and-downhill-vary-performance`, `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose`
+- **Rationale:** Footing and hazards must remain explicit, but the exact vocabulary and gates are Product-selected operational categories rather than validated technicality or safety scores.
+- **Exact value:**
+
+```json
+{
+  "hazard_gates": {
+    "fixed_rope": {
+      "allowed": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "eligible_value": "no",
+      "unknown_result": "clarification_required",
+      "yes_result": "policy_unavailable.technical_features_outside_v2"
+    },
+    "hands_assist": {
+      "allowed": [
+        "yes",
+        "no",
+        "unknown"
+      ],
+      "eligible_value": "no",
+      "unknown_result": "clarification_required",
+      "yes_result": "policy_unavailable.technical_features_outside_v2"
+    },
+    "reducible_to_ordinary_footing": false,
+    "technical_skill_or_safety_score": false
+  },
+  "ordinary_footing": {
+    "allowed": [
+      "firm_smooth",
+      "loose_gravel",
+      "mud",
+      "rocks_or_roots",
+      "built_steps",
+      "water_crossing"
+    ],
+    "difficulty_score": false,
+    "duplicates_invalid": true,
+    "free_text_allowed": false,
+    "other_value_allowed": false,
+    "type": "nonempty_unordered_set",
+    "unknown_members_invalid": true
+  }
+}
+```
+
+#### `trail_training_constraints_schema` — guardrail
+
+- **Applies to:** non_ultra_trail_constraints_v2 and owner-scoped readiness
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `trail-ontology.uphill-downhill-demands-differ`, `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose`
+- **Rationale:** Schedule and terrain access must be explicit and recent history must remain server-derived. The exact closed DTO is an operational guardrail; it does not establish a safe terrain dose.
+- **Exact value:**
+
+```json
+{
+  "client_may_submit_or_attest_history": false,
+  "client_reviewable_fields": {
+    "accessible_footing": {
+      "envelope": "known_or_unknown",
+      "materiality": "core_when_course_footing_known",
+      "missing_required_member_result": "readiness_blocked.insufficient_terrain_access",
+      "type": "nonempty_unordered_closed_set",
+      "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
+    },
+    "adult_nonclinical_scope_confirmed": {
+      "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+      "materiality": "core",
+      "required_value_for_eligibility": true,
+      "type": "strict_boolean"
+    },
+    "available_weekdays": {
+      "allowed_iso_weekdays": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "type": "unique_unordered_set",
+      "unknown_result": "clarification_required.training_constraints_missing"
+    },
+    "controlled_downhill_terrain_accessible": {
+      "duration_distance_grade_speed_or_repeat_fields_allowed": false,
+      "envelope": "known_or_unknown",
+      "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+      "materiality": "core",
+      "type": "strict_boolean"
+    },
+    "current_symptom_stop": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "stop_value": true,
+      "true_result": "readiness_blocked.current_symptom_stop",
+      "type": "tri_state_boolean",
+      "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+    },
+    "nontechnical_continuous_three_minute_uphill_accessible": {
+      "envelope": "known_or_unknown",
+      "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+      "materiality": "core",
+      "type": "strict_boolean"
+    },
+    "performance_intent_confirmed": {
+      "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+      "materiality": "core",
+      "required_value_for_eligibility": true,
+      "type": "strict_boolean"
+    }
+  },
+  "history_provenance": "history_observed",
+  "schema_id": "non_ultra_trail_constraints_v2",
+  "server_derived_history_fields": [
+    "recent_running_continuity",
+    "recent_ascent_exposure",
+    "recent_descent_exposure",
+    "recently_observed_footing"
+  ]
+}
+```
+
+#### `trail_optional_context_shapes` — guardrail
+
+- **Applies to:** optional v2 course context only
+- **Evidence claims:** `trail-ontology.environment-and-altitude-are-distinct-context`, `trail-ontology.duration-and-fueling-practice-are-context`
+- **Rationale:** Environment and fueling are relevant context, while every exact bound and enum is a reversible minimization and validation choice. None establishes an exposure, equipment, fueling, gastrointestinal, or safety prescription.
+- **Exact value:**
+
+```json
+{
+  "aid_and_support": {
+    "aid_station_count": {
+      "maximum": 50,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "aid_support_mode": {
+      "known_allowed": [
+        "organized_aid",
+        "mixed",
+        "self_supported"
+      ]
+    },
+    "food_availability": {
+      "known_allowed": [
+        "none",
+        "some_stations",
+        "all_stations"
+      ],
+      "unknown_uses_field_envelope": true
+    },
+    "mandatory_gear": {
+      "allowed": [
+        "water_carry",
+        "food_carry",
+        "weather_shell",
+        "lighting",
+        "navigation_device",
+        "other_required"
+      ],
+      "other_required_has_no_label_or_free_text": true,
+      "type": "unordered_closed_set"
+    },
+    "max_aid_station_gap_km": {
+      "maximum": 50,
+      "minimum": 0.1,
+      "null_allowed_only_for": "no_applicable_gap",
+      "type": "finite_number"
+    },
+    "water_availability": {
+      "known_allowed": [
+        "none",
+        "some_stations",
+        "all_stations"
+      ],
+      "unknown_uses_field_envelope": true
+    }
+  },
+  "environment_and_altitude": {
+    "conditions_basis": {
+      "athlete_assumption_provenance": "explicit_assumption",
+      "athlete_assumption_requires_confirmation": true,
+      "known_allowed": [
+        "organizer_information",
+        "seasonal_expectation",
+        "athlete_assumption"
+      ]
+    },
+    "humidity_range_pct": {
+      "maximum": 100,
+      "minimum": 0,
+      "minimum_may_equal_maximum": true,
+      "type": "finite_number_range"
+    },
+    "maximum_altitude_m": {
+      "maximum": 9000,
+      "minimum": -500,
+      "type": "integer"
+    },
+    "sun_exposure": {
+      "known_allowed": [
+        "low",
+        "mixed",
+        "high"
+      ],
+      "unknown_uses_field_envelope": true
+    },
+    "temperature_range_c": {
+      "maximum": 55,
+      "minimum": -30,
+      "minimum_may_equal_maximum": true,
+      "type": "finite_number_range"
+    },
+    "wind_exposure": {
+      "known_allowed": [
+        "sheltered",
+        "mixed",
+        "exposed"
+      ],
+      "unknown_uses_field_envelope": true
+    }
+  },
+  "fixed_prescription_from_known_context": false,
+  "fueling_and_gastrointestinal_context": {
+    "gastrointestinal_experience": {
+      "known_allowed": [
+        "no_plan_altering_issue",
+        "plan_altering_issue"
+      ],
+      "non_diagnostic": true,
+      "unknown_uses_field_envelope": true
+    },
+    "intake_form": {
+      "known_allowed": [
+        "none",
+        "fluids_only",
+        "carbohydrate_drink",
+        "mixed_food_and_drink"
+      ]
+    },
+    "longest_practiced_duration_min": {
+      "maximum": 1440,
+      "minimum": 0,
+      "type": "integer"
+    },
+    "practice_sessions_last_42_days": {
+      "maximum": 84,
+      "minimum": 0,
+      "type": "integer"
+    }
+  },
+  "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+}
+```
+
+#### `trail_unknown_and_materiality_policy` — guardrail
+
+- **Applies to:** v2 capability matching and readiness receipts
+- **Evidence claims:** `trail-ontology.course-demand-is-multidimensional`, `trail-ontology.technicality-and-downhill-vary-performance`
+- **Rationale:** This exact Product-selected block-versus-limit mapping keeps material missingness visible without manufacturing certainty or broadening the accepted Science scope.
+- **Exact value:**
+
+```json
+{
+  "bounded_alternative_requires_separate_review": true,
+  "core_fields": [
+    "event_id",
+    "event_date",
+    "distance_meters",
+    "total_ascent_m",
+    "total_descent_m",
+    "planning_duration_range",
+    "event_format",
+    "distance_family",
+    "planning_intent",
+    "hands_assist",
+    "fixed_rope",
+    "adult_nonclinical_scope_confirmed",
+    "performance_intent_confirmed",
+    "current_symptom_stop",
+    "available_weekdays",
+    "nontechnical_continuous_three_minute_uphill_accessible",
+    "controlled_downhill_terrain_accessible",
+    "accessible_footing_when_course_footing_known",
+    "recent_running_continuity",
+    "recent_ascent_exposure",
+    "recent_descent_exposure",
+    "recently_observed_footing_when_course_footing_known"
+  ],
+  "known_value_automatically_enables_module": false,
+  "limited_module_may_substitute_generic_or_road_behavior": false,
+  "limited_modules_sorted_allowed": [
+    "environment_altitude",
+    "fueling",
+    "grade_specificity",
+    "technical_terrain"
+  ],
+  "limited_unknown_mapping": {
+    "aid_and_support": "fueling",
+    "course_footing": "technical_terrain",
+    "environment_and_altitude": "environment_altitude",
+    "fueling_and_gastrointestinal_context": "fueling",
+    "grade_distribution": "grade_specificity"
+  },
+  "material_unknown_result": [
+    "clarification_required",
+    "policy_unavailable"
+  ],
+  "unknown_defaults_to_easy": false,
+  "unknown_defaults_to_nontechnical": false,
+  "unknown_defaults_to_road": false,
+  "unknown_defaults_to_zero": false
+}
+```
+
+#### `trail_distinct_demand_invariants` — guardrail
+
+- **Applies to:** v2 course, access, history, and intensity boundaries
+- **Evidence claims:** `trail-ontology.uphill-downhill-demands-differ`, `trail-ontology.technicality-and-downhill-vary-performance`, `trail-ontology.heart-rate-and-road-pace-are-insufficient-alone`
+- **Rationale:** Distinct demands follow the evidence; exact set containment is a deterministic conservative matching guardrail, not a validated safety or similarity model.
+- **Exact value:**
+
+```json
+{
+  "activity_average_power_allowed": false,
+  "ascent_and_descent_separate": true,
+  "downhill_history_required_when_descent_material": true,
+  "footing_set_containment": {
+    "access_failure_reason": "readiness_blocked.insufficient_terrain_access",
+    "access_requirement": "C subset_of A",
+    "accessible_set_symbol": "A",
+    "applies_only_when_course_footing_known": true,
+    "course_set_symbol": "C",
+    "history_failure_reason": "readiness_blocked.insufficient_comparable_trail_history",
+    "history_requirement": "C subset_of H",
+    "observed_history_set_symbol": "H",
+    "similarity_synonyms_or_model_inference_allowed": false
+  },
+  "grade_distribution_descriptive_only": true,
+  "heart_rate_alone_sufficient_for_hilly_intensity": false,
+  "level_pace_alone_sufficient_for_hilly_intensity": false,
+  "technicality_score_allowed": false,
+  "universal_distance_vertical_equivalence": false
+}
+```
+
+#### `trail_revision_and_confirmation` — guardrail
+
+- **Applies to:** every v2 mutation, readiness receipt, and later proposal
+- **Evidence claims:** _None; product rationale only_
+- **Rationale:** Exact revisions prevent stale confirmation from silently acquiring new meaning. This is an operational replay and user-control guardrail.
+- **Exact value:**
+
+```json
+{
+  "confirm_all_allowed": false,
+  "confirmation_invalidated_by": [
+    "value_change",
+    "known_unknown_state_change",
+    "server_stamped_source_change",
+    "source_revision_change"
+  ],
+  "confirmation_is_truth_safety_or_eligibility_attestation": false,
+  "confirmation_scope": "exact_visible_field_or_section_revision",
+  "mutation_creates_new_immutable_revision": true,
+  "proposal_binds_same_exact_revisions": true,
+  "readiness_binds_exact_revisions": [
+    "goal",
+    "course",
+    "constraints",
+    "history_snapshot",
+    "policy",
+    "generator"
+  ],
+  "stale_confirmation_rebound_allowed": false,
+  "stale_source_revision_rebound_allowed": false
+}
+```
+
+#### `trail_science_safety_and_privacy_boundary` — guardrail
+
+- **Applies to:** all v2 science, storage, API, client, audit, and deletion surfaces
+- **Evidence claims:** `trail-ontology.heart-rate-and-road-pace-are-insufficient-alone`, `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose`
+- **Rationale:** These preserve the accepted v1 nonclinical, intensity, claim, and minimization boundaries while making the v2 storage exclusion explicit.
+- **Exact value:**
+
+```json
+{
+  "activity_average_power_valid_for_intensity": false,
+  "authenticated_owner_scoped_reset_export_and_deletion_required": true,
+  "diagnosis_treatment_clearance_or_return_to_sport": false,
+  "forbidden_collection_or_persistence": [
+    "gps_points",
+    "route_files",
+    "polylines",
+    "maps",
+    "inferred_course_geometry",
+    "course_source_urls",
+    "scraped_course_content",
+    "provider_request_or_response_payloads",
+    "provider_account_activity_or_workout_ids",
+    "device_identifiers",
+    "free_text_health_symptom_fueling_surface_or_course_narratives",
+    "diagnoses_or_medical_clearance",
+    "injury_probability",
+    "activity_average_power",
+    "road_equivalent_distance_pace_or_load"
+  ],
+  "generic_audit_or_telemetry_may_copy_sensitive_payloads": false,
+  "inferred_and_athlete_stated_fields_correctable_and_deletable": true,
+  "minimum_age_years": 18,
+  "minimum_normalized_storage_only": true,
+  "nonclinical_only": true,
+  "performance_injury_or_safety_guarantee": false,
+  "permitted_persisted_categories": [
+    "canonical_field_values_and_unknown_states",
+    "server_stamped_provenance",
+    "source_and_field_or_section_revisions",
+    "confirmations",
+    "owner_scoped_history_snapshot_reference_and_hash",
+    "readiness_and_proposal_binding_digests"
+  ],
+  "personal_finish_probability": false,
+  "suggestion_only": true,
+  "symptom_stop_required": true,
+  "valid_intensity_sources": [
+    "activity_splits",
+    "activity_samples"
+  ]
+}
+```
+
+#### `trail_exact_values` — guardrail
+
+- **Applies to:** unresolved ontology and prescription values
+- **Evidence claims:** `trail-ontology.uphill-downhill-demands-differ`, `trail-ontology.training-and-injury-evidence-does-not-set-safe-dose`
+- **Rationale:** The accepted evidence supports explicit dimensions but not universal scoring, inference, equivalence, prediction, progression, or dose. Only the closed validation DTO is proposed here.
+- **Exact value:**
+
+```json
+{
+  "core_and_limited_materiality": "operational_guardrail_only",
+  "distance_vertical_conversion": "not_accepted",
+  "downhill_progression": "not_accepted",
+  "environment_or_altitude_dose": "not_accepted",
+  "finish_time_prediction": "not_accepted",
+  "footing_vocabulary": "descriptive_operational_guardrail_only",
+  "fueling_amount_or_frequency": "not_accepted",
+  "optional_context_bounds": "operational_guardrail_only",
+  "planning_duration_range_shape": "operational_guardrail_only",
+  "road_trail_equivalence": "not_accepted",
+  "route_or_provider_inference": "not_accepted",
+  "signed_grade_buckets": "descriptive_operational_guardrail_only",
+  "technical_terrain_dose": "not_accepted",
+  "technicality_score": "not_accepted",
+  "vertical_progression": "not_accepted"
+}
+```
+
+#### `trail_non_science_authority_boundary` — guardrail
+
+- **Applies to:** all work outside the Science role
+- **Evidence claims:** _None; product rationale only_
+- **Rationale:** A Science successor cannot originate or widen Product, Design, Engineering, Trust, Operations, provider, rollout, or activation authority.
+- **Exact value:**
+
+```json
+{
+  "deployment": "not_accepted",
+  "implementation_review": "required",
+  "lifecycle_supersession": "not_accepted",
+  "owner_only_dogfood": "not_accepted",
+  "product_and_experience_dependency": "human_acceptance_required",
+  "product_visibility_or_catalog": "not_accepted",
+  "production_data_use": "not_accepted",
+  "provider_mapping_or_delivery": "not_accepted",
+  "runtime_activation": "not_accepted",
+  "science_authority": [
+    "evidence",
+    "applicability",
+    "uncertainty",
+    "claim_limits",
+    "safety_scope"
+  ]
+}
+```
+
+### Rejected alternatives
+
+#### Keep the ambiguous v1 object fields and let each caller interpret them
+
+Caller-specific interpretation would make missingness, provenance, materiality, and replay nondeterministic.
+
+#### Infer grade, footing, or technical demand from a route or provider payload
+
+v2 does not collect those payloads, and the evidence does not validate a universal inference or technicality score.
+
+#### Require every optional course descriptor before any proposal
+
+Core-versus-limited materiality can preserve uncertainty without hiding it or inventing a dependent module.
+
+#### Treat an unknown or inaccessible Trail field as ordinary road running
+
+That would erase course-specific demand and violate the accepted no-road- fallback boundary.
+
+### Applicability
+
+- Adult nonclinical single-day non-ultra Trail performance goal representation
+- Strict provider-neutral course and athlete-constraint capture before capability matching
+- Server-derived owner-scoped recent-history context
+- Evidence, uncertainty, claim limits, safety, and privacy boundaries only
+
+### User-facing claim limits
+
+- Do not claim the exact v2 DTO, bins, footing vocabulary, bounds, or materiality map is scientifically optimal or validated as a safety rule.
+- Do not claim planning duration is a finish-time prediction, feasibility verdict, or performance promise.
+- Do not claim distance and ascent alone describe Trail demand or present a universal road-equivalent distance, grade, ascent, or descent conversion.
+- Do not present unknown footing, hazard, environment, support, fueling, or gastrointestinal context as known, easy, safe, or average.
+- Do not present a technicality score, personal finish probability, performance guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance.
+
+### Safety implications
+
+- Every core unknown or failed gate prevents an eligible proposal; only named non-core unknowns can limit a dependent module.
+- Uphill, downhill, ordinary footing, hazards, altitude, heat, support, and fueling context remain distinct when applicable.
+- Hands-assist or fixed-rope use stays outside v2; unknown hazard gates require clarification.
+- Current symptoms stop performance optimization without creating a diagnosis.
+- Intensity provenance uses activity splits or samples, never activity-average power.
+
+### Privacy implications
+
+- Collect and persist only normalized typed values, explicit unknown states, server provenance, revisions, confirmations, and owner-scoped replay references.
+- Do not ingest GPS, routes, maps, source URLs, scraped content, provider payloads or identifiers, device identifiers, or free-text planning narratives.
+- Reset invalidates confirmation and creates a new revision; export and deletion include the current owner-scoped v2 state under existing data-rights controls.
+- No public sharing, cross-user aggregate, administrator planning access, or value telemetry is authorized.
+
+### Validation plan
+
+- Validate every closed enum, set, integer, finite number, range relation, explicit unknown state, and field-specific provenance rule deterministically.
+- Boundary-test all five signed-grade intervals and require nonnegative integer shares summing exactly to 10000.
+- Replay reordered footing and weekday sets and verify one canonical digest; reject duplicates, unknown members, synonyms, and free text.
+- Verify exact course-footing containment against both accessible and observed-history sets and preserve the distinct access and history failures.
+- Mutate every field value, state, and server source revision and verify the prior confirmation and readiness binding becomes stale.
+- Exercise every core unknown and limited unknown and verify no road policy, hidden default, provider behavior, or success-shaped plan is selected.
+- Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests.
+
+### Falsification conditions
+
+- A malformed or stale v2 value is treated as confirmed, or client-provided provenance or history is accepted.
+- A grade share falls into two buckets, the five shares do not total 10000, or grade becomes a difficulty, dose, equivalence, or prediction input.
+- Footing comparison uses order, similarity, synonyms, inference, or a road category instead of exact set containment.
+- A core unknown yields eligible_proposal, or a limited unknown silently enables or substitutes a module.
+- Ascent and descent collapse, route or provider data enters the contract, free text is retained, or activity-average power drives intensity.
+- A personal safety, finish, or performance claim appears, or the generated contract becomes active without separate implementation review and activation authority.
+
+### Decision notes
+
+- Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim.
+- Proposed predecessor transition: after separate digest-bound human approval and coordinated lifecycle review, this record may replace sdr-trail-running-goal-ontology-v1; no supersession link is active in this draft.
+- The accepted evidence remains sufficient only because every new exact value is classified as a reversible operational guardrail rather than a published biological rule.
+- Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.
+- Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.
+- Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.
+- Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168.
+
+</details>
+
+<details><summary>Exact machine contract — code consumption audit</summary>
+
+```json
+{
+  "affected_models": [
+    "trail_course_demand_v2 ontology",
+    "non_ultra_trail_constraints_v2 input and confirmation envelope",
+    "future v2 Trail capability matching contract"
+  ],
+  "contract_digest": "sha256:12c107e9d19f6c5e7204f09ef680ab5c4517a4f9385179d72822630a61df1c96",
+  "decision_id": "sdr-trail-running-goal-ontology-v2",
+  "decision_status": "draft",
+  "decision_version": 2,
+  "evidence_claim_ids": [
+    "trail-ontology.course-demand-is-multidimensional",
+    "trail-ontology.uphill-downhill-demands-differ",
+    "trail-ontology.technicality-and-downhill-vary-performance",
+    "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+    "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose",
+    "trail-ontology.environment-and-altitude-are-distinct-context",
+    "trail-ontology.duration-and-fueling-practice-are-context"
+  ],
+  "evidence_review_ids": [
+    "evidence-trail-running-goal-ontology-v1"
+  ],
+  "linked_evidence_digests": {
+    "evidence-trail-running-goal-ontology-v1": "sha256:60f0e785e4fc2b4226fed3bb30750191195cffbb0236b4a81d34431c0002c87a"
+  },
+  "model_version": "trail-course-demand-v2",
+  "parameters": {
+    "trail_course_demand_schema": {
+      "applies_to": "trail_course_demand_v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.uphill-downhill-demands-differ"
+      ],
+      "value": {
+        "event_identity": {
+          "client_writable": false,
+          "field": "event_id",
+          "materiality": "core",
+          "type": "server_owned_identifier"
+        },
+        "fields": {
+          "aid_and_support": {
+            "envelope": "known_or_unknown",
+            "limited_module": "fueling",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "course_footing": {
+            "envelope": "known_or_unknown",
+            "limited_module": "technical_terrain",
+            "materiality": "limited_with_core_matching_when_known",
+            "type": "nonempty_unordered_closed_set"
+          },
+          "distance_family": {
+            "allowed": [
+              "non_ultra"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "distance_meters": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 1,
+            "type": "integer",
+            "unit": "meters"
+          },
+          "environment_and_altitude": {
+            "envelope": "known_or_unknown",
+            "limited_module": "environment_altitude",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "event_date": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "iso_date"
+          },
+          "event_format": {
+            "allowed": [
+              "single_day"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "fixed_rope": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "materiality": "core",
+            "type": "tri_state"
+          },
+          "fueling_and_gastrointestinal_context": {
+            "envelope": "known_or_unknown",
+            "limited_module": "fueling",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "grade_distribution": {
+            "envelope": "known_or_unknown",
+            "limited_module": "grade_specificity",
+            "materiality": "limited",
+            "type": "five_bucket_basis_point_object"
+          },
+          "hands_assist": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "materiality": "core",
+            "type": "tri_state"
+          },
+          "planning_duration_range": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "integer_range",
+            "unit": "minutes"
+          },
+          "planning_intent": {
+            "allowed": [
+              "performance"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "total_ascent_m": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 0,
+            "type": "integer",
+            "unit": "meters"
+          },
+          "total_descent_m": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 0,
+            "type": "integer",
+            "unit": "meters"
+          }
+        },
+        "schema_id": "trail_course_demand_v2",
+        "strict_unknown_fields_rejected": true
+      }
+    },
+    "trail_distinct_demand_invariants": {
+      "applies_to": "v2 course, access, history, and intensity boundaries",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.technicality-and-downhill-vary-performance",
+        "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone"
+      ],
+      "value": {
+        "activity_average_power_allowed": false,
+        "ascent_and_descent_separate": true,
+        "downhill_history_required_when_descent_material": true,
+        "footing_set_containment": {
+          "access_failure_reason": "readiness_blocked.insufficient_terrain_access",
+          "access_requirement": "C subset_of A",
+          "accessible_set_symbol": "A",
+          "applies_only_when_course_footing_known": true,
+          "course_set_symbol": "C",
+          "history_failure_reason": "readiness_blocked.insufficient_comparable_trail_history",
+          "history_requirement": "C subset_of H",
+          "observed_history_set_symbol": "H",
+          "similarity_synonyms_or_model_inference_allowed": false
+        },
+        "grade_distribution_descriptive_only": true,
+        "heart_rate_alone_sufficient_for_hilly_intensity": false,
+        "level_pace_alone_sufficient_for_hilly_intensity": false,
+        "technicality_score_allowed": false,
+        "universal_distance_vertical_equivalence": false
+      }
+    },
+    "trail_exact_values": {
+      "applies_to": "unresolved ontology and prescription values",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "core_and_limited_materiality": "operational_guardrail_only",
+        "distance_vertical_conversion": "not_accepted",
+        "downhill_progression": "not_accepted",
+        "environment_or_altitude_dose": "not_accepted",
+        "finish_time_prediction": "not_accepted",
+        "footing_vocabulary": "descriptive_operational_guardrail_only",
+        "fueling_amount_or_frequency": "not_accepted",
+        "optional_context_bounds": "operational_guardrail_only",
+        "planning_duration_range_shape": "operational_guardrail_only",
+        "road_trail_equivalence": "not_accepted",
+        "route_or_provider_inference": "not_accepted",
+        "signed_grade_buckets": "descriptive_operational_guardrail_only",
+        "technical_terrain_dose": "not_accepted",
+        "technicality_score": "not_accepted",
+        "vertical_progression": "not_accepted"
+      }
+    },
+    "trail_field_provenance": {
+      "applies_to": "every reviewable v2 course, constraint, and history field",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "assumption_requires_revision_bound_confirmation": true,
+        "client_may_submit_history_hash": false,
+        "client_may_submit_model_version": false,
+        "client_may_submit_provenance": false,
+        "client_may_submit_source_revision": false,
+        "client_may_submit_source_timestamp": false,
+        "field_restrictions": {
+          "athlete_assumption_conditions": [
+            "explicit_assumption"
+          ],
+          "event_id": "server_owned",
+          "grade_distribution": [
+            "athlete_stated",
+            "course_verified",
+            "unknown"
+          ],
+          "recent_history": [
+            "history_observed"
+          ]
+        },
+        "inferred_requires_server_model_version": true,
+        "request_envelope": {
+          "arbitrary_object_invalid": true,
+          "empty_string_invalid": true,
+          "guessed_zero_invalid": true,
+          "known": {
+            "exact_keys": [
+              "state",
+              "value"
+            ],
+            "schema_valid_value_required": true,
+            "state_literal": "known"
+          },
+          "missing_state_invalid": true,
+          "null_invalid_except_explicit_aid_gap_case": true,
+          "numeric_values_must_be_finite": true,
+          "sentinel_number_invalid": true,
+          "unknown": {
+            "exact_keys": [
+              "state"
+            ],
+            "state_literal": "unknown",
+            "value_forbidden": true
+          }
+        },
+        "server_stamped_provenance_allowed": [
+          "athlete_stated",
+          "course_verified",
+          "history_observed",
+          "model_inferred",
+          "explicit_assumption",
+          "unknown"
+        ],
+        "unknown_is_preserved": true
+      }
+    },
+    "trail_footing_and_hazard_contract": {
+      "applies_to": "course, access, and observed-history footing plus v2 hazard gates",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.technicality-and-downhill-vary-performance",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "hazard_gates": {
+          "fixed_rope": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "eligible_value": "no",
+            "unknown_result": "clarification_required",
+            "yes_result": "policy_unavailable.technical_features_outside_v2"
+          },
+          "hands_assist": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "eligible_value": "no",
+            "unknown_result": "clarification_required",
+            "yes_result": "policy_unavailable.technical_features_outside_v2"
+          },
+          "reducible_to_ordinary_footing": false,
+          "technical_skill_or_safety_score": false
+        },
+        "ordinary_footing": {
+          "allowed": [
+            "firm_smooth",
+            "loose_gravel",
+            "mud",
+            "rocks_or_roots",
+            "built_steps",
+            "water_crossing"
+          ],
+          "difficulty_score": false,
+          "duplicates_invalid": true,
+          "free_text_allowed": false,
+          "other_value_allowed": false,
+          "type": "nonempty_unordered_set",
+          "unknown_members_invalid": true
+        }
+      }
+    },
+    "trail_grade_distribution": {
+      "applies_to": "known grade_distribution in trail_course_demand_v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ"
+      ],
+      "value": {
+        "allowed_provenance": [
+          "athlete_stated",
+          "course_verified"
+        ],
+        "buckets": {
+          "below_neg_10": {
+            "interval": "g < -10%",
+            "upper_bound_percent": -10,
+            "upper_inclusive": false
+          },
+          "neg_10_to_below_neg_3": {
+            "interval": "-10% <= g < -3%",
+            "lower_bound_percent": -10,
+            "lower_inclusive": true,
+            "upper_bound_percent": -3,
+            "upper_inclusive": false
+          },
+          "neg_3_to_below_pos_3": {
+            "interval": "-3% <= g < 3%",
+            "lower_bound_percent": -3,
+            "lower_inclusive": true,
+            "upper_bound_percent": 3,
+            "upper_inclusive": false
+          },
+          "pos_10_and_above": {
+            "interval": "g >= 10%",
+            "lower_bound_percent": 10,
+            "lower_inclusive": true
+          },
+          "pos_3_to_below_pos_10": {
+            "interval": "3% <= g < 10%",
+            "lower_bound_percent": 3,
+            "lower_inclusive": true,
+            "upper_bound_percent": 10,
+            "upper_inclusive": false
+          }
+        },
+        "descriptive_only": true,
+        "difficulty_score": false,
+        "each_share_minimum": 0,
+        "each_share_type": "integer",
+        "equivalence_or_prediction_input": false,
+        "exact_sum": 10000,
+        "known_value_exact_keys": [
+          "below_neg_10",
+          "neg_10_to_below_neg_3",
+          "neg_3_to_below_pos_3",
+          "pos_3_to_below_pos_10",
+          "pos_10_and_above"
+        ],
+        "ordering_semantic": false,
+        "route_or_model_inference": false,
+        "safety_threshold": false,
+        "unit": "basis_points_of_course_distance",
+        "workout_dose_input": false
+      }
+    },
+    "trail_non_science_authority_boundary": {
+      "applies_to": "all work outside the Science role",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "deployment": "not_accepted",
+        "implementation_review": "required",
+        "lifecycle_supersession": "not_accepted",
+        "owner_only_dogfood": "not_accepted",
+        "product_and_experience_dependency": "human_acceptance_required",
+        "product_visibility_or_catalog": "not_accepted",
+        "production_data_use": "not_accepted",
+        "provider_mapping_or_delivery": "not_accepted",
+        "runtime_activation": "not_accepted",
+        "science_authority": [
+          "evidence",
+          "applicability",
+          "uncertainty",
+          "claim_limits",
+          "safety_scope"
+        ]
+      }
+    },
+    "trail_optional_context_shapes": {
+      "applies_to": "optional v2 course context only",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.environment-and-altitude-are-distinct-context",
+        "trail-ontology.duration-and-fueling-practice-are-context"
+      ],
+      "value": {
+        "aid_and_support": {
+          "aid_station_count": {
+            "maximum": 50,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "aid_support_mode": {
+            "known_allowed": [
+              "organized_aid",
+              "mixed",
+              "self_supported"
+            ]
+          },
+          "food_availability": {
+            "known_allowed": [
+              "none",
+              "some_stations",
+              "all_stations"
+            ],
+            "unknown_uses_field_envelope": true
+          },
+          "mandatory_gear": {
+            "allowed": [
+              "water_carry",
+              "food_carry",
+              "weather_shell",
+              "lighting",
+              "navigation_device",
+              "other_required"
+            ],
+            "other_required_has_no_label_or_free_text": true,
+            "type": "unordered_closed_set"
+          },
+          "max_aid_station_gap_km": {
+            "maximum": 50,
+            "minimum": 0.1,
+            "null_allowed_only_for": "no_applicable_gap",
+            "type": "finite_number"
+          },
+          "water_availability": {
+            "known_allowed": [
+              "none",
+              "some_stations",
+              "all_stations"
+            ],
+            "unknown_uses_field_envelope": true
+          }
+        },
+        "environment_and_altitude": {
+          "conditions_basis": {
+            "athlete_assumption_provenance": "explicit_assumption",
+            "athlete_assumption_requires_confirmation": true,
+            "known_allowed": [
+              "organizer_information",
+              "seasonal_expectation",
+              "athlete_assumption"
+            ]
+          },
+          "humidity_range_pct": {
+            "maximum": 100,
+            "minimum": 0,
+            "minimum_may_equal_maximum": true,
+            "type": "finite_number_range"
+          },
+          "maximum_altitude_m": {
+            "maximum": 9000,
+            "minimum": -500,
+            "type": "integer"
+          },
+          "sun_exposure": {
+            "known_allowed": [
+              "low",
+              "mixed",
+              "high"
+            ],
+            "unknown_uses_field_envelope": true
+          },
+          "temperature_range_c": {
+            "maximum": 55,
+            "minimum": -30,
+            "minimum_may_equal_maximum": true,
+            "type": "finite_number_range"
+          },
+          "wind_exposure": {
+            "known_allowed": [
+              "sheltered",
+              "mixed",
+              "exposed"
+            ],
+            "unknown_uses_field_envelope": true
+          }
+        },
+        "fixed_prescription_from_known_context": false,
+        "fueling_and_gastrointestinal_context": {
+          "gastrointestinal_experience": {
+            "known_allowed": [
+              "no_plan_altering_issue",
+              "plan_altering_issue"
+            ],
+            "non_diagnostic": true,
+            "unknown_uses_field_envelope": true
+          },
+          "intake_form": {
+            "known_allowed": [
+              "none",
+              "fluids_only",
+              "carbohydrate_drink",
+              "mixed_food_and_drink"
+            ]
+          },
+          "longest_practiced_duration_min": {
+            "maximum": 1440,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "practice_sessions_last_42_days": {
+            "maximum": 84,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+      }
+    },
+    "trail_planning_duration_range": {
+      "applies_to": "trail_course_demand_v2 core confirmation",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.duration-and-fueling-practice-are-context"
+      ],
+      "value": {
+        "athlete_confirmed": true,
+        "feasibility_verdict": false,
+        "field": "planning_duration_range",
+        "finish_time_prediction": false,
+        "minimum_strictly_less_than_maximum": true,
+        "minimum_value": 1,
+        "performance_promise": false,
+        "purpose": "planning_context",
+        "unit": "integer_minutes"
+      }
+    },
+    "trail_revision_and_confirmation": {
+      "applies_to": "every v2 mutation, readiness receipt, and later proposal",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "value": {
+        "confirm_all_allowed": false,
+        "confirmation_invalidated_by": [
+          "value_change",
+          "known_unknown_state_change",
+          "server_stamped_source_change",
+          "source_revision_change"
+        ],
+        "confirmation_is_truth_safety_or_eligibility_attestation": false,
+        "confirmation_scope": "exact_visible_field_or_section_revision",
+        "mutation_creates_new_immutable_revision": true,
+        "proposal_binds_same_exact_revisions": true,
+        "readiness_binds_exact_revisions": [
+          "goal",
+          "course",
+          "constraints",
+          "history_snapshot",
+          "policy",
+          "generator"
+        ],
+        "stale_confirmation_rebound_allowed": false,
+        "stale_source_revision_rebound_allowed": false
+      }
+    },
+    "trail_science_safety_and_privacy_boundary": {
+      "applies_to": "all v2 science, storage, API, client, audit, and deletion surfaces",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "activity_average_power_valid_for_intensity": false,
+        "authenticated_owner_scoped_reset_export_and_deletion_required": true,
+        "diagnosis_treatment_clearance_or_return_to_sport": false,
+        "forbidden_collection_or_persistence": [
+          "gps_points",
+          "route_files",
+          "polylines",
+          "maps",
+          "inferred_course_geometry",
+          "course_source_urls",
+          "scraped_course_content",
+          "provider_request_or_response_payloads",
+          "provider_account_activity_or_workout_ids",
+          "device_identifiers",
+          "free_text_health_symptom_fueling_surface_or_course_narratives",
+          "diagnoses_or_medical_clearance",
+          "injury_probability",
+          "activity_average_power",
+          "road_equivalent_distance_pace_or_load"
+        ],
+        "generic_audit_or_telemetry_may_copy_sensitive_payloads": false,
+        "inferred_and_athlete_stated_fields_correctable_and_deletable": true,
+        "minimum_age_years": 18,
+        "minimum_normalized_storage_only": true,
+        "nonclinical_only": true,
+        "performance_injury_or_safety_guarantee": false,
+        "permitted_persisted_categories": [
+          "canonical_field_values_and_unknown_states",
+          "server_stamped_provenance",
+          "source_and_field_or_section_revisions",
+          "confirmations",
+          "owner_scoped_history_snapshot_reference_and_hash",
+          "readiness_and_proposal_binding_digests"
+        ],
+        "personal_finish_probability": false,
+        "suggestion_only": true,
+        "symptom_stop_required": true,
+        "valid_intensity_sources": [
+          "activity_splits",
+          "activity_samples"
+        ]
+      }
+    },
+    "trail_training_constraints_schema": {
+      "applies_to": "non_ultra_trail_constraints_v2 and owner-scoped readiness",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "value": {
+        "client_may_submit_or_attest_history": false,
+        "client_reviewable_fields": {
+          "accessible_footing": {
+            "envelope": "known_or_unknown",
+            "materiality": "core_when_course_footing_known",
+            "missing_required_member_result": "readiness_blocked.insufficient_terrain_access",
+            "type": "nonempty_unordered_closed_set",
+            "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
+          },
+          "adult_nonclinical_scope_confirmed": {
+            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "materiality": "core",
+            "required_value_for_eligibility": true,
+            "type": "strict_boolean"
+          },
+          "available_weekdays": {
+            "allowed_iso_weekdays": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "unique_unordered_set",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "controlled_downhill_terrain_accessible": {
+            "duration_distance_grade_speed_or_repeat_fields_allowed": false,
+            "envelope": "known_or_unknown",
+            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean"
+          },
+          "current_symptom_stop": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "stop_value": true,
+            "true_result": "readiness_blocked.current_symptom_stop",
+            "type": "tri_state_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+          },
+          "nontechnical_continuous_three_minute_uphill_accessible": {
+            "envelope": "known_or_unknown",
+            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean"
+          },
+          "performance_intent_confirmed": {
+            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "materiality": "core",
+            "required_value_for_eligibility": true,
+            "type": "strict_boolean"
+          }
+        },
+        "history_provenance": "history_observed",
+        "schema_id": "non_ultra_trail_constraints_v2",
+        "server_derived_history_fields": [
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing"
+        ]
+      }
+    },
+    "trail_unknown_and_materiality_policy": {
+      "applies_to": "v2 capability matching and readiness receipts",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.technicality-and-downhill-vary-performance"
+      ],
+      "value": {
+        "bounded_alternative_requires_separate_review": true,
+        "core_fields": [
+          "event_id",
+          "event_date",
+          "distance_meters",
+          "total_ascent_m",
+          "total_descent_m",
+          "planning_duration_range",
+          "event_format",
+          "distance_family",
+          "planning_intent",
+          "hands_assist",
+          "fixed_rope",
+          "adult_nonclinical_scope_confirmed",
+          "performance_intent_confirmed",
+          "current_symptom_stop",
+          "available_weekdays",
+          "nontechnical_continuous_three_minute_uphill_accessible",
+          "controlled_downhill_terrain_accessible",
+          "accessible_footing_when_course_footing_known",
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing_when_course_footing_known"
+        ],
+        "known_value_automatically_enables_module": false,
+        "limited_module_may_substitute_generic_or_road_behavior": false,
+        "limited_modules_sorted_allowed": [
+          "environment_altitude",
+          "fueling",
+          "grade_specificity",
+          "technical_terrain"
+        ],
+        "limited_unknown_mapping": {
+          "aid_and_support": "fueling",
+          "course_footing": "technical_terrain",
+          "environment_and_altitude": "environment_altitude",
+          "fueling_and_gastrointestinal_context": "fueling",
+          "grade_distribution": "grade_specificity"
+        },
+        "material_unknown_result": [
+          "clarification_required",
+          "policy_unavailable"
+        ],
+        "unknown_defaults_to_easy": false,
+        "unknown_defaults_to_nontechnical": false,
+        "unknown_defaults_to_road": false,
+        "unknown_defaults_to_zero": false
+      }
+    }
+  },
+  "runtime_state": "inactive",
+  "schema_version": 1,
+  "source_decision_digest": "sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b"
+}
+```
+
+</details>
+
+<details><summary>Implementation approval — not part of decision approval</summary>
+
+Runtime activation remains fail-closed until implementation approval can bind both the active contract digest and the exact reviewed code diff/validation evidence. Evidence or decision approval cannot fill this role.
+
+</details>
+
+<details><summary>Exact reviewed decision payload</summary>
+
+```json
+{
+  "accepted_interpretation": "If separately accepted by the decision approver, this successor would keep every accepted v1 science and safety boundary while defining trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict, provider-neutral, revision-bound data contracts. Reviewable fields carry an explicit known value or explicit unknown state; the server, never the client, stamps provenance and source revisions. Core course, scope, hazard, schedule, terrain-access, symptom, and recent-history gates fail closed. Unknown grade, ordinary course footing, environment, support, or fueling context can limit only their named module after all core gates pass. Five signed-grade basis-point buckets, six unordered footing flags, exact footing set containment, and bounded optional context are reversible Praxys operational guardrails, not validated difficulty scores, training doses, equivalence formulas, predictions, or safety thresholds. No route, GPS, free-text planning, provider payload, activity-average power, road fallback, personal performance prediction, or runtime behavior is accepted.",
+  "affected_surfaces": {
+    "apis": [
+      "future inactive Trail course, constraint, confirmation, and readiness contracts"
+    ],
+    "clients": [
+      "future inactive Praxys Web Trail course-ledger experience",
+      "future unavailable miniapp Trail setup handoff"
+    ],
+    "models": [
+      "trail_course_demand_v2 ontology",
+      "non_ultra_trail_constraints_v2 input and confirmation envelope",
+      "future v2 Trail capability matching contract"
+    ],
+    "science_notes": [
+      "Why Trail demand needs more than distance and ascent",
+      "Why grade shares and footing flags are descriptive operational guardrails",
+      "Why planning duration is context rather than a prediction"
+    ]
+  },
+  "applicability": [
+    "Adult nonclinical single-day non-ultra Trail performance goal representation",
+    "Strict provider-neutral course and athlete-constraint capture before capability matching",
+    "Server-derived owner-scoped recent-history context",
+    "Evidence, uncertainty, claim limits, safety, and privacy boundaries only"
+  ],
+  "artifact_policy": {
+    "runtime_state": "inactive"
+  },
+  "decision_date": "2026-09-04",
+  "decision_notes": [
+    "Decision Proposal mode; this record is draft and inactive and adds no Evidence Review or scientific claim.",
+    "Proposed predecessor transition: after separate digest-bound human approval and coordinated lifecycle review, this record may replace sdr-trail-running-goal-ontology-v1; no supersession link is active in this draft.",
+    "The accepted evidence remains sufficient only because every new exact value is classified as a reversible operational guardrail rather than a published biological rule.",
+    "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.",
+    "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.",
+    "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.",
+    "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."
+  ],
+  "decision_review": {
+    "approval_statement": "I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and hazard vocabularies, exact footing containment, bounded optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.",
+    "items": [
+      {
+        "approval_effect": [
+          "Missing values cannot be represented as zero, empty text, or a client-selected source.",
+          "Readiness and proposals can bind the exact confirmed source revisions used."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "Source scraping, route inference, model truth claims, or automatic confirmation."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.course-demand-is-multidimensional"
+        ],
+        "id": "strict-value-provenance-envelope",
+        "parameter_names": [
+          "trail_field_provenance",
+          "trail_revision_and_confirmation"
+        ],
+        "proposed_decision": "Accept the closed envelope, provenance categories, field-specific provenance restrictions, immutable revisions, and confirmation invalidation rules as operational guardrails.",
+        "question": "Should every reviewable v2 field use an exact known-or-unknown envelope while provenance, source metadata, and history hashes remain server-owned and revision-bound?",
+        "title": "Adopt explicit field states and server-owned provenance"
+      },
+      {
+        "approval_effect": [
+          "Distance and ascent alone cannot select a Trail policy.",
+          "A material core unknown prevents an eligible proposal."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "A finish-time estimate, feasibility verdict, performance promise, or course equivalence."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.course-demand-is-multidimensional",
+          "trail-ontology.uphill-downhill-demands-differ",
+          "trail-ontology.duration-and-fueling-practice-are-context"
+        ],
+        "id": "core-course-and-planning-context",
+        "parameter_names": [
+          "trail_course_demand_schema",
+          "trail_planning_duration_range"
+        ],
+        "proposed_decision": "Require those typed fields and treat planning duration only as athlete-confirmed planning context, never as a finish-time prediction.",
+        "question": "Should event identity, date, distance, ascent, descent, scope, intent, hazard gates, and a confirmed planning-duration range be core inputs?",
+        "title": "Adopt the v2 core course tuple and planning-duration range"
+      },
+      {
+        "approval_effect": [
+          "Grade boundaries and footing matching replay identically.",
+          "Course footing cannot be approximated by synonyms or a road category."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "Route-derived grade, a technical score, downhill dose, or terrain equivalence."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.uphill-downhill-demands-differ",
+          "trail-ontology.technicality-and-downhill-vary-performance"
+        ],
+        "id": "descriptive-course-and-access-vocabularies",
+        "parameter_names": [
+          "trail_grade_distribution",
+          "trail_footing_and_hazard_contract",
+          "trail_training_constraints_schema"
+        ],
+        "proposed_decision": "Accept these closed DTOs and exact set-containment rules as deterministic descriptions, not as technicality scores or doses.",
+        "question": "Should v2 use the exact five signed-grade share buckets, six unordered footing flags, two tri-state hazard gates, and weekday/uphill/downhill/ footing access fields?",
+        "title": "Adopt descriptive grade, footing, hazard, and terrain-access DTOs"
+      },
+      {
+        "approval_effect": [
+          "Optional unknowns remain visible without becoming hidden defaults.",
+          "A known mismatch still blocks the affected core access or history gate."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "An environment, altitude, equipment, fueling, gastrointestinal, or safety prescription."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.course-demand-is-multidimensional",
+          "trail-ontology.environment-and-altitude-are-distinct-context",
+          "trail-ontology.duration-and-fueling-practice-are-context"
+        ],
+        "id": "bounded-context-and-materiality",
+        "parameter_names": [
+          "trail_optional_context_shapes",
+          "trail_unknown_and_materiality_policy",
+          "trail_distinct_demand_invariants"
+        ],
+        "proposed_decision": "Accept the bounded shapes, exact core/limited mapping, sorted module vocabulary, and course-footing containment against access and observed history.",
+        "question": "Should environment, altitude, aid, equipment, fueling, and gastrointestinal context use closed bounded shapes, with only named non-core unknowns limiting dependent modules?",
+        "title": "Adopt bounded optional context and exact block-versus-limit rules"
+      },
+      {
+        "approval_effect": [
+          "Activity-average power cannot satisfy intensity provenance.",
+          "Route, GPS, free-text, diagnosis, and provider payloads remain outside the contract."
+        ],
+        "disposition": "approve",
+        "does_not_authorize": [
+          "Diagnosis, clearance, treatment, injury prevention, safety assurance, or personal performance prediction."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+          "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+        ],
+        "id": "science-safety-and-privacy-boundary",
+        "parameter_names": [
+          "trail_science_safety_and_privacy_boundary"
+        ],
+        "proposed_decision": "Carry the accepted v1 boundaries forward unchanged and apply them to every v2 field, receipt, and later implementation surface.",
+        "question": "Should v2 preserve the adult nonclinical scope, symptom stop, split/sample intensity provenance, minimum normalized storage, and all prohibitions on personal guarantees and sensitive planning payloads?",
+        "title": "Preserve the accepted nonclinical, intensity, claim, and privacy limits"
+      },
+      {
+        "approval_effect": [
+          "Exact DTO validation cannot silently become scientific prescription or runtime authority."
+        ],
+        "disposition": "defer",
+        "does_not_authorize": [
+          "Any behavior listed as not_accepted or any lifecycle transition for v1."
+        ],
+        "evidence_claim_ids": [
+          "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+        ],
+        "id": "unresolved-values-and-authority-deferred",
+        "parameter_names": [
+          "trail_exact_values",
+          "trail_non_science_authority_boundary"
+        ],
+        "proposed_decision": "Preserve literal not_accepted values and the inactive role boundary until separate specialist and human review authorizes a successor.",
+        "question": "Should every technicality score, route inference, dose, progression, equivalence, prediction, provider, rollout, and activation behavior remain unaccepted?",
+        "title": "Keep dose, scoring, equivalence, provider, and activation decisions deferred"
+      }
+    ],
+    "reviewer_task": "Decide whether the six proposed v2 ontology actions preserve the accepted v1 evidence, uncertainty, safety, and privacy boundaries while making the inactive input contract deterministic enough to implement. Approve the sheet as a unit or request changes by item ID."
+  },
+  "evidence_claim_ids": [
+    "trail-ontology.course-demand-is-multidimensional",
+    "trail-ontology.uphill-downhill-demands-differ",
+    "trail-ontology.technicality-and-downhill-vary-performance",
+    "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+    "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose",
+    "trail-ontology.environment-and-altitude-are-distinct-context",
+    "trail-ontology.duration-and-fueling-practice-are-context"
+  ],
+  "evidence_review_ids": [
+    "evidence-trail-running-goal-ontology-v1"
+  ],
+  "falsification_conditions": [
+    "A malformed or stale v2 value is treated as confirmed, or client-provided provenance or history is accepted.",
+    "A grade share falls into two buckets, the five shares do not total 10000, or grade becomes a difficulty, dose, equivalence, or prediction input.",
+    "Footing comparison uses order, similarity, synonyms, inference, or a road category instead of exact set containment.",
+    "A core unknown yields eligible_proposal, or a limited unknown silently enables or substitutes a module.",
+    "Ascent and descent collapse, route or provider data enters the contract, free text is retained, or activity-average power drives intensity.",
+    "A personal safety, finish, or performance claim appears, or the generated contract becomes active without separate implementation review and activation authority."
+  ],
+  "id": "sdr-trail-running-goal-ontology-v2",
+  "model_parameters": [
+    {
+      "applies_to": "trail_course_demand_v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.uphill-downhill-demands-differ"
+      ],
+      "name": "trail_course_demand_schema",
+      "rationale": "The evidence supports explicit distinct dimensions; field names, types, units, and the core/limited representation are reversible Praxys DTO choices selected to make missingness and replay unambiguous.",
+      "value": {
+        "event_identity": {
+          "client_writable": false,
+          "field": "event_id",
+          "materiality": "core",
+          "type": "server_owned_identifier"
+        },
+        "fields": {
+          "aid_and_support": {
+            "envelope": "known_or_unknown",
+            "limited_module": "fueling",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "course_footing": {
+            "envelope": "known_or_unknown",
+            "limited_module": "technical_terrain",
+            "materiality": "limited_with_core_matching_when_known",
+            "type": "nonempty_unordered_closed_set"
+          },
+          "distance_family": {
+            "allowed": [
+              "non_ultra"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "distance_meters": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 1,
+            "type": "integer",
+            "unit": "meters"
+          },
+          "environment_and_altitude": {
+            "envelope": "known_or_unknown",
+            "limited_module": "environment_altitude",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "event_date": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "iso_date"
+          },
+          "event_format": {
+            "allowed": [
+              "single_day"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "fixed_rope": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "materiality": "core",
+            "type": "tri_state"
+          },
+          "fueling_and_gastrointestinal_context": {
+            "envelope": "known_or_unknown",
+            "limited_module": "fueling",
+            "materiality": "limited",
+            "type": "bounded_object"
+          },
+          "grade_distribution": {
+            "envelope": "known_or_unknown",
+            "limited_module": "grade_specificity",
+            "materiality": "limited",
+            "type": "five_bucket_basis_point_object"
+          },
+          "hands_assist": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "materiality": "core",
+            "type": "tri_state"
+          },
+          "planning_duration_range": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "integer_range",
+            "unit": "minutes"
+          },
+          "planning_intent": {
+            "allowed": [
+              "performance"
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "closed_enum"
+          },
+          "total_ascent_m": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 0,
+            "type": "integer",
+            "unit": "meters"
+          },
+          "total_descent_m": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "minimum": 0,
+            "type": "integer",
+            "unit": "meters"
+          }
+        },
+        "schema_id": "trail_course_demand_v2",
+        "strict_unknown_fields_rejected": true
+      }
+    },
+    {
+      "applies_to": "every reviewable v2 course, constraint, and history field",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "name": "trail_field_provenance",
+      "rationale": "A strict server-owned provenance envelope prevents client-selected trust, hidden defaults, and stale source metadata. These are operational integrity controls, not published scientific values.",
+      "value": {
+        "assumption_requires_revision_bound_confirmation": true,
+        "client_may_submit_history_hash": false,
+        "client_may_submit_model_version": false,
+        "client_may_submit_provenance": false,
+        "client_may_submit_source_revision": false,
+        "client_may_submit_source_timestamp": false,
+        "field_restrictions": {
+          "athlete_assumption_conditions": [
+            "explicit_assumption"
+          ],
+          "event_id": "server_owned",
+          "grade_distribution": [
+            "athlete_stated",
+            "course_verified",
+            "unknown"
+          ],
+          "recent_history": [
+            "history_observed"
+          ]
+        },
+        "inferred_requires_server_model_version": true,
+        "request_envelope": {
+          "arbitrary_object_invalid": true,
+          "empty_string_invalid": true,
+          "guessed_zero_invalid": true,
+          "known": {
+            "exact_keys": [
+              "state",
+              "value"
+            ],
+            "schema_valid_value_required": true,
+            "state_literal": "known"
+          },
+          "missing_state_invalid": true,
+          "null_invalid_except_explicit_aid_gap_case": true,
+          "numeric_values_must_be_finite": true,
+          "sentinel_number_invalid": true,
+          "unknown": {
+            "exact_keys": [
+              "state"
+            ],
+            "state_literal": "unknown",
+            "value_forbidden": true
+          }
+        },
+        "server_stamped_provenance_allowed": [
+          "athlete_stated",
+          "course_verified",
+          "history_observed",
+          "model_inferred",
+          "explicit_assumption",
+          "unknown"
+        ],
+        "unknown_is_preserved": true
+      }
+    },
+    {
+      "applies_to": "trail_course_demand_v2 core confirmation",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.duration-and-fueling-practice-are-context"
+      ],
+      "name": "trail_planning_duration_range",
+      "rationale": "Expected duration is relevant context, while the exact range shape is a reversible Product DTO and cannot be presented as a prediction.",
+      "value": {
+        "athlete_confirmed": true,
+        "feasibility_verdict": false,
+        "field": "planning_duration_range",
+        "finish_time_prediction": false,
+        "minimum_strictly_less_than_maximum": true,
+        "minimum_value": 1,
+        "performance_promise": false,
+        "purpose": "planning_context",
+        "unit": "integer_minutes"
+      }
+    },
+    {
+      "applies_to": "known grade_distribution in trail_course_demand_v2",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ"
+      ],
+      "name": "trail_grade_distribution",
+      "rationale": "Literature supports keeping signed grade demand explicit but does not validate these exact bins. The half-open intervals and basis-point sum are reversible deterministic description guardrails only.",
+      "value": {
+        "allowed_provenance": [
+          "athlete_stated",
+          "course_verified"
+        ],
+        "buckets": {
+          "below_neg_10": {
+            "interval": "g < -10%",
+            "upper_bound_percent": -10,
+            "upper_inclusive": false
+          },
+          "neg_10_to_below_neg_3": {
+            "interval": "-10% <= g < -3%",
+            "lower_bound_percent": -10,
+            "lower_inclusive": true,
+            "upper_bound_percent": -3,
+            "upper_inclusive": false
+          },
+          "neg_3_to_below_pos_3": {
+            "interval": "-3% <= g < 3%",
+            "lower_bound_percent": -3,
+            "lower_inclusive": true,
+            "upper_bound_percent": 3,
+            "upper_inclusive": false
+          },
+          "pos_10_and_above": {
+            "interval": "g >= 10%",
+            "lower_bound_percent": 10,
+            "lower_inclusive": true
+          },
+          "pos_3_to_below_pos_10": {
+            "interval": "3% <= g < 10%",
+            "lower_bound_percent": 3,
+            "lower_inclusive": true,
+            "upper_bound_percent": 10,
+            "upper_inclusive": false
+          }
+        },
+        "descriptive_only": true,
+        "difficulty_score": false,
+        "each_share_minimum": 0,
+        "each_share_type": "integer",
+        "equivalence_or_prediction_input": false,
+        "exact_sum": 10000,
+        "known_value_exact_keys": [
+          "below_neg_10",
+          "neg_10_to_below_neg_3",
+          "neg_3_to_below_pos_3",
+          "pos_3_to_below_pos_10",
+          "pos_10_and_above"
+        ],
+        "ordering_semantic": false,
+        "route_or_model_inference": false,
+        "safety_threshold": false,
+        "unit": "basis_points_of_course_distance",
+        "workout_dose_input": false
+      }
+    },
+    {
+      "applies_to": "course, access, and observed-history footing plus v2 hazard gates",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.technicality-and-downhill-vary-performance",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "name": "trail_footing_and_hazard_contract",
+      "rationale": "Footing and hazards must remain explicit, but the exact vocabulary and gates are Product-selected operational categories rather than validated technicality or safety scores.",
+      "value": {
+        "hazard_gates": {
+          "fixed_rope": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "eligible_value": "no",
+            "unknown_result": "clarification_required",
+            "yes_result": "policy_unavailable.technical_features_outside_v2"
+          },
+          "hands_assist": {
+            "allowed": [
+              "yes",
+              "no",
+              "unknown"
+            ],
+            "eligible_value": "no",
+            "unknown_result": "clarification_required",
+            "yes_result": "policy_unavailable.technical_features_outside_v2"
+          },
+          "reducible_to_ordinary_footing": false,
+          "technical_skill_or_safety_score": false
+        },
+        "ordinary_footing": {
+          "allowed": [
+            "firm_smooth",
+            "loose_gravel",
+            "mud",
+            "rocks_or_roots",
+            "built_steps",
+            "water_crossing"
+          ],
+          "difficulty_score": false,
+          "duplicates_invalid": true,
+          "free_text_allowed": false,
+          "other_value_allowed": false,
+          "type": "nonempty_unordered_set",
+          "unknown_members_invalid": true
+        }
+      }
+    },
+    {
+      "applies_to": "non_ultra_trail_constraints_v2 and owner-scoped readiness",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "name": "trail_training_constraints_schema",
+      "rationale": "Schedule and terrain access must be explicit and recent history must remain server-derived. The exact closed DTO is an operational guardrail; it does not establish a safe terrain dose.",
+      "value": {
+        "client_may_submit_or_attest_history": false,
+        "client_reviewable_fields": {
+          "accessible_footing": {
+            "envelope": "known_or_unknown",
+            "materiality": "core_when_course_footing_known",
+            "missing_required_member_result": "readiness_blocked.insufficient_terrain_access",
+            "type": "nonempty_unordered_closed_set",
+            "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
+          },
+          "adult_nonclinical_scope_confirmed": {
+            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "materiality": "core",
+            "required_value_for_eligibility": true,
+            "type": "strict_boolean"
+          },
+          "available_weekdays": {
+            "allowed_iso_weekdays": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ],
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "type": "unique_unordered_set",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "controlled_downhill_terrain_accessible": {
+            "duration_distance_grade_speed_or_repeat_fields_allowed": false,
+            "envelope": "known_or_unknown",
+            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean"
+          },
+          "current_symptom_stop": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "stop_value": true,
+            "true_result": "readiness_blocked.current_symptom_stop",
+            "type": "tri_state_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+          },
+          "nontechnical_continuous_three_minute_uphill_accessible": {
+            "envelope": "known_or_unknown",
+            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean"
+          },
+          "performance_intent_confirmed": {
+            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "materiality": "core",
+            "required_value_for_eligibility": true,
+            "type": "strict_boolean"
+          }
+        },
+        "history_provenance": "history_observed",
+        "schema_id": "non_ultra_trail_constraints_v2",
+        "server_derived_history_fields": [
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing"
+        ]
+      }
+    },
+    {
+      "applies_to": "optional v2 course context only",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.environment-and-altitude-are-distinct-context",
+        "trail-ontology.duration-and-fueling-practice-are-context"
+      ],
+      "name": "trail_optional_context_shapes",
+      "rationale": "Environment and fueling are relevant context, while every exact bound and enum is a reversible minimization and validation choice. None establishes an exposure, equipment, fueling, gastrointestinal, or safety prescription.",
+      "value": {
+        "aid_and_support": {
+          "aid_station_count": {
+            "maximum": 50,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "aid_support_mode": {
+            "known_allowed": [
+              "organized_aid",
+              "mixed",
+              "self_supported"
+            ]
+          },
+          "food_availability": {
+            "known_allowed": [
+              "none",
+              "some_stations",
+              "all_stations"
+            ],
+            "unknown_uses_field_envelope": true
+          },
+          "mandatory_gear": {
+            "allowed": [
+              "water_carry",
+              "food_carry",
+              "weather_shell",
+              "lighting",
+              "navigation_device",
+              "other_required"
+            ],
+            "other_required_has_no_label_or_free_text": true,
+            "type": "unordered_closed_set"
+          },
+          "max_aid_station_gap_km": {
+            "maximum": 50,
+            "minimum": 0.1,
+            "null_allowed_only_for": "no_applicable_gap",
+            "type": "finite_number"
+          },
+          "water_availability": {
+            "known_allowed": [
+              "none",
+              "some_stations",
+              "all_stations"
+            ],
+            "unknown_uses_field_envelope": true
+          }
+        },
+        "environment_and_altitude": {
+          "conditions_basis": {
+            "athlete_assumption_provenance": "explicit_assumption",
+            "athlete_assumption_requires_confirmation": true,
+            "known_allowed": [
+              "organizer_information",
+              "seasonal_expectation",
+              "athlete_assumption"
+            ]
+          },
+          "humidity_range_pct": {
+            "maximum": 100,
+            "minimum": 0,
+            "minimum_may_equal_maximum": true,
+            "type": "finite_number_range"
+          },
+          "maximum_altitude_m": {
+            "maximum": 9000,
+            "minimum": -500,
+            "type": "integer"
+          },
+          "sun_exposure": {
+            "known_allowed": [
+              "low",
+              "mixed",
+              "high"
+            ],
+            "unknown_uses_field_envelope": true
+          },
+          "temperature_range_c": {
+            "maximum": 55,
+            "minimum": -30,
+            "minimum_may_equal_maximum": true,
+            "type": "finite_number_range"
+          },
+          "wind_exposure": {
+            "known_allowed": [
+              "sheltered",
+              "mixed",
+              "exposed"
+            ],
+            "unknown_uses_field_envelope": true
+          }
+        },
+        "fixed_prescription_from_known_context": false,
+        "fueling_and_gastrointestinal_context": {
+          "gastrointestinal_experience": {
+            "known_allowed": [
+              "no_plan_altering_issue",
+              "plan_altering_issue"
+            ],
+            "non_diagnostic": true,
+            "unknown_uses_field_envelope": true
+          },
+          "intake_form": {
+            "known_allowed": [
+              "none",
+              "fluids_only",
+              "carbohydrate_drink",
+              "mixed_food_and_drink"
+            ]
+          },
+          "longest_practiced_duration_min": {
+            "maximum": 1440,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "practice_sessions_last_42_days": {
+            "maximum": 84,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "notes_labels_urls_provider_ids_or_embedded_unit_strings_allowed": false
+      }
+    },
+    {
+      "applies_to": "v2 capability matching and readiness receipts",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.course-demand-is-multidimensional",
+        "trail-ontology.technicality-and-downhill-vary-performance"
+      ],
+      "name": "trail_unknown_and_materiality_policy",
+      "rationale": "This exact Product-selected block-versus-limit mapping keeps material missingness visible without manufacturing certainty or broadening the accepted Science scope.",
+      "value": {
+        "bounded_alternative_requires_separate_review": true,
+        "core_fields": [
+          "event_id",
+          "event_date",
+          "distance_meters",
+          "total_ascent_m",
+          "total_descent_m",
+          "planning_duration_range",
+          "event_format",
+          "distance_family",
+          "planning_intent",
+          "hands_assist",
+          "fixed_rope",
+          "adult_nonclinical_scope_confirmed",
+          "performance_intent_confirmed",
+          "current_symptom_stop",
+          "available_weekdays",
+          "nontechnical_continuous_three_minute_uphill_accessible",
+          "controlled_downhill_terrain_accessible",
+          "accessible_footing_when_course_footing_known",
+          "recent_running_continuity",
+          "recent_ascent_exposure",
+          "recent_descent_exposure",
+          "recently_observed_footing_when_course_footing_known"
+        ],
+        "known_value_automatically_enables_module": false,
+        "limited_module_may_substitute_generic_or_road_behavior": false,
+        "limited_modules_sorted_allowed": [
+          "environment_altitude",
+          "fueling",
+          "grade_specificity",
+          "technical_terrain"
+        ],
+        "limited_unknown_mapping": {
+          "aid_and_support": "fueling",
+          "course_footing": "technical_terrain",
+          "environment_and_altitude": "environment_altitude",
+          "fueling_and_gastrointestinal_context": "fueling",
+          "grade_distribution": "grade_specificity"
+        },
+        "material_unknown_result": [
+          "clarification_required",
+          "policy_unavailable"
+        ],
+        "unknown_defaults_to_easy": false,
+        "unknown_defaults_to_nontechnical": false,
+        "unknown_defaults_to_road": false,
+        "unknown_defaults_to_zero": false
+      }
+    },
+    {
+      "applies_to": "v2 course, access, history, and intensity boundaries",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.technicality-and-downhill-vary-performance",
+        "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone"
+      ],
+      "name": "trail_distinct_demand_invariants",
+      "rationale": "Distinct demands follow the evidence; exact set containment is a deterministic conservative matching guardrail, not a validated safety or similarity model.",
+      "value": {
+        "activity_average_power_allowed": false,
+        "ascent_and_descent_separate": true,
+        "downhill_history_required_when_descent_material": true,
+        "footing_set_containment": {
+          "access_failure_reason": "readiness_blocked.insufficient_terrain_access",
+          "access_requirement": "C subset_of A",
+          "accessible_set_symbol": "A",
+          "applies_only_when_course_footing_known": true,
+          "course_set_symbol": "C",
+          "history_failure_reason": "readiness_blocked.insufficient_comparable_trail_history",
+          "history_requirement": "C subset_of H",
+          "observed_history_set_symbol": "H",
+          "similarity_synonyms_or_model_inference_allowed": false
+        },
+        "grade_distribution_descriptive_only": true,
+        "heart_rate_alone_sufficient_for_hilly_intensity": false,
+        "level_pace_alone_sufficient_for_hilly_intensity": false,
+        "technicality_score_allowed": false,
+        "universal_distance_vertical_equivalence": false
+      }
+    },
+    {
+      "applies_to": "every v2 mutation, readiness receipt, and later proposal",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "name": "trail_revision_and_confirmation",
+      "rationale": "Exact revisions prevent stale confirmation from silently acquiring new meaning. This is an operational replay and user-control guardrail.",
+      "value": {
+        "confirm_all_allowed": false,
+        "confirmation_invalidated_by": [
+          "value_change",
+          "known_unknown_state_change",
+          "server_stamped_source_change",
+          "source_revision_change"
+        ],
+        "confirmation_is_truth_safety_or_eligibility_attestation": false,
+        "confirmation_scope": "exact_visible_field_or_section_revision",
+        "mutation_creates_new_immutable_revision": true,
+        "proposal_binds_same_exact_revisions": true,
+        "readiness_binds_exact_revisions": [
+          "goal",
+          "course",
+          "constraints",
+          "history_snapshot",
+          "policy",
+          "generator"
+        ],
+        "stale_confirmation_rebound_allowed": false,
+        "stale_source_revision_rebound_allowed": false
+      }
+    },
+    {
+      "applies_to": "all v2 science, storage, API, client, audit, and deletion surfaces",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.heart-rate-and-road-pace-are-insufficient-alone",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "name": "trail_science_safety_and_privacy_boundary",
+      "rationale": "These preserve the accepted v1 nonclinical, intensity, claim, and minimization boundaries while making the v2 storage exclusion explicit.",
+      "value": {
+        "activity_average_power_valid_for_intensity": false,
+        "authenticated_owner_scoped_reset_export_and_deletion_required": true,
+        "diagnosis_treatment_clearance_or_return_to_sport": false,
+        "forbidden_collection_or_persistence": [
+          "gps_points",
+          "route_files",
+          "polylines",
+          "maps",
+          "inferred_course_geometry",
+          "course_source_urls",
+          "scraped_course_content",
+          "provider_request_or_response_payloads",
+          "provider_account_activity_or_workout_ids",
+          "device_identifiers",
+          "free_text_health_symptom_fueling_surface_or_course_narratives",
+          "diagnoses_or_medical_clearance",
+          "injury_probability",
+          "activity_average_power",
+          "road_equivalent_distance_pace_or_load"
+        ],
+        "generic_audit_or_telemetry_may_copy_sensitive_payloads": false,
+        "inferred_and_athlete_stated_fields_correctable_and_deletable": true,
+        "minimum_age_years": 18,
+        "minimum_normalized_storage_only": true,
+        "nonclinical_only": true,
+        "performance_injury_or_safety_guarantee": false,
+        "permitted_persisted_categories": [
+          "canonical_field_values_and_unknown_states",
+          "server_stamped_provenance",
+          "source_and_field_or_section_revisions",
+          "confirmations",
+          "owner_scoped_history_snapshot_reference_and_hash",
+          "readiness_and_proposal_binding_digests"
+        ],
+        "personal_finish_probability": false,
+        "suggestion_only": true,
+        "symptom_stop_required": true,
+        "valid_intensity_sources": [
+          "activity_splits",
+          "activity_samples"
+        ]
+      }
+    },
+    {
+      "applies_to": "unresolved ontology and prescription values",
+      "classification": "guardrail",
+      "evidence_claim_ids": [
+        "trail-ontology.uphill-downhill-demands-differ",
+        "trail-ontology.training-and-injury-evidence-does-not-set-safe-dose"
+      ],
+      "name": "trail_exact_values",
+      "rationale": "The accepted evidence supports explicit dimensions but not universal scoring, inference, equivalence, prediction, progression, or dose. Only the closed validation DTO is proposed here.",
+      "value": {
+        "core_and_limited_materiality": "operational_guardrail_only",
+        "distance_vertical_conversion": "not_accepted",
+        "downhill_progression": "not_accepted",
+        "environment_or_altitude_dose": "not_accepted",
+        "finish_time_prediction": "not_accepted",
+        "footing_vocabulary": "descriptive_operational_guardrail_only",
+        "fueling_amount_or_frequency": "not_accepted",
+        "optional_context_bounds": "operational_guardrail_only",
+        "planning_duration_range_shape": "operational_guardrail_only",
+        "road_trail_equivalence": "not_accepted",
+        "route_or_provider_inference": "not_accepted",
+        "signed_grade_buckets": "descriptive_operational_guardrail_only",
+        "technical_terrain_dose": "not_accepted",
+        "technicality_score": "not_accepted",
+        "vertical_progression": "not_accepted"
+      }
+    },
+    {
+      "applies_to": "all work outside the Science role",
+      "classification": "guardrail",
+      "evidence_claim_ids": [],
+      "name": "trail_non_science_authority_boundary",
+      "rationale": "A Science successor cannot originate or widen Product, Design, Engineering, Trust, Operations, provider, rollout, or activation authority.",
+      "value": {
+        "deployment": "not_accepted",
+        "implementation_review": "required",
+        "lifecycle_supersession": "not_accepted",
+        "owner_only_dogfood": "not_accepted",
+        "product_and_experience_dependency": "human_acceptance_required",
+        "product_visibility_or_catalog": "not_accepted",
+        "production_data_use": "not_accepted",
+        "provider_mapping_or_delivery": "not_accepted",
+        "runtime_activation": "not_accepted",
+        "science_authority": [
+          "evidence",
+          "applicability",
+          "uncertainty",
+          "claim_limits",
+          "safety_scope"
+        ]
+      }
+    }
+  ],
+  "model_version": "trail-course-demand-v2",
+  "owners": [
+    "team:praxys"
+  ],
+  "privacy_implications": [
+    "Collect and persist only normalized typed values, explicit unknown states, server provenance, revisions, confirmations, and owner-scoped replay references.",
+    "Do not ingest GPS, routes, maps, source URLs, scraped content, provider payloads or identifiers, device identifiers, or free-text planning narratives.",
+    "Reset invalidates confirmation and creates a new revision; export and deletion include the current owner-scoped v2 state under existing data-rights controls.",
+    "No public sharing, cross-user aggregate, administrator planning access, or value telemetry is authorized."
+  ],
+  "rejected_alternatives": [
+    {
+      "alternative": "Keep the ambiguous v1 object fields and let each caller interpret them",
+      "rationale": "Caller-specific interpretation would make missingness, provenance, materiality, and replay nondeterministic."
+    },
+    {
+      "alternative": "Infer grade, footing, or technical demand from a route or provider payload",
+      "rationale": "v2 does not collect those payloads, and the evidence does not validate a universal inference or technicality score."
+    },
+    {
+      "alternative": "Require every optional course descriptor before any proposal",
+      "rationale": "Core-versus-limited materiality can preserve uncertainty without hiding it or inventing a dependent module."
+    },
+    {
+      "alternative": "Treat an unknown or inaccessible Trail field as ordinary road running",
+      "rationale": "That would erase course-specific demand and violate the accepted no-road- fallback boundary."
+    }
+  ],
+  "safety_implications": [
+    "Every core unknown or failed gate prevents an eligible proposal; only named non-core unknowns can limit a dependent module.",
+    "Uphill, downhill, ordinary footing, hazards, altitude, heat, support, and fueling context remain distinct when applicable.",
+    "Hands-assist or fixed-rope use stays outside v2; unknown hazard gates require clarification.",
+    "Current symptoms stop performance optimization without creating a diagnosis.",
+    "Intensity provenance uses activity splits or samples, never activity-average power."
+  ],
+  "schema_version": 1,
+  "supersedes": [],
+  "title": "Define the strict v2 Trail course-demand and constraint envelope",
+  "user_facing_claim_limits": [
+    "Do not claim the exact v2 DTO, bins, footing vocabulary, bounds, or materiality map is scientifically optimal or validated as a safety rule.",
+    "Do not claim planning duration is a finish-time prediction, feasibility verdict, or performance promise.",
+    "Do not claim distance and ascent alone describe Trail demand or present a universal road-equivalent distance, grade, ascent, or descent conversion.",
+    "Do not present unknown footing, hazard, environment, support, fueling, or gastrointestinal context as known, easy, safe, or average.",
+    "Do not present a technicality score, personal finish probability, performance guarantee, injury-prevention guarantee, diagnosis, treatment, or clearance."
+  ],
+  "validation_plan": [
+    "Validate every closed enum, set, integer, finite number, range relation, explicit unknown state, and field-specific provenance rule deterministically.",
+    "Boundary-test all five signed-grade intervals and require nonnegative integer shares summing exactly to 10000.",
+    "Replay reordered footing and weekday sets and verify one canonical digest; reject duplicates, unknown members, synonyms, and free text.",
+    "Verify exact course-footing containment against both accessible and observed-history sets and preserve the distinct access and history failures.",
+    "Mutate every field value, state, and server source revision and verify the prior confirmation and readiness binding becomes stale.",
+    "Exercise every core unknown and limited unknown and verify no road policy, hidden default, provider behavior, or success-shaped plan is selected.",
+    "Generate the matching review packet and inactive machine contract and bind any later approval to their exact digests."
+  ],
+  "version": 2
+}
+```
+
+</details>

--- a/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
+++ b/data/science/generated/review-packets/sdr-trail-running-goal-ontology-v2.md
@@ -6,8 +6,8 @@
 - **Lifecycle:** `draft`
 - **Model version:** `trail-course-demand-v2`
 - **Runtime state:** `inactive`
-- **Decision digest:** `sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b`
-- **Contract digest:** `sha256:12c107e9d19f6c5e7204f09ef680ab5c4517a4f9385179d72822630a61df1c96`
+- **Decision digest:** `sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c`
+- **Contract digest:** `sha256:1297f713b992822335978dac92cfaa9b968b092d4ff6869ad73baa3d94ee2e7a`
 - **Required decision role:** `decision_approver`
 - **Decision approval:** _Pending_
 - **Required activation role:** `implementation_reviewer`
@@ -64,7 +64,7 @@ Do not approve merely because the audit appendix looks reasonable or because you
 
 #### `descriptive-course-and-access-vocabularies` — Adopt descriptive grade, footing, hazard, and terrain-access DTOs
 
-- **Question:** Should v2 use the exact five signed-grade share buckets, six unordered footing flags, two tri-state hazard gates, and weekday/uphill/downhill/ footing access fields?
+- **Question:** Should v2 use the exact five signed-grade share buckets, six unordered footing flags, two known-or-unknown boolean hazard fields, and bounded schedule plus uphill/downhill/footing access fields?
 - **Proposed decision:** Accept these closed DTOs and exact set-containment rules as deterministic descriptions, not as technicality scores or doses.
 - **Approval means:**
   - Grade boundaries and footing matching replay identically.
@@ -135,7 +135,7 @@ Do not approve merely because the audit appendix looks reasonable or because you
 
 A decision approval bound to the displayed digest attests:
 
-> I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and hazard vocabularies, exact footing containment, bounded optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+> I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and known-or-unknown boolean hazard fields, exact footing containment, bounded schedule and optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
 - **Decision approval:** _Pending_
 
@@ -148,12 +148,12 @@ Praxys science approval — **APPROVE**
 
 - Role: `decision_approver`
 - Subject: `sdr-trail-running-goal-ontology-v2`
-- Digest: `sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b`
+- Digest: `sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c`
 
-> I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and hazard vocabularies, exact footing containment, bounded optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
+> I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and known-or-unknown boolean hazard fields, exact footing containment, bounded schedule and optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.
 
 <!-- praxys-science-approval:v1
-{"role":"decision_approver","subject_digest":"sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b","subject_id":"sdr-trail-running-goal-ontology-v2","subject_kind":"science_decision"}
+{"role":"decision_approver","subject_digest":"sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c","subject_id":"sdr-trail-running-goal-ontology-v2","subject_kind":"science_decision"}
 -->
 ```
 
@@ -163,7 +163,7 @@ Praxys science approval — **APPROVE**
 
 ### Accepted interpretation
 
-If separately accepted by the decision approver, this successor would keep every accepted v1 science and safety boundary while defining trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict, provider-neutral, revision-bound data contracts. Reviewable fields carry an explicit known value or explicit unknown state; the server, never the client, stamps provenance and source revisions. Core course, scope, hazard, schedule, terrain-access, symptom, and recent-history gates fail closed. Unknown grade, ordinary course footing, environment, support, or fueling context can limit only their named module after all core gates pass. Five signed-grade basis-point buckets, six unordered footing flags, exact footing set containment, and bounded optional context are reversible Praxys operational guardrails, not validated difficulty scores, training doses, equivalence formulas, predictions, or safety thresholds. No route, GPS, free-text planning, provider payload, activity-average power, road fallback, personal performance prediction, or runtime behavior is accepted.
+If separately accepted by the decision approver, this successor would keep every accepted v1 science and safety boundary while defining trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict, provider-neutral, revision-bound data contracts. Reviewable fields carry an explicit known value or explicit unknown state; the server, never the client, stamps provenance and source revisions. Core course, scope, hazard, schedule, terrain-access, symptom, and recent-history gates fail closed. Unknown grade, ordinary course footing, environment, support, or fueling context can limit only their named module after all core gates pass. Five signed-grade basis-point buckets, six unordered footing flags, known-or- unknown boolean hazard fields, exact footing set containment, bounded schedule capacity, and bounded optional context are reversible Praxys operational guardrails, not validated difficulty scores, training doses, equivalence formulas, predictions, or safety thresholds. No route, GPS, free-text planning, provider payload, activity-average power, road fallback, personal performance prediction, or runtime behavior is accepted.
 
 ### Linked evidence
 
@@ -264,6 +264,7 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "distance_meters": {
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "maximum": 49999,
       "minimum": 1,
       "type": "integer",
       "unit": "meters"
@@ -288,13 +289,9 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "type": "closed_enum"
     },
     "fixed_rope": {
-      "allowed": [
-        "yes",
-        "no",
-        "unknown"
-      ],
+      "envelope": "known_or_unknown",
       "materiality": "core",
-      "type": "tri_state"
+      "type": "strict_boolean"
     },
     "fueling_and_gastrointestinal_context": {
       "envelope": "known_or_unknown",
@@ -309,13 +306,9 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "type": "five_bucket_basis_point_object"
     },
     "hands_assist": {
-      "allowed": [
-        "yes",
-        "no",
-        "unknown"
-      ],
+      "envelope": "known_or_unknown",
       "materiality": "core",
-      "type": "tri_state"
+      "type": "strict_boolean"
     },
     "planning_duration_range": {
       "envelope": "known_or_unknown",
@@ -334,6 +327,7 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "total_ascent_m": {
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "maximum": 20000,
       "minimum": 0,
       "type": "integer",
       "unit": "meters"
@@ -341,6 +335,7 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "total_descent_m": {
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "maximum": 20000,
       "minimum": 0,
       "type": "integer",
       "unit": "meters"
@@ -430,8 +425,11 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
   "feasibility_verdict": false,
   "field": "planning_duration_range",
   "finish_time_prediction": false,
+  "minimum_and_maximum_each": {
+    "maximum": 1440,
+    "minimum": 1
+  },
   "minimum_strictly_less_than_maximum": true,
-  "minimum_value": 1,
   "performance_promise": false,
   "purpose": "planning_context",
   "unit": "integer_minutes"
@@ -516,24 +514,18 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
 {
   "hazard_gates": {
     "fixed_rope": {
-      "allowed": [
-        "yes",
-        "no",
-        "unknown"
-      ],
-      "eligible_value": "no",
-      "unknown_result": "clarification_required",
-      "yes_result": "policy_unavailable.technical_features_outside_v2"
+      "eligible_value": "known_false",
+      "envelope": "known_or_unknown",
+      "known_true_result": "policy_unavailable.technical_features_outside_v2",
+      "known_value_type": "strict_boolean",
+      "unknown_result": "clarification_required.material_course_demand_unknown"
     },
     "hands_assist": {
-      "allowed": [
-        "yes",
-        "no",
-        "unknown"
-      ],
-      "eligible_value": "no",
-      "unknown_result": "clarification_required",
-      "yes_result": "policy_unavailable.technical_features_outside_v2"
+      "eligible_value": "known_false",
+      "envelope": "known_or_unknown",
+      "known_true_result": "policy_unavailable.technical_features_outside_v2",
+      "known_value_type": "strict_boolean",
+      "unknown_result": "clarification_required.material_course_demand_unknown"
     },
     "reducible_to_ordinary_footing": false,
     "technical_skill_or_safety_score": false
@@ -576,10 +568,12 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
     },
     "adult_nonclinical_scope_confirmed": {
-      "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+      "envelope": "known_or_unknown",
+      "false_result": "policy_unavailable.unsupported_population_or_intent",
       "materiality": "core",
       "required_value_for_eligibility": true,
-      "type": "strict_boolean"
+      "type": "strict_boolean",
+      "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
     },
     "available_weekdays": {
       "allowed_iso_weekdays": [
@@ -593,35 +587,81 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
       ],
       "envelope": "known_or_unknown",
       "materiality": "core",
+      "minimum_members": 1,
       "type": "unique_unordered_set",
       "unknown_result": "clarification_required.training_constraints_missing"
     },
-    "controlled_downhill_terrain_accessible": {
+    "controlled_downhill_access": {
       "duration_distance_grade_speed_or_repeat_fields_allowed": false,
       "envelope": "known_or_unknown",
-      "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+      "false_result": "readiness_blocked.insufficient_terrain_access",
       "materiality": "core",
-      "type": "strict_boolean"
+      "type": "strict_boolean",
+      "unknown_result": "clarification_required.training_constraints_missing"
     },
     "current_symptom_stop": {
       "envelope": "known_or_unknown",
       "materiality": "core",
       "stop_value": true,
       "true_result": "readiness_blocked.current_symptom_stop",
-      "type": "tri_state_boolean",
-      "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+      "type": "strict_boolean",
+      "unknown_result": "clarification_required.training_constraints_missing"
     },
-    "nontechnical_continuous_three_minute_uphill_accessible": {
+    "maximum_session_duration_min": {
       "envelope": "known_or_unknown",
-      "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
       "materiality": "core",
-      "type": "strict_boolean"
+      "maximum": 1440,
+      "minimum": 1,
+      "not_greater_than": "weekly_time_limit_min",
+      "type": "integer",
+      "unknown_result": "clarification_required.training_constraints_missing"
+    },
+    "nontechnical_three_minute_uphill_access": {
+      "envelope": "known_or_unknown",
+      "false_result": "readiness_blocked.insufficient_terrain_access",
+      "materiality": "core",
+      "type": "strict_boolean",
+      "unknown_result": "clarification_required.training_constraints_missing"
     },
     "performance_intent_confirmed": {
-      "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+      "envelope": "known_or_unknown",
+      "false_result": "policy_unavailable.unsupported_population_or_intent",
       "materiality": "core",
       "required_value_for_eligibility": true,
-      "type": "strict_boolean"
+      "type": "strict_boolean",
+      "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+    },
+    "preferred_longest_weekday": {
+      "allowed": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "conflict_result": "clarification_required.contradictory_input",
+      "omitted_means_no_preference": true,
+      "type": "optional_iso_weekday",
+      "when_present_must_be_in": "available_weekdays"
+    },
+    "unavailable_dates": {
+      "all_dates_within_requested_14_day_horizon": true,
+      "empty_known_set_allowed": true,
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "maximum_members": 14,
+      "type": "sorted_unique_iso_date_set",
+      "unknown_result": "clarification_required.training_constraints_missing"
+    },
+    "weekly_time_limit_min": {
+      "envelope": "known_or_unknown",
+      "materiality": "core",
+      "maximum": 10080,
+      "minimum": 1,
+      "type": "integer",
+      "unknown_result": "clarification_required.training_constraints_missing"
     }
   },
   "history_provenance": "history_observed",
@@ -795,8 +835,12 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
     "performance_intent_confirmed",
     "current_symptom_stop",
     "available_weekdays",
-    "nontechnical_continuous_three_minute_uphill_accessible",
-    "controlled_downhill_terrain_accessible",
+    "weekly_time_limit_min",
+    "maximum_session_duration_min",
+    "unavailable_dates",
+    "preferred_longest_weekday_consistency_when_present",
+    "nontechnical_three_minute_uphill_access",
+    "controlled_downhill_access",
     "accessible_footing_when_course_footing_known",
     "recent_running_continuity",
     "recent_ascent_exposure",
@@ -956,6 +1000,7 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
 ```json
 {
   "core_and_limited_materiality": "operational_guardrail_only",
+  "course_domain_bounds": "product_scope_and_operability_guardrail_only",
   "distance_vertical_conversion": "not_accepted",
   "downhill_progression": "not_accepted",
   "environment_or_altitude_dose": "not_accepted",
@@ -966,6 +1011,7 @@ Endurance carbohydrate strategy varies with expected exercise duration, feeding 
   "planning_duration_range_shape": "operational_guardrail_only",
   "road_trail_equivalence": "not_accepted",
   "route_or_provider_inference": "not_accepted",
+  "schedule_capacity_bounds": "product_scope_and_operability_guardrail_only",
   "signed_grade_buckets": "descriptive_operational_guardrail_only",
   "technical_terrain_dose": "not_accepted",
   "technicality_score": "not_accepted",
@@ -1075,6 +1121,9 @@ That would erase course-specific demand and violate the accepted no-road- fallba
 - The accepted evidence remains sufficient only because every new exact value is classified as a reversible operational guardrail rather than a published biological rule.
 - Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.
 - Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.
+- Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.
+- Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.
+- This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.
 - Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.
 - Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168.
 
@@ -1089,7 +1138,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
     "non_ultra_trail_constraints_v2 input and confirmation envelope",
     "future v2 Trail capability matching contract"
   ],
-  "contract_digest": "sha256:12c107e9d19f6c5e7204f09ef680ab5c4517a4f9385179d72822630a61df1c96",
+  "contract_digest": "sha256:1297f713b992822335978dac92cfaa9b968b092d4ff6869ad73baa3d94ee2e7a",
   "decision_id": "sdr-trail-running-goal-ontology-v2",
   "decision_status": "draft",
   "decision_version": 2,
@@ -1148,6 +1197,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "distance_meters": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 49999,
             "minimum": 1,
             "type": "integer",
             "unit": "meters"
@@ -1172,13 +1222,9 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "type": "closed_enum"
           },
           "fixed_rope": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
+            "envelope": "known_or_unknown",
             "materiality": "core",
-            "type": "tri_state"
+            "type": "strict_boolean"
           },
           "fueling_and_gastrointestinal_context": {
             "envelope": "known_or_unknown",
@@ -1193,13 +1239,9 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "type": "five_bucket_basis_point_object"
           },
           "hands_assist": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
+            "envelope": "known_or_unknown",
             "materiality": "core",
-            "type": "tri_state"
+            "type": "strict_boolean"
           },
           "planning_duration_range": {
             "envelope": "known_or_unknown",
@@ -1218,6 +1260,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "total_ascent_m": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 20000,
             "minimum": 0,
             "type": "integer",
             "unit": "meters"
@@ -1225,6 +1268,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "total_descent_m": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 20000,
             "minimum": 0,
             "type": "integer",
             "unit": "meters"
@@ -1273,6 +1317,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
       ],
       "value": {
         "core_and_limited_materiality": "operational_guardrail_only",
+        "course_domain_bounds": "product_scope_and_operability_guardrail_only",
         "distance_vertical_conversion": "not_accepted",
         "downhill_progression": "not_accepted",
         "environment_or_altitude_dose": "not_accepted",
@@ -1283,6 +1328,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
         "planning_duration_range_shape": "operational_guardrail_only",
         "road_trail_equivalence": "not_accepted",
         "route_or_provider_inference": "not_accepted",
+        "schedule_capacity_bounds": "product_scope_and_operability_guardrail_only",
         "signed_grade_buckets": "descriptive_operational_guardrail_only",
         "technical_terrain_dose": "not_accepted",
         "technicality_score": "not_accepted",
@@ -1360,24 +1406,18 @@ That would erase course-specific demand and violate the accepted no-road- fallba
       "value": {
         "hazard_gates": {
           "fixed_rope": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
-            "eligible_value": "no",
-            "unknown_result": "clarification_required",
-            "yes_result": "policy_unavailable.technical_features_outside_v2"
+            "eligible_value": "known_false",
+            "envelope": "known_or_unknown",
+            "known_true_result": "policy_unavailable.technical_features_outside_v2",
+            "known_value_type": "strict_boolean",
+            "unknown_result": "clarification_required.material_course_demand_unknown"
           },
           "hands_assist": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
-            "eligible_value": "no",
-            "unknown_result": "clarification_required",
-            "yes_result": "policy_unavailable.technical_features_outside_v2"
+            "eligible_value": "known_false",
+            "envelope": "known_or_unknown",
+            "known_true_result": "policy_unavailable.technical_features_outside_v2",
+            "known_value_type": "strict_boolean",
+            "unknown_result": "clarification_required.material_course_demand_unknown"
           },
           "reducible_to_ordinary_footing": false,
           "technical_skill_or_safety_score": false
@@ -1630,8 +1670,11 @@ That would erase course-specific demand and violate the accepted no-road- fallba
         "feasibility_verdict": false,
         "field": "planning_duration_range",
         "finish_time_prediction": false,
+        "minimum_and_maximum_each": {
+          "maximum": 1440,
+          "minimum": 1
+        },
         "minimum_strictly_less_than_maximum": true,
-        "minimum_value": 1,
         "performance_promise": false,
         "purpose": "planning_context",
         "unit": "integer_minutes"
@@ -1735,10 +1778,12 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
           },
           "adult_nonclinical_scope_confirmed": {
-            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "envelope": "known_or_unknown",
+            "false_result": "policy_unavailable.unsupported_population_or_intent",
             "materiality": "core",
             "required_value_for_eligibility": true,
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
           },
           "available_weekdays": {
             "allowed_iso_weekdays": [
@@ -1752,35 +1797,81 @@ That would erase course-specific demand and violate the accepted no-road- fallba
             ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "minimum_members": 1,
             "type": "unique_unordered_set",
             "unknown_result": "clarification_required.training_constraints_missing"
           },
-          "controlled_downhill_terrain_accessible": {
+          "controlled_downhill_access": {
             "duration_distance_grade_speed_or_repeat_fields_allowed": false,
             "envelope": "known_or_unknown",
-            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "false_result": "readiness_blocked.insufficient_terrain_access",
             "materiality": "core",
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
           "current_symptom_stop": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "stop_value": true,
             "true_result": "readiness_blocked.current_symptom_stop",
-            "type": "tri_state_boolean",
-            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
-          "nontechnical_continuous_three_minute_uphill_accessible": {
+          "maximum_session_duration_min": {
             "envelope": "known_or_unknown",
-            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
             "materiality": "core",
-            "type": "strict_boolean"
+            "maximum": 1440,
+            "minimum": 1,
+            "not_greater_than": "weekly_time_limit_min",
+            "type": "integer",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "nontechnical_three_minute_uphill_access": {
+            "envelope": "known_or_unknown",
+            "false_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
           "performance_intent_confirmed": {
-            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "envelope": "known_or_unknown",
+            "false_result": "policy_unavailable.unsupported_population_or_intent",
             "materiality": "core",
             "required_value_for_eligibility": true,
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+          },
+          "preferred_longest_weekday": {
+            "allowed": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ],
+            "conflict_result": "clarification_required.contradictory_input",
+            "omitted_means_no_preference": true,
+            "type": "optional_iso_weekday",
+            "when_present_must_be_in": "available_weekdays"
+          },
+          "unavailable_dates": {
+            "all_dates_within_requested_14_day_horizon": true,
+            "empty_known_set_allowed": true,
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "maximum_members": 14,
+            "type": "sorted_unique_iso_date_set",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "weekly_time_limit_min": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "maximum": 10080,
+            "minimum": 1,
+            "type": "integer",
+            "unknown_result": "clarification_required.training_constraints_missing"
           }
         },
         "history_provenance": "history_observed",
@@ -1818,8 +1909,12 @@ That would erase course-specific demand and violate the accepted no-road- fallba
           "performance_intent_confirmed",
           "current_symptom_stop",
           "available_weekdays",
-          "nontechnical_continuous_three_minute_uphill_accessible",
-          "controlled_downhill_terrain_accessible",
+          "weekly_time_limit_min",
+          "maximum_session_duration_min",
+          "unavailable_dates",
+          "preferred_longest_weekday_consistency_when_present",
+          "nontechnical_three_minute_uphill_access",
+          "controlled_downhill_access",
           "accessible_footing_when_course_footing_known",
           "recent_running_continuity",
           "recent_ascent_exposure",
@@ -1854,7 +1949,7 @@ That would erase course-specific demand and violate the accepted no-road- fallba
   },
   "runtime_state": "inactive",
   "schema_version": 1,
-  "source_decision_digest": "sha256:ba9e6a4fff48ab0138bb1d00cbe1bdccbefcaebbdcdc30d87fbb57652e66659b"
+  "source_decision_digest": "sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c"
 }
 ```
 
@@ -1870,7 +1965,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
 
 ```json
 {
-  "accepted_interpretation": "If separately accepted by the decision approver, this successor would keep every accepted v1 science and safety boundary while defining trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict, provider-neutral, revision-bound data contracts. Reviewable fields carry an explicit known value or explicit unknown state; the server, never the client, stamps provenance and source revisions. Core course, scope, hazard, schedule, terrain-access, symptom, and recent-history gates fail closed. Unknown grade, ordinary course footing, environment, support, or fueling context can limit only their named module after all core gates pass. Five signed-grade basis-point buckets, six unordered footing flags, exact footing set containment, and bounded optional context are reversible Praxys operational guardrails, not validated difficulty scores, training doses, equivalence formulas, predictions, or safety thresholds. No route, GPS, free-text planning, provider payload, activity-average power, road fallback, personal performance prediction, or runtime behavior is accepted.",
+  "accepted_interpretation": "If separately accepted by the decision approver, this successor would keep every accepted v1 science and safety boundary while defining trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict, provider-neutral, revision-bound data contracts. Reviewable fields carry an explicit known value or explicit unknown state; the server, never the client, stamps provenance and source revisions. Core course, scope, hazard, schedule, terrain-access, symptom, and recent-history gates fail closed. Unknown grade, ordinary course footing, environment, support, or fueling context can limit only their named module after all core gates pass. Five signed-grade basis-point buckets, six unordered footing flags, known-or- unknown boolean hazard fields, exact footing set containment, bounded schedule capacity, and bounded optional context are reversible Praxys operational guardrails, not validated difficulty scores, training doses, equivalence formulas, predictions, or safety thresholds. No route, GPS, free-text planning, provider payload, activity-average power, road fallback, personal performance prediction, or runtime behavior is accepted.",
   "affected_surfaces": {
     "apis": [
       "future inactive Trail course, constraint, confirmation, and readiness contracts"
@@ -1906,11 +2001,14 @@ Runtime activation remains fail-closed until implementation approval can bind bo
     "The accepted evidence remains sufficient only because every new exact value is classified as a reversible operational guardrail rather than a published biological rule.",
     "Product dependency: docs/dev/trail-running-plan-product-amendment-v2.md.",
     "Experience dependency: docs/dev/trail-running-plan-experience-amendment-v2.md.",
+    "Architecture dependency: docs/dev/trail-running-plan-architecture-decision-v2.md.",
+    "Trust dependency: docs/dev/trail-running-plan-trust-decision-v2.md.",
+    "This revision incorporates the bounded Product correction at repository commit 81c58c1b; it does not approve that role-owned artifact.",
     "Work Contract classification digest: sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607.",
     "Work Contract route digest: sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168."
   ],
   "decision_review": {
-    "approval_statement": "I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and hazard vocabularies, exact footing containment, bounded optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.",
+    "approval_statement": "I approve trail_course_demand_v2 and non_ultra_trail_constraints_v2 as strict revision-bound Trail planning envelopes: explicit known or unknown fields, server-owned provenance, separate ascent and descent, descriptive signed-grade shares, closed footing and known-or-unknown boolean hazard fields, exact footing containment, bounded schedule and optional context, and fail-closed core materiality. I approve the exact DTO values only as reversible Praxys operational guardrails, not as published biological findings, difficulty or safety scores, doses, equivalences, or predictions. This approval authorizes only preparation and review of a separately reviewed inactive implementation bound to this exact decision and contract. It does not approve lifecycle supersession, merge, deployment, production data use, dogfood, catalog visibility, provider behavior, delivery, or runtime activation.",
     "items": [
       {
         "approval_effect": [
@@ -1976,7 +2074,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "trail_training_constraints_schema"
         ],
         "proposed_decision": "Accept these closed DTOs and exact set-containment rules as deterministic descriptions, not as technicality scores or doses.",
-        "question": "Should v2 use the exact five signed-grade share buckets, six unordered footing flags, two tri-state hazard gates, and weekday/uphill/downhill/ footing access fields?",
+        "question": "Should v2 use the exact five signed-grade share buckets, six unordered footing flags, two known-or-unknown boolean hazard fields, and bounded schedule plus uphill/downhill/footing access fields?",
         "title": "Adopt descriptive grade, footing, hazard, and terrain-access DTOs"
       },
       {
@@ -2109,6 +2207,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "distance_meters": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 49999,
             "minimum": 1,
             "type": "integer",
             "unit": "meters"
@@ -2133,13 +2232,9 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "type": "closed_enum"
           },
           "fixed_rope": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
+            "envelope": "known_or_unknown",
             "materiality": "core",
-            "type": "tri_state"
+            "type": "strict_boolean"
           },
           "fueling_and_gastrointestinal_context": {
             "envelope": "known_or_unknown",
@@ -2154,13 +2249,9 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "type": "five_bucket_basis_point_object"
           },
           "hands_assist": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
+            "envelope": "known_or_unknown",
             "materiality": "core",
-            "type": "tri_state"
+            "type": "strict_boolean"
           },
           "planning_duration_range": {
             "envelope": "known_or_unknown",
@@ -2179,6 +2270,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "total_ascent_m": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 20000,
             "minimum": 0,
             "type": "integer",
             "unit": "meters"
@@ -2186,6 +2278,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "total_descent_m": {
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "maximum": 20000,
             "minimum": 0,
             "type": "integer",
             "unit": "meters"
@@ -2271,8 +2364,11 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "feasibility_verdict": false,
         "field": "planning_duration_range",
         "finish_time_prediction": false,
+        "minimum_and_maximum_each": {
+          "maximum": 1440,
+          "minimum": 1
+        },
         "minimum_strictly_less_than_maximum": true,
-        "minimum_value": 1,
         "performance_promise": false,
         "purpose": "planning_context",
         "unit": "integer_minutes"
@@ -2356,24 +2452,18 @@ Runtime activation remains fail-closed until implementation approval can bind bo
       "value": {
         "hazard_gates": {
           "fixed_rope": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
-            "eligible_value": "no",
-            "unknown_result": "clarification_required",
-            "yes_result": "policy_unavailable.technical_features_outside_v2"
+            "eligible_value": "known_false",
+            "envelope": "known_or_unknown",
+            "known_true_result": "policy_unavailable.technical_features_outside_v2",
+            "known_value_type": "strict_boolean",
+            "unknown_result": "clarification_required.material_course_demand_unknown"
           },
           "hands_assist": {
-            "allowed": [
-              "yes",
-              "no",
-              "unknown"
-            ],
-            "eligible_value": "no",
-            "unknown_result": "clarification_required",
-            "yes_result": "policy_unavailable.technical_features_outside_v2"
+            "eligible_value": "known_false",
+            "envelope": "known_or_unknown",
+            "known_true_result": "policy_unavailable.technical_features_outside_v2",
+            "known_value_type": "strict_boolean",
+            "unknown_result": "clarification_required.material_course_demand_unknown"
           },
           "reducible_to_ordinary_footing": false,
           "technical_skill_or_safety_score": false
@@ -2417,10 +2507,12 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             "vocabulary": "trail_footing_and_hazard_contract.ordinary_footing.allowed"
           },
           "adult_nonclinical_scope_confirmed": {
-            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "envelope": "known_or_unknown",
+            "false_result": "policy_unavailable.unsupported_population_or_intent",
             "materiality": "core",
             "required_value_for_eligibility": true,
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
           },
           "available_weekdays": {
             "allowed_iso_weekdays": [
@@ -2434,35 +2526,81 @@ Runtime activation remains fail-closed until implementation approval can bind bo
             ],
             "envelope": "known_or_unknown",
             "materiality": "core",
+            "minimum_members": 1,
             "type": "unique_unordered_set",
             "unknown_result": "clarification_required.training_constraints_missing"
           },
-          "controlled_downhill_terrain_accessible": {
+          "controlled_downhill_access": {
             "duration_distance_grade_speed_or_repeat_fields_allowed": false,
             "envelope": "known_or_unknown",
-            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
+            "false_result": "readiness_blocked.insufficient_terrain_access",
             "materiality": "core",
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
           "current_symptom_stop": {
             "envelope": "known_or_unknown",
             "materiality": "core",
             "stop_value": true,
             "true_result": "readiness_blocked.current_symptom_stop",
-            "type": "tri_state_boolean",
-            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
-          "nontechnical_continuous_three_minute_uphill_accessible": {
+          "maximum_session_duration_min": {
             "envelope": "known_or_unknown",
-            "false_or_unknown_result": "readiness_blocked.insufficient_terrain_access",
             "materiality": "core",
-            "type": "strict_boolean"
+            "maximum": 1440,
+            "minimum": 1,
+            "not_greater_than": "weekly_time_limit_min",
+            "type": "integer",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "nontechnical_three_minute_uphill_access": {
+            "envelope": "known_or_unknown",
+            "false_result": "readiness_blocked.insufficient_terrain_access",
+            "materiality": "core",
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.training_constraints_missing"
           },
           "performance_intent_confirmed": {
-            "false_or_unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed",
+            "envelope": "known_or_unknown",
+            "false_result": "policy_unavailable.unsupported_population_or_intent",
             "materiality": "core",
             "required_value_for_eligibility": true,
-            "type": "strict_boolean"
+            "type": "strict_boolean",
+            "unknown_result": "clarification_required.adult_scope_or_constraints_unconfirmed"
+          },
+          "preferred_longest_weekday": {
+            "allowed": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ],
+            "conflict_result": "clarification_required.contradictory_input",
+            "omitted_means_no_preference": true,
+            "type": "optional_iso_weekday",
+            "when_present_must_be_in": "available_weekdays"
+          },
+          "unavailable_dates": {
+            "all_dates_within_requested_14_day_horizon": true,
+            "empty_known_set_allowed": true,
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "maximum_members": 14,
+            "type": "sorted_unique_iso_date_set",
+            "unknown_result": "clarification_required.training_constraints_missing"
+          },
+          "weekly_time_limit_min": {
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+            "maximum": 10080,
+            "minimum": 1,
+            "type": "integer",
+            "unknown_result": "clarification_required.training_constraints_missing"
           }
         },
         "history_provenance": "history_observed",
@@ -2636,8 +2774,12 @@ Runtime activation remains fail-closed until implementation approval can bind bo
           "performance_intent_confirmed",
           "current_symptom_stop",
           "available_weekdays",
-          "nontechnical_continuous_three_minute_uphill_accessible",
-          "controlled_downhill_terrain_accessible",
+          "weekly_time_limit_min",
+          "maximum_session_duration_min",
+          "unavailable_dates",
+          "preferred_longest_weekday_consistency_when_present",
+          "nontechnical_three_minute_uphill_access",
+          "controlled_downhill_access",
           "accessible_footing_when_course_footing_known",
           "recent_running_continuity",
           "recent_ascent_exposure",
@@ -2795,6 +2937,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
       "rationale": "The accepted evidence supports explicit dimensions but not universal scoring, inference, equivalence, prediction, progression, or dose. Only the closed validation DTO is proposed here.",
       "value": {
         "core_and_limited_materiality": "operational_guardrail_only",
+        "course_domain_bounds": "product_scope_and_operability_guardrail_only",
         "distance_vertical_conversion": "not_accepted",
         "downhill_progression": "not_accepted",
         "environment_or_altitude_dose": "not_accepted",
@@ -2805,6 +2948,7 @@ Runtime activation remains fail-closed until implementation approval can bind bo
         "planning_duration_range_shape": "operational_guardrail_only",
         "road_trail_equivalence": "not_accepted",
         "route_or_provider_inference": "not_accepted",
+        "schedule_capacity_bounds": "product_scope_and_operability_guardrail_only",
         "signed_grade_buckets": "descriptive_operational_guardrail_only",
         "technical_terrain_dose": "not_accepted",
         "technicality_score": "not_accepted",

--- a/docs/dev/trail-running-plan-architecture-decision-v2.md
+++ b/docs/dev/trail-running-plan-architecture-decision-v2.md
@@ -26,6 +26,12 @@ This decision depends on human acceptance of the exact Product and Experience
 v2 artifacts. If either changes materially, this record must be reviewed and
 rebound before Engineering starts.
 
+Until an accepted Trust digest exists, the normative Trust dependency is
+`d8c83a87750db02d232f5efd757be5fdc17b8632:docs/dev/trail-running-plan-trust-decision-v2.md`.
+That immutable commit binding does not approve the proposed TDR. Engineering
+remains blocked until a human accepts that exact content or a reviewed
+successor and this ADR is rebound to its approval digest.
+
 ## Context and constraints
 
 The current pure Trail core is unreachable and has no Trail API or editor. The
@@ -80,10 +86,10 @@ or:
 {"state":"unknown"}
 ```
 
-`known` must contain `value`; `unknown` must not. Missing states, `null`, empty
+`known` must contain `value`; `unknown` must not. Missing states, empty
 sentinels, strings for numbers or booleans, and extra metadata fail validation.
-The one Product-approved nullable aid-gap meaning remains a typed known value,
-not a third envelope state.
+`null` is invalid except for the sole aid-gap known-null case defined below;
+that case remains a known value, not a third envelope state.
 
 `hands_assist` and `fixed_rope` use this same envelope with a strict boolean
 value. The UI maps Yes/No/Not sure to known `true`, known `false`, or unknown;
@@ -101,6 +107,12 @@ The wire and persisted contract accepts one unit per value: meters for
 distance/elevation, minutes for duration, Celsius for temperature, percentage
 points for humidity, ISO dates, and ISO weekday integers `1..7`. UI hours,
 kilometres, and percentages are presentation conversions only.
+
+The aid-gap wire field is `max_aid_station_gap_m`. Its known value is an integer
+from `100` through `50000`, except that `{"state":"known","value":null}` is
+the one explicit known-null value and means `not_applicable`. UI kilometres are
+display/input conversion only; there is no separate kilometre-named wire or
+stored field.
 
 Grade shares are five integer basis-point values, each `0..10000`, whose sum is
 exactly `10000`. Sets must already be unique and serialize in canonical enum or
@@ -129,7 +141,30 @@ or training-science thresholds. The chosen values are well above the closed
 v2 payload's legitimate maximum while bounding parser, validation, logging,
 and canonicalization work.
 
-### 5. Complete the planning-context DTO
+### 5. Freeze optional-context structure
+
+`optional_context` has three strict fixed-key objects: `environment`,
+`support`, and `fueling`. The group objects never have a known/unknown envelope;
+every leaf inside them uses the common envelope above, and every declared leaf
+key is present. Unknown or extra group/leaf keys fail validation.
+
+The environment leaves are `maximum_altitude_m`, `temperature_min_c`,
+`temperature_max_c`, `humidity_min_pct`, `humidity_max_pct`, `sun_exposure`,
+`wind_exposure`, and `conditions_basis`. Support contains `aid_support_mode`,
+`aid_station_count`, `max_aid_station_gap_m`, `water_availability`,
+`food_availability`, and `mandatory_gear`. Fueling contains
+`longest_practiced_duration_min`, `practice_sessions_last_42_days`,
+`intake_form`, and `gastrointestinal_experience`.
+
+No closed enum contains an `unknown` literal; unknownness exists only in the
+leaf envelope. A UI group-level “unknown” control is a batch action that writes
+`{"state":"unknown"}` to every leaf and has no separate wire representation.
+Temperature and humidity ranges are two independent leaf envelopes. Their
+minimum/maximum ordering rule runs only when both leaves are known; one unknown
+leaf remains unknown and limits the corresponding module rather than failing a
+comparison.
+
+### 6. Complete the planning-context DTO
 
 The schedule portion of `non_ultra_trail_constraints_v2` contains:
 
@@ -147,7 +182,7 @@ No time value or unavailable date is inferred from a calendar provider. A
 schedule that is complete but cannot fit policy constraints is a readiness
 block; it is not rewritten into a smaller or road plan.
 
-### 6. Split revision ownership
+### 7. Split revision ownership
 
 The server issues four opaque `sha256:` revisions:
 
@@ -176,12 +211,16 @@ revision, and refuses any mismatch before it creates immutable records. An
 idempotent replay may return the existing proposal only when its complete
 fingerprint matches.
 
-### 7. Store only current drafts until a proposal exists
+### 8. Store only current drafts until a proposal exists
 
 The only mutable Trail course and planning draft lives in a versioned namespace
 inside `UserConfig.goal`. Saving a new value overwrites the old draft value,
 revision, and confirmation state atomically. Praxys does not retain prior draft
 values, a confirmation event stream, or standalone readiness snapshots.
+
+The current revision token is mutable state beside the current draft. Each
+successful edit replaces the prior token; neither the prior value nor token is
+retained elsewhere. No immutable edit history exists before a proposal.
 
 An immutable `AdaptivePlanGoalSnapshot` is created only in the same transaction
 as a `PlanProposal`. It contains the exact canonical course and planning values
@@ -204,21 +243,26 @@ ID, credential, or device state. The audit row and immutable snapshot are part
 of owner data export and goal/account deletion. Standalone readiness calls do
 not write an audit row.
 
-### 8. Make module availability explicit
+### 9. Make module availability explicit
 
-Readiness returns every one of the four closed module keys in an authoritative
-`module_availability` object. Each value is exactly:
+Readiness returns every one of the four closed module keys in this fixed order:
+`grade_specificity`, `technical_terrain`, `environment_altitude`, `fueling`.
+The authoritative `module_availability` value for each key is exactly:
 
-- `not_evaluated`: a core, validation, or policy condition prevented a safe
-  module decision;
+- `not_evaluated`: eligibility prevented a module decision;
 - `available`: the module may be considered by generation, but is not yet
   included; or
 - `limited`: the accepted input requires that module to be omitted or remain
   descriptive, with the matching reason reference.
 
-`limited_modules` may remain only as a sorted redundant projection of keys
-whose status is `limited`. Clients must not infer “Included” from its absence.
-Actual inclusion exists only in an immutable proposal, where each module is
+When the top-level status is not `eligible_proposal`, all four module states are
+`not_evaluated` and each cites the same primary namespaced result reason
+`<status>.<detail_reason>`. Only `eligible_proposal` evaluates modules as
+`available` or `limited`, in the fixed order above. `limited_modules` may remain
+only as the sorted redundant projection of `limited` keys; an empty projection
+does not mean Included.
+
+Actual inclusion exists only in an immutable proposal, where every module is
 explicitly `included` or `omitted` and references the readiness receipt.
 `limited` cannot become `included`; `available` need not become `included`.
 
@@ -226,7 +270,7 @@ This corrects a semantic conflict in the proposed Experience v2 receipt.
 Design must rebind its readiness labels before implementation; Architecture
 does not choose the replacement copy or layout.
 
-### 9. Keep navigation data-free
+### 10. Keep navigation data-free
 
 The application route is fixed. URL paths, query strings, fragments, browser
 history, return-focus state, and deep links may carry only closed route,
@@ -239,28 +283,35 @@ API reason targets are closed keys, not arbitrary URLs. Web maps them to known
 focus targets. This preserves refresh/navigation without turning history,
 analytics, logs, or referrers into a planning-data channel.
 
-### 10. Require owner authorization everywhere
+### 11. Require first-party owner authorization everywhere
 
 Every read, save, reset, confirmation, readiness, proposal, proposal read,
-adoption-related read, export, deletion, and Garmin-preview operation derives
-the owner from the authenticated principal. User identity is not accepted as
-request authority. Cross-owner objects return the repository's private
-not-found response and do not disclose existence.
+adoption-related read, export, deletion, and Garmin-preview operation requires
+an active, non-demo owner authenticated through the first-party Praxys viewer.
+The endpoint rejects a demo before resolving `demo_of`; there is no source-owner
+fallback. MCP grants/sessions, administrators, and support actors have no Trail
+authority or surface. User or actor identity in a request is never authority.
+Unauthenticated calls follow the repository authentication failure and never
+reach Trail evaluation. After that boundary, every inactive, demo, MCP,
+admin/support, missing, or cross-owner outcome on every Trail operation uses
+the same private `404`; every lookup is owner-scoped and discloses no object
+existence, as required by the commit-bound TDR.
 
-### 11. Bound Garmin to a pure internal projection
+### 12. Bound Garmin to a pure internal projection
 
 The post-adoption Garmin preview reads only the authenticated owner's stored
 canonical plan/workout structures and a versioned internal compatibility
 matrix. It is a deterministic, no-write projection that may report only
 internal `unverified` or `blocked` compatibility and per-workout reasons.
 
-The preview loads no Garmin credential or tokenstore, invokes no adapter,
-performs no provider or network I/O, reads or emits no provider workout/device
-ID, schedules nothing, and writes no consent, delivery, retry, ledger, or
-provider state. It cannot prove device support. Connect, send, reconcile,
-replace, and delete remain outside this decision.
+The preview loads no credential or tokenstore, invokes no adapter or network,
+and reads or emits no provider identifier. It does not read or write provider
+connections, account region, device/firmware state, consent, delivery ledger,
+retry state, or any provider state. It schedules nothing and performs no send,
+reconcile, replace, or delete. It cannot prove device support; live checks and
+delivery remain outside this decision.
 
-### 12. Preserve unknown schemas without executing them
+### 13. Preserve unknown schemas without executing them
 
 An authenticated read or export preserves a stored Trail namespace whose
 schema ID is unknown to the running code as an opaque value. The code reports

--- a/docs/dev/trail-running-plan-architecture-decision-v2.md
+++ b/docs/dev/trail-running-plan-architecture-decision-v2.md
@@ -1,0 +1,364 @@
+# Trail-running managed-plan Architecture decision v2
+
+- **Artifact type:** Architecture Decision Record
+- **Owner role:** Architecture
+- **Status:** proposed; human-review-required; runtime inactive
+- **Work Contract classification:**
+  `sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607`
+- **Work Contract route:**
+  `sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168`
+- **Decision ID:** `adr-owner-non-ultra-trail-plan-v2`
+- **Decision horizon:** through the first reviewed inactive v2 implementation,
+  or until a successor changes its storage, provider, or revision boundary
+- **Authority boundary:** this record proposes architecture only. It does not
+  approve implementation, merge, deployment, production data, owner dogfood,
+  capability visibility, activation, adoption, or Garmin delivery.
+
+## Decision requested
+
+Keep Trail v2 inside the existing Praxys application, database, adaptive-plan
+proposal lifecycle, and authenticated UI. Add strict versioned DTOs, a
+server-owned revision fence, one proposal-linked policy audit row, and a pure
+internal Garmin compatibility projection. Do not add a service, datastore,
+route ingestion path, provider session, or second plan lifecycle.
+
+This decision depends on human acceptance of the exact Product and Experience
+v2 artifacts. If either changes materially, this record must be reviewed and
+rebound before Engineering starts.
+
+## Context and constraints
+
+The current pure Trail core is unreachable and has no Trail API or editor. The
+existing architecture already provides `UserConfig.goal`, immutable
+`AdaptivePlanGoalSnapshot` and `PlanProposal` records, owner-scoped
+authentication, capability discovery, data export, and account deletion.
+Reusing these boundaries is cheaper to operate and safer to roll back than a
+new service or parallel plan store.
+
+Reviewer findings require the architecture to resolve these ambiguities before
+implementation:
+
+- requests must not let clients claim server provenance or observed history;
+- hazards must use the same known/unknown envelope as other reviewable facts;
+- schedule capacity needs explicit time and exception fields, not weekdays
+  alone;
+- course, planning context, and observed history must not share one mutable
+  revision;
+- an empty `limited_modules` list must not be rendered as “Included”;
+- navigation state must not copy personal values or concurrency tokens into a
+  URL or browser history; and
+- a Garmin preview must not become an accidental credential or provider-I/O
+  path.
+
+## Decision
+
+### 1. Preserve the current application boundary
+
+Implement v2 as modules in the existing analysis, API, database, Web, and
+managed-plan layers. The pure evaluator remains free of database, HTTP,
+provider, clock, locale, and UI dependencies. API orchestration loads and
+validates owner-scoped state, calls the pure evaluator, and persists only at
+the proposal boundary.
+
+No new process, queue, cache, database, blob store, or provider integration is
+authorized. The capability registry stays inactive and undiscoverable unless
+a later, separately reviewed activation changes that state.
+
+### 2. Separate request DTOs from server response DTOs
+
+Define strict request DTOs for `trail_course_demand_v2` and
+`non_ultra_trail_constraints_v2`. Every DTO forbids unknown keys and coercion.
+Reviewable factual values have exactly one request shape:
+
+```json
+{"state":"known","value":"<strict typed value>"}
+```
+
+or:
+
+```json
+{"state":"unknown"}
+```
+
+`known` must contain `value`; `unknown` must not. Missing states, `null`, empty
+sentinels, strings for numbers or booleans, and extra metadata fail validation.
+The one Product-approved nullable aid-gap meaning remains a typed known value,
+not a third envelope state.
+
+`hands_assist` and `fixed_rope` use this same envelope with a strict boolean
+value. The UI maps Yes/No/Not sure to known `true`, known `false`, or unknown;
+the API does not accept a separate `yes|no|unknown` wire type.
+
+Request DTOs have no provenance, field revision, source timestamp, source
+model, history hash, provider identifier, or actor field. The server response
+uses a different type that adds server-stamped provenance and opaque revision
+metadata. A client may echo a server-issued revision only as a concurrency
+precondition; it cannot create or modify that revision or provenance.
+
+### 3. Use one canonical representation
+
+The wire and persisted contract accepts one unit per value: meters for
+distance/elevation, minutes for duration, Celsius for temperature, percentage
+points for humidity, ISO dates, and ISO weekday integers `1..7`. UI hours,
+kilometres, and percentages are presentation conversions only.
+
+Grade shares are five integer basis-point values, each `0..10000`, whose sum is
+exactly `10000`. Sets must already be unique and serialize in canonical enum or
+numeric order. Objects are serialized with sorted keys. Decimal inputs are
+parsed losslessly, allow at most two fractional digits, and serialize as
+normalized base-10 numbers without exponent notation or insignificant zeros.
+Non-finite values are invalid. Digests use UTF-8 canonical JSON and SHA-256;
+locale labels and display formatting never enter a digest.
+
+### 4. Impose structural anti-abuse limits
+
+Before JSON parsing, each Trail v2 request is limited to **32 KiB UTF-8** and
+compressed request bodies are rejected. From the root object, maximum nesting
+depth is **8**. An object has at most **64 members**, an array or set at most
+**32 entries**, and a string at most **128 Unicode scalar values** after NFC
+normalization. Enum and schema identifiers retain their tighter DTO limits.
+
+Numeric tokens are at most **16 ASCII characters**, cannot use exponent
+notation, and must fit signed 32-bit integer range or absolute decimal value
+`<= 1,000,000` before the tighter field-domain checks run. Duplicate JSON keys
+are rejected. Duplicate set members are rejected rather than silently removed.
+
+These limits are reversible Product/Engineering abuse and operability
+guardrails. They are not biological, medical, course-difficulty, eligibility,
+or training-science thresholds. The chosen values are well above the closed
+v2 payload's legitimate maximum while bounding parser, validation, logging,
+and canonicalization work.
+
+### 5. Complete the planning-context DTO
+
+The schedule portion of `non_ultra_trail_constraints_v2` contains:
+
+- a non-empty unique set of available ISO weekdays `1..7`, or explicit
+  unknown;
+- `weekly_time_limit_min`, a strict positive integer or explicit unknown;
+- `maximum_session_duration_min`, a strict positive integer or explicit
+  unknown, not greater than the weekly limit;
+- `unavailable_dates`, a known, possibly empty, sorted set of at most **14**
+  unique ISO dates, all inside the requested 14-day horizon; and
+- optional `preferred_longest_weekday`; omission means no preference, while a
+  supplied value must be an available ISO weekday. `null` is invalid.
+
+No time value or unavailable date is inferred from a calendar provider. A
+schedule that is complete but cannot fit policy constraints is a readiness
+block; it is not rewritten into a smaller or road plan.
+
+### 6. Split revision ownership
+
+The server issues four opaque `sha256:` revisions:
+
+- `course_revision` covers canonical current course values plus server-stamped
+  field provenance and source metadata, but not confirmation state;
+- `planning_context_revision` covers schedule, access, scope, intent,
+  symptom-stop, and optional-context values plus their server metadata, but not
+  confirmation state;
+- `history_revision` covers only the owner-scoped, policy-minimized aggregates,
+  observation windows, accepted activity source revisions, and evaluator
+  schema; and
+- `composite_revision` hashes the three revisions, the canonical map of current
+  section-confirmation bindings, exact course/constraint schema IDs,
+  policy/Science contract digests, and generator version.
+
+Each editable section has a value-and-source server revision included in its
+parent aggregate. Confirmation stores a fixed section key and that exact
+revision; it does not change the revision it confirms. An edit or server-source
+change makes the prior binding stale, so the composite changes without a
+self-referential confirmation hash.
+
+Mutation and confirmation endpoints use authenticated row locking plus an
+`If-Match` precondition. Readiness is no-write. Proposal creation locks and
+re-reads the current draft and plan, recomputes history and the composite
+revision, and refuses any mismatch before it creates immutable records. An
+idempotent replay may return the existing proposal only when its complete
+fingerprint matches.
+
+### 7. Store only current drafts until a proposal exists
+
+The only mutable Trail course and planning draft lives in a versioned namespace
+inside `UserConfig.goal`. Saving a new value overwrites the old draft value,
+revision, and confirmation state atomically. Praxys does not retain prior draft
+values, a confirmation event stream, or standalone readiness snapshots.
+
+An immutable `AdaptivePlanGoalSnapshot` is created only in the same transaction
+as a `PlanProposal`. It contains the exact canonical course and planning values
+used for that proposal. The proposal remains non-canonical until adoption under
+the existing adaptive-plan lifecycle.
+
+A proposal-linked Trail policy audit row stores only:
+
+- owner and proposal foreign keys;
+- schema, policy, generator, Science decision, and contract identifiers;
+- course, planning-context, history, and composite revisions;
+- privacy-minimized history aggregates and observation-window bounds;
+- canonical input, output, and receipt digests;
+- the complete readiness receipt, including all matching reasons and module
+  availability; and
+- idempotency/request fingerprint and creation time.
+
+It stores no raw activities, GPS, route, free text, provider payload, provider
+ID, credential, or device state. The audit row and immutable snapshot are part
+of owner data export and goal/account deletion. Standalone readiness calls do
+not write an audit row.
+
+### 8. Make module availability explicit
+
+Readiness returns every one of the four closed module keys in an authoritative
+`module_availability` object. Each value is exactly:
+
+- `not_evaluated`: a core, validation, or policy condition prevented a safe
+  module decision;
+- `available`: the module may be considered by generation, but is not yet
+  included; or
+- `limited`: the accepted input requires that module to be omitted or remain
+  descriptive, with the matching reason reference.
+
+`limited_modules` may remain only as a sorted redundant projection of keys
+whose status is `limited`. Clients must not infer “Included” from its absence.
+Actual inclusion exists only in an immutable proposal, where each module is
+explicitly `included` or `omitted` and references the readiness receipt.
+`limited` cannot become `included`; `available` need not become `included`.
+
+This corrects a semantic conflict in the proposed Experience v2 receipt.
+Design must rebind its readiness labels before implementation; Architecture
+does not choose the replacement copy or layout.
+
+### 9. Keep navigation data-free
+
+The application route is fixed. URL paths, query strings, fragments, browser
+history, return-focus state, and deep links may carry only closed route,
+section, field, or reason-target keys. They never carry entered values,
+unknown states, revisions, digests, dates, event IDs, owner IDs, proposal IDs,
+tokens, provider IDs, or serialized DTOs. The authenticated page fetches its
+current state from the server.
+
+API reason targets are closed keys, not arbitrary URLs. Web maps them to known
+focus targets. This preserves refresh/navigation without turning history,
+analytics, logs, or referrers into a planning-data channel.
+
+### 10. Require owner authorization everywhere
+
+Every read, save, reset, confirmation, readiness, proposal, proposal read,
+adoption-related read, export, deletion, and Garmin-preview operation derives
+the owner from the authenticated principal. User identity is not accepted as
+request authority. Cross-owner objects return the repository's private
+not-found response and do not disclose existence.
+
+### 11. Bound Garmin to a pure internal projection
+
+The post-adoption Garmin preview reads only the authenticated owner's stored
+canonical plan/workout structures and a versioned internal compatibility
+matrix. It is a deterministic, no-write projection that may report only
+internal `unverified` or `blocked` compatibility and per-workout reasons.
+
+The preview loads no Garmin credential or tokenstore, invokes no adapter,
+performs no provider or network I/O, reads or emits no provider workout/device
+ID, schedules nothing, and writes no consent, delivery, retry, ledger, or
+provider state. It cannot prove device support. Connect, send, reconcile,
+replace, and delete remain outside this decision.
+
+### 12. Preserve unknown schemas without executing them
+
+An authenticated read or export preserves a stored Trail namespace whose
+schema ID is unknown to the running code as an opaque value. The code reports
+`policy_unavailable`/version mismatch and offers no readiness, generation,
+adoption, or Garmin projection. It must not coerce, partially normalize,
+silently drop, or overwrite that namespace.
+
+Reset or deletion may remove it through the owner-scoped data-rights path.
+Normal v2 writes never accept an unknown schema. This permits a safe code
+rollback or mixed backup restore without treating future data as current.
+
+## Persistence migration and rollback
+
+Use an expand-first migration: add the proposal-linked Trail audit table and
+its owner/proposal constraints without rewriting `UserConfig.goal`, existing
+goals, plans, or proposals. There is no v1-to-v2 value backfill. Any existing
+Trail v1 or unknown namespace remains readable/exportable but unavailable for
+generation until the owner explicitly creates a v2 draft.
+
+Before activation, rollback removes the inactive endpoints and registry entry
+while preserving v2 goal JSON as unknown data. Retain the new empty or populated
+audit table across a code rollback. A database downgrade may drop it only when
+it contains zero rows; otherwise export plus separately authorized destructive
+data loss is required. No automatic downgrade deletes audit evidence.
+
+If proposal persistence fails, the snapshot, proposal, and audit row roll back
+together. If the exact composite revision changes, the client must fetch and
+confirm current state; no migration or retry silently rebinds it.
+
+## Consequences and trade-offs
+
+- Reusing the monolith and adaptive-plan lifecycle minimizes operations and
+  makes the inactive slice readily removable.
+- Separate revisions prevent unrelated history refreshes from masquerading as
+  course edits, at the cost of more explicit concurrency handling.
+- Overwriting unproposed drafts minimizes sensitive retention, but removes
+  draft history and undo across saves.
+- A proposal-linked audit row makes replay and review inspectable without raw
+  activity duplication, at the cost of one table and export/delete work.
+- Strict bounds and closed DTOs reject some forward-compatible client input;
+  explicit schema negotiation is preferred to ambiguous coercion.
+- A pure Garmin projection is safe to implement inactive, but cannot claim
+  real account, device, region, or provider compatibility.
+
+## Rejected alternatives
+
+- **New Trail service or datastore:** rejected; it duplicates owner auth,
+  proposal lifecycle, deletion, export, and recovery without current scale or
+  isolation evidence.
+- **Append every edit/readiness result:** rejected; it retains unnecessary
+  personal planning history before the owner creates a proposal.
+- **One source revision:** rejected; course, schedule, and activity history
+  have different writers and invalidation cadence.
+- **Client-stamped provenance or athlete-entered history:** rejected; it makes
+  server evidence spoofable and breaks replay authority.
+- **Infer inclusion from `limited_modules`:** rejected; absence of a limitation
+  does not prove a generator selected a module.
+- **Put state in URLs or browser history:** rejected; it leaks values and makes
+  stale concurrency tokens replayable outside the authenticated fetch path.
+- **Live Garmin check for preview:** rejected; it crosses credential, consent,
+  availability, and provider-state boundaries not authorized here.
+- **Coerce v1/unknown schemas into v2:** rejected; defaults would manufacture
+  confirmation, provenance, or meaning.
+
+## Implementation impact map and handoff
+
+- **Engineering:** versioned DTOs and orchestration in `api/`; pure canonical
+  evaluation in `analysis/`; current draft namespace and transactional
+  proposal/audit persistence in `db/`; inactive capability registration only.
+- **Database:** additive audit-table migration, owner/proposal constraints, and
+  atomic snapshot/proposal/audit creation; no draft-history table.
+- **Web:** authenticated course ledger, closed navigation keys, explicit
+  concurrency handling, and module availability semantics after Design rebind.
+- **Miniapp:** honest unavailable/Web handoff only; no partial editor.
+- **Garmin:** internal compatibility-matrix projection only; no change to the
+  provider adapter or credentials.
+- **Trust:** independently review minimization, owner authorization, opaque
+  unknown-schema retention, URL leakage, export, reset, and deletion.
+- **Operations:** review migration, rollback, readiness, and inactive feature
+  configuration; no deployment or activation follows from this ADR.
+- **Quality:** independently verify canonical replay, payload limits, duplicate
+  rejection, revision races, transaction rollback, owner isolation, data
+  rights, unknown-schema behavior, navigation leakage, and zero Garmin I/O.
+
+## Review and verification triggers
+
+A successor Architecture review is required for a new service/datastore,
+route/provider ingestion, draft-history retention, a different payload bound,
+schema coercion, client-authored evidence, cross-user data, background jobs,
+provider I/O, a second proposal lifecycle, material scale pressure, or an
+irreversible migration. Product, Science, Trust, Design, Operations, and
+Quality retain their own authority; this ADR cannot approve their decisions or
+its implementation.
+
+## Human Architecture decision requested
+
+Approve, revise, or reject this exact proposed boundary. Approval would permit
+Engineering to prepare only an inactive implementation after every prerequisite
+decision is accepted and rebound. It would not authorize merge, deployment,
+production data, owner exposure, catalog visibility, capability activation,
+plan adoption, Garmin access, or delivery.

--- a/docs/dev/trail-running-plan-experience-amendment-v2.md
+++ b/docs/dev/trail-running-plan-experience-amendment-v2.md
@@ -5,14 +5,17 @@ successor; human Design review required; runtime inactive and unreachable.
 **Evidence:** no implementation or rendered verification is claimed.
 
 **Dependency binding:** [Product v2](trail-running-plan-product-amendment-v2.md)
-is `pdr-owner-non-ultra-trail-plan-v2-amendment` at commit `81c58c1b`;
+is `pdr-owner-non-ultra-trail-plan-v2-amendment` at commit
+`f9678d64a599d814473470c6b8eaf09b5bc00c75`;
 [Architecture v2](trail-running-plan-architecture-decision-v2.md) is
-`adr-owner-non-ultra-trail-plan-v2`; [Trust v2](trail-running-plan-trust-decision-v2.md)
-is `tdr-owner-non-ultra-trail-plan-v2`; the draft Science decisions at commit
-`b5177e40` are `sdr-trail-running-goal-ontology-v2` at decision digest
-`sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c`
+`adr-owner-non-ultra-trail-plan-v2` at commit
+`a52d23ce8534ce4c29082cacb31b5ab5e856de51`; [Trust v2](trail-running-plan-trust-decision-v2.md)
+is `tdr-owner-non-ultra-trail-plan-v2` at commit
+`d8c83a87750db02d232f5efd757be5fdc17b8632`; the draft Science decisions are
+`sdr-trail-running-goal-ontology-v2` at decision digest
+`sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1`
 and `sdr-non-ultra-trail-plan-generation-policy-v2` at decision digest
-`sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56`.
+`sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe`.
 All four v2 specialist decisions remain proposed/draft and require human
 acceptance plus an accepted inactive-contract rebind before implementation.
 
@@ -65,9 +68,12 @@ The mode is **Operate**. The owner should finish with one answer—what Praxys
 can do next—and a complete receipt showing why. The route is a dedicated page,
 `/training/plan-start/trail/course-review`; Goal may link to it but its dialog
 does not host the ledger. The path has no variable segment or query string.
-Optional hashes are limited to `#event`, `#grade-footing`,
-`#training-access`, `#recent-experience`, and
-`#conditions-support-fueling`. In-page focus and browser navigation state may
+The fixed section keys are `section.event-duration`,
+`section.grade-footing`, `section.training-access`,
+`section.recent-experience`, `section.optional-context`, and
+`section.policy-receipt`; optional hashes use only the corresponding suffix
+(`event-duration` through `policy-receipt`). In-page focus and browser
+navigation state may
 carry only the fixed section/field/action target keys defined below—never a
 value, unknown state, date, identifier, revision, digest, DTO, token, or source
 metadata.
@@ -103,6 +109,12 @@ Server response provenance always uses these labels: **You entered this /
 required / 你的假设—需要确认** (`explicit_assumption`), and **Unknown / 未知**
 (`unknown`). Clients never author provenance.
 
+UI conversions that serialize integer meters—race distance and aid-station
+gap—accept at most three fractional kilometre digits. Grade percentages and
+canonical decimal temperature/humidity values accept at most two fractional
+digits. Every other numeric field below is integer-only; exponent notation,
+non-finite values, coercion, and silently rounded input are invalid.
+
 ### 1. Event & planning duration / 赛事与计划用时
 
 | EN / 中文 label | Product v2 field and UI mapping |
@@ -114,9 +126,9 @@ required / 你的假设—需要确认** (`explicit_assumption`), and **Unknown 
 | Total descent / 累计下降 | Integer meters `0..20000`. |
 | Minimum planning duration / 计划用时下限 | Hours/minutes control → integer minutes `1..1440`. |
 | Maximum planning duration / 计划用时上限 | Hours/minutes control → integer minutes `1..1440`, strictly greater than minimum. |
-| Event format / 比赛形式 | `single_day` → **One-day event / 单日赛事**. |
-| Distance category / 距离类别 | `non_ultra` → **Non-ultra Trail / 非超长距离越野**. |
-| Planning goal / 计划目标 | `performance` → **Improve race performance / 提升比赛表现**. |
+| Event format / 比赛形式 | `single_day` → **One-day event / 单日赛事**; recognized unsupported `multi_day` → **Multi-day event / 多日赛事**. |
+| Distance category / 距离类别 | `non_ultra` → **Non-ultra Trail / 非超长距离越野**; recognized unsupported `ultra` → **Ultra-distance Trail / 超长距离越野**. |
+| Planning goal / 计划目标 | `performance` → **Improve race performance / 提升比赛表现**; recognized unsupported `first_completion` → **Finish the event / 完成赛事**; `return_to_consistency` → **Rebuild training consistency / 恢复训练规律**. |
 
 Planning-duration help is **The range you want Praxys to plan around—not a
 finish-time prediction. / 这是你希望 Praxys 用于制定计划的时长范围，并非完赛时间预测。**
@@ -132,8 +144,8 @@ finish-time prediction. / 这是你希望 Praxys 用于制定计划的时长范�
 - **Steep uphill (10% and above) / 陡上坡（10% 及以上）**
 
 Display percentages accept at most two decimal places and convert exactly to
-five integer basis-point shares. The live summary is **Total / 合计**; the five
-values must equal `100.00%` (`10000` basis points). The entire distribution may
+five integer basis-point shares. Each input is `0..100.00`; the live summary is
+**Total / 合计**; the five values must equal `100.00%` (`10000` basis points). The entire distribution may
 instead be explicitly unknown. Boundaries are explanatory text, not sliders
 or inferred route geometry.
 
@@ -149,7 +161,8 @@ plain-language values:
 | Built steps / 人工台阶 | `built_steps` |
 | Water crossings / 涉水路段 | `water_crossing` |
 
-The set may be explicitly unknown; there is no Other or free text. Use
+When known, the set is non-empty. It may instead be explicitly unknown; there
+is no Other or free text. Use
 **Does any section require hands for progress? / 是否有路段需要用手辅助通过？**
 for `hands_assist`, and **Does any section use fixed ropes? /
 是否有路段需要使用固定绳索？** for `fixed_rope`. Both offer exactly **Yes /
@@ -179,9 +192,10 @@ for `hands_assist`, and **Does any section use fixed ropes? /
   你能使用适合受控下坡训练的路线吗？** uses the same mapping and asks for no
   slope, speed, distance, or duration.
 - **Footing available for training / 可用于训练的路面** uses the same six
-  footing values or explicit unknown.
-- **I confirm this is an adult, non-clinical planning context. /
-  我确认这是成人、非医疗场景的训练计划。** binds the scope confirmation.
+  footing values; a known set is non-empty, otherwise use explicit unknown.
+- **I confirm I am 18 or older and this is not clinical or return-to-sport
+  planning. / 我确认本人已满 18 岁，且这不是医疗或重返运动计划。** binds the
+  adult/non-clinical scope confirmation.
 - **I confirm the goal is race performance. / 我确认目标是提升比赛表现。**
   binds the intent confirmation.
 - **Do you currently have symptoms that should stop performance planning? /
@@ -202,20 +216,26 @@ correction, attestation, or athlete-entered replacement inside plan start.
 Open this collapsed section before it can be confirmed. Environment, support,
 and fueling must each be explicitly completed or set to unknown; opening one
 group never reviews another. Each group offers **Set this group to unknown /
-将本组设为未知**, which writes strict unknown envelopes for that group's
-fields, creates a new section revision, and never supplies defaults.
+将本组设为未知**. `optional_context` remains three fixed objects whose every
+declared leaf is always present and independently uses the strict known/unknown
+envelope; group objects have no envelope. The batch control writes unknown to
+every leaf, creates a new section revision, and supplies no group-level wire
+value or default. No closed enum contains an `unknown` literal.
 
-- Environment: **Maximum course altitude / 赛道最高海拔** (integer m),
-  **Expected temperature range / 预计气温范围** (°C min/max), **Expected
-  humidity range / 预计湿度范围** (% min/max), **Sun exposure / 日晒暴露**
+- Environment: **Maximum course altitude / 赛道最高海拔** (integer
+  `-500..9000` m), **Expected temperature range / 预计气温范围** (`-30..55`
+  °C, minimum ≤ maximum when both are known), **Expected humidity range /
+  预计湿度范围** (`0..100%`, minimum ≤ maximum when both are known), **Sun exposure / 日晒暴露**
   (Low/Mixed/High / 低/混合/高), **Wind exposure / 风力暴露**
   (Sheltered/Mixed/Exposed / 遮蔽/混合/暴露), and **Conditions based on /
   环境信息依据** (Organizer information/Seasonal expectation/My assumption /
   赛事方信息/季节预期/我的假设). My assumption requires explicit confirmation.
 - Support: **Support setup / 补给支持方式** (Organized aid/Mixed/Self-supported
-  / 赛事补给/混合/自助), **Number of aid stations / 补给站数量**,
-  **Longest gap between aid stations / 最长补给站间距** (km value, No
-  applicable gap / 不适用, or Not sure / 不确定), **Water availability /
+  / 赛事补给/混合/自助), **Number of aid stations / 补给站数量** (integer
+  `0..50`), **Longest gap between aid stations / 最长补给站间距** (UI km
+  `0.1..50`, at most three decimals, converting exactly to integer
+  `max_aid_station_gap_m` `100..50000`; **Not applicable / 不适用** maps only
+  to known `null`; **Not sure / 不确定** maps to the leaf unknown envelope), **Water availability /
   饮水供应** and **Food availability / 食物供应** (None/Some stations/Every
   station/Not sure / 无/部分站点/每个站点/不确定), and **Required equipment /
   强制装备** (Carry water/Carry food/Weather shell/Lighting/Navigation
@@ -224,8 +244,8 @@ fields, creates a new section revision, and never supplies defaults.
   equipment listed / 未列出强制装备** is a known-empty set and is distinct from
   **I don't know yet / 目前不确定**.
 - Fueling: **Longest practiced fueling duration / 最长补给练习时长** (integer
-  minutes), **Fueling practice sessions in the past 42 days /
-  过去 42 天的补给练习次数** (integer), **Practiced intake / 已练习的摄入形式**
+  `0..1440` minutes), **Fueling practice sessions in the past 42 days /
+  过去 42 天的补给练习次数** (integer `0..84`), **Practiced intake / 已练习的摄入形式**
   (None/Fluids only/Carbohydrate drink/Mixed food and drink /
   无/仅液体/碳水饮料/食物与饮品混合), and **Did stomach or gut issues change
   your plan? / 胃肠不适是否曾让你改变计划？** (No plan-altering issue/Plan-
@@ -267,12 +287,35 @@ they are never user-visible. Target keys are fixed internal keys, not URLs or
 personal state. `first-*` actions resolve from the server's closed field-error
 or reason-target data and never from client-authored strings.
 
+Fixed field targets resolve as follows: `field.event-date` and
+`field.event-scope` open `section.event-duration`; `field.adult-performance-scope`
+and `field.symptom-stop` open `section.training-access`; and
+`field.history-running`, `field.history-comparable-trail`, and
+`field.history-descent` open `section.recent-experience` and focus their
+read-only row. `section.policy-receipt` focuses the policy explanation in the
+receipt. Every target opens a collapsed section before focus and announces its
+heading.
+
+Generic action targets are also closed. `action.first-invalid-field`,
+`action.first-unknown-core-field`, `action.first-unconfirmed-assumption`,
+`action.first-missing-training-field`, and `action.first-conflicting-field`
+focus the first server-targeted field in canonical field order;
+`action.first-confirmed-hazard` orders hands assistance before fixed ropes;
+`action.first-stale-section` uses the six fixed section keys in page order.
+`action.reload-supported-version` refetches and focuses
+`section.policy-receipt` without writing; `action.retry-readiness` reruns the
+no-write check only for the current composite revision. `action.review-history-envelope`
+opens `section.recent-experience`, focuses its heading, and renders a read-only
+requested-versus-observed comparison. If authoritative target data is absent
+or invalid, the action focuses the receipt error and fails closed; the client
+never guesses a destination.
+
 | Reason code | Finding — EN / 中文 | Effect — EN / 中文 | Fixed target; action — EN / 中文 |
 | --- | --- | --- | --- |
 | `validation_failed.invalid_field_value` | One or more values is outside the accepted format or range. / 一项或多项数据不符合格式或范围要求。 | Praxys cannot interpret this revision safely. / Praxys 无法安全解释当前版本。 | `action.first-invalid-field`; **Review the first invalid value / 查看首个无效值** |
 | `validation_failed.schema_version_mismatch` | This course review was created with an unsupported version. / 此赛道核对使用了不受支持的版本。 | Praxys will not guess how old or future fields map to v2. / Praxys 不会猜测旧版或未来字段如何映射到 v2。 | `action.reload-supported-version`; **Reload the supported version / 重新加载受支持版本** |
 | `validation_failed.deterministic_invariant_failed` | Praxys could not reproduce the same readiness receipt. / Praxys 无法复现同一份准备情况回执。 | No proposal can be trusted from this result. / 无法信任基于此结果生成的提案。 | `action.retry-readiness`; **Retry the readiness check / 重新检查准备情况** |
-| `policy_unavailable.policy_inactive` | This Trail policy is not active. / 此越野策略尚未启用。 | No proposal is available from this inactive slice. / 此未启用切片不能生成提案。 | `section.policy-status`; **Review policy status / 查看策略状态** |
+| `policy_unavailable.policy_inactive` | This Trail policy is not active. / 此越野策略尚未启用。 | No proposal is available from this inactive slice. / 此未启用切片不能生成提案。 | `section.policy-receipt`; **Review policy status / 查看策略状态** |
 | `policy_unavailable.event_inside_unapproved_taper_window` | The event is inside a period without an accepted taper policy. / 比赛已进入尚无获批减量策略的阶段。 | This policy cannot organize the event-near period. / 此策略无法安排临赛阶段。 | `field.event-date`; **Review the event date / 查看比赛日期** |
 | `policy_unavailable.unsupported_ultra_or_multiday` | This event is ultra-distance or multiday. / 此赛事属于超长距离或多日赛。 | It is outside the non-ultra, one-day policy. / 它超出非超长距离单日策略范围。 | `field.event-scope`; **Review event scope / 查看赛事范围** |
 | `policy_unavailable.unsupported_population_or_intent` | The confirmed context or goal is outside this performance policy. / 已确认的适用场景或目标不在此竞速策略范围内。 | Praxys will not substitute another population or intent. / Praxys 不会替换为其他人群或目标。 | `field.adult-performance-scope`; **Review planning scope / 查看计划适用范围** |
@@ -282,7 +325,7 @@ or reason-target data and never from client-authored strings.
 | `readiness_blocked.insufficient_descent_history` | Recent descent exposure is insufficient. / 近期下降训练经历不足。 | Downhill work cannot be bounded from observed history. / 无法依据已观察历史约束下坡训练。 | `field.history-descent`; **Review descent experience / 查看下降训练经历** |
 | `readiness_blocked.insufficient_terrain_access` | Required uphill, downhill, or footing access is unavailable. / 缺少所需的上坡、下坡或路面训练条件。 | Praxys will not replace the course demand with road training. / Praxys 不会用公路训练替代赛道需求。 | `section.training-access`; **Review training access / 查看训练场地条件** |
 | `readiness_blocked.current_symptom_stop` | You confirmed a current symptom that should stop performance planning. / 你确认目前有应停止竞速计划的症状。 | Performance planning stops; Praxys makes no diagnosis. / 竞速计划将停止；Praxys 不作诊断。 | `field.symptom-stop`; **Review your response / 查看你的回答** |
-| `readiness_blocked.no_schedule_within_envelope` | No 14-day schedule fits the confirmed availability and accepted limits. / 没有 14 天安排能同时满足已确认时间和已接受限制。 | Praxys will not compress, stack, or substitute sessions. / Praxys 不会压缩、堆叠或替换训练。 | `section.training-schedule`; **Review your schedule / 查看训练时间安排** |
+| `readiness_blocked.no_schedule_within_envelope` | No 14-day schedule fits the confirmed availability and accepted limits. / 没有 14 天安排能同时满足已确认时间和已接受限制。 | Praxys will not compress, stack, or substitute sessions. / Praxys 不会压缩、堆叠或替换训练。 | `section.training-access`; **Review your schedule / 查看训练时间安排** |
 | `clarification_required.material_course_demand_unknown` | A core course detail is still unknown. / 仍有核心赛道信息未知。 | Readiness cannot be decided without that detail. / 缺少该信息时无法判断准备情况。 | `action.first-unknown-core-field`; **Complete the next course detail / 补充下一项赛道信息** |
 | `clarification_required.assumption_confirmation_required` | A course or conditions assumption has not been confirmed. / 一项赛道或环境假设尚未确认。 | Praxys will not treat an assumption as reviewed fact. / Praxys 不会把未确认假设当作已核对事实。 | `action.first-unconfirmed-assumption`; **Review the assumption / 查看该假设** |
 | `clarification_required.adult_scope_or_constraints_unconfirmed` | Adult, non-clinical performance scope is not confirmed. / 尚未确认成人、非医疗的竞速适用范围。 | This policy cannot be applied yet. / 暂时无法应用此策略。 | `field.adult-performance-scope`; **Confirm planning scope / 确认计划适用范围** |

--- a/docs/dev/trail-running-plan-experience-amendment-v2.md
+++ b/docs/dev/trail-running-plan-experience-amendment-v2.md
@@ -4,6 +4,18 @@
 successor; human Design review required; runtime inactive and unreachable.
 **Evidence:** no implementation or rendered verification is claimed.
 
+**Dependency binding:** [Product v2](trail-running-plan-product-amendment-v2.md)
+is `pdr-owner-non-ultra-trail-plan-v2-amendment` at commit `81c58c1b`;
+[Architecture v2](trail-running-plan-architecture-decision-v2.md) is
+`adr-owner-non-ultra-trail-plan-v2`; [Trust v2](trail-running-plan-trust-decision-v2.md)
+is `tdr-owner-non-ultra-trail-plan-v2`; the draft Science decisions at commit
+`b5177e40` are `sdr-trail-running-goal-ontology-v2` at decision digest
+`sha256:73dd653f8637004ff2ab3a754c3e775225eaf9faa79ccc52c97de3c3dbbf0b7c`
+and `sdr-non-ultra-trail-plan-generation-policy-v2` at decision digest
+`sha256:8c10f0846e356afa0522025fe2c02f095fe4487537eaae9d7d0203449a36bb56`.
+All four v2 specialist decisions remain proposed/draft and require human
+acceptance plus an accepted inactive-contract rebind before implementation.
+
 This amendment preserves the Field Lab visual system and the proposal,
 adoption, and delivery hierarchy in
 `trail-running-plan-experience-spec.md`. It replaces only the v1 course-review
@@ -21,7 +33,7 @@ not imply another.
 | 1 | Route and hierarchy | Use one progressive full-page course ledger under Training, not the current Goal dialog. |
 | 2 | Input meaning | Use the exact bilingual labels, explicit unknown controls, and canonical-unit mappings below. |
 | 3 | Confirmation | Confirm each visible section at its exact revision; any edit invalidates that section and readiness. Never offer confirm-all. |
-| 4 | Result receipt | Show one natural-language verdict, every matching reason as finding → effect → next action, and each module as Included or Limited. |
+| 4 | Result receipt | Show one natural-language verdict, every matching reason as finding → effect → next action, and readiness modules as Not evaluated, Available, or Limited. Reserve Included/Omitted for an actual proposal. |
 | 5 | Responsive and accessibility | Use a desktop ledger plus sticky receipt and a mobile ordered accordion, with the complete state and access requirements below. |
 | 6 | Platform boundary | Keep miniapp unavailable with an honest Web handoff; keep Garmin post-adoption, read-only, blocked or unverified, with no provider action in v2. |
 
@@ -39,9 +51,10 @@ not imply another.
   contracts or mistaking a limited module for a safe default?
 - **Recommendation:** adopt the full-page progressive ledger and receipt below.
 - **Dependencies:** the accepted v1 Trail Science and Product/Experience
-  decisions, plus human acceptance of
-  `trail-running-plan-product-amendment-v2.md`. If Product v2 changes, this
-  artifact must be reviewed and rebound before implementation.
+  decisions and the exact proposed/draft v2 Product, Architecture, Trust, and
+  Science subjects bound above. None is treated as accepted here. Every v2
+  decision must be human-accepted and the inactive contracts rebound before
+  implementation; a dependency change requires Design re-review.
 - **Review route:** human-review-required. Design does not approve this record.
 - **Outcome plan:** later independent rendered verification with synthetic
   data; no value telemetry is authorized here.
@@ -51,8 +64,13 @@ not imply another.
 The mode is **Operate**. The owner should finish with one answer—what Praxys
 can do next—and a complete receipt showing why. The route is a dedicated page,
 `/training/plan-start/trail/course-review`; Goal may link to it but its dialog
-does not host the ledger. Browser history, page title, and deep links preserve
-the current section and field.
+does not host the ledger. The path has no variable segment or query string.
+Optional hashes are limited to `#event`, `#grade-footing`,
+`#training-access`, `#recent-experience`, and
+`#conditions-support-fueling`. In-page focus and browser navigation state may
+carry only the fixed section/field/action target keys defined below—never a
+value, unknown state, date, identifier, revision, digest, DTO, token, or source
+metadata.
 
 The page title is **Review Trail event / 核对越野赛事**. Supporting copy is
 **Describe the course and where you can train. Praxys will keep unknowns
@@ -77,20 +95,28 @@ v2 permits `state: unknown`. Selecting it removes the value rather than
 submitting an empty string, zero, or placeholder. Core unknowns remain visible
 and prevent eligibility; optional unknowns limit only their named modules.
 
+Server response provenance always uses these labels: **You entered this /
+由你填写** (`athlete_stated`), **Verified course information / 已核实的赛道信息**
+(`course_verified`), **From your activity history / 来自你的活动历史**
+(`history_observed`), **Estimated by Praxys / 由 Praxys 推断**
+(`model_inferred`, with model version), **Your assumption—confirmation
+required / 你的假设—需要确认** (`explicit_assumption`), and **Unknown / 未知**
+(`unknown`). Clients never author provenance.
+
 ### 1. Event & planning duration / 赛事与计划用时
 
 | EN / 中文 label | Product v2 field and UI mapping |
 | --- | --- |
 | Event / 赛事 | Existing server-stamped event identity; read-only, with **Edit Goal / 编辑目标** deep link. |
 | Event date / 比赛日期 | ISO date; locale-formatted display. |
-| Race distance / 比赛距离 | Decimal km input; convert exactly to integer `distance_meters`. |
-| Total ascent / 累计爬升 | Integer m → `total_ascent_m`. |
-| Total descent / 累计下降 | Integer m → `total_descent_m`. |
-| Minimum planning duration / 计划用时下限 | Hours/minutes control → integer minimum minutes. |
-| Maximum planning duration / 计划用时上限 | Hours/minutes control → integer maximum minutes; must exceed minimum. |
-| Event format / 比赛形式 | Closed Product value, rendered in natural language. |
-| Distance category / 距离类别 | Closed Product value, rendered in natural language. |
-| Planning goal / 计划目标 | Closed Product intent, rendered in natural language. |
+| Race distance / 比赛距离 | Decimal km with at most 3 decimals; convert exactly to integer meters `1..49999`. |
+| Total ascent / 累计爬升 | Integer meters `0..20000`. |
+| Total descent / 累计下降 | Integer meters `0..20000`. |
+| Minimum planning duration / 计划用时下限 | Hours/minutes control → integer minutes `1..1440`. |
+| Maximum planning duration / 计划用时上限 | Hours/minutes control → integer minutes `1..1440`, strictly greater than minimum. |
+| Event format / 比赛形式 | `single_day` → **One-day event / 单日赛事**. |
+| Distance category / 距离类别 | `non_ultra` → **Non-ultra Trail / 非超长距离越野**. |
+| Planning goal / 计划目标 | `performance` → **Improve race performance / 提升比赛表现**. |
 
 Planning-duration help is **The range you want Praxys to plan around—not a
 finish-time prediction. / 这是你希望 Praxys 用于制定计划的时长范围，并非完赛时间预测。**
@@ -127,14 +153,25 @@ The set may be explicitly unknown; there is no Other or free text. Use
 **Does any section require hands for progress? / 是否有路段需要用手辅助通过？**
 for `hands_assist`, and **Does any section use fixed ropes? /
 是否有路段需要使用固定绳索？** for `fixed_rope`. Both offer exactly **Yes /
-是**, **No / 否**, and **Not sure / 不确定**, mapping to `yes`, `no`, and
-`unknown`.
+是**, **No / 否**, and **Not sure / 不确定**. They serialize only as known
+`true`, known `false`, or the strict unknown envelope.
 
 ### 3. When and where you can train / 可训练时间与场地
 
-- **Days available to run / 可跑步的星期** maps Monday through Sunday to
-  unique ISO weekday integers `1..7`; **I don't know yet / 目前不确定** is a
-  distinct unknown state, never an empty known set.
+- **Days available to run / 可跑步的星期** maps Monday through Sunday to a
+  known, non-empty, unique set of ISO weekday integers `1..7`; **I don't know
+  yet / 目前不确定** is distinct from an empty known set.
+- **Weekly training time available / 每周可训练时间** maps hours/minutes to
+  integer `weekly_time_limit_min` in `1..10080`.
+- **Longest training session available / 单次最长可训练时间** maps
+  hours/minutes to integer `maximum_session_duration_min` in `1..1440` and
+  cannot exceed the weekly limit.
+- **Dates you cannot train / 无法训练的日期** maps to a known, sorted, unique
+  set of at most 14 ISO dates inside the displayed 14-day horizon; **No dates /
+  无** is a valid known-empty set.
+- **Preferred day for the longest easy session / 最长轻松训练的首选星期** is
+  optional; **No preference / 无偏好** omits it, while a chosen ISO weekday
+  must also be available.
 - **Can you access a continuous, nontechnical uphill for at least 3 minutes? /
   你能使用可连续进行至少 3 分钟、非技术性的上坡路线吗？** maps Yes/No/Not
   sure to known `true`, known `false`, or unknown.
@@ -162,8 +199,11 @@ correction, attestation, or athlete-entered replacement inside plan start.
 
 ### 5. Conditions, support, and fueling / 环境、支持与补给
 
-Open this collapsed section before it can be confirmed. All groups support an
-explicit unknown state.
+Open this collapsed section before it can be confirmed. Environment, support,
+and fueling must each be explicitly completed or set to unknown; opening one
+group never reviews another. Each group offers **Set this group to unknown /
+将本组设为未知**, which writes strict unknown envelopes for that group's
+fields, creates a new section revision, and never supplies defaults.
 
 - Environment: **Maximum course altitude / 赛道最高海拔** (integer m),
   **Expected temperature range / 预计气温范围** (°C min/max), **Expected
@@ -180,7 +220,9 @@ explicit unknown state.
   station/Not sure / 无/部分站点/每个站点/不确定), and **Required equipment /
   强制装备** (Carry water/Carry food/Weather shell/Lighting/Navigation
   device/Other required / 携水/携带食物/防风雨外套/照明/导航设备/其他必需装备).
-  Other records presence only; it opens no free-text field.
+  Other records presence only; it opens no free-text field. **No required
+  equipment listed / 未列出强制装备** is a known-empty set and is distinct from
+  **I don't know yet / 目前不确定**.
 - Fueling: **Longest practiced fueling duration / 最长补给练习时长** (integer
   minutes), **Fueling practice sessions in the past 42 days /
   过去 42 天的补给练习次数** (integer), **Practiced intake / 已练习的摄入形式**
@@ -214,27 +256,59 @@ headline is one of:
 | --- | --- |
 | Validation failure | We couldn't check this information / 暂时无法检查这些信息 |
 | Policy unavailable | Trail planning isn't available for this case / 此情况暂不支持越野计划 |
-| Readiness blocked | Your current history or access doesn't support a proposal yet / 当前训练历史或场地条件暂不支持生成计划 |
+| Readiness blocked | Your symptoms, schedule, history, or terrain access blocks a proposal for now / 当前症状、时间安排、训练历史或场地条件暂时阻止生成计划 |
 | Clarification required | A few answers are needed before Praxys can check readiness / 还需补充少量信息，Praxys 才能检查准备情况 |
 | Eligible | Ready to review a 14-day proposal / 可以查看 14 天计划提案 |
 
-Render every matching reason, not only the primary one, as three labeled lines:
+Every matching reason renders as three labeled lines: **Finding / 发现**,
+**Effect / 影响**, and a focusable **Next action / 下一步**. The table below is
+the complete copy and target contract. Codes appear only for implementation;
+they are never user-visible. Target keys are fixed internal keys, not URLs or
+personal state. `first-*` actions resolve from the server's closed field-error
+or reason-target data and never from client-authored strings.
 
-- **Finding / 发现：** the plain-language fact Praxys evaluated;
-- **Effect / 影响：** why it blocks, requires clarification, or limits scope;
-- **Next action / 下一步：** a focusable deep link to the exact ledger field,
-  section, recent-history row, or policy explanation.
+| Reason code | Finding — EN / 中文 | Effect — EN / 中文 | Fixed target; action — EN / 中文 |
+| --- | --- | --- | --- |
+| `validation_failed.invalid_field_value` | One or more values is outside the accepted format or range. / 一项或多项数据不符合格式或范围要求。 | Praxys cannot interpret this revision safely. / Praxys 无法安全解释当前版本。 | `action.first-invalid-field`; **Review the first invalid value / 查看首个无效值** |
+| `validation_failed.schema_version_mismatch` | This course review was created with an unsupported version. / 此赛道核对使用了不受支持的版本。 | Praxys will not guess how old or future fields map to v2. / Praxys 不会猜测旧版或未来字段如何映射到 v2。 | `action.reload-supported-version`; **Reload the supported version / 重新加载受支持版本** |
+| `validation_failed.deterministic_invariant_failed` | Praxys could not reproduce the same readiness receipt. / Praxys 无法复现同一份准备情况回执。 | No proposal can be trusted from this result. / 无法信任基于此结果生成的提案。 | `action.retry-readiness`; **Retry the readiness check / 重新检查准备情况** |
+| `policy_unavailable.policy_inactive` | This Trail policy is not active. / 此越野策略尚未启用。 | No proposal is available from this inactive slice. / 此未启用切片不能生成提案。 | `section.policy-status`; **Review policy status / 查看策略状态** |
+| `policy_unavailable.event_inside_unapproved_taper_window` | The event is inside a period without an accepted taper policy. / 比赛已进入尚无获批减量策略的阶段。 | This policy cannot organize the event-near period. / 此策略无法安排临赛阶段。 | `field.event-date`; **Review the event date / 查看比赛日期** |
+| `policy_unavailable.unsupported_ultra_or_multiday` | This event is ultra-distance or multiday. / 此赛事属于超长距离或多日赛。 | It is outside the non-ultra, one-day policy. / 它超出非超长距离单日策略范围。 | `field.event-scope`; **Review event scope / 查看赛事范围** |
+| `policy_unavailable.unsupported_population_or_intent` | The confirmed context or goal is outside this performance policy. / 已确认的适用场景或目标不在此竞速策略范围内。 | Praxys will not substitute another population or intent. / Praxys 不会替换为其他人群或目标。 | `field.adult-performance-scope`; **Review planning scope / 查看计划适用范围** |
+| `policy_unavailable.technical_features_outside_v2` | The course requires hands assistance or fixed ropes. / 赛道需要用手辅助或使用固定绳索。 | Those technical features are outside v2. / 这些技术特征超出 v2 范围。 | `action.first-confirmed-hazard`; **Review the technical feature / 查看技术特征** |
+| `readiness_blocked.insufficient_recent_running_history` | Recent running continuity is below the accepted history gate. / 近期跑步连续性未达到已接受的历史门槛。 | Praxys cannot anchor a proposal to enough recent running. / Praxys 无法用足够的近期跑步记录约束提案。 | `field.history-running`; **Review recent running / 查看近期跑步记录** |
+| `readiness_blocked.insufficient_comparable_trail_history` | Comparable Trail, ascent, or footing history is insufficient. / 可比的越野、爬升或路面训练历史不足。 | Course-specific work cannot be bounded from observed experience. / 无法依据已观察经历约束赛道专项训练。 | `field.history-comparable-trail`; **Review comparable experience / 查看可比训练经历** |
+| `readiness_blocked.insufficient_descent_history` | Recent descent exposure is insufficient. / 近期下降训练经历不足。 | Downhill work cannot be bounded from observed history. / 无法依据已观察历史约束下坡训练。 | `field.history-descent`; **Review descent experience / 查看下降训练经历** |
+| `readiness_blocked.insufficient_terrain_access` | Required uphill, downhill, or footing access is unavailable. / 缺少所需的上坡、下坡或路面训练条件。 | Praxys will not replace the course demand with road training. / Praxys 不会用公路训练替代赛道需求。 | `section.training-access`; **Review training access / 查看训练场地条件** |
+| `readiness_blocked.current_symptom_stop` | You confirmed a current symptom that should stop performance planning. / 你确认目前有应停止竞速计划的症状。 | Performance planning stops; Praxys makes no diagnosis. / 竞速计划将停止；Praxys 不作诊断。 | `field.symptom-stop`; **Review your response / 查看你的回答** |
+| `readiness_blocked.no_schedule_within_envelope` | No 14-day schedule fits the confirmed availability and accepted limits. / 没有 14 天安排能同时满足已确认时间和已接受限制。 | Praxys will not compress, stack, or substitute sessions. / Praxys 不会压缩、堆叠或替换训练。 | `section.training-schedule`; **Review your schedule / 查看训练时间安排** |
+| `clarification_required.material_course_demand_unknown` | A core course detail is still unknown. / 仍有核心赛道信息未知。 | Readiness cannot be decided without that detail. / 缺少该信息时无法判断准备情况。 | `action.first-unknown-core-field`; **Complete the next course detail / 补充下一项赛道信息** |
+| `clarification_required.assumption_confirmation_required` | A course or conditions assumption has not been confirmed. / 一项赛道或环境假设尚未确认。 | Praxys will not treat an assumption as reviewed fact. / Praxys 不会把未确认假设当作已核对事实。 | `action.first-unconfirmed-assumption`; **Review the assumption / 查看该假设** |
+| `clarification_required.adult_scope_or_constraints_unconfirmed` | Adult, non-clinical performance scope is not confirmed. / 尚未确认成人、非医疗的竞速适用范围。 | This policy cannot be applied yet. / 暂时无法应用此策略。 | `field.adult-performance-scope`; **Confirm planning scope / 确认计划适用范围** |
+| `clarification_required.training_constraints_missing` | A required schedule, access, or symptom answer is missing. / 缺少必填的时间、场地或症状回答。 | Praxys cannot evaluate the complete planning envelope. / Praxys 无法评估完整计划边界。 | `action.first-missing-training-field`; **Complete the next training detail / 补充下一项训练信息** |
+| `clarification_required.training_constraints_outside_history_envelope` | A requested workload or edit is above recent observed history. / 请求的训练量或编辑超出近期已观察历史。 | Praxys will not increase the accepted history envelope. / Praxys 不会提高已接受的历史边界。 | `action.review-history-envelope`; **Compare the request with recent history / 对照近期历史查看请求** |
+| `clarification_required.stale_confirmation_or_source_revision` | A confirmed section or source changed after review. / 已确认的分段或来源在核对后发生变化。 | Readiness is stale and cannot be silently rebound. / 准备情况已过期，不能静默重新绑定。 | `action.first-stale-section`; **Review the latest revision / 查看最新版本** |
+| `clarification_required.contradictory_input` | Two otherwise valid answers conflict. / 两项各自有效的回答彼此冲突。 | Praxys cannot choose which answer should govern the plan. / Praxys 无法自行选择哪项回答应约束计划。 | `action.first-conflicting-field`; **Resolve the first conflict / 处理首个冲突** |
 
-Reason order follows the backend receipt and cannot be changed by severity
-styling. If a target is outside this route, preserve return focus. Never offer
-a road plan, change `trail_running` to `running`, or imply that completing more
-fields makes the event safe.
+Reason order follows the authoritative backend receipt and is never reordered
+by styling. A focus target outside the current viewport opens its section and
+focuses the labeled control; return focus uses only the fixed target key.
+Never offer a road plan, change `trail_running` to `running`, or imply that
+completing fields makes the event safe.
 
-Show four module rows—**Grade-specific training / 坡度专项训练**, **Technical
-terrain / 技术路面训练**, **Environment and altitude / 环境与海拔适应**, and
-**Fueling practice / 补给练习**—with only **Included / 已包含** or **Limited /
-受限**. A Limited row states what is omitted and deep-links to the relevant
-unknown; it never substitutes a generic or road module.
+Readiness shows all four authoritative module rows: **Grade-specific training
+/ 坡度专项训练**, **Technical terrain / 技术路面训练**, **Environment and altitude
+/ 环境与海拔适应**, and **Fueling practice / 补给练习**. Each uses exactly
+**Not evaluated / 尚未评估**, **Available / 可用于生成**, or **Limited / 受限**
+from `module_availability`; it never infers state from `limited_modules`.
+Available means only that generation may consider the module. Limited states
+what would be omitted and links to the authoritative fixed reason target.
+
+Only an immutable proposal may label a module **Included / 已包含** or
+**Omitted / 未包含**, using the proposal's explicit selection. A readiness
+module marked Limited cannot be Included; Available does not require Included.
+Neither surface substitutes a generic or road module.
 
 ## Layout, state space, and accessibility
 
@@ -247,12 +321,18 @@ reasoning. It uses no horizontal table and no floating action over content.
 Required states are: stable loading skeleton; online saved; offline/slow;
 unsaved memory-only edits; retryable request error; field validation plus
 linked error summary; stale section/source/readiness revision; unknown;
-blocked; eligible with limited modules; policy unavailable; private/not found;
-and version mismatch. Offline copy is **Offline. Changes are kept only on this
-page and have not been saved. / 当前离线。更改仅保留在此页面，尚未保存。**
-Reloading or leaving warns that memory-only edits will be lost. A stale result
-never overwrites edits; offer **Review latest version / 查看最新版本** and a
-safe compare/reapply path.
+blocked; eligible with authoritative module availability; policy unavailable;
+private/not found; and version mismatch. Offline copy is **Offline. Changes are
+kept only on this page and have not been saved. /
+当前离线。更改仅保留在此页面，尚未保存。**
+Offline edits are labeled **Pending changes / 待保存更改** and remain only in
+page memory—not local/session storage, a URL, or browser history. Reloading or
+leaving warns that they will be lost. After reconnect, fetch the current
+server revision before offering **Restore pending changes / 恢复待保存更改**;
+offer **Discard pending changes / 放弃待保存更改** at the same level. Restore
+reapplies the in-memory values to the visible editor but does not silently save
+or confirm them. A server change opens **Review latest version / 查看最新版本**
+and a compare/reapply path; it never overwrites pending edits.
 
 All interactive targets are at least 44px in both dimensions. Keyboard order
 follows the visible ledger; accordion, multi-select, percentages, unknown
@@ -269,19 +349,53 @@ surfaces, inputs, accordion/collapsible behavior, Alerts, ScienceNote, and
 receipt grammar cover the route. Green remains action; cobalt remains
 reasoning. No nested cards, new tokens, or ambient shadows are introduced.
 
+## Owner data controls
+
+The page's locale-only **More actions / 更多操作** menu contains:
+
+- **Reset course review / 重置赛道核对**. Its confirmation states **Reset
+  replaces the current editable answers with unknowns. It does not erase
+  source activities or retained proposal records. / 重置会把当前可编辑回答改为
+  未知；不会删除来源活动或已保留的提案记录。** Success invalidates all current
+  confirmations and readiness.
+- **Export my Trail plan data / 导出我的越野计划数据**. This uses the existing
+  authenticated owner export and explains that current values, unknowns,
+  provenance, confirmations, retained snapshots, audits, and receipts are
+  included.
+- **Delete Trail goal / 删除越野目标**. A destructive confirmation distinguishes
+  goal deletion from account deletion and states that owned draft, snapshots,
+  proposals, audits, indexes, and caches are removed. Rollback or durable
+  cleanup-pending is shown honestly; success is never reported while known
+  owned data remains.
+
+These controls accept no owner identifier and create no administrator, MCP,
+demo, or support-user Trail surface.
+
 ## Miniapp and Garmin boundary
 
 Miniapp renders no partial editor. It shows **Trail plan setup is currently
 available on Praxys Web. / 越野计划设置目前仅支持 Praxys 网页版。** with an
-honest **Open Praxys Web / 打开 Praxys 网页版** handoff that preserves the
-authenticated destination when supported. It remains unavailable until API,
-write, state, localization, native rendering, and verification parity exist.
+honest **Open Praxys Web / 打开 Praxys 网页版** handoff to the fixed route when
+the platform supports it. The URL carries no authentication, owner/event
+identifier, state, or return token. If deep opening is unavailable, show
+**Open Praxys Web in your browser and sign in to continue. /
+请在浏览器中打开 Praxys 网页版并登录后继续。** It remains unavailable until
+API, write, state, localization, native rendering, and verification parity
+exist.
 
 Garmin remains absent before adoption. After adoption, v2 may show only a
-read-only **Garmin delivery / Garmin 下发** summary with natural **Unverified /
-未验证** or **Blocked / 已阻止** states and per-workout reasons. It preserves
-the canonical Trail type and offers no connect, preview-consent, send, retry,
-or other provider action under this amendment.
+read-only **Garmin compatibility / Garmin 兼容性** summary with **Internal
+check only. Praxys has not contacted Garmin. / 仅为内部检查，Praxys 尚未连接
+Garmin。**, natural **Unverified / 未验证** or **Blocked / 已阻止** states, and
+closed per-workout reasons. It is a pure projection over the owner's stored
+canonical workouts and the versioned internal matrix.
+
+The projection performs zero token, credential, tokenstore, adapter, network,
+provider, consent, or delivery-ledger reads or writes; accesses or emits zero
+provider/account/device/workout/region identifiers; persists nothing; and
+cannot claim actual Garmin support. It preserves `trail_running` and offers no
+connect, consent, send, schedule, retry, replace, reconcile, delete, or other
+provider action under v2.
 
 ## Verification and handoff
 

--- a/docs/dev/trail-running-plan-experience-amendment-v2.md
+++ b/docs/dev/trail-running-plan-experience-amendment-v2.md
@@ -1,0 +1,301 @@
+# Trail-running course-ledger Experience amendment v2
+
+**Status:** proposed Design Decision Record and Experience Specification
+successor; human Design review required; runtime inactive and unreachable.
+**Evidence:** no implementation or rendered verification is claimed.
+
+This amendment preserves the Field Lab visual system and the proposal,
+adoption, and delivery hierarchy in
+`trail-running-plan-experience-spec.md`. It replaces only the v1 course-review
+interaction where it conflicts with the proposed Product v2 contract. It does
+not redesign Praxys or authorize implementation, activation, dogfood,
+production data, catalog visibility, provider consent, or delivery.
+
+## Human decision sheet
+
+Record **approve**, **revise**, or **reject** for each row. One approval does
+not imply another.
+
+| # | Design choice | Recommendation |
+| --- | --- | --- |
+| 1 | Route and hierarchy | Use one progressive full-page course ledger under Training, not the current Goal dialog. |
+| 2 | Input meaning | Use the exact bilingual labels, explicit unknown controls, and canonical-unit mappings below. |
+| 3 | Confirmation | Confirm each visible section at its exact revision; any edit invalidates that section and readiness. Never offer confirm-all. |
+| 4 | Result receipt | Show one natural-language verdict, every matching reason as finding → effect → next action, and each module as Included or Limited. |
+| 5 | Responsive and accessibility | Use a desktop ledger plus sticky receipt and a mobile ordered accordion, with the complete state and access requirements below. |
+| 6 | Platform boundary | Keep miniapp unavailable with an honest Web handoff; keep Garmin post-adoption, read-only, blocked or unverified, with no provider action in v2. |
+
+## Work Contract and decision
+
+- **Classification:**
+  `sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607`
+- **Route:**
+  `sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168`
+- **ID:** `ddr-owner-trail-course-ledger-v2-amendment`
+- **Schema version:** logical-contract.
+- **Owner role:** Design.
+- **Question:** How should an owner describe a Trail event, confirm each
+  revision, and understand every readiness reason without reading machine
+  contracts or mistaking a limited module for a safe default?
+- **Recommendation:** adopt the full-page progressive ledger and receipt below.
+- **Dependencies:** the accepted v1 Trail Science and Product/Experience
+  decisions, plus human acceptance of
+  `trail-running-plan-product-amendment-v2.md`. If Product v2 changes, this
+  artifact must be reviewed and rebound before implementation.
+- **Review route:** human-review-required. Design does not approve this record.
+- **Outcome plan:** later independent rendered verification with synthetic
+  data; no value telemetry is authorized here.
+
+## Experience thesis and route
+
+The mode is **Operate**. The owner should finish with one answer—what Praxys
+can do next—and a complete receipt showing why. The route is a dedicated page,
+`/training/plan-start/trail/course-review`; Goal may link to it but its dialog
+does not host the ledger. Browser history, page title, and deep links preserve
+the current section and field.
+
+The page title is **Review Trail event / 核对越野赛事**. Supporting copy is
+**Describe the course and where you can train. Praxys will keep unknowns
+visible. / 填写赛道情况和可训练条件。Praxys 会明确保留未知项。**
+
+The page has five ordered sections:
+
+1. Event & planning duration / 赛事与计划用时
+2. Grade & footing / 坡度与路面
+3. When and where you can train / 可训练时间与场地
+4. Recent experience / 近期训练经历
+5. Conditions, support, and fueling / 环境、支持与补给
+
+The fifth section is collapsed initially. Recent experience is read-only. All
+other sections use locale-only product chrome; the paired labels below are the
+translation contract, not simultaneous bilingual UI.
+
+## Field and unit contract
+
+Every reviewable value offers **I don't know yet / 目前不确定** when Product
+v2 permits `state: unknown`. Selecting it removes the value rather than
+submitting an empty string, zero, or placeholder. Core unknowns remain visible
+and prevent eligibility; optional unknowns limit only their named modules.
+
+### 1. Event & planning duration / 赛事与计划用时
+
+| EN / 中文 label | Product v2 field and UI mapping |
+| --- | --- |
+| Event / 赛事 | Existing server-stamped event identity; read-only, with **Edit Goal / 编辑目标** deep link. |
+| Event date / 比赛日期 | ISO date; locale-formatted display. |
+| Race distance / 比赛距离 | Decimal km input; convert exactly to integer `distance_meters`. |
+| Total ascent / 累计爬升 | Integer m → `total_ascent_m`. |
+| Total descent / 累计下降 | Integer m → `total_descent_m`. |
+| Minimum planning duration / 计划用时下限 | Hours/minutes control → integer minimum minutes. |
+| Maximum planning duration / 计划用时上限 | Hours/minutes control → integer maximum minutes; must exceed minimum. |
+| Event format / 比赛形式 | Closed Product value, rendered in natural language. |
+| Distance category / 距离类别 | Closed Product value, rendered in natural language. |
+| Planning goal / 计划目标 | Closed Product intent, rendered in natural language. |
+
+Planning-duration help is **The range you want Praxys to plan around—not a
+finish-time prediction. / 这是你希望 Praxys 用于制定计划的时长范围，并非完赛时间预测。**
+
+### 2. Grade & footing / 坡度与路面
+
+**Course grade distribution / 赛道坡度分布** uses five percentage inputs:
+
+- **Steep downhill (below −10%) / 陡下坡（低于 −10%）**
+- **Downhill (−10% to below −3%) / 下坡（−10% 至低于 −3%）**
+- **Near level (−3% to below 3%) / 近似平缓（−3% 至低于 3%）**
+- **Uphill (3% to below 10%) / 上坡（3% 至低于 10%）**
+- **Steep uphill (10% and above) / 陡上坡（10% 及以上）**
+
+Display percentages accept at most two decimal places and convert exactly to
+five integer basis-point shares. The live summary is **Total / 合计**; the five
+values must equal `100.00%` (`10000` basis points). The entire distribution may
+instead be explicitly unknown. Boundaries are explanatory text, not sliders
+or inferred route geometry.
+
+**Course footing / 赛道路面** is a multi-select with exactly these six
+plain-language values:
+
+| EN / 中文 | Product value |
+| --- | --- |
+| Firm, smooth trail / 坚实平整路面 | `firm_smooth` |
+| Loose gravel / 松散碎石 | `loose_gravel` |
+| Mud / 泥地 | `mud` |
+| Rocks or roots / 岩石或树根 | `rocks_or_roots` |
+| Built steps / 人工台阶 | `built_steps` |
+| Water crossings / 涉水路段 | `water_crossing` |
+
+The set may be explicitly unknown; there is no Other or free text. Use
+**Does any section require hands for progress? / 是否有路段需要用手辅助通过？**
+for `hands_assist`, and **Does any section use fixed ropes? /
+是否有路段需要使用固定绳索？** for `fixed_rope`. Both offer exactly **Yes /
+是**, **No / 否**, and **Not sure / 不确定**, mapping to `yes`, `no`, and
+`unknown`.
+
+### 3. When and where you can train / 可训练时间与场地
+
+- **Days available to run / 可跑步的星期** maps Monday through Sunday to
+  unique ISO weekday integers `1..7`; **I don't know yet / 目前不确定** is a
+  distinct unknown state, never an empty known set.
+- **Can you access a continuous, nontechnical uphill for at least 3 minutes? /
+  你能使用可连续进行至少 3 分钟、非技术性的上坡路线吗？** maps Yes/No/Not
+  sure to known `true`, known `false`, or unknown.
+- **Can you access terrain for controlled downhill training? /
+  你能使用适合受控下坡训练的路线吗？** uses the same mapping and asks for no
+  slope, speed, distance, or duration.
+- **Footing available for training / 可用于训练的路面** uses the same six
+  footing values or explicit unknown.
+- **I confirm this is an adult, non-clinical planning context. /
+  我确认这是成人、非医疗场景的训练计划。** binds the scope confirmation.
+- **I confirm the goal is race performance. / 我确认目标是提升比赛表现。**
+  binds the intent confirmation.
+- **Do you currently have symptoms that should stop performance planning? /
+  你目前是否有应停止竞速计划的症状？** offers Yes/No/Not sure without asking
+  for diagnosis or free text.
+
+### 4. Recent experience / 近期训练经历
+
+This read-only receipt shows **Recent running continuity / 近期跑步连续性**,
+**Recent ascent exposure / 近期爬升训练**, **Recent descent exposure /
+近期下降训练**, and **Recently observed footing / 近期记录到的路面**. Every
+row shows the observation window, freshness, server source, and source
+revision. It may deep-link to owner-visible Activities, but offers no edit,
+correction, attestation, or athlete-entered replacement inside plan start.
+
+### 5. Conditions, support, and fueling / 环境、支持与补给
+
+Open this collapsed section before it can be confirmed. All groups support an
+explicit unknown state.
+
+- Environment: **Maximum course altitude / 赛道最高海拔** (integer m),
+  **Expected temperature range / 预计气温范围** (°C min/max), **Expected
+  humidity range / 预计湿度范围** (% min/max), **Sun exposure / 日晒暴露**
+  (Low/Mixed/High / 低/混合/高), **Wind exposure / 风力暴露**
+  (Sheltered/Mixed/Exposed / 遮蔽/混合/暴露), and **Conditions based on /
+  环境信息依据** (Organizer information/Seasonal expectation/My assumption /
+  赛事方信息/季节预期/我的假设). My assumption requires explicit confirmation.
+- Support: **Support setup / 补给支持方式** (Organized aid/Mixed/Self-supported
+  / 赛事补给/混合/自助), **Number of aid stations / 补给站数量**,
+  **Longest gap between aid stations / 最长补给站间距** (km value, No
+  applicable gap / 不适用, or Not sure / 不确定), **Water availability /
+  饮水供应** and **Food availability / 食物供应** (None/Some stations/Every
+  station/Not sure / 无/部分站点/每个站点/不确定), and **Required equipment /
+  强制装备** (Carry water/Carry food/Weather shell/Lighting/Navigation
+  device/Other required / 携水/携带食物/防风雨外套/照明/导航设备/其他必需装备).
+  Other records presence only; it opens no free-text field.
+- Fueling: **Longest practiced fueling duration / 最长补给练习时长** (integer
+  minutes), **Fueling practice sessions in the past 42 days /
+  过去 42 天的补给练习次数** (integer), **Practiced intake / 已练习的摄入形式**
+  (None/Fluids only/Carbohydrate drink/Mixed food and drink /
+  无/仅液体/碳水饮料/食物与饮品混合), and **Did stomach or gut issues change
+  your plan? / 胃肠不适是否曾让你改变计划？** (No plan-altering issue/Plan-
+  altering issue/Not sure / 未影响计划/曾影响计划/不确定). Copy remains
+  non-diagnostic and gives no quantity prescription.
+
+## Section confirmation and revision behavior
+
+Each editable section ends with **Confirm this section / 确认本节** and shows
+**Confirmed for revision {n} / 已确认版本 {n}** only after the server accepts
+that exact visible revision. Editing a value, choosing unknown, or receiving a
+new server-stamped source invalidates only that section's confirmation and any
+downstream readiness receipt. The state becomes **Changed—confirm again /
+已更改，请重新确认**.
+
+There is no page-level confirm-all, and confirming an open section never
+confirms collapsed or unseen content. **Check readiness / 检查准备情况** becomes
+the one green action only when every required visible section is confirmed;
+**Save and leave / 保存并稍后继续** remains secondary. Confirmation attests
+review, not truth, safety, eligibility, or likely performance.
+
+## Readiness receipt
+
+The receipt never displays machine status or reason identifiers. Its stable
+headline is one of:
+
+| Result | EN / 中文 label |
+| --- | --- |
+| Validation failure | We couldn't check this information / 暂时无法检查这些信息 |
+| Policy unavailable | Trail planning isn't available for this case / 此情况暂不支持越野计划 |
+| Readiness blocked | Your current history or access doesn't support a proposal yet / 当前训练历史或场地条件暂不支持生成计划 |
+| Clarification required | A few answers are needed before Praxys can check readiness / 还需补充少量信息，Praxys 才能检查准备情况 |
+| Eligible | Ready to review a 14-day proposal / 可以查看 14 天计划提案 |
+
+Render every matching reason, not only the primary one, as three labeled lines:
+
+- **Finding / 发现：** the plain-language fact Praxys evaluated;
+- **Effect / 影响：** why it blocks, requires clarification, or limits scope;
+- **Next action / 下一步：** a focusable deep link to the exact ledger field,
+  section, recent-history row, or policy explanation.
+
+Reason order follows the backend receipt and cannot be changed by severity
+styling. If a target is outside this route, preserve return focus. Never offer
+a road plan, change `trail_running` to `running`, or imply that completing more
+fields makes the event safe.
+
+Show four module rows—**Grade-specific training / 坡度专项训练**, **Technical
+terrain / 技术路面训练**, **Environment and altitude / 环境与海拔适应**, and
+**Fueling practice / 补给练习**—with only **Included / 已包含** or **Limited /
+受限**. A Limited row states what is omitted and deep-links to the relevant
+unknown; it never substitutes a generic or road module.
+
+## Layout, state space, and accessibility
+
+Desktop is a two-column workbench: the progressive ledger occupies the main
+column; a compact readiness receipt is sticky in the secondary column and
+never covers page actions. Mobile is one ordered accordion: current verdict,
+next required section, remaining sections, recent-experience receipt, then
+reasoning. It uses no horizontal table and no floating action over content.
+
+Required states are: stable loading skeleton; online saved; offline/slow;
+unsaved memory-only edits; retryable request error; field validation plus
+linked error summary; stale section/source/readiness revision; unknown;
+blocked; eligible with limited modules; policy unavailable; private/not found;
+and version mismatch. Offline copy is **Offline. Changes are kept only on this
+page and have not been saved. / 当前离线。更改仅保留在此页面，尚未保存。**
+Reloading or leaving warns that memory-only edits will be lost. A stale result
+never overwrites edits; offer **Review latest version / 查看最新版本** and a
+safe compare/reapply path.
+
+All interactive targets are at least 44px in both dimensions. Keyboard order
+follows the visible ledger; accordion, multi-select, percentages, unknown
+controls, confirmation, errors, and deep links have visible focus. Submit
+moves focus to the error-summary heading, whose links return to fields. Status
+is never color-only. Long English and Simplified Chinese labels wrap without
+truncation at 320px; numeric values use tabular type. Light/dark themes retain
+WCAG AA meaning. Reduced motion removes accordion and receipt transitions;
+live regions announce save, invalidation, and readiness changes without moving
+focus.
+
+Design-system impact: none—existing Field Lab tokens, flat rule-separated
+surfaces, inputs, accordion/collapsible behavior, Alerts, ScienceNote, and
+receipt grammar cover the route. Green remains action; cobalt remains
+reasoning. No nested cards, new tokens, or ambient shadows are introduced.
+
+## Miniapp and Garmin boundary
+
+Miniapp renders no partial editor. It shows **Trail plan setup is currently
+available on Praxys Web. / 越野计划设置目前仅支持 Praxys 网页版。** with an
+honest **Open Praxys Web / 打开 Praxys 网页版** handoff that preserves the
+authenticated destination when supported. It remains unavailable until API,
+write, state, localization, native rendering, and verification parity exist.
+
+Garmin remains absent before adoption. After adoption, v2 may show only a
+read-only **Garmin delivery / Garmin 下发** summary with natural **Unverified /
+未验证** or **Blocked / 已阻止** states and per-workout reasons. It preserves
+the canonical Trail type and offers no connect, preview-consent, send, retry,
+or other provider action under this amendment.
+
+## Verification and handoff
+
+Engineering must not invent labels, confirmation scope, result priority,
+unknown behavior, provider actions, or a road fallback. Before any later
+activation, Quality independently renders synthetic complete, unknown,
+blocked, limited, error, stale, offline, and post-adoption Garmin states at
+desktop and mobile sizes; verifies EN/zh, keyboard/focus, touch, wrapping,
+light/dark, reduced motion, console, and no overflow; and performs native
+WeChat verification before claiming miniapp parity.
+
+## Human Design decision requested
+
+Approve, revise, or reject the six rows in the decision sheet. Approval binds
+only this intended inactive experience. It does not approve Product v2,
+implementation, rendered quality, merge, deployment, activation, production
+data, dogfood, catalog exposure, Garmin integration, consent, or delivery.

--- a/docs/dev/trail-running-plan-product-amendment-v2.md
+++ b/docs/dev/trail-running-plan-product-amendment-v2.md
@@ -80,10 +80,12 @@ owner found the Product and Experience documents easier to review than the
 machine-oriented Science packets. That is a usability signal for the review
 contract, not evidence that the proposed training policy is effective.
 
-The current inactive implementation exposes v1 inputs and collapses many
-different facts into a single result/detail pair. It can therefore hide
-simultaneous next actions and can make a non-core missing value look equivalent
-to a core readiness stop.
+The accepted v1 contracts and pure generation core have incomplete input and
+result semantics: they collapse many different facts into a single
+result/detail pair. No Trail API or UI exposes those inputs, and the runtime
+remains unreachable. The incomplete pure-core semantics can still hide
+simultaneous next actions and make a non-core missing value look equivalent to
+a core readiness stop if carried forward unchanged.
 
 No broader demand, adoption rate, safety outcome, or efficacy signal is
 claimed. No product-value telemetry exists for this proposed behavior.
@@ -230,25 +232,43 @@ Every reviewable input uses one of two shapes:
 ```
 
 `known` requires exactly one schema-valid value. `unknown` carries no value.
-Missing state, `null`, empty string, sentinel numbers, guessed zero, `other`,
-and client-provided arbitrary objects are invalid. The server response may add
+Missing state, empty string, sentinel numbers, guessed zero, `other`, and
+client-provided arbitrary objects are invalid. `null` is invalid except for
+the single explicit aid-station-gap case below. The server response may add
 provenance and revision metadata, but clients cannot submit or overwrite those
 fields.
 
+Every numeric value must be finite before domain validation. Architecture and
+Engineering must impose and verify an overall serialized-payload bound,
+nesting bound, and collection-length bounds; Product does not invent those
+implementation limits here.
+
 ### Provenance and revision fence
 
-The server stamps provenance from the authenticated write path. The client may
-submit a value but may not label itself `course_entered`, `history_observed`,
-or otherwise choose a more authoritative source. Grade distribution accepts
-only server-stamped `athlete_entered` or `course_entered` provenance. It is
-never inferred from a route, model, activity trace, or provider payload in v2.
+The client submits only a typed value or explicit unknown state plus an
+explicit confirmation action. It never submits provenance, source revision,
+model identity, timestamp, or history hash. The server stamps every response
+field with exactly one canonical v1 provenance value:
 
-Each mutation creates a new immutable course/constraint revision. Confirmation
-names the exact revision being confirmed. Any value, state, or server-stamped
-provenance change invalidates the previous confirmation. Readiness and a later
-proposal bind the exact goal, course, constraint, history-snapshot, policy, and
-generator revisions; a stale confirmation or source revision cannot be
-silently rebound.
+- `athlete_stated`;
+- `course_verified`;
+- `history_observed`;
+- `model_inferred`;
+- `explicit_assumption`; or
+- `unknown`.
+
+The server also owns any source revision, source-model version, source
+timestamp, and owner-scoped history hash. Provider identifiers are neither
+provenance nor permitted metadata. Grade distribution accepts only
+server-stamped `athlete_stated` or `course_verified` provenance. It is never
+inferred from a route, model, activity trace, or provider payload in v2.
+
+Each mutation creates a new immutable course/constraint field or section
+revision. Confirmation names the exact field or section revision being
+confirmed. Any value, state, or server-stamped source change invalidates that
+confirmation. Readiness and a later proposal bind the exact goal, course,
+constraint, history-snapshot, policy, and generator revisions; a stale
+confirmation or source revision cannot be silently rebound.
 
 ## `trail_course_demand_v2`
 
@@ -287,7 +307,7 @@ five integers must sum to `10000`:
 
 These basis points describe the share of distance in each bucket; they are not
 grade values. Boundary values belong only to the bucket shown above. The
-distribution may carry only `athlete_entered` or `course_entered` provenance.
+distribution may carry only `athlete_stated` or `course_verified` provenance.
 It is descriptive and must not be turned into a difficulty score, equivalent
 road distance, finish-time adjustment, workout dose, or safety threshold.
 
@@ -332,26 +352,51 @@ diagnosis, skill assessment, or training dose.
 
 ### Bounded optional context
 
-Optional context uses closed values only and may remain unknown:
+Optional context uses the following closed, bounded shapes and may remain
+unknown.
 
-- maximum altitude: a canonical metric integer from `-500` through `9000`
-  meters;
-- expected temperature band: `below_0_c`, `0_to_below_10_c`,
-  `10_to_below_20_c`, `20_to_below_30_c`, or `30_c_and_above`;
-- expected humidity: `low`, `moderate`, or `high`;
-- wind exposure: `sheltered`, `mixed`, or `exposed`;
-- sun exposure: `low`, `mixed`, or `exposed`;
-- aid/support mode: `self_supported`, `organizer_aid`, or
-  `organizer_aid_and_personal_crew`;
-- aid interval: `none`, `below_5_km`, `5_to_below_10_km`, or
-  `10_km_and_above`;
-- fueling practice: `none`, `some`, or `repeated`; and
-- gastrointestinal experience: `no_issue_reported` or `issue_reported`.
+Environment and altitude:
 
-The gastrointestinal value is a non-diagnostic athlete report. It cannot be
-presented as a condition, clearance, treatment need, or causal explanation.
-These fields accept no notes, labels, URLs, units embedded in strings, or other
-free text. Missing wind or exposure information limits
+- `maximum_altitude_m` is a canonical metric integer from `-500` through
+  `9000` meters;
+- `temperature_min_c` and `temperature_max_c` are finite numbers from `-30`
+  through `55`, with minimum less than or equal to maximum;
+- `humidity_min_pct` and `humidity_max_pct` are finite numbers from `0` through
+  `100`, with minimum less than or equal to maximum;
+- `sun_exposure` is `low`, `mixed`, `high`, or `unknown`;
+- `wind_exposure` is `sheltered`, `mixed`, `exposed`, or `unknown`; and
+- `conditions_basis` is `organizer_information`, `seasonal_expectation`, or
+  `athlete_assumption`. An athlete assumption receives server-stamped
+  `explicit_assumption` provenance and requires revision-bound confirmation.
+
+Aid and support:
+
+- `aid_support_mode` is `organized_aid`, `mixed`, or `self_supported`;
+- `aid_station_count` is an integer from `0` through `50`;
+- `max_aid_station_gap_km` is a finite number from `0.1` through `50`, or
+  `null` when no applicable gap can be represented;
+- `water_availability` and `food_availability` are each `none`,
+  `some_stations`, `all_stations`, or `unknown`; and
+- `mandatory_gear` is an unordered set containing only `water_carry`,
+  `food_carry`, `weather_shell`, `lighting`, `navigation_device`, or
+  `other_required`. `other_required` records only that another organizer
+  requirement exists; it carries no label or free text.
+
+Fueling and gastrointestinal context:
+
+- `longest_practiced_duration_min` is an integer from `0` through `1440`;
+- `practice_sessions_last_42_days` is an integer from `0` through `84`;
+- `intake_form` is `none`, `fluids_only`, `carbohydrate_drink`, or
+  `mixed_food_and_drink`; and
+- `gastrointestinal_experience` is `no_plan_altering_issue`,
+  `plan_altering_issue`, or `unknown`.
+
+These fields are optional and module-limiting. Gastrointestinal experience is
+a non-diagnostic athlete report; it cannot be presented as a condition,
+clearance, treatment need, or causal explanation. No optional value authorizes
+a fueling, environment, altitude, equipment, or support prescription. These
+fields accept no notes, labels, URLs, provider IDs, units embedded in strings,
+or other free text. Missing wind or exposure information limits
 `environment_altitude`; it cannot be silently treated as sheltered. Missing
 aid/support, fueling, or gastrointestinal context limits `fueling`; no fixed
 fueling quantity follows from a known value.
@@ -442,7 +487,8 @@ The v2 planning contract does not collect or persist:
 
 - GPS points, route files, polylines, maps, or inferred course geometry;
 - course-source URLs or scraped course content;
-- provider request/response payloads or device identifiers;
+- provider request/response payloads, provider account/activity/workout IDs, or
+  device identifiers;
 - free-text health, symptom, fueling, surface, or course narratives;
 - diagnoses, medical clearance, or injury probability;
 - activity `avg_power` as readiness or intensity evidence; or

--- a/docs/dev/trail-running-plan-product-amendment-v2.md
+++ b/docs/dev/trail-running-plan-product-amendment-v2.md
@@ -54,10 +54,13 @@ for each choice. Approval of one row does not imply approval of another.
   Decision Records; an independently accepted Science successor for any v2
   applicability or safety change; Design review of the resulting journey; the
   proposed [Trail v2 Architecture decision](trail-running-plan-architecture-decision-v2.md)
-  for serialization, revisions, persistence, URL, and zero-I/O projection;
-  the proposed [Trail v2 Trust decision](trail-running-plan-trust-decision-v2.md)
-  for minimization, first-party owner authorization, retention, export, reset,
-  deletion, and side-channel boundaries; and Quality verification of the exact
+  exactly at commit
+  `a52d23ce8534ce4c29082cacb31b5ab5e856de51` for serialization,
+  revisions, persistence, URL, and zero-I/O projection; the proposed
+  [Trail v2 Trust decision](trail-running-plan-trust-decision-v2.md) exactly at
+  commit `d8c83a87750db02d232f5efd757be5fdc17b8632` for minimization,
+  first-party owner authorization, retention, export, reset, deletion, and
+  side-channel boundaries; and Quality verification of the exact
   implementation. Both proposed specialist records require their own human
   acceptance before implementation.
 - **Review route:** human-review-required. Product neither approves this
@@ -179,9 +182,9 @@ receipt preserves all other independently evaluable matches.
 
 ### Exhaustive reason catalog
 
-The following is the complete v2 Product catalog. Adding, removing, renaming,
-or reclassifying a reason requires a successor Product decision and matching
-specialist review.
+The following is the complete 21-reason v2 Product catalog. Adding, removing,
+renaming, or reclassifying a reason requires a successor Product decision and
+matching specialist review.
 
 | Status | Ordered `detail_reason` values | Product meaning |
 | --- | --- | --- |
@@ -209,7 +212,7 @@ maps as follows. Multiple rows may match and must all remain in
 | Required accepted ontology, Science contract, Product/Design/Architecture/Trust dependency, or inactive capability contract is absent, mismatched, or not runtime-authorized | `policy_unavailable.policy_inactive` |
 | Event identity/date, distance, ascent, descent, planning-duration range, or either hazard gate is unknown | `clarification_required.material_course_demand_unknown` |
 | An `explicit_assumption` section has not been confirmed at its exact revision | `clarification_required.assumption_confirmation_required` |
-| Required adult/non-clinical confirmation is absent or unknown | `clarification_required.adult_scope_or_constraints_unconfirmed` |
+| Required adult/non-clinical confirmation or a recognized scope enum is absent or unknown | `clarification_required.adult_scope_or_constraints_unconfirmed` |
 | Available weekdays, weekly time, maximum session, unavailable dates, access booleans, accessible footing, or symptom response is missing or unknown | `clarification_required.training_constraints_missing` |
 | An explicit requested workload or proposal edit is above the server-derived recent-history envelope | `clarification_required.training_constraints_outside_history_envelope` |
 | Any required field/section confirmation, course source, planning source, or history source revision is stale | `clarification_required.stale_confirmation_or_source_revision` |
@@ -221,8 +224,8 @@ maps as follows. Multiple rows may match and must all remain in
 | Confirmed current symptom-stop is true | `readiness_blocked.current_symptom_stop` |
 | Valid complete constraints, unavailable dates, history caps, and policy spacing leave no 14-day schedule | `readiness_blocked.no_schedule_within_envelope` |
 | Event falls inside the unapproved event-near/taper window | `policy_unavailable.event_inside_unapproved_taper_window` |
-| Event is ultra-distance or multiday | `policy_unavailable.unsupported_ultra_or_multiday` |
-| Population, clinical/return-to-sport state, or intent is outside the accepted performance scope | `policy_unavailable.unsupported_population_or_intent` |
+| Recognized `event_format` is `multi_day` or recognized `distance_family` is `ultra` | `policy_unavailable.unsupported_ultra_or_multiday` |
+| Population/clinical state is unsupported or recognized `planning_intent` is `first_completion` or `return_to_consistency` | `policy_unavailable.unsupported_population_or_intent` |
 | `hands_assist` or `fixed_rope` is known `true` | `policy_unavailable.technical_features_outside_v2` |
 
 A capacity limit above recent history does not request extra work and therefore
@@ -243,8 +246,8 @@ Readiness returns all four keys in `module_availability`:
 Each value contains exactly one state plus a closed `reason_target`:
 
 - `not_evaluated`: a validation, policy, clarification, or core-readiness
-  condition prevented a safe module decision; `reason_target` points to the
-  applicable namespaced readiness reason;
+  status prevented a safe module decision; `reason_target` is the top-level
+  result's primary namespaced reason;
 - `available`: the module may be considered by generation, not that it will be
   included; `reason_target` is `null`; or
 - `limited`: accepted input requires the module to be omitted or remain
@@ -253,6 +256,11 @@ Each value contains exactly one state plus a closed `reason_target`:
 
 Reason targets are fixed keys resolved inside the authenticated UI. They are
 not URLs, fragments, values, identifiers, or client-authored strings.
+
+When the top-level status is anything other than `eligible_proposal`, all four
+modules are `not_evaluated` and all four cite the same primary namespaced
+reason. Only `eligible_proposal` evaluates each module as `available` or
+`limited`.
 
 `limited_modules` is only the sorted list of keys whose authoritative state is
 `limited`. It is redundant compatibility output, not a source of truth.
@@ -366,9 +374,20 @@ maximum are each from `1` through `1440`, with `minimum < maximum`. It is the
 range the athlete wants Praxys to use for planning context. It is not a
 finish-time prediction, forecast, feasibility verdict, or performance promise.
 
-Event format, distance family, and performance intent remain closed enums.
-Unsupported ultra/multiday scope or population/intent produces the appropriate
-`policy_unavailable` reason; it is not coerced into the non-ultra policy.
+The request recognizes only these closed scope enums:
+
+- `event_format`: `single_day` or `multi_day`;
+- `distance_family`: `non_ultra` or `ultra`; and
+- `planning_intent`: `performance`, `first_completion`, or
+  `return_to_consistency`.
+
+An unknown recognized scope field yields
+`clarification_required.adult_scope_or_constraints_unconfirmed`. Known
+`multi_day` or `ultra` yields
+`policy_unavailable.unsupported_ultra_or_multiday`. A known non-performance
+intent yields `policy_unavailable.unsupported_population_or_intent`. An
+unrecognized enum literal is `validation_failed.invalid_field_value`; it is
+never treated as unknown or coerced into the non-ultra performance policy.
 
 ### Canonical grade-share buckets
 
@@ -433,8 +452,13 @@ diagnosis, skill assessment, or training dose.
 
 ### Bounded optional context
 
-Optional context uses the following closed, bounded shapes and may remain
-unknown.
+`optional_context` is exactly three strict fixed-key objects: `environment`,
+`support`, and `fueling`. Group objects have no known/unknown envelope and
+every declared leaf key is always present. Every leaf independently uses the
+common known/unknown envelope. A UI “set group unknown” control is only a batch
+action that writes unknown to every leaf; it has no group-level wire value.
+Unknown or extra group/leaf keys fail validation, and no enum below contains an
+`unknown` literal.
 
 Environment and altitude:
 
@@ -444,20 +468,27 @@ Environment and altitude:
   through `55`, with minimum less than or equal to maximum;
 - `humidity_min_pct` and `humidity_max_pct` are finite numbers from `0` through
   `100`, with minimum less than or equal to maximum;
-- `sun_exposure` is `low`, `mixed`, `high`, or `unknown`;
-- `wind_exposure` is `sheltered`, `mixed`, `exposed`, or `unknown`; and
+- `sun_exposure`, when known, is `low`, `mixed`, or `high`;
+- `wind_exposure`, when known, is `sheltered`, `mixed`, or `exposed`; and
 - `conditions_basis` is `organizer_information`, `seasonal_expectation`, or
   `athlete_assumption`. An athlete assumption receives server-stamped
   `explicit_assumption` provenance and requires revision-bound confirmation.
+
+Temperature and humidity minima and maxima are separate leaf envelopes. Their
+ordering rule is evaluated only when both leaves in the pair are known. One
+unknown leaf remains unknown and limits `environment_altitude`; it does not
+fail or invent the other bound.
 
 Aid and support:
 
 - `aid_support_mode` is `organized_aid`, `mixed`, or `self_supported`;
 - `aid_station_count` is an integer from `0` through `50`;
-- `max_aid_station_gap_km` is a finite number from `0.1` through `50`, or
-  `null` when no applicable gap can be represented;
+- `max_aid_station_gap_m`, when known, is an integer from `100` through
+  `50000`, except that `{"state":"known","value":null}` is the one explicit
+  known-null value and means not applicable; kilometers are UI display/input
+  conversion only;
 - `water_availability` and `food_availability` are each `none`,
-  `some_stations`, `all_stations`, or `unknown`; and
+  `some_stations`, or `all_stations` when known; and
 - `mandatory_gear` is an unordered set containing only `water_carry`,
   `food_carry`, `weather_shell`, `lighting`, `navigation_device`, or
   `other_required`. `other_required` records only that another organizer
@@ -469,8 +500,8 @@ Fueling and gastrointestinal context:
 - `practice_sessions_last_42_days` is an integer from `0` through `84`;
 - `intake_form` is `none`, `fluids_only`, `carbohydrate_drink`, or
   `mixed_food_and_drink`; and
-- `gastrointestinal_experience` is `no_plan_altering_issue`,
-  `plan_altering_issue`, or `unknown`.
+- `gastrointestinal_experience` is `no_plan_altering_issue` or
+  `plan_altering_issue` when known.
 
 These fields are optional and module-limiting. Gastrointestinal experience is
 a non-diagnostic athlete report; it cannot be presented as a condition,

--- a/docs/dev/trail-running-plan-product-amendment-v2.md
+++ b/docs/dev/trail-running-plan-product-amendment-v2.md
@@ -18,12 +18,12 @@ for each choice. Approval of one row does not imply approval of another.
 
 | # | Choice | Recommended Product decision |
 | --- | --- | --- |
-| 1 | Stable readiness result | Adopt the five canonical statuses, exhaustive namespaced reason catalog, deterministic precedence, complete matching-reason receipt, and separate `limited_modules`. |
+| 1 | Stable readiness result | Adopt the five canonical statuses, exhaustive namespaced reason catalog, deterministic precedence, and complete matching-reason receipt. |
 | 2 | Versioned input contract | Adopt `trail_course_demand_v2` and `non_ultra_trail_constraints_v2`, strict known/unknown request values, server-stamped provenance, and revision-bound confirmation. |
 | 3 | Course description | Adopt integer grade-share buckets, the six-value footing vocabulary, explicit hazard gates, and bounded environment, support, fueling, and gastrointestinal context without routes or free-text planning inputs. |
-| 4 | Access and history | Require explicit training weekdays and terrain access while keeping the 42/21-day recent-history assessment server-derived. Treat planning duration as an athlete-confirmed range, not a prediction. |
-| 5 | Block versus limit | Keep core readiness gates fail-closed, but allow ordinary grade, footing, environment, support, and fueling unknowns to limit only their named modules when all core gates pass. |
-| 6 | Data and runtime boundary | Preserve reset, export, and deletion for the current goal; collect no value telemetry; forbid diagnosis, activity `avg_power`, road fallback, route/provider payloads, and any authority beyond inactive implementation. |
+| 4 | Schedule, access, and history | Require bounded schedule capacity, explicit terrain access, and server-derived 42/21-day recent history. Treat planning duration as a confirmed range, not a prediction. |
+| 5 | Block versus module availability | Keep core gates fail-closed; return authoritative availability for four modules; let non-core unknowns limit only their named module. |
+| 6 | Data, actor, and runtime boundary | Keep one current draft, complete reset/export/deletion, first-party owner-only access, data-free navigation, zero-I/O Garmin projection, no value telemetry, and inactive-only authority. |
 
 ## Work Contract and shared decision fields
 
@@ -52,10 +52,14 @@ for each choice. Approval of one row does not imply approval of another.
   unknown.
 - **Dependencies:** the accepted v1 Trail Evidence Reviews and inactive Science
   Decision Records; an independently accepted Science successor for any v2
-  applicability or safety change; Design review of the resulting journey;
-  Architecture review of canonical serialization and revision fences; Trust
-  review of minimization, authorization, export, reset, and deletion; Quality
-  verification of the exact implementation.
+  applicability or safety change; Design review of the resulting journey; the
+  proposed [Trail v2 Architecture decision](trail-running-plan-architecture-decision-v2.md)
+  for serialization, revisions, persistence, URL, and zero-I/O projection;
+  the proposed [Trail v2 Trust decision](trail-running-plan-trust-decision-v2.md)
+  for minimization, first-party owner authorization, retention, export, reset,
+  deletion, and side-channel boundaries; and Quality verification of the exact
+  implementation. Both proposed specialist records require their own human
+  acceptance before implementation.
 - **Review route:** human-review-required. Product neither approves this
   proposal nor selects a different route.
 - **Outcome plan:** verify the inactive contract deterministically, then use
@@ -159,8 +163,10 @@ The response also carries:
 - `matching_reasons`: every matching `(status, detail_reason)` pair across all
   statuses, de-duplicated and ordered first by status precedence and then by
   catalog order; and
-- `limited_modules`: a separate sorted set that never changes the top-level
-  status or hides a matching reason.
+- `module_availability`: the authoritative four-module decision described
+  below; and
+- `limited_modules`: a redundant sorted projection that never changes the
+  top-level status or hides a matching reason.
 
 The fully qualified, namespaced identity of a reason is
 `<status>.<detail_reason>`. Clients must not construct new reason strings,
@@ -179,7 +185,7 @@ specialist review.
 
 | Status | Ordered `detail_reason` values | Product meaning |
 | --- | --- | --- |
-| `clarification_required` | `material_course_demand_unknown`; `assumption_confirmation_required`; `adult_scope_or_constraints_unconfirmed`; `training_constraints_missing`; `contradictory_input` | The owner can resolve or confirm required input; no proposal is returned. |
+| `clarification_required` | `material_course_demand_unknown`; `assumption_confirmation_required`; `adult_scope_or_constraints_unconfirmed`; `training_constraints_missing`; `training_constraints_outside_history_envelope`; `stale_confirmation_or_source_revision`; `contradictory_input` | The owner can resolve or confirm required input; no proposal is returned. |
 | `readiness_blocked` | `insufficient_recent_running_history`; `insufficient_comparable_trail_history`; `insufficient_descent_history`; `insufficient_terrain_access`; `current_symptom_stop`; `no_schedule_within_envelope` | Valid, confirmed input does not satisfy a current core readiness gate; no substitute plan is returned. |
 | `policy_unavailable` | `policy_inactive`; `event_inside_unapproved_taper_window`; `unsupported_ultra_or_multiday`; `unsupported_population_or_intent`; `technical_features_outside_v2` | The requested use is outside the exact available policy or its current runtime state. `policy_inactive` is a detail reason here, never a sixth top-level status. |
 | `validation_failed` | `invalid_field_value`; `schema_version_mismatch`; `deterministic_invariant_failed` | The request or result cannot be safely interpreted or replayed. |
@@ -189,15 +195,71 @@ Authorization failures remain fail-closed before this Product result and do
 not become readiness reasons. A private owner-only boundary must not be leaked
 through this catalog.
 
-### Limited modules
+### Exhaustive condition mapping
 
-`limited_modules` is an unordered set serialized in deterministic sorted order.
-It permits only these values:
+Every safely evaluable core, constraint, dependency, and contract condition
+maps as follows. Multiple rows may match and must all remain in
+`matching_reasons`.
+
+| Condition | Required namespaced reason |
+| --- | --- |
+| Invalid type, non-finite or out-of-domain number, duplicate/unsorted bounded collection, grade sum other than `10000`, forbidden key, maximum session above weekly time, or unavailable date outside the horizon | `validation_failed.invalid_field_value` |
+| Course or constraint schema ID differs from the exact v2 ID | `validation_failed.schema_version_mismatch` |
+| Canonical replay, receipt, proposal, or other deterministic invariant cannot be reproduced | `validation_failed.deterministic_invariant_failed` |
+| Required accepted ontology, Science contract, Product/Design/Architecture/Trust dependency, or inactive capability contract is absent, mismatched, or not runtime-authorized | `policy_unavailable.policy_inactive` |
+| Event identity/date, distance, ascent, descent, planning-duration range, or either hazard gate is unknown | `clarification_required.material_course_demand_unknown` |
+| An `explicit_assumption` section has not been confirmed at its exact revision | `clarification_required.assumption_confirmation_required` |
+| Required adult/non-clinical confirmation is absent or unknown | `clarification_required.adult_scope_or_constraints_unconfirmed` |
+| Available weekdays, weekly time, maximum session, unavailable dates, access booleans, accessible footing, or symptom response is missing or unknown | `clarification_required.training_constraints_missing` |
+| An explicit requested workload or proposal edit is above the server-derived recent-history envelope | `clarification_required.training_constraints_outside_history_envelope` |
+| Any required field/section confirmation, course source, planning source, or history source revision is stale | `clarification_required.stale_confirmation_or_source_revision` |
+| Individually valid values conflict, including preferred weekday not available or mutually inconsistent event/support context | `clarification_required.contradictory_input` |
+| Recent server-derived running continuity is insufficient | `readiness_blocked.insufficient_recent_running_history` |
+| Recent comparable ascent/Trail exposure is insufficient, or known course footing is not contained in recently observed footing | `readiness_blocked.insufficient_comparable_trail_history` |
+| Recent server-derived descent exposure is insufficient | `readiness_blocked.insufficient_descent_history` |
+| Required uphill/downhill access is false, or known course footing is not contained in accessible footing | `readiness_blocked.insufficient_terrain_access` |
+| Confirmed current symptom-stop is true | `readiness_blocked.current_symptom_stop` |
+| Valid complete constraints, unavailable dates, history caps, and policy spacing leave no 14-day schedule | `readiness_blocked.no_schedule_within_envelope` |
+| Event falls inside the unapproved event-near/taper window | `policy_unavailable.event_inside_unapproved_taper_window` |
+| Event is ultra-distance or multiday | `policy_unavailable.unsupported_ultra_or_multiday` |
+| Population, clinical/return-to-sport state, or intent is outside the accepted performance scope | `policy_unavailable.unsupported_population_or_intent` |
+| `hands_assist` or `fixed_rope` is known `true` | `policy_unavailable.technical_features_outside_v2` |
+
+A capacity limit above recent history does not request extra work and therefore
+does not fail by itself; generation remains capped by accepted history. The
+outside-history reason applies only to an explicit request or edit that would
+exceed that envelope. A complete, in-envelope request that still cannot be
+scheduled uses `no_schedule_within_envelope`.
+
+### Authoritative module availability
+
+Readiness returns all four keys in `module_availability`:
 
 - `grade_specificity`;
 - `technical_terrain`;
 - `environment_altitude`; and
 - `fueling`.
+
+Each value contains exactly one state plus a closed `reason_target`:
+
+- `not_evaluated`: a validation, policy, clarification, or core-readiness
+  condition prevented a safe module decision; `reason_target` points to the
+  applicable namespaced readiness reason;
+- `available`: the module may be considered by generation, not that it will be
+  included; `reason_target` is `null`; or
+- `limited`: accepted input requires the module to be omitted or remain
+  descriptive; `reason_target` is the closed first-party field/section target
+  that explains the limit.
+
+Reason targets are fixed keys resolved inside the authenticated UI. They are
+not URLs, fragments, values, identifiers, or client-authored strings.
+
+`limited_modules` is only the sorted list of keys whose authoritative state is
+`limited`. It is redundant compatibility output, not a source of truth.
+Clients must not infer “included” from an absent limitation. Actual module
+selection exists only in an immutable proposal, where each proposal module is
+explicitly `included` or `omitted` and references the readiness receipt.
+`limited` cannot become `included`; `available` does not require inclusion.
 
 Unknown grade distribution limits `grade_specificity`. Unknown ordinary
 footing limits `technical_terrain`. Unknown altitude, temperature, humidity,
@@ -205,9 +267,13 @@ wind, or exposure limits `environment_altitude`. Unknown aid/support, fueling
 practice, or non-diagnostic gastrointestinal experience limits `fueling`; v2
 does not expose a separate aid-support training module.
 
-A module limit means that module is omitted or remains descriptive. It never
-authorizes a generic replacement, a hidden default, a dose increase, or a
-claim that the missing module is unnecessary.
+A module limit never authorizes a generic replacement, hidden default, dose
+increase, or claim that the missing module is unnecessary.
+
+Hiking, strength, and taper are disabled and deferred in v2. They are not
+module-availability keys and may not be included in a v2 proposal because no
+accepted v2 input and dose contract exists for them. Event-near use remains
+`policy_unavailable.event_inside_unapproved_taper_window`.
 
 ## Versioned request and confirmation contract
 
@@ -238,10 +304,14 @@ the single explicit aid-station-gap case below. The server response may add
 provenance and revision metadata, but clients cannot submit or overwrite those
 fields.
 
-Every numeric value must be finite before domain validation. Architecture and
-Engineering must impose and verify an overall serialized-payload bound,
-nesting bound, and collection-length bounds; Product does not invent those
-implementation limits here.
+Every numeric value must be finite before domain validation. This amendment
+adopts by reference the exact request-size, UTF-8, compression, nesting,
+member, collection, string, numeric-token, duplicate-key, and canonicalization
+bounds in the proposed Trail v2 Architecture and Trust decisions. Those are
+abuse and operability controls, not Product value, scientific applicability,
+safety, course-difficulty, or training-dose claims. A material change to those
+bounds requires dependency re-review rather than an undocumented Product
+override.
 
 ### Provenance and revision fence
 
@@ -263,12 +333,15 @@ provenance nor permitted metadata. Grade distribution accepts only
 server-stamped `athlete_stated` or `course_verified` provenance. It is never
 inferred from a route, model, activity trace, or provider payload in v2.
 
-Each mutation creates a new immutable course/constraint field or section
-revision. Confirmation names the exact field or section revision being
+Each successful mutation computes a new opaque revision for the current
+course/constraint field or section and atomically overwrites the previous
+unproposed draft state. It does not retain an immutable edit or confirmation
+history. Confirmation names the exact current field or section revision being
 confirmed. Any value, state, or server-stamped source change invalidates that
 confirmation. Readiness and a later proposal bind the exact goal, course,
 constraint, history-snapshot, policy, and generator revisions; a stale
-confirmation or source revision cannot be silently rebound.
+confirmation or source revision cannot be silently rebound. Immutable
+snapshot and audit retention begins only when a proposal is created.
 
 ## `trail_course_demand_v2`
 
@@ -282,10 +355,16 @@ must be valid, known, and bound to the confirmed course revision before
 Event identity is the existing server-stamped goal/event identifier. The v2
 generator request does not accept a free-text event identity or source label.
 
-Planning duration is a confirmed integer minute range with `minimum < maximum`.
-It is the range the athlete wants Praxys to use for planning context. It is not
-a finish-time prediction, forecast, feasibility verdict, or performance
-promise.
+Distance is an integer from `1` through `49999` meters. This upper limit is a
+reversible Product v2 non-ultra scope guardrail, not a scientific definition of
+ultra distance. Total ascent and total descent are separate integers from `0`
+through `20000` meters. Their bounds are structural/domain validation limits,
+not safety, difficulty, equivalence, or training-dose claims.
+
+Planning duration is a confirmed integer minute range whose minimum and
+maximum are each from `1` through `1440`, with `minimum < maximum`. It is the
+range the athlete wants Praxys to use for planning context. It is not a
+finish-time prediction, forecast, feasibility verdict, or performance promise.
 
 Event format, distance family, and performance intent remain closed enums.
 Unsupported ultra/multiday scope or population/intent produces the appropriate
@@ -339,13 +418,15 @@ footing. `C` must be a subset of `A`; otherwise readiness includes
 
 ### Hazard gates
 
-`hands_assist` and `fixed_rope` are separate tri-state values: `yes`, `no`, or
-`unknown`.
+`hands_assist` and `fixed_rope` each use the strict known/unknown request
+envelope. A known value is a strict boolean. The UI may present the three
+choices Yes, No, and Not sure, but it serializes them only as known `true`,
+known `false`, or unknown.
 
-- `unknown` requires clarification and cannot be reduced to ordinary footing;
-- `yes` is outside v2 and yields
+- unknown requires clarification and cannot be reduced to ordinary footing;
+- known `true` is outside v2 and yields
   `policy_unavailable.technical_features_outside_v2`; and
-- both must be confirmed `no` for `eligible_proposal`.
+- both must be confirmed known `false` for `eligible_proposal`.
 
 These gates are not technical-difficulty ratings and do not authorize a
 diagnosis, skill assessment, or training dose.
@@ -407,24 +488,39 @@ fueling quantity follows from a known value.
 
 Core constraints are:
 
-- explicit available weekdays as a unique set of ISO weekday integers `1..7`
-  (`1` Monday, `7` Sunday);
-- a strict boolean stating whether a nontechnical continuous three-minute
-  uphill is accessible;
-- a strict boolean stating whether controlled downhill terrain is accessible,
-  with no duration estimate requested or implied;
+- `available_weekdays`, known as a non-empty unique set of ISO weekday integers
+  `1..7` (`1` Monday, `7` Sunday);
+- `weekly_time_limit_min`, known as an integer from `1` through `10080`;
+- `maximum_session_duration_min`, known as an integer from `1` through `1440`
+  and not greater than `weekly_time_limit_min`;
+- `unavailable_dates`, known as a sorted unique set of at most `14` ISO dates,
+  all inside the requested 14-day horizon; an empty set is valid;
+- optional `preferred_longest_weekday`; omission means no preference, and a
+  supplied ISO weekday must appear in `available_weekdays`;
+- `nontechnical_three_minute_uphill_access`, known as a strict boolean;
+- `controlled_downhill_access`, known as a strict boolean, with no duration
+  estimate requested or implied;
 - accessible footing as the same six-value unordered set used by the course;
 - current adult/non-clinical scope and performance-intent confirmations; and
 - the current symptom-stop response required by the accepted Science boundary.
 
-Absent schedule input produces clarification. The planning-duration range is
-owned by the confirmed course revision above. A complete schedule that cannot
-fit the accepted envelope produces
-`readiness_blocked.no_schedule_within_envelope`. A missing or false uphill or
-downhill access boolean produces
-`readiness_blocked.insufficient_terrain_access`; it never triggers a flat-road
+Any missing or unknown required schedule field produces
+`clarification_required.training_constraints_missing`. Field values outside
+the Product/domain bounds above fail validation. A preferred weekday outside
+the available set is contradictory input. The planning-duration range is owned
+by the confirmed course revision above. A complete valid schedule that cannot
+fit unavailable dates, accepted history caps, or policy spacing produces
+`readiness_blocked.no_schedule_within_envelope`. An unknown uphill or downhill
+access boolean requires clarification; a known `false` value produces
+`readiness_blocked.insufficient_terrain_access`. Neither triggers a flat-road
 replacement. If course footing is known, missing required footing from the
 access set produces the same terrain-access block.
+
+An explicit request or proposal edit above the server-derived history envelope
+produces
+`clarification_required.training_constraints_outside_history_envelope`. A
+larger capacity limit by itself is not a request to increase load and never
+raises the accepted history cap.
 
 The downhill boolean intentionally has no minutes, distance, slope, speed, or
 maximum-repeat field. Product does not turn “access exists” into a safe dose.
@@ -465,7 +561,8 @@ The following are always core and cannot be converted into a module limit:
 - confirmed planning-duration range;
 - supported population, format, distance family, and intent;
 - current symptom-stop response;
-- available schedule and accepted time/session envelope;
+- known available weekdays, weekly time, maximum session, unavailable dates,
+  preferred-day consistency, and the accepted history envelope;
 - nontechnical three-minute uphill access and controlled-downhill access;
 - recent running, ascent, and descent history;
 - `hands_assist` and `fixed_rope`; and
@@ -496,30 +593,79 @@ The v2 planning contract does not collect or persist:
 
 The current goal must remain user-controllable in the Praxys UI:
 
-- **Reset:** reset the current v2 course/constraint draft to explicit unknowns,
-  invalidate its confirmation, and create a new revision. Reset does not
-  rewrite source activities.
-- **Export:** include the current goal, canonical entered values, server-stamped
-  provenance, revisions, confirmations, readiness status, all matching
-  reasons, limited modules, and any proposal/adoption records already covered
-  by the account export contract.
-- **Deletion:** remove the current goal's v2 drafts, confirmations, derived
-  readiness snapshots, and proposal linkage under the accepted account/goal
-  deletion contract. Failures remain visible and retryable according to Trust
-  policy; Product does not define storage mechanics here.
+Before a proposal, Praxys retains only the current mutable unproposed v2 draft.
+A successful save atomically overwrites its previous values, current revisions,
+and invalidated confirmations. It creates no immutable edit history,
+confirmation event stream, standalone readiness snapshot, or value telemetry.
+Immutable retention begins only when proposal creation atomically writes its
+exact goal snapshot, proposal, and minimized policy audit.
 
-Reset, export, and deletion are authenticated, owner-scoped actions. This
-amendment does not create public sharing, course catalogs sourced from user
-data, cross-user aggregates, or administrator access to planning content.
+- **Reset:** replace the current editable v2 values with explicit unknowns,
+  invalidate current confirmations, and issue new current revisions. Reset is
+  not erasure: it does not rewrite source activities or remove retained
+  immutable proposal snapshots and audits. The Praxys UI must state this
+  distinction.
+- **Export:** include the complete current draft, canonical values and unknowns,
+  server-stamped provenance and source metadata, revisions, confirmations, and
+  every retained immutable goal/proposal snapshot, policy audit, readiness
+  receipt, matching reason, module-availability result, and redundant limited
+  module projection covered by the account export contract.
+- **Deletion:** goal deletion and account deletion remove the current v2
+  namespace and every retained owned snapshot, proposal linkage, audit, index,
+  and cache under the accepted deletion contract. Unknown schema versions have
+  the same export and deletion rights. Failure rolls back or uses the
+  repository's explicit durable cleanup-pending behavior; it never reports
+  completion while known owned data remains.
+
+Reset, export, and deletion follow the Trust decision's first-party,
+authenticated, non-demo owner boundary. This amendment creates no public
+sharing, user-sourced course catalog, cross-user aggregate, MCP surface, or
+administrator Trail surface.
+
+## Actor, navigation, and compatibility boundaries
+
+This amendment adopts by reference the exact owner-isolation, data-free URL,
+and zero-I/O Garmin constraints in the proposed Trail v2 Architecture and
+Trust decisions.
+
+Every Trail read, save, reset, confirmation, readiness, proposal creation/read,
+adoption-related read, export, goal deletion, and compatibility-summary
+operation derives authority only from the active first-party authenticated,
+non-demo owner. Missing and cross-owner objects return the same repository
+private `404`. A demo viewer is rejected before demo-source resolution. No
+Trail operation accepts an owner/actor ID, MCP grant, administrator identity,
+support identity, or client hiding as authority. Existing whole-account
+administration may perform its already-authorized cascade without exposing
+Trail content; it is not a Trail read/write surface.
+
+URL paths, query strings, fragments, browser history, navigation state, deep
+links, analytics, logs, and referrers may carry only closed route, section,
+field, or reason-target keys. They carry no entered value, unknown state, date,
+event/goal/proposal/owner/provider ID, revision, digest, serialized DTO, token,
+or source metadata. The authenticated page fetches current state from the
+server.
+
+Only after an adopted canonical plan exists may the future inactive slice
+compute a Garmin compatibility summary. It is a pure, deterministic, no-write
+projection over stored canonical workouts and a versioned internal matrix. It
+may report only internal `unverified` or `blocked` compatibility and closed
+per-workout reasons; it cannot claim actual account, device, firmware, region,
+or provider support.
+
+The projection performs zero credential/tokenstore loads, adapter or network
+calls, provider reads/writes, identifier access, discovery, consent/ledger
+access, persistence, scheduling, send, retry, replace, reconcile, or delete.
+Live provider compatibility and every form of Garmin delivery remain outside
+v2 and require a new reviewed decision.
 
 ## Product promise and scenarios
 
 ### Product promise
 
 Inside Praxys, the owner can see one stable readiness status, every applicable
-reason, and every omitted module before deciding whether to review a bounded
-proposal. Praxys never makes a missing value look known and never substitutes
-a road plan.
+reason, and the authoritative availability of every module before deciding
+whether to review a bounded proposal. Praxys never makes a missing value look
+known and never substitutes a road plan.
 
 Design owns how this appears in the UI and must preserve the accepted
 Experience Specification's distinction between goal, readiness, proposal,
@@ -528,10 +674,11 @@ component, layout, color, or copy string.
 
 ### Representative scenarios
 
-- **Core complete, grade unknown:** return `eligible_proposal`, include
-  `grade_specificity`, and omit grade-specific behavior.
-- **Core complete, footing unknown:** return `eligible_proposal`, include
-  `technical_terrain`, and do not infer an easy surface.
+- **Core complete, grade unknown:** return `eligible_proposal`, set
+  `grade_specificity` to `limited`, and omit grade-specific behavior from a
+  later proposal.
+- **Core complete, footing unknown:** return `eligible_proposal`, set
+  `technical_terrain` to `limited`, and do not infer an easy surface.
 - **Known rocky course, no rocky access:** include
   `readiness_blocked.insufficient_terrain_access`; preserve every other
   matching reason.
@@ -543,27 +690,32 @@ component, layout, color, or copy string.
   `technical_features_outside_v2`.
 - **Policy inactive and recent descent absent:** top-level status is
   `policy_unavailable`, primary detail is `policy_inactive`, and the complete
-  reason receipt also preserves `insufficient_descent_history`.
+  reason receipt also preserves `insufficient_descent_history`; affected
+  modules are `not_evaluated` rather than “included.”
 - **Malformed grade total plus inactive policy:** top-level status is
   `validation_failed`; the receipt still preserves the policy reason if the
   request can be safely classified without interpreting the malformed value.
 - **Course environment unknown:** permit eligibility only if core gates pass,
-  include `environment_altitude`, and show no environment-specific dose.
+  set `environment_altitude` to `limited`, and show no environment-specific
+  dose.
 - **Fueling or aid context unknown:** permit eligibility only if core gates
-  pass, include `fueling`, and prescribe no quantity.
+  pass, set `fueling` to `limited`, and prescribe no quantity.
 
 ## Non-goals
 
 - Changing the accepted 14-day proposal, seven-day reassessment, history, load,
   workout-template, taper, or intensity Science parameters.
+- Hiking, strength, or taper input/dose modules; all three remain disabled
+  pending a separately accepted input and Science contract.
 - Declaring grade, footing, support, environment, or gastrointestinal values a
   safety score or performance predictor.
 - Finish-time prediction, personal finish probability, diagnosis, clearance,
   rehabilitation, or treatment advice.
 - Ultra, multiday, first-completion, pediatric, clinical, return-to-sport, or
   unsupported-intent planning.
-- Route ingestion, route search, course scraping, provider data import, Garmin
-  workout mapping, provider consent, or delivery.
+- Route ingestion, route search, course scraping, provider data import, live
+  Garmin compatibility, workout mapping, provider consent, or delivery. The
+  data-free pure internal summary above is the only v2 compatibility surface.
 - Automatic adoption, invitation, promotion, catalog exposure, owner pilot,
   deployment, activation, or production use.
 - Value analytics, behavioral telemetry, experimentation, cross-user
@@ -578,9 +730,10 @@ human comprehension, not adoption or retention metrics.
 ### Success measures
 
 - Every valid test fixture produces one of the five statuses and only cataloged
-  reason/module values.
+  reason/module values, with all four authoritative module states present.
 - Reordered inputs, sets, and independent evaluator paths produce the same
-  canonical status, reason order, limited-module order, and replay digest.
+  canonical status, reason order, module availability, redundant
+  limited-module order, and replay digest.
 - Every matching reason remains available in the response while one stable
   status and primary detail provide the next action.
 - Core unknowns and failed gates never yield `eligible_proposal`; non-core
@@ -600,11 +753,17 @@ The tolerated count is zero for:
 - non-catalog status, detail, module, footing, or enum values;
 - stale confirmation or source-revision acceptance;
 - grade shares not summing to `10000` or boundary misclassification;
+- schedule, planning-duration, distance, ascent, or descent domain-bound
+  escape;
 - athlete-provided recent-history aggregates or client-selected provenance;
 - GPS, route, URL, provider-payload, diagnosis, free-text planning, or value
   telemetry collection;
-- use of activity `avg_power`, road fallback, lossy Trail relabeling, automatic
-  adoption, or provider delivery; and
+- Trail state or authority in navigation, demo, MCP, administrator, support,
+  or cross-owner surfaces;
+- any Garmin credential, adapter, provider, consent, delivery-ledger, or
+  network I/O;
+- use of activity `avg_power`, road fallback, lossy Trail relabeling,
+  automatic adoption, or provider delivery; and
 - any visibility or activation beyond a separately authorized runtime change.
 
 ### Falsification conditions
@@ -636,7 +795,8 @@ establish efficacy, safety, or general demand.
 - **Trust** owns data minimization, authorization, retention, reset/export/
   deletion enforcement, and sensitive-data handling.
 - **Design** owns the complete Praxys UI journey, content, accessibility, and
-  rendered distinction among status, reasons, and limited modules.
+  rendered distinction among status, reasons, module availability, and actual
+  proposal inclusion.
 - **Engineering** may implement only the exact accepted inactive slice.
 - **Quality** independently verifies the exact head and all status/reason,
   data-rights, privacy, and fail-closed scenarios.

--- a/docs/dev/trail-running-plan-product-amendment-v2.md
+++ b/docs/dev/trail-running-plan-product-amendment-v2.md
@@ -1,0 +1,609 @@
+# Trail-running managed-plan Product amendment v2
+
+**Status:** proposed logical-contract successor/addendum; human Product review
+required; runtime inactive.
+
+**Authority boundary:** this amendment may authorize only a future inactive
+implementation after human acceptance. It does not authorize a pilot,
+owner-only exposure, production-data use, provider integration or delivery,
+deployment, capability activation, catalog visibility, or wider rollout.
+
+**Digest:** pending deterministic generation after the review text is frozen;
+no digest is assigned or implied by this draft.
+
+## Human decision sheet
+
+The human Product reviewer should record **approve**, **revise**, or **reject**
+for each choice. Approval of one row does not imply approval of another.
+
+| # | Choice | Recommended Product decision |
+| --- | --- | --- |
+| 1 | Stable readiness result | Adopt the five canonical statuses, exhaustive namespaced reason catalog, deterministic precedence, complete matching-reason receipt, and separate `limited_modules`. |
+| 2 | Versioned input contract | Adopt `trail_course_demand_v2` and `non_ultra_trail_constraints_v2`, strict known/unknown request values, server-stamped provenance, and revision-bound confirmation. |
+| 3 | Course description | Adopt integer grade-share buckets, the six-value footing vocabulary, explicit hazard gates, and bounded environment, support, fueling, and gastrointestinal context without routes or free-text planning inputs. |
+| 4 | Access and history | Require explicit training weekdays and terrain access while keeping the 42/21-day recent-history assessment server-derived. Treat planning duration as an athlete-confirmed range, not a prediction. |
+| 5 | Block versus limit | Keep core readiness gates fail-closed, but allow ordinary grade, footing, environment, support, and fueling unknowns to limit only their named modules when all core gates pass. |
+| 6 | Data and runtime boundary | Preserve reset, export, and deletion for the current goal; collect no value telemetry; forbid diagnosis, activity `avg_power`, road fallback, route/provider payloads, and any authority beyond inactive implementation. |
+
+## Work Contract and shared decision fields
+
+- **Classification:**
+  `sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607`
+- **Route:**
+  `sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168`
+- **ID:** `pdr-owner-non-ultra-trail-plan-v2-amendment`
+- **Schema version:** logical-contract; the repository does not yet define a
+  persisted Product Decision Record schema.
+- **Decision type:** Product Decision Record successor/addendum.
+- **Owner role:** Product.
+- **Question:** Should Praxys replace the ambiguous v1 Trail readiness input
+  and outcome surface with a strict v2 contract that remains useful when
+  non-core context is unknown, without weakening course, history, access,
+  hazard, data-rights, or runtime boundaries?
+- **Options:** adopt v2 as proposed; retain v1 and patch individual failures;
+  require every descriptive field before any proposal; or infer missing
+  values and fall back to an existing plan family.
+- **Recommendation:** adopt the bounded v2 behavior in this amendment for
+  future inactive implementation only.
+- **Rationale:** users need one stable verdict, every applicable reason, and a
+  clear distinction between “no proposal” and “one module is limited.” Strict
+  typed values and explicit confirmation prevent hidden defaults while still
+  allowing a useful proposal when only non-core descriptive context is
+  unknown.
+- **Dependencies:** the accepted v1 Trail Evidence Reviews and inactive Science
+  Decision Records; an independently accepted Science successor for any v2
+  applicability or safety change; Design review of the resulting journey;
+  Architecture review of canonical serialization and revision fences; Trust
+  review of minimization, authorization, export, reset, and deletion; Quality
+  verification of the exact implementation.
+- **Review route:** human-review-required. Product neither approves this
+  proposal nor selects a different route.
+- **Outcome plan:** verify the inactive contract deterministically, then use
+  only explicit owner-supplied dogfood feedback after a separately authorized
+  activation. This amendment adds no value telemetry.
+- **Digest:** generated later from the frozen artifact; deliberately absent
+  from this proposal.
+
+This document is an additive successor to
+`trail-running-plan-product-proposal.md`. Where the two conflict, this v2
+proposal describes the requested future behavior, but it has no authority
+until human review accepts its exact frozen content.
+
+## User problem, observed signal, and assumptions
+
+### Observed signal
+
+The authenticated owner is preparing for the Ninghai Trail Challenge on
+2026-11-15 (24.7 km and 618 m stated ascent), wants the complete experience in
+the Praxys UI, and prefers to improve it through their own dogfood use. The
+owner found the Product and Experience documents easier to review than the
+machine-oriented Science packets. That is a usability signal for the review
+contract, not evidence that the proposed training policy is effective.
+
+The current inactive implementation exposes v1 inputs and collapses many
+different facts into a single result/detail pair. It can therefore hide
+simultaneous next actions and can make a non-core missing value look equivalent
+to a core readiness stop.
+
+No broader demand, adoption rate, safety outcome, or efficacy signal is
+claimed. No product-value telemetry exists for this proposed behavior.
+
+### Assumptions to test later
+
+- An owner can provide the bounded event and access fields without uploading a
+  route, linking a course URL, or understanding the Science registry.
+- One stable status plus a complete reason receipt is easier to act on than a
+  long flat outcome enumeration.
+- A proposal with explicitly limited grade, technical-terrain, environment, or
+  fueling modules can still be useful when every core readiness gate passes.
+- A confirmed planning-duration range is sufficient planning context without
+  presenting a finish-time prediction.
+
+These are Product hypotheses. They are not scientific findings or activation
+criteria.
+
+## Product options and trade-offs
+
+### A. Adopt the strict v2 contract — recommended
+
+Use two versioned schemas, five statuses, a closed reason catalog, complete
+reason preservation, and independent module limits. This creates more input
+work for the owner but makes every default, limit, and stop inspectable.
+
+### B. Keep v1 and patch individual outcomes — not recommended
+
+This is the smallest code change, but it preserves an unstable response
+contract and continues to conflate course clarification, readiness, policy
+availability, and validation.
+
+### C. Require every course descriptor before a proposal — not recommended
+
+This is simple and conservative, but it blocks useful organization when grade,
+ordinary footing, environment, support, or fueling context is genuinely
+unknown and the corresponding module can instead be omitted honestly.
+
+### D. Infer unknowns or fall back to a road plan — rejected
+
+This reduces input burden by manufacturing certainty. It would erase material
+Trail distinctions, contradict the accepted boundary, and undermine trust.
+
+## Minimum valuable v2 behavior
+
+The minimum valuable behavior is a versioned, replayable readiness receipt
+that can either authorize the existing bounded proposal envelope or explain
+all reasons it cannot. It does not itself create, adopt, deliver, or activate a
+plan.
+
+### Canonical status contract
+
+Every v2 evaluation returns exactly one top-level `status`:
+
+1. `validation_failed`
+2. `policy_unavailable`
+3. `readiness_blocked`
+4. `clarification_required`
+5. `eligible_proposal`
+
+This list is also the deterministic precedence from highest to lowest. A
+malformed or non-replayable request cannot be presented as a meaningful policy
+or readiness outcome. An unavailable policy outranks athlete readiness. A
+confirmed stop outranks missing clarification. `eligible_proposal` is possible
+only when no reason in a higher status matches.
+
+The response also carries:
+
+- `detail_reason`: the first matching reason inside the selected status,
+  following the fixed catalog order below;
+- `matching_reasons`: every matching `(status, detail_reason)` pair across all
+  statuses, de-duplicated and ordered first by status precedence and then by
+  catalog order; and
+- `limited_modules`: a separate sorted set that never changes the top-level
+  status or hides a matching reason.
+
+The fully qualified, namespaced identity of a reason is
+`<status>.<detail_reason>`. Clients must not construct new reason strings,
+replace the full receipt with the first reason, or infer eligibility from an
+empty module-limit list.
+
+“Every matching reason” means every condition the server can safely evaluate.
+A malformed value is never dereferenced merely to discover more reasons; the
+receipt preserves all other independently evaluable matches.
+
+### Exhaustive reason catalog
+
+The following is the complete v2 Product catalog. Adding, removing, renaming,
+or reclassifying a reason requires a successor Product decision and matching
+specialist review.
+
+| Status | Ordered `detail_reason` values | Product meaning |
+| --- | --- | --- |
+| `clarification_required` | `material_course_demand_unknown`; `assumption_confirmation_required`; `adult_scope_or_constraints_unconfirmed`; `training_constraints_missing`; `contradictory_input` | The owner can resolve or confirm required input; no proposal is returned. |
+| `readiness_blocked` | `insufficient_recent_running_history`; `insufficient_comparable_trail_history`; `insufficient_descent_history`; `insufficient_terrain_access`; `current_symptom_stop`; `no_schedule_within_envelope` | Valid, confirmed input does not satisfy a current core readiness gate; no substitute plan is returned. |
+| `policy_unavailable` | `policy_inactive`; `event_inside_unapproved_taper_window`; `unsupported_ultra_or_multiday`; `unsupported_population_or_intent`; `technical_features_outside_v2` | The requested use is outside the exact available policy or its current runtime state. `policy_inactive` is a detail reason here, never a sixth top-level status. |
+| `validation_failed` | `invalid_field_value`; `schema_version_mismatch`; `deterministic_invariant_failed` | The request or result cannot be safely interpreted or replayed. |
+| `eligible_proposal` | none | Core gates pass. Any non-core omissions are visible only through `limited_modules`. |
+
+Authorization failures remain fail-closed before this Product result and do
+not become readiness reasons. A private owner-only boundary must not be leaked
+through this catalog.
+
+### Limited modules
+
+`limited_modules` is an unordered set serialized in deterministic sorted order.
+It permits only these values:
+
+- `grade_specificity`;
+- `technical_terrain`;
+- `environment_altitude`; and
+- `fueling`.
+
+Unknown grade distribution limits `grade_specificity`. Unknown ordinary
+footing limits `technical_terrain`. Unknown altitude, temperature, humidity,
+wind, or exposure limits `environment_altitude`. Unknown aid/support, fueling
+practice, or non-diagnostic gastrointestinal experience limits `fueling`; v2
+does not expose a separate aid-support training module.
+
+A module limit means that module is omitted or remains descriptive. It never
+authorizes a generic replacement, a hidden default, a dose increase, or a
+claim that the missing module is unnecessary.
+
+## Versioned request and confirmation contract
+
+### Schema identities
+
+- Course demand: `trail_course_demand_v2`.
+- Athlete constraints: `non_ultra_trail_constraints_v2`.
+
+Schema identity is exact. There is no “closest supported” interpretation. A v1
+payload sent to a v2 boundary, an unknown field, a duplicate set member, a
+wrong unit, or a mismatched schema produces
+`validation_failed.schema_version_mismatch` or
+`validation_failed.invalid_field_value` as applicable.
+
+### Strict known/unknown values
+
+Every reviewable input uses one of two shapes:
+
+```text
+{ state: known, value: <typed value> }
+{ state: unknown }
+```
+
+`known` requires exactly one schema-valid value. `unknown` carries no value.
+Missing state, `null`, empty string, sentinel numbers, guessed zero, `other`,
+and client-provided arbitrary objects are invalid. The server response may add
+provenance and revision metadata, but clients cannot submit or overwrite those
+fields.
+
+### Provenance and revision fence
+
+The server stamps provenance from the authenticated write path. The client may
+submit a value but may not label itself `course_entered`, `history_observed`,
+or otherwise choose a more authoritative source. Grade distribution accepts
+only server-stamped `athlete_entered` or `course_entered` provenance. It is
+never inferred from a route, model, activity trace, or provider payload in v2.
+
+Each mutation creates a new immutable course/constraint revision. Confirmation
+names the exact revision being confirmed. Any value, state, or server-stamped
+provenance change invalidates the previous confirmation. Readiness and a later
+proposal bind the exact goal, course, constraint, history-snapshot, policy, and
+generator revisions; a stale confirmation or source revision cannot be
+silently rebound.
+
+## `trail_course_demand_v2`
+
+### Core confirmed course fields
+
+The following are core: event identity, event date, distance, total ascent,
+total descent, planning-duration range, scope, and the two hazard gates. They
+must be valid, known, and bound to the confirmed course revision before
+`eligible_proposal`.
+
+Event identity is the existing server-stamped goal/event identifier. The v2
+generator request does not accept a free-text event identity or source label.
+
+Planning duration is a confirmed integer minute range with `minimum < maximum`.
+It is the range the athlete wants Praxys to use for planning context. It is not
+a finish-time prediction, forecast, feasibility verdict, or performance
+promise.
+
+Event format, distance family, and performance intent remain closed enums.
+Unsupported ultra/multiday scope or population/intent produces the appropriate
+`policy_unavailable` reason; it is not coerced into the non-ultra policy.
+
+### Canonical grade-share buckets
+
+Grade distribution is optional descriptive context. When known, it is exactly
+five non-negative integer shares in basis points of course distance, and the
+five integers must sum to `10000`:
+
+| Bucket key | Exact grade boundary |
+| --- | --- |
+| `below_neg_10` | `g < -10%` |
+| `neg_10_to_below_neg_3` | `-10% <= g < -3%` |
+| `neg_3_to_below_pos_3` | `-3% <= g < 3%` |
+| `pos_3_to_below_pos_10` | `3% <= g < 10%` |
+| `pos_10_and_above` | `g >= 10%` |
+
+These basis points describe the share of distance in each bucket; they are not
+grade values. Boundary values belong only to the bucket shown above. The
+distribution may carry only `athlete_entered` or `course_entered` provenance.
+It is descriptive and must not be turned into a difficulty score, equivalent
+road distance, finish-time adjustment, workout dose, or safety threshold.
+
+Unknown grade is permitted only as `state: unknown` and adds
+`grade_specificity` to `limited_modules`.
+
+### Ordinary footing
+
+Known footing is a non-empty unordered set containing only:
+
+- `firm_smooth`;
+- `loose_gravel`;
+- `mud`;
+- `rocks_or_roots`;
+- `built_steps`; and
+- `water_crossing`.
+
+There is no `other`, difficulty score, ordering significance, or free-text
+surface description. Duplicate or unknown values fail validation. Unknown
+ordinary footing is allowed and limits `technical_terrain`.
+
+When course footing is known, access and observed-history matching use exact
+set containment, not similarity, synonyms, or model inference. Let `C` be the
+known course-footing set, `A` accessible footing, and `H` recently observed
+footing. `C` must be a subset of `A`; otherwise readiness includes
+`readiness_blocked.insufficient_terrain_access`. `C` must also be a subset of
+`H`; otherwise readiness includes
+`readiness_blocked.insufficient_comparable_trail_history`.
+
+### Hazard gates
+
+`hands_assist` and `fixed_rope` are separate tri-state values: `yes`, `no`, or
+`unknown`.
+
+- `unknown` requires clarification and cannot be reduced to ordinary footing;
+- `yes` is outside v2 and yields
+  `policy_unavailable.technical_features_outside_v2`; and
+- both must be confirmed `no` for `eligible_proposal`.
+
+These gates are not technical-difficulty ratings and do not authorize a
+diagnosis, skill assessment, or training dose.
+
+### Bounded optional context
+
+Optional context uses closed values only and may remain unknown:
+
+- maximum altitude: a canonical metric integer from `-500` through `9000`
+  meters;
+- expected temperature band: `below_0_c`, `0_to_below_10_c`,
+  `10_to_below_20_c`, `20_to_below_30_c`, or `30_c_and_above`;
+- expected humidity: `low`, `moderate`, or `high`;
+- wind exposure: `sheltered`, `mixed`, or `exposed`;
+- sun exposure: `low`, `mixed`, or `exposed`;
+- aid/support mode: `self_supported`, `organizer_aid`, or
+  `organizer_aid_and_personal_crew`;
+- aid interval: `none`, `below_5_km`, `5_to_below_10_km`, or
+  `10_km_and_above`;
+- fueling practice: `none`, `some`, or `repeated`; and
+- gastrointestinal experience: `no_issue_reported` or `issue_reported`.
+
+The gastrointestinal value is a non-diagnostic athlete report. It cannot be
+presented as a condition, clearance, treatment need, or causal explanation.
+These fields accept no notes, labels, URLs, units embedded in strings, or other
+free text. Missing wind or exposure information limits
+`environment_altitude`; it cannot be silently treated as sheltered. Missing
+aid/support, fueling, or gastrointestinal context limits `fueling`; no fixed
+fueling quantity follows from a known value.
+
+## `non_ultra_trail_constraints_v2`
+
+### Athlete-confirmed schedule and access
+
+Core constraints are:
+
+- explicit available weekdays as a unique set of ISO weekday integers `1..7`
+  (`1` Monday, `7` Sunday);
+- a strict boolean stating whether a nontechnical continuous three-minute
+  uphill is accessible;
+- a strict boolean stating whether controlled downhill terrain is accessible,
+  with no duration estimate requested or implied;
+- accessible footing as the same six-value unordered set used by the course;
+- current adult/non-clinical scope and performance-intent confirmations; and
+- the current symptom-stop response required by the accepted Science boundary.
+
+Absent schedule input produces clarification. The planning-duration range is
+owned by the confirmed course revision above. A complete schedule that cannot
+fit the accepted envelope produces
+`readiness_blocked.no_schedule_within_envelope`. A missing or false uphill or
+downhill access boolean produces
+`readiness_blocked.insufficient_terrain_access`; it never triggers a flat-road
+replacement. If course footing is known, missing required footing from the
+access set produces the same terrain-access block.
+
+The downhill boolean intentionally has no minutes, distance, slope, speed, or
+maximum-repeat field. Product does not turn “access exists” into a safe dose.
+
+### Server-derived recent history
+
+The client cannot submit, correct, or attest recent-history aggregates through
+the planning request. The server derives the current owner-scoped aggregate
+from accepted activity records and binds it to a source revision.
+
+The v2 readiness receipt keeps the accepted 42-day comparable-history window
+and 21-day recency check. It separately evaluates:
+
+- recent running continuity;
+- recent ascent exposure;
+- recent descent exposure; and
+- recently observed footing from the closed six-value vocabulary.
+
+Missing recent running produces
+`readiness_blocked.insufficient_recent_running_history`. Missing comparable
+ascent/Trail context or known course footing not contained in observed recent
+footing produces
+`readiness_blocked.insufficient_comparable_trail_history`. Missing descent
+exposure produces `readiness_blocked.insufficient_descent_history`.
+
+History provenance is server-derived. It is not replaced by athlete-entered
+claims, route geometry, provider summaries, or activity `avg_power`. When
+intensity context is needed, the accepted Science contract continues to allow
+only supported split/sample evidence; this Product amendment selects no new
+intensity target.
+
+## Core blockers versus module limits
+
+The following are always core and cannot be converted into a module limit:
+
+- event identity and date;
+- distance, total ascent, and total descent;
+- confirmed planning-duration range;
+- supported population, format, distance family, and intent;
+- current symptom-stop response;
+- available schedule and accepted time/session envelope;
+- nontechnical three-minute uphill access and controlled-downhill access;
+- recent running, ascent, and descent history;
+- `hands_assist` and `fixed_rope`; and
+- exact schema, confirmation, source revision, and deterministic invariants.
+
+Grade distribution and ordinary footing may be unknown and limit only
+`grade_specificity` and `technical_terrain`. Environment/altitude may be
+unknown and limit `environment_altitude`. Aid/support, fueling, and
+gastrointestinal context may be unknown and limit `fueling`.
+
+Known values do not automatically enable a module. Specialist Science limits,
+accepted access/history matching, and deterministic validation still apply.
+Product is deciding the user-value trade-off between block and limit, not a
+biological dose.
+
+## Data minimization and user control
+
+The v2 planning contract does not collect or persist:
+
+- GPS points, route files, polylines, maps, or inferred course geometry;
+- course-source URLs or scraped course content;
+- provider request/response payloads or device identifiers;
+- free-text health, symptom, fueling, surface, or course narratives;
+- diagnoses, medical clearance, or injury probability;
+- activity `avg_power` as readiness or intensity evidence; or
+- a road-equivalent distance, pace, load, or fallback plan.
+
+The current goal must remain user-controllable in the Praxys UI:
+
+- **Reset:** reset the current v2 course/constraint draft to explicit unknowns,
+  invalidate its confirmation, and create a new revision. Reset does not
+  rewrite source activities.
+- **Export:** include the current goal, canonical entered values, server-stamped
+  provenance, revisions, confirmations, readiness status, all matching
+  reasons, limited modules, and any proposal/adoption records already covered
+  by the account export contract.
+- **Deletion:** remove the current goal's v2 drafts, confirmations, derived
+  readiness snapshots, and proposal linkage under the accepted account/goal
+  deletion contract. Failures remain visible and retryable according to Trust
+  policy; Product does not define storage mechanics here.
+
+Reset, export, and deletion are authenticated, owner-scoped actions. This
+amendment does not create public sharing, course catalogs sourced from user
+data, cross-user aggregates, or administrator access to planning content.
+
+## Product promise and scenarios
+
+### Product promise
+
+Inside Praxys, the owner can see one stable readiness status, every applicable
+reason, and every omitted module before deciding whether to review a bounded
+proposal. Praxys never makes a missing value look known and never substitutes
+a road plan.
+
+Design owns how this appears in the UI and must preserve the accepted
+Experience Specification's distinction between goal, readiness, proposal,
+adoption, and provider delivery. This Product amendment does not dictate a
+component, layout, color, or copy string.
+
+### Representative scenarios
+
+- **Core complete, grade unknown:** return `eligible_proposal`, include
+  `grade_specificity`, and omit grade-specific behavior.
+- **Core complete, footing unknown:** return `eligible_proposal`, include
+  `technical_terrain`, and do not infer an easy surface.
+- **Known rocky course, no rocky access:** include
+  `readiness_blocked.insufficient_terrain_access`; preserve every other
+  matching reason.
+- **Known rocky course, access present, no recent rocky observation:** include
+  `readiness_blocked.insufficient_comparable_trail_history`.
+- **Hazard unknown:** return `clarification_required` with the material unknown
+  and confirmation reason as applicable.
+- **Fixed rope or hands-assist confirmed:** return `policy_unavailable` with
+  `technical_features_outside_v2`.
+- **Policy inactive and recent descent absent:** top-level status is
+  `policy_unavailable`, primary detail is `policy_inactive`, and the complete
+  reason receipt also preserves `insufficient_descent_history`.
+- **Malformed grade total plus inactive policy:** top-level status is
+  `validation_failed`; the receipt still preserves the policy reason if the
+  request can be safely classified without interpreting the malformed value.
+- **Course environment unknown:** permit eligibility only if core gates pass,
+  include `environment_altitude`, and show no environment-specific dose.
+- **Fueling or aid context unknown:** permit eligibility only if core gates
+  pass, include `fueling`, and prescribe no quantity.
+
+## Non-goals
+
+- Changing the accepted 14-day proposal, seven-day reassessment, history, load,
+  workout-template, taper, or intensity Science parameters.
+- Declaring grade, footing, support, environment, or gastrointestinal values a
+  safety score or performance predictor.
+- Finish-time prediction, personal finish probability, diagnosis, clearance,
+  rehabilitation, or treatment advice.
+- Ultra, multiday, first-completion, pediatric, clinical, return-to-sport, or
+  unsupported-intent planning.
+- Route ingestion, route search, course scraping, provider data import, Garmin
+  workout mapping, provider consent, or delivery.
+- Automatic adoption, invitation, promotion, catalog exposure, owner pilot,
+  deployment, activation, or production use.
+- Value analytics, behavioral telemetry, experimentation, cross-user
+  aggregation, or using one owner's dogfood as efficacy or safety evidence.
+
+## Success, guardrails, and falsification
+
+Because this amendment authorizes no runtime use or value telemetry, its
+pre-activation success measures are deterministic verification and explicit
+human comprehension, not adoption or retention metrics.
+
+### Success measures
+
+- Every valid test fixture produces one of the five statuses and only cataloged
+  reason/module values.
+- Reordered inputs, sets, and independent evaluator paths produce the same
+  canonical status, reason order, limited-module order, and replay digest.
+- Every matching reason remains available in the response while one stable
+  status and primary detail provide the next action.
+- Core unknowns and failed gates never yield `eligible_proposal`; non-core
+  unknowns never become hidden defaults.
+- The owner can reset, export, and delete the current goal through Praxys-owned
+  controls in later independently verified UI work.
+- A human reviewer can explain, from the readiness receipt, why the result is a
+  block, clarification, unavailable policy, validation failure, or eligible
+  proposal without reading a machine contract.
+
+### Guardrail measures
+
+The tolerated count is zero for:
+
+- unknown-to-known coercion;
+- missing or overwritten matching reasons;
+- non-catalog status, detail, module, footing, or enum values;
+- stale confirmation or source-revision acceptance;
+- grade shares not summing to `10000` or boundary misclassification;
+- athlete-provided recent-history aggregates or client-selected provenance;
+- GPS, route, URL, provider-payload, diagnosis, free-text planning, or value
+  telemetry collection;
+- use of activity `avg_power`, road fallback, lossy Trail relabeling, automatic
+  adoption, or provider delivery; and
+- any visibility or activation beyond a separately authorized runtime change.
+
+### Falsification conditions
+
+Revise or reject this Product recommendation before activation if independent
+verification shows that:
+
+- the five-status model cannot preserve materially different next actions;
+- module limits allow a session that the accepted Science contract requires to
+  block;
+- an ordinary unknown cannot be distinguished from a core unknown;
+- strict structured inputs make the owner unable to describe the real event
+  without adding sensitive free text or route data;
+- reset, export, or deletion cannot remain complete and owner-scoped; or
+- Architecture, Trust, Science, Design, or Quality identifies an unresolved
+  constraint that this Product trade-off would override.
+
+After a separately reviewed activation, Product may assess explicit owner
+feedback through existing private feedback controls. No automatic value
+telemetry is authorized by this amendment, and one owner's experience cannot
+establish efficacy, safety, or general demand.
+
+## Specialist authority and implementation handoff
+
+- **Science** owns applicability, materiality, history and safety boundaries,
+  and whether any module or generated workout remains inside accepted claims.
+- **Architecture** owns canonical DTO serialization, revision and replay
+  boundaries, concurrency, storage, and compatibility strategy.
+- **Trust** owns data minimization, authorization, retention, reset/export/
+  deletion enforcement, and sensitive-data handling.
+- **Design** owns the complete Praxys UI journey, content, accessibility, and
+  rendered distinction among status, reasons, and limited modules.
+- **Engineering** may implement only the exact accepted inactive slice.
+- **Quality** independently verifies the exact head and all status/reason,
+  data-rights, privacy, and fail-closed scenarios.
+- **Operations** owns any later deployment, configuration, observability, and
+  rollback decision.
+
+No specialist constraint is accepted merely because it is summarized here;
+the corresponding role's reviewed artifact remains authoritative.
+
+## Human Product decision requested
+
+Approve, revise, or reject each of the six choices in the decision sheet. If
+approved, the effect is limited to preparing a future inactive v2
+implementation under the accepted specialist constraints. Acceptance does not
+merge code, deploy, use production data, start dogfood, expose a catalog item,
+activate a capability, or send anything to Garmin or another provider.

--- a/docs/dev/trail-running-plan-trust-decision-v2.md
+++ b/docs/dev/trail-running-plan-trust-decision-v2.md
@@ -1,0 +1,273 @@
+# Trail-running managed-plan Trust decision v2
+
+- **Artifact type:** Trust Decision Record
+- **Owner role:** Trust
+- **Status:** proposed; human-review-required; runtime inactive
+- **Decision ID:** `tdr-owner-non-ultra-trail-plan-v2`
+- **Work Contract classification:**
+  `sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607`
+- **Work Contract route:**
+  `sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168`
+
+## Decision requested
+
+Approve, revise, or reject the Trust boundary for a future inactive Trail v2
+implementation.
+
+The proposed implementation may store one current owner draft, create
+immutable proposal snapshots and a minimized proposal audit, evaluate
+readiness, and show a pure internal Garmin compatibility summary. It must not
+expose Trail data or authority through demo accounts, MCP, administrator
+views, URLs, telemetry, logs, provider integrations, or cross-owner
+identifiers.
+
+This record depends on the exact accepted Product, Experience, Science, and
+Architecture v2 decisions. A material dependency change requires Trust
+re-review and digest rebinding.
+
+## Human decision sheet
+
+| # | Trust decision | Recommendation |
+| --- | --- | --- |
+| 1 | Owner isolation | Require an active, non-demo first-party authenticated owner for every Trail operation; provide no demo, MCP, administrator, or source-account fallback. |
+| 2 | Input authority | Separate strict client request DTOs from server-owned provenance, history, revisions, and policy results. |
+| 3 | Minimization and abuse bounds | Accept only the closed typed fields and exact structural limits below; collect no route, free text, provider data, or value telemetry. |
+| 4 | Retention and data rights | Keep only the current mutable unproposed draft; retain proposal snapshots and audit under existing proposal/account policy; distinguish reset from erasure. |
+| 5 | Sensitive context | Keep symptom and gastrointestinal input coarse, bounded, non-diagnostic, and unusable for clinical inference. |
+| 6 | Leakage controls | Permit only closed navigation keys and low-cardinality operational logs containing no personal value, revision, identifier, or user hash. |
+| 7 | Garmin boundary | Permit only a deterministic internal compatibility projection with zero credential, adapter, provider, consent, or delivery access. |
+| 8 | Unknown versions and migration | Preserve unknown schemas for owner read/export but never execute them; require complete export/delete coverage for the additive audit migration. |
+
+## Protected assets, actors, and threats
+
+Protected assets are the current Trail draft, explicit unknown states,
+server-owned provenance and revisions, confirmation bindings, minimized
+history aggregates, immutable proposal snapshots, audit receipts,
+symptom-stop and gastrointestinal context, cross-owner object existence, and
+complete export/deletion. Browser history, logs, caches, metrics, Garmin
+credentials, tokenstores, sessions, consent, provider identifiers, and
+delivery ledgers are also protected boundaries.
+
+The only authorized interactive actor is the active, non-demo owner using a
+first-party Praxys viewer session. The API, database, evaluator, internal
+compatibility matrix, export service, and deletion service enforce that
+authority. Unauthenticated callers, another owner, demo viewers, MCP sessions
+or grants, administrators, support users, browser extensions, and modified
+clients have no Trail read or write authority. Existing whole-account
+lifecycle administration may perform its already-authorized cascade without
+exposing Trail content; it is not a Trail administration surface. Garmin and
+other providers are not actors in this slice.
+
+Threats include cross-owner reference and existence probing, demo-source
+inheritance, an MCP/admin route being treated as consent, client-forged
+provenance or revisions, stale-confirmation races, pathological request
+payloads, planning values leaking into URLs/logs/caches, unnecessary draft
+history, incomplete export or deletion, unknown schemas being partially
+interpreted, health answers becoming clinical inference, and a Garmin preview
+crossing into credential or provider access.
+
+## Trust decision
+
+### 1. Enforce first-party owner isolation on every operation
+
+Every Trail read, save, reset, confirmation, readiness evaluation, proposal
+creation/read, adoption-related read, export, goal deletion, and Garmin-summary
+operation derives ownership solely from the active first-party authenticated
+viewer.
+
+Trail endpoints reject demo viewers before resolving `demo_of`; they are not
+MCP-allowlisted and do not accept an MCP grant, administrator identity, owner
+ID, or actor ID as authority. Every object lookup includes the authenticated
+owner predicate. A missing or cross-owner object returns the same private
+`404`, without disclosing existence or state. Authentication and legal-bundle
+failures stay outside Product readiness results. Client hiding is not an
+authorization boundary.
+
+### 2. Separate client input from server authority
+
+A request may carry only the exact schema identity, closed typed known/unknown
+values, an allowed confirmation action, and an opaque server-issued
+concurrency precondition. It cannot author provenance, source timestamp,
+model, revision, history aggregate/hash, owner identity, policy result, module
+availability, compatibility state, or audit metadata. Extra keys and coercion
+fail validation.
+
+The server stamps provenance and revisions only after owner-scoped validation.
+Recent history remains server-derived. Each mutation and confirmation uses
+owner-scoped locking and the exact revision precondition. Editing a value or
+source invalidates its confirmation. Proposal creation locks and re-reads the
+draft and plan, recomputes history and the composite revision, and creates
+nothing when any binding changed. Confirmation means only “reviewed this
+revision”; it is not truth, safety, eligibility, or medical attestation.
+
+### 3. Apply exact structural anti-abuse limits
+
+Before JSON parsing, a Trail v2 body is at most **32 KiB UTF-8**; compressed
+bodies and malformed UTF-8 are rejected. After parsing:
+
+- maximum nesting depth is **8**;
+- each object has at most **64 members**;
+- each array or set has at most **32 entries**;
+- each string has at most **128 Unicode scalar values** after NFC
+  normalization;
+- duplicate object keys and set members are rejected;
+- numeric tokens have at most **16 ASCII characters**;
+- exponent notation and non-finite values are rejected; and
+- before tighter field checks, integers fit signed 32-bit range and decimals
+  have absolute value at most `1,000,000` with at most two fractional digits.
+
+Canonicalization never logs rejected values. Product/Science field bounds
+remain tighter where specified. These are abuse and operability bounds, not
+training, safety, or biological thresholds.
+
+### 4. Minimize collected and derived data
+
+The slice may process or retain only normalized closed values, explicit
+unknown states, server provenance, revisions and confirmations, minimized
+history aggregates, immutable proposal content, and replay digests accepted by
+its dependency decisions.
+
+It does not collect, persist, copy into generic audit, or emit free-text
+course/health/fueling narratives; GPS, routes, maps, inferred geometry or
+course URLs; scraped content; provider payloads or identifiers; device IDs;
+credentials or sessions; request bodies; diagnoses, clearance, injury or
+performance probabilities; activity `avg_power`; entered-value analytics; or
+a stable, pseudonymous, or hashed user identifier. Normal owner/proposal
+foreign keys remain internal authorization and deletion locators, not
+telemetry identities.
+
+### 5. Define retention, reset, export, and erasure separately
+
+Before a proposal, the only mutable Trail draft is the current namespace in
+`UserConfig.goal`. A successful save atomically overwrites the previous
+unproposed value, revision, and invalidated confirmation. It creates no draft
+history, confirmation event stream, readiness snapshot, or value telemetry;
+superseded values do not remain in application caches or generic audit.
+
+Proposal creation may retain one exact immutable goal snapshot, proposal, and
+minimized proposal-linked policy audit under existing proposal/account
+retention. They commit or roll back together. The audit contains only closed
+identifiers, minimized aggregates/window bounds, revisions, digests, and the
+complete readiness receipt—never raw activities, request bodies, entered-value
+telemetry, provider data, free text, or routes.
+
+**Reset is not erasure.** Reset replaces current editable values with explicit
+unknowns and invalidates confirmation; it does not delete source activities or
+retained proposal snapshots/audits. The UI must say so.
+
+Owner export includes the complete current draft/provenance/revisions/
+confirmations, every retained immutable goal/proposal snapshot, and every
+retained Trail policy audit and receipt. Goal deletion and account deletion
+erase the current namespace and cascade through owned snapshots, audits,
+indexes, and caches. No deletion reports complete while a known owned row or
+cache remains. Failure rolls back or uses the repository’s explicit durable
+cleanup-pending behavior without exposing values or internal errors. Unknown
+schemas follow the same export and erasure rules.
+
+### 6. Keep sensitive context coarse
+
+The symptom request is a known boolean or explicit unknown stop signal. It asks
+for no symptom, diagnosis, duration, severity, treatment, clearance, or free
+text. A confirmed stop blocks planning; unknown requires clarification.
+
+Gastrointestinal experience is limited to `no_plan_altering_issue`,
+`plan_altering_issue`, or explicit unknown. It is optional module context, not
+a diagnosis or causal explanation, and cannot create an intake prescription,
+medical advice, risk score, or referral.
+
+### 7. Keep navigation, logs, and telemetry data-free
+
+Paths, query strings, fragments, titles, browser history, return-focus state,
+deep links, analytics, and referrers may carry only closed route, section,
+field, or reason-target keys. They never carry entered values, dates,
+event/goal/proposal or owner IDs, revisions, digests, serialized DTOs,
+provider IDs, or tokens. The authenticated route fetches state from the
+server.
+
+Trail logs and metrics contain only closed low-cardinality `action`, `status`,
+and `reason` keys. They contain no body, value, source metadata, digest, object
+identifier, URL, provider data, raw error, owner ID, email, or user hash. No
+value telemetry or cross-user Trail aggregation is authorized.
+
+### 8. Constrain Garmin to a pure internal summary
+
+Only after an adopted canonical plan exists may the authenticated owner request
+a Garmin compatibility summary. It reads only stored canonical workout
+structures and a versioned internal matrix. It is deterministic and no-write,
+returns closed `unverified` or `blocked` states and closed per-workout reasons,
+and preserves `trail_running`.
+
+The operation performs zero credential/tokenstore loads, connection/region/
+device discovery, adapter or network invocation, provider reads or writes,
+provider identifier access, consent reads or writes, delivery-ledger access,
+compatibility persistence, scheduling, send, retry, replace, reconcile, or
+delete. It cannot claim actual account, device, firmware, region, or provider
+support. Any live check or delivery requires new Product, Architecture, Trust,
+Operations, Quality, and human decisions.
+
+### 9. Preserve unknown schemas without executing them
+
+Authenticated owner read and export preserve an unknown Trail namespace as an
+opaque value without normalization, coercion, evaluation, v2 rendering, or
+overwrite. Capability evaluation reports unavailable/version mismatch;
+readiness, generation, adoption, and Garmin projection are disabled. Normal
+v2 writes cannot replace the namespace. Only explicit reset or deletion may
+remove it. Logs record only the closed version-mismatch reason.
+
+### 10. Make the audit migration fail closed
+
+The proposal-linked audit table is additive and enforces owner/proposal
+relationships. It performs no v1/future-schema backfill and creates no admin
+read surface. The implementation adds it to export, goal deletion, and account
+deletion in the same change. Code rollback preserves the table as unavailable
+data. Database downgrade drops it only when empty; otherwise it refuses data
+loss. Restore, retry, or migration never rebinds owner, provenance, or
+revision.
+
+## Required independent verification
+
+Verification must cover every operation as owner, unauthenticated, inactive,
+demo, MCP, admin, and second owner; forged provenance and stale races; every
+structural limit; absence of forbidden data from persistence/export/logs;
+draft overwrite and transactional proposal rollback; reset versus erasure;
+complete export/deletion and cleanup failure; sensitive-context enums; URL and
+referrer leakage; zero-call traps around every Garmin/provider accessor;
+unknown-schema round-trip; SQLite/PostgreSQL migration behavior; and exact-head
+Quality plus independent Trust review.
+
+Any owner-isolation, deletion, Garmin-purity, provenance, or forbidden-data
+failure is release-blocking. Owner-only status does not waive these checks.
+
+## Rejected alternatives
+
+Rejected alternatives are demo-source reads; MCP/admin Trail surfaces;
+client-stamped provenance; append-only draft/readiness history; free text,
+route or URL ingestion; values or identifiers in URLs; reset presented as
+erasure; partial export/best-effort deletion; live Garmin preview; unknown
+schema coercion; and value logging under hashed user identifiers.
+
+## Consequences and handoff
+
+The boundary intentionally permits fewer actors, less draft history, and no
+live provider confirmation. Engineering owns implementation; Operations owns
+later configuration, migration, deployment, and recovery; Quality verifies;
+Trust independently reviews the exact implementation and does not approve its
+own security-sensitive changes.
+
+## Exact no-authority boundary
+
+Approval authorizes only preparation and independent review of an **inactive,
+undiscoverable, synthetic-data-verifiable implementation** conforming to all
+accepted dependencies. It does not authorize implementation approval, merge,
+deployment, production migration or data, dogfood, catalog visibility,
+activation, adoption, MCP/admin/miniapp exposure, Garmin credential or
+provider access, consent, delivery, or efficacy/safety/medical claims.
+
+Later activation or provider work requires a new digest-bound Work Contract,
+specialist review, independent verification, Decision Review, and explicit
+human authority.
+
+## Human Trust decision requested
+
+Approve, revise, or reject the eight rows in the decision sheet and this exact
+boundary. Trust proposes the record but does not approve it.

--- a/docs/dev/trail-running-plan-v2-lifecycle-transition.md
+++ b/docs/dev/trail-running-plan-v2-lifecycle-transition.md
@@ -1,0 +1,154 @@
+# Trail v2 Science 生命周期原子转换清单
+
+- **Subject ID:** `science-lifecycle-trail-v2-transition-v1`
+- **Subject kind:** coordinated Science lifecycle transition
+- **Status:** `proposed`
+- **Required human role:** `decision_approver`
+- **Prepared from repository snapshot:**
+  `ee21b355621fb09127fddf984c4df49e33df65fd`
+- **Transition shape:** all-or-nothing
+- **Runtime invariant:** every affected contract remains `inactive`; the Trail
+  capability remains undiscoverable and unreachable.
+
+## 审批人实际决定什么
+
+批准本清单，只表示同意把两组已经分别审阅的 v2 Science Decision Record
+作为一个不可拆分的生命周期转换接受，同时把对应 v1 标记为 superseded。
+Ontology 与 policy 不能只转换其中一个，也不能只改一侧链接。
+
+现有 v2 decision digest 有意排除了 `status`、`supersedes` 和
+`superseded_by` 等生命周期字段。因此，现有 v2 决策批准**不能**被推断为已
+批准本次转换；本清单的完整 SHA-256 才是新的审批对象。
+
+## 当前四条记录（转换前）
+
+| Record | Status | Runtime | Source decision digest | Current contract digest |
+| --- | --- | --- | --- | --- |
+| `sdr-trail-running-goal-ontology-v1` | `accepted` | `inactive` | `sha256:cb53936289927d0f5f73268b5b6468e17a5b771532e2eaeee5c5c8781e541774` | `sha256:5bf6b47ede65af84af85fb364d148bffa38c1ea330272a3e71553d091a8695dc` |
+| `sdr-trail-running-goal-ontology-v2` | `draft` | `inactive` | `sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1` | `sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617` |
+| `sdr-non-ultra-trail-plan-generation-policy-v1` | `accepted` | `inactive` | `sha256:afc9fecefd55c699a8fdf3d3ab885968c7f7981fadbcba7bf09494fdfcdcd606` | `sha256:472c895bc4c3d467eac4a59dbacaeaaf665ddee462fdc76bba4cdf772df8e42b` |
+| `sdr-non-ultra-trail-plan-generation-policy-v2` | `draft` | `inactive` | `sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe` | `sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d` |
+
+两条已有、按角色和 decision digest 绑定的审批来源是：
+
+- Ontology v2:
+  <https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653482>
+- Policy v2:
+  <https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653739>
+
+这些评论批准各自的 v2 决策内容，但明确未批准 lifecycle supersession；它们
+是后续 approval ledger 的来源证据，不代替对本清单的批准。
+
+## 拟议的不可拆分转换
+
+同一个候选 patch 必须精确完成以下四项；任意一项缺失均拒绝整个 patch：
+
+| Record | Exact post-transition lifecycle |
+| --- | --- |
+| `sdr-trail-running-goal-ontology-v1` | `status: superseded`; `superseded_by: sdr-trail-running-goal-ontology-v2`; `supersedes: []` |
+| `sdr-trail-running-goal-ontology-v2` | `status: accepted`; `supersedes: [sdr-trail-running-goal-ontology-v1]`; empty `superseded_by` |
+| `sdr-non-ultra-trail-plan-generation-policy-v1` | `status: superseded`; `superseded_by: sdr-non-ultra-trail-plan-generation-policy-v2`; `supersedes: []` |
+| `sdr-non-ultra-trail-plan-generation-policy-v2` | `status: accepted`; `supersedes: [sdr-non-ultra-trail-plan-generation-policy-v1]`; empty `superseded_by` |
+
+四条记录的 `artifact_policy.runtime_state` 必须继续为 `inactive`。Policy v2
+必须继续依赖 ontology v2；不得形成 v1/v2 混搭的当前依赖。
+
+## Evidence 保持不变
+
+本次不新增、不替换、不重写任何 Evidence Review。下列已接受记录及其 claims、
+citations、verification notes、approvals 和 lifecycle 必须保持不变：
+
+- `evidence-trail-running-goal-ontology-v1`
+- `evidence-non-ultra-trail-plan-generation-policy-v1`
+- `evidence-plan-generation-eligibility-safety-v1`
+
+## 后续原子 patch 的受治理文件边界
+
+后续执行者必须在同一个受审候选 patch 中更新以下类别，不能只改 YAML：
+
+1. **Canonical lifecycle source:**
+   `data/science/decisions/sdr-trail-running-goal-ontology-v1.yaml`、
+   `data/science/decisions/sdr-trail-running-goal-ontology-v2.yaml`、
+   `data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v1.yaml`
+   与
+   `data/science/decisions/sdr-non-ultra-trail-plan-generation-policy-v2.yaml`。
+2. **Approval ledger:** 新增且只新增两条 v2 `decision_approver` artifact：
+   `data/science/approvals/sdr-trail-running-goal-ontology-v2--decision_approver--github-dddtc2005.yaml`
+   与
+   `data/science/approvals/sdr-non-ultra-trail-plan-generation-policy-v2--decision_approver--github-dddtc2005.yaml`；
+   `source_ref` 必须分别是上面的两个评论 URL。
+3. **Inactive implementation binding:**
+   `analysis/non_ultra_trail_contract.py` 中的 accepted decision IDs、model/schema
+   IDs、source/contract digests 与参数投影，以及
+   `analysis/non_ultra_trail_plan_generation.py` 中消费这些投影、验证输入和写入
+   replay/provenance receipt 的绑定。任何不完整的 v1/v2 混用都必须 fail closed。
+4. **Lifecycle、artifact 与纯核心测试:** 至少包括
+   `tests/test_evidence_registry.py`、`tests/test_science_artifacts.py`、
+   `tests/test_science_approval_workflow.py` 和
+   `tests/test_non_ultra_trail_plan_generation.py` 中对应断言。
+5. **确定性派生文件:** `data/science/REGISTRY.md`，四条 SDR 的
+   `data/science/generated/review-packets/*.md` 与
+   `data/science/generated/contracts/*.json`。
+
+已经按各自 digest 批准的 Product、Design、Architecture、Trust 文档和 v2 合并
+审阅稿是历史审核输入，不得为刷新状态说明而原地改写。
+
+## 派生 digest 预测（不是审批对象）
+
+下列值只是从当前 snapshot 将 `decision_status` 改为目标状态后得到的确定性预测。
+可信生成器必须在后续 patch 中重新计算；任何不一致都必须停止，不得“采用最接近
+的值”或自动扩大本批准。
+
+| Post-transition contract | Predicted digest |
+| --- | --- |
+| Ontology v1, `superseded + inactive` | `sha256:e341c379d8f60a27ee5919beab4800721c96b79458c861237d6e14800cdcd752` |
+| Ontology v2, `accepted + inactive` | `sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c` |
+| Policy v1, `superseded + inactive` | `sha256:2035f855cea2c1c117bd092796615148e98e59f1536013f86fb2bba1cab73ce2` |
+| Policy v2, `accepted + inactive` | `sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9` |
+
+Approval YAML、REGISTRY、packets、contracts 和这些 digest 都是本清单批准后
+重新生成或核验的输出，不是本次 human approval 的独立 subjects。
+
+## 执行前置条件
+
+- 生命周期 patch 必须位于同仓库、`base=main`、带 `science` label 的开放 PR；
+  其 head 必须包含执行时的 current `main`。当前 stacked PR #776 的 base 不是
+  `main`，因此本身不满足此条件。
+- PR head 在身份、权限、评论来源和 exact candidate 校验期间不得变化。
+- GitHub 必须验证评论作者身份与仓库权限；两条 source decision digest 必须仍
+  与当前 v2 records 完全匹配。
+- 转换前四条记录、linked evidence、runtime 和 current contract digests 必须
+  与本清单表格完全一致；否则停止并提交新的清单审核。
+- 同一 patch 必须同时包含 reciprocal lifecycle、approval ledger、所有 governed
+  references、派生 artifacts 与测试更新。
+
+## All-or-nothing 验证与回滚
+
+提交前必须全部通过：registry schema、reciprocal/acyclic supersession、authenticated
+approval source verification、`generate_science_artifacts.py --check`、
+`generate_science_registry_index.py --check`、上述四组定向测试、完整相关 Python
+测试、`git diff --check`，以及 inactive implementation 的 exact ID/digest/schema
+replay 测试。还必须证明没有 catalog/discovery/route 注册，并且两个 v2 contracts
+都是 `accepted + inactive`。
+
+任一前置条件、digest 或验证失败时，不得提交部分转换：恢复整个候选 diff 到转换
+前状态，保留现有 v1 `accepted + inactive` 与 v2 `draft + inactive`。如果完整转换
+已合并后发现缺陷，回滚单位是整个 lifecycle transition commit；不得手工只撤销
+一条记录、一个 reciprocal link、一个 approval artifact 或一个 implementation pin。
+
+## 明确不授权
+
+本清单及其批准不构成 implementation approval，也不授权 merge、deployment、
+activation、production data、owner dogfood、discovery/catalog、Garmin credentials、
+adapter、network、provider、consent 或 delivery-ledger 的任何读写，也不授权任何
+delivery。它不授权改变 Product/Design/Architecture/Trust 决策，不授权 Evidence
+变更，不授权 miniapp 或生产 Web 路由。能力必须继续不可发现且不可到达。
+
+## 可复制的批准语句
+
+> 我以 `decision_approver` 身份批准
+> `science-lifecycle-trail-v2-transition-v1`，manifest digest
+> `<MANIFEST_SHA256>`。我批准按该 manifest 将 Trail ontology 与 policy 两对
+> SDR 做 all-or-nothing 的 reciprocal v1→superseded / v2→accepted 转换，并始终
+> 保持 contracts `inactive`、capability 不可发现且不可到达。本批准不扩大该
+> manifest 的明确边界或 no-authority 列表。

--- a/docs/dev/trail-running-plan-v2-review-sheet.md
+++ b/docs/dev/trail-running-plan-v2-review-sheet.md
@@ -1,0 +1,167 @@
+# 越野托管计划 v2 合并审阅稿
+
+**状态：** 待人工批准；所有合同仍为 `draft + inactive`。
+
+这份文件是本轮的主要人工审阅材料。两个 Science review packet 的完整
+附录、JSON contract、registry 和测试仍保留作审计证据，但不需要逐页阅读。
+
+## 为什么需要 v2
+
+v1 已经批准了越野计划的科学边界和 14 天训练框架，但有两个实现缺口：
+
+- `grade_distribution`、技术路面和训练场地只有字段名称，没有可填写、可校验的
+  rubric；
+- Product 与 Science 对部分结果码的命名不完全一致。
+
+因此 v1 纯核心可以确定性排程和验证，却不能诚实地把真实宁海输入判断为
+`eligible_proposal`。v2 只补齐输入和结果合同，不扩大人群、剂量、训练模板或
+运行权限。
+
+## 六项需要批准的决定
+
+### 1. 统一准备情况结果
+
+每次检查只返回一个主状态，同时保留所有可安全判断的原因：
+
+1. `validation_failed`：输入或结果无法可靠解释；
+2. `policy_unavailable`：策略未启用，或目标超出本策略；
+3. `readiness_blocked`：当前症状、历史、场地或时间条件不支持计划；
+4. `clarification_required`：还需补充或重新确认信息；
+5. `eligible_proposal`：核心条件通过，可以生成提案。
+
+21 个固定原因覆盖版本、未知项、过期确认、历史、下降经历、场地、症状、
+日程、taper 窗口和不支持的人群/赛事。UI 显示自然语言，不显示机器码。
+
+### 2. 明确哪些信息必须知道
+
+生成核心计划前必须确认：
+
+- 赛事、日期、距离、累计爬升、累计下降；
+- 用于制定计划的预计时长范围；它不是完赛预测；
+- 18 岁以上、非医疗、单日、非超长距离、竞速目标；
+- 赛道是否需要用手辅助或固定绳索；
+- 每周可跑日期、每周时间上限、单次时间上限和不可训练日期；
+- 是否能使用连续 3 分钟的非技术上坡和受控下坡场地；
+- 当前是否有应停止竞速计划的症状；
+- 服务端观察到的近期跑步、爬升和下降历史。
+
+未知的核心项不会被默认成 0、简单、公路或“应该没问题”。
+
+### 3. 允许非核心模块诚实受限
+
+以下信息可以明确选择“不知道”，而不阻止 14 天核心提案：
+
+- 五档坡度分布；
+- 普通路面类型；
+- 环境和海拔；
+- 赛事补给支持；
+- 已练习的补给及粗粒度胃肠反馈。
+
+对应模块会显示 `Limited / 受限` 并被省略或仅作描述，绝不使用公路训练或其他
+地形静默替代。准备情况只显示 `Not evaluated / Available / Limited`；只有实际
+提案才能显示某模块 `Included / Omitted`。
+
+坡度只使用五个描述性区间，按赛道距离的整数 basis points 保存：
+
+- `< -10%`；
+- `-10% 至 < -3%`；
+- `-3% 至 < 3%`；
+- `3% 至 < 10%`；
+- `>= 10%`。
+
+它们合计必须为 `10000`，但不是难度分、配速换算、安全阈值或训练剂量。
+路面只是六个无顺序标记：坚实平整、松散碎石、泥地、岩石/树根、人工台阶、
+涉水。没有综合技术难度分。
+
+### 4. 全程使用 Praxys UI
+
+Web 使用一个完整页面，而不是把复杂表单塞进 Goal 弹窗：
+
+1. 赛事与计划用时；
+2. 坡度与路面；
+3. 可训练时间与场地；
+4. 近期训练经历；
+5. 环境、支持与补给；
+6. 准备情况回执。
+
+每节单独确认；任何值或来源变化都会使该节确认过期。每个失败原因都提供
+“发现 → 影响 → 下一步”，并定位到固定字段或只读解释。Web 覆盖中英文、
+桌面/移动、键盘、44px 触控、离线未保存、版本冲突和恢复状态。
+
+小程序第一阶段只诚实提示转到 Praxys Web，不提供半套编辑器。
+
+### 5. 固定隐私与架构边界
+
+- 只有真实、非 demo 的第一方登录 owner 能访问；无 MCP、管理员或跨用户回退；
+- 客户端只能提交值、未知状态和确认动作；来源、历史、revision 与结果由服务端
+  生成；
+- 只保留当前尚未生成提案的草稿；保存会覆盖旧草稿，不保留编辑历史；
+- 创建提案后才保留不可变 snapshot 和最小化 audit；
+- Reset 只把当前草稿恢复成未知，不等于删除历史提案；Export 与 Delete 覆盖所有
+  当前和已保留数据；
+- 不收集自由文本、GPS、路线、URL、provider payload/ID、诊断或值级 telemetry；
+- URL、浏览器历史和日志只允许固定低基数键，不含赛事值、ID、revision 或 token；
+- 请求有 32 KiB、深度、集合、字符串和数值边界，防止解析和规范化滥用。
+
+### 6. Garmin 仍是独立边界
+
+本轮只允许在采纳后读取 Praxys 已保存的 canonical workout 和内部 compatibility
+matrix，显示 `Unverified / Blocked` 及逐训练原因。它必须保持：
+
+- 零 Garmin credential/token 读取；
+- 零 adapter、网络或 provider 读写；
+- 零 connection、region、device、consent 或 delivery-ledger 读写；
+- 零 provider ID；
+- `trail_running` 不得改名为 `running`。
+
+真实 Garmin 下发仍由 #680 和单独的账户/设备验证与人类批准处理。
+
+## 没有改变的训练规则
+
+v2 完整继承 v1：
+
+- 一次只生成 14 天，完成 7 天后建议复核；
+- 查看最近 8 个完整周，至少 4 个可用周、每周至少 3 次跑步；
+- 最近一次跑步不超过 10 天；
+- 42 天内至少 2 次可比越野经历，其中 1 次在 21 天内；
+- 首块不增加近期典型训练量；
+- 每 7 天最多一个质量刺激；
+- 至少 75% 跑步时间为低强度；
+- 不生成连续跑步日或补课堆叠；
+- 爬升和下降分别受近期周中位数、周最大值和单次最大值约束；
+- 唯一质量模板仍为 10 分钟热身、4 ×（3 分钟受控上坡 + 2 分钟轻松恢复）、
+  8 分钟放松；无固定心率、配速、功率或 RPE 目标；
+- hiking、strength、taper、超历史进阶、固定补给量和真实 Garmin 下发继续禁用。
+
+## 精确审核对象
+
+- Product amendment：
+  `sha256:d029b72ec58ee1a04a0035412367bb80cf498dff2a74d85d0e5bb2a63d781bbc`
+- Experience amendment：
+  `sha256:3e30519aa68199916c226c2306360c4911c6aeeec4f0fb40bf2da6dce9197e1f`
+- Architecture decision：
+  `sha256:506e87fc08f6414db6beb12bdedce2d9184bda0a1c0567b8fa2cdc0a3360ed72`
+- Trust decision：
+  `sha256:f3241d753cbb76d16d0908ddef29417f6af967da5fc8e3014aac054244e2627c`
+- Science ontology v2 decision：
+  `sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1`
+  （当前 draft contract：
+  `sha256:e243bf433223452e86ded967c2575b7089f506d2bef248e9f749349cf27bd617`）
+- Science policy v2 decision：
+  `sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe`
+  （当前 draft contract：
+  `sha256:fd2c7966d29e2bcdc3337c46e1f96d5a9aed6289c802bfe34e3a9098ede24f0d`）
+
+注意：Product、Experience 与 Architecture 的文件摘要会在任何内容修改后失效；
+Science decision digest 同样绑定完整决策。Science contract 在审批物化生命周期
+状态后会重新生成，后续 implementation approval 必须绑定物化后的 accepted +
+inactive contract digest。
+
+## 审阅与权限结论
+
+对 exact head `6c4bcf64` 的独立 Science、Product、Design、Trust review 均无
+阻塞；本地相关测试 `191 passed`。这不是批准，也不授权运行时行为。
+
+批准本页列出的六项决定，只允许继续准备并审查 inactive implementation；不允许
+合并、部署、生产数据、owner dogfood、目录曝光、能力激活、提案采纳或 Garmin
+下发。

--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -167,7 +167,22 @@ def _seed_account_rows(db_session, user_id: str = "delete-me") -> None:
                 channel="web",
             )
         )
-        db.add(UserConfig(user_id=user_id, display_name="Delete Me"))
+        db.add(UserConfig(
+            user_id=user_id,
+            display_name="Delete Me",
+            goal={
+                "goal_kind": "race",
+                "trail_plan": {
+                    "namespace_version": 1,
+                    "course_demand": {
+                        "schema_id": "trail_course_demand_v2",
+                    },
+                    "last_revision_bindings": {
+                        "composite_revision": "sha256:" + ("a" * 64),
+                    },
+                },
+            },
+        ))
         db.add(UserConnection(user_id=user_id, platform="garmin", encrypted_credentials=b"secret"))
         db.add(Activity(user_id=user_id, activity_id="a1", date=date(2026, 6, 1)))
         db.add(ActivitySplit(user_id=user_id, activity_id="a1", split_num=1))
@@ -666,6 +681,11 @@ def test_delete_me_removes_user_and_owned_rows(account_client):
     """DELETE /api/me hard-deletes account data, credentials, demo, and invitation links."""
     client, db_session = account_client
     _seed_account_rows(db_session)
+
+    from db.models import UserConfig as _UserConfig
+
+    with db_session.SessionLocal() as seeded_db:
+        assert "trail_plan" in seeded_db.get(_UserConfig, "delete-me").goal
 
     res = client.delete("/api/me")
     assert res.status_code == 200, res.text

--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -68,7 +68,29 @@ def test_data_export_is_downloadable_and_isolated_to_the_authenticated_user(api_
                 user_id=owner_id,
                 display_name="Owner",
                 preferences={"activities": "garmin"},
-                goal={"distance": "marathon", "target_label": "owner-goal"},
+                goal={
+                    "distance": "marathon",
+                    "target_label": "owner-goal",
+                    "trail_plan": {
+                        "namespace_version": 1,
+                        "course_demand": {
+                            "schema_id": "trail_course_demand_v2",
+                            "fields": {
+                                "event_date": {
+                                    "state": "unknown",
+                                    "provenance": "unknown",
+                                    "source_revision": "sha256:" + ("a" * 64),
+                                },
+                            },
+                        },
+                        "confirmations": {
+                            "section.event-duration": None,
+                        },
+                        "last_revision_bindings": {
+                            "composite_revision": "sha256:" + ("b" * 64),
+                        },
+                    },
+                },
                 source_options={
                     "athlete_timezone": "UTC",
                     "oauth_token": "config-raw-token",
@@ -576,6 +598,23 @@ def test_data_export_is_downloadable_and_isolated_to_the_authenticated_user(api_
         }
     ]
     assert payload["user_config"]["goal"]["target_label"] == "owner-goal"
+    assert payload["user_config"]["goal"]["trail_plan"] == {
+        "namespace_version": 1,
+        "course_demand": {
+            "schema_id": "trail_course_demand_v2",
+            "fields": {
+                "event_date": {
+                    "state": "unknown",
+                    "provenance": "unknown",
+                    "source_revision": "sha256:" + ("a" * 64),
+                },
+            },
+        },
+        "confirmations": {"section.event-duration": None},
+        "last_revision_bindings": {
+            "composite_revision": "sha256:" + ("b" * 64),
+        },
+    }
     assert [row["activity_id"] for row in payload["activities"]] == ["owner-activity"]
     assert [row["activity_id"] for row in payload["activity_splits"]] == ["owner-activity"]
     assert payload["activity_samples"] == [

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -111,7 +111,7 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
         assert review.reviewed_on == date(2026, 9, 3)
         _assert_exact_verification_notes(review)
     for decision in (trail_ontology_decision, trail_policy_decision):
-        assert decision.status == RecordStatus.ACCEPTED
+        assert decision.status == RecordStatus.SUPERSEDED
         assert decision.approval_mode == ApprovalMode.ARTIFACT
         assert decision.artifact_policy is not None
         assert (
@@ -119,6 +119,7 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
             == ArtifactRuntimeState.INACTIVE
         )
         assert decision.human_reviewers == []
+        assert decision.supersedes == []
     assert trail_policy_decision.evidence_review_ids[:2] == [
         trail_ontology_review.id,
         trail_policy_review.id,
@@ -133,8 +134,12 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     trail_policy_v2 = registry.decisions[
         "sdr-non-ultra-trail-plan-generation-policy-v2"
     ]
+    assert trail_ontology_decision.superseded_by == trail_ontology_v2.id
+    assert trail_policy_decision.superseded_by == trail_policy_v2.id
+    assert trail_ontology_v2.supersedes == [trail_ontology_decision.id]
+    assert trail_policy_v2.supersedes == [trail_policy_decision.id]
     for decision in (trail_ontology_v2, trail_policy_v2):
-        assert decision.status == RecordStatus.DRAFT
+        assert decision.status == RecordStatus.ACCEPTED
         assert decision.approval_mode == ApprovalMode.ARTIFACT
         assert decision.artifact_policy is not None
         assert (
@@ -142,7 +147,6 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
             == ArtifactRuntimeState.INACTIVE
         )
         assert decision.human_reviewers == []
-        assert decision.supersedes == []
         assert decision.superseded_by is None
         assert decision.decision_review is not None
         assert len(decision.decision_review.items) == 6

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -87,7 +87,9 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
         "sdr-road-half-marathon-plan-generation-policy-v1",
         "sdr-road-marathon-plan-generation-policy-v1",
         "sdr-trail-running-goal-ontology-v1",
+        "sdr-trail-running-goal-ontology-v2",
         "sdr-non-ultra-trail-plan-generation-policy-v1",
+        "sdr-non-ultra-trail-plan-generation-policy-v2",
     }
 
     trail_ontology_review = registry.evidence_reviews[
@@ -124,6 +126,91 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     assert trail_ontology_decision.model_parameters[0].value[
         "schema_id"
     ] == "trail_course_demand_v1"
+
+    trail_ontology_v2 = registry.decisions[
+        "sdr-trail-running-goal-ontology-v2"
+    ]
+    trail_policy_v2 = registry.decisions[
+        "sdr-non-ultra-trail-plan-generation-policy-v2"
+    ]
+    for decision in (trail_ontology_v2, trail_policy_v2):
+        assert decision.status == RecordStatus.DRAFT
+        assert decision.approval_mode == ApprovalMode.ARTIFACT
+        assert decision.artifact_policy is not None
+        assert (
+            decision.artifact_policy.runtime_state
+            == ArtifactRuntimeState.INACTIVE
+        )
+        assert decision.human_reviewers == []
+        assert decision.supersedes == []
+        assert decision.superseded_by is None
+        assert decision.decision_review is not None
+        assert len(decision.decision_review.items) == 6
+        assert "inactive implementation" in (
+            decision.decision_review.approval_statement
+        )
+        assert "runtime activation" in (
+            decision.decision_review.approval_statement
+        )
+
+    ontology_v2_parameters = {
+        parameter.name: parameter.value
+        for parameter in trail_ontology_v2.model_parameters
+    }
+    assert ontology_v2_parameters["trail_course_demand_schema"][
+        "schema_id"
+    ] == "trail_course_demand_v2"
+    assert ontology_v2_parameters["trail_training_constraints_schema"][
+        "schema_id"
+    ] == "non_ultra_trail_constraints_v2"
+    assert ontology_v2_parameters["trail_grade_distribution"][
+        "exact_sum"
+    ] == 10000
+    assert ontology_v2_parameters["trail_footing_and_hazard_contract"][
+        "ordinary_footing"
+    ]["allowed"] == [
+        "firm_smooth",
+        "loose_gravel",
+        "mud",
+        "rocks_or_roots",
+        "built_steps",
+        "water_crossing",
+    ]
+
+    policy_v1_parameters = {
+        parameter.name: parameter.value
+        for parameter in trail_policy_decision.model_parameters
+    }
+    policy_v2_parameters = {
+        parameter.name: parameter.value
+        for parameter in trail_policy_v2.model_parameters
+    }
+    assert set(policy_v2_parameters) == set(policy_v1_parameters)
+    changed_policy_groups = {
+        name
+        for name in policy_v1_parameters
+        if policy_v1_parameters[name] != policy_v2_parameters[name]
+    }
+    assert changed_policy_groups == {
+        "trail_policy_scope_and_dependencies",
+        "trail_policy_required_inputs",
+        "trail_policy_typed_outcomes",
+        "trail_policy_non_science_authority",
+    }
+    outcomes = policy_v2_parameters["trail_policy_typed_outcomes"]
+    assert outcomes["status_precedence"] == [
+        "validation_failed",
+        "policy_unavailable",
+        "readiness_blocked",
+        "clarification_required",
+        "eligible_proposal",
+    ]
+    assert outcomes["limited_modules"]["allowed_sorted_order"] == [
+        "environment_altitude",
+        "fueling",
+        "grade_specificity",
+        "technical_terrain",
+    ]
     assert registry.evidence_reviews[
         "evidence-personal-environment-response-v1"
     ].status == "accepted"

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -163,6 +163,27 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     assert ontology_v2_parameters["trail_training_constraints_schema"][
         "schema_id"
     ] == "non_ultra_trail_constraints_v2"
+    course_fields = ontology_v2_parameters["trail_course_demand_schema"][
+        "fields"
+    ]
+    assert (course_fields["distance_meters"]["minimum"], course_fields["distance_meters"]["maximum"]) == (1, 49999)
+    assert (course_fields["total_ascent_m"]["minimum"], course_fields["total_ascent_m"]["maximum"]) == (0, 20000)
+    assert (course_fields["total_descent_m"]["minimum"], course_fields["total_descent_m"]["maximum"]) == (0, 20000)
+    for hazard in ("hands_assist", "fixed_rope"):
+        assert course_fields[hazard] == {
+            "type": "strict_boolean",
+            "envelope": "known_or_unknown",
+            "materiality": "core",
+        }
+    constraints = ontology_v2_parameters[
+        "trail_training_constraints_schema"
+    ]["client_reviewable_fields"]
+    assert (constraints["weekly_time_limit_min"]["minimum"], constraints["weekly_time_limit_min"]["maximum"]) == (1, 10080)
+    assert (constraints["maximum_session_duration_min"]["minimum"], constraints["maximum_session_duration_min"]["maximum"]) == (1, 1440)
+    assert constraints["maximum_session_duration_min"][
+        "not_greater_than"
+    ] == "weekly_time_limit_min"
+    assert constraints["unavailable_dates"]["maximum_members"] == 14
     assert ontology_v2_parameters["trail_grade_distribution"][
         "exact_sum"
     ] == 10000
@@ -194,7 +215,13 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     assert changed_policy_groups == {
         "trail_policy_scope_and_dependencies",
         "trail_policy_required_inputs",
+        "trail_policy_history_guardrails",
+        "trail_policy_schedule_construction",
+        "trail_policy_course_exposure_caps",
+        "trail_policy_event_and_taper",
         "trail_policy_typed_outcomes",
+        "trail_policy_modular_structure",
+        "trail_policy_evidence_use",
         "trail_policy_non_science_authority",
     }
     outcomes = policy_v2_parameters["trail_policy_typed_outcomes"]
@@ -211,6 +238,54 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
         "grade_specificity",
         "technical_terrain",
     ]
+    assert outcomes["module_availability"][
+        "required_keys_in_sorted_order"
+    ] == outcomes["limited_modules"]["allowed_sorted_order"]
+    assert outcomes["module_availability"]["allowed_states"] == [
+        "not_evaluated",
+        "available",
+        "limited",
+    ]
+    catalog_pairs = {
+        (status, detail_reason)
+        for status, detail_reasons in outcomes[
+            "detail_reason_catalog"
+        ].items()
+        for detail_reason in detail_reasons
+    }
+    mapped_pairs = {
+        (item["result"]["status"], item["result"]["detail_reason"])
+        for item in outcomes["condition_reason_mapping"]
+        if item["result"]["detail_reason"] is not None
+    }
+    assert mapped_pairs == catalog_pairs
+    assert policy_v2_parameters["trail_policy_modular_structure"][
+        "disabled_deferred_modules"
+    ] == {
+        module: {
+            "state": "not_accepted",
+            "reason": "no_accepted_v2_input_and_dose_contract",
+        }
+        for module in ("hiking", "strength", "taper")
+    }
+    assert policy_v2_parameters["trail_policy_history_guardrails"][
+        "insufficient_recent_running_result"
+    ] == {
+        "status": "readiness_blocked",
+        "detail_reason": "insufficient_recent_running_history",
+    }
+    assert policy_v2_parameters["trail_policy_schedule_construction"][
+        "no_schedule_result"
+    ] == {
+        "status": "readiness_blocked",
+        "detail_reason": "no_schedule_within_envelope",
+    }
+    assert policy_v2_parameters["trail_policy_event_and_taper"][
+        "target_within_14_days_of_start_result"
+    ] == {
+        "status": "policy_unavailable",
+        "detail_reason": "event_inside_unapproved_taper_window",
+    }
     assert registry.evidence_reviews[
         "evidence-personal-environment-response-v1"
     ].status == "accepted"

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -166,9 +166,31 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     course_fields = ontology_v2_parameters["trail_course_demand_schema"][
         "fields"
     ]
-    assert (course_fields["distance_meters"]["minimum"], course_fields["distance_meters"]["maximum"]) == (1, 49999)
-    assert (course_fields["total_ascent_m"]["minimum"], course_fields["total_ascent_m"]["maximum"]) == (0, 20000)
-    assert (course_fields["total_descent_m"]["minimum"], course_fields["total_descent_m"]["maximum"]) == (0, 20000)
+    assert (
+        course_fields["distance_meters"]["minimum"],
+        course_fields["distance_meters"]["maximum"],
+    ) == (1, 49999)
+    assert (
+        course_fields["total_ascent_m"]["minimum"],
+        course_fields["total_ascent_m"]["maximum"],
+    ) == (0, 20000)
+    assert (
+        course_fields["total_descent_m"]["minimum"],
+        course_fields["total_descent_m"]["maximum"],
+    ) == (0, 20000)
+    assert course_fields["event_format"]["recognized"] == [
+        "single_day",
+        "multi_day",
+    ]
+    assert course_fields["distance_family"]["recognized"] == [
+        "non_ultra",
+        "ultra",
+    ]
+    assert course_fields["planning_intent"]["recognized"] == [
+        "performance",
+        "first_completion",
+        "return_to_consistency",
+    ]
     for hazard in ("hands_assist", "fixed_rope"):
         assert course_fields[hazard] == {
             "type": "strict_boolean",
@@ -178,12 +200,46 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
     constraints = ontology_v2_parameters[
         "trail_training_constraints_schema"
     ]["client_reviewable_fields"]
-    assert (constraints["weekly_time_limit_min"]["minimum"], constraints["weekly_time_limit_min"]["maximum"]) == (1, 10080)
-    assert (constraints["maximum_session_duration_min"]["minimum"], constraints["maximum_session_duration_min"]["maximum"]) == (1, 1440)
+    assert (
+        constraints["weekly_time_limit_min"]["minimum"],
+        constraints["weekly_time_limit_min"]["maximum"],
+    ) == (1, 10080)
+    assert (
+        constraints["maximum_session_duration_min"]["minimum"],
+        constraints["maximum_session_duration_min"]["maximum"],
+    ) == (1, 1440)
     assert constraints["maximum_session_duration_min"][
         "not_greater_than"
     ] == "weekly_time_limit_min"
     assert constraints["unavailable_dates"]["maximum_members"] == 14
+    optional_context = ontology_v2_parameters[
+        "trail_optional_context_shapes"
+    ]
+    assert optional_context["exact_groups"] == [
+        "environment",
+        "support",
+        "fueling",
+    ]
+    assert optional_context["group_envelope_allowed"] is False
+    assert optional_context["enum_unknown_literals_allowed"] is False
+    aid_gap = optional_context["support"]["max_aid_station_gap_m"]
+    assert aid_gap == {
+        "envelope": "known_or_unknown",
+        "known_value_type": "integer_or_explicit_null",
+        "integer_minimum": 100,
+        "integer_maximum": 50000,
+        "known_null_meaning": "not_applicable",
+        "kilometer_wire_or_storage_field_allowed": False,
+    }
+    assert "max_aid_station_gap_km" not in yaml.safe_dump(
+        optional_context
+    )
+    revisions = ontology_v2_parameters[
+        "trail_revision_and_confirmation"
+    ]
+    assert revisions["prior_draft_value_retained"] is False
+    assert revisions["prior_revision_token_retained"] is False
+    assert revisions["immutable_snapshot_begins_only_with_proposal"] is True
     assert ontology_v2_parameters["trail_grade_distribution"][
         "exact_sum"
     ] == 10000
@@ -239,13 +295,26 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
         "technical_terrain",
     ]
     assert outcomes["module_availability"][
-        "required_keys_in_sorted_order"
-    ] == outcomes["limited_modules"]["allowed_sorted_order"]
+        "required_keys_in_fixed_order"
+    ] == [
+        "grade_specificity",
+        "technical_terrain",
+        "environment_altitude",
+        "fueling",
+    ]
     assert outcomes["module_availability"]["allowed_states"] == [
         "not_evaluated",
         "available",
         "limited",
     ]
+    not_evaluated = outcomes["module_availability"]["state_rules"][
+        "not_evaluated"
+    ]
+    assert not_evaluated == {
+        "when": "top_level_status_is_not_eligible_proposal",
+        "reason_target": "top_level_primary_namespaced_reason",
+        "all_four_modules_use_same_reason_target": True,
+    }
     catalog_pairs = {
         (status, detail_reason)
         for status, detail_reasons in outcomes[

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -103,13 +103,13 @@ def test_shipped_registry_is_valid_and_heat_migration_is_complete() -> None:
         "sdr-non-ultra-trail-plan-generation-policy-v1"
     ]
     for review in (trail_ontology_review, trail_policy_review):
-        assert review.status == RecordStatus.DRAFT
+        assert review.status == RecordStatus.ACCEPTED
         assert review.approval_mode == ApprovalMode.ARTIFACT
         assert review.human_reviewers == []
-        assert review.reviewed_on is None
+        assert review.reviewed_on == date(2026, 9, 3)
         _assert_exact_verification_notes(review)
     for decision in (trail_ontology_decision, trail_policy_decision):
-        assert decision.status == RecordStatus.DRAFT
+        assert decision.status == RecordStatus.ACCEPTED
         assert decision.approval_mode == ApprovalMode.ARTIFACT
         assert decision.artifact_policy is not None
         assert (

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -689,3 +689,22 @@ def test_very_large_vertical_values_remain_bounded_without_per_meter_work() -> N
     for week in result.plan.weeks:
         assert week.weekly_ascent_ceiling_meters == huge * 2
         assert week.weekly_descent_ceiling_meters == (huge - 1) * 2
+
+
+def test_arbitrary_size_integer_duration_and_distance_do_not_overflow() -> None:
+    huge = 10**400
+    first = replace(
+        _history()[0],
+        duration_min=huge,
+        distance_km=huge,
+    )
+    generation_input = _generation_input(
+        history=(first, *_history()[1:])
+    )
+    result = generate_non_ultra_trail_plan(generation_input)
+    replay = generate_non_ultra_trail_plan(generation_input)
+    assert result == replay
+    assert result.code == "eligible_proposal"
+    assert deterministic_input_hash(generation_input) == (
+        result.deterministic_input_hash
+    )

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -2,36 +2,54 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import date, datetime, time, timedelta, timezone
-from decimal import localcontext
+from decimal import getcontext
+import hashlib
+import math
 
 import pytest
 
+import analysis.non_ultra_trail_plan_generation as trail_generation
 from analysis.non_ultra_trail_contract import (
+    NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID,
     NON_ULTRA_TRAIL_CONTRACT,
     NON_ULTRA_TRAIL_CONTRACT_DIGEST,
     NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
-    NON_ULTRA_TRAIL_GUARDRAILS,
+    NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG,
+    NON_ULTRA_TRAIL_GENERATOR_VERSION,
+    NON_ULTRA_TRAIL_MODULE_KEYS,
     NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT,
     NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
     NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
     NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
     NON_ULTRA_TRAIL_POLICY_VERSION,
+    NON_ULTRA_TRAIL_REASON_PAIRS,
     NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
     NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_STATUS_PRECEDENCE,
 )
 from analysis.non_ultra_trail_plan_generation import (
     CONTROLLED_UPHILL_TEMPLATE,
     GeneratedNonUltraTrailPlan,
-    InternalTrailPrevalidation,
     NonUltraTrailGenerationInput,
-    NonUltraTrailGoal,
     ProvenancedValue,
+    RecentTrailHistoryStatistics,
     TrailCourseDemand,
+    TrailEnvironmentContext,
+    TrailFuelingContext,
+    TrailGradeDistribution,
+    TrailOptionalContext,
     TrailPlanGenerationConstraints,
+    TrailPlanningDurationRange,
     TrailRunningHistoryObservation,
+    TrailSupportContext,
+    TrailWorkloadRequest,
     derive_recent_history_statistics,
+    derive_revision_bindings,
     deterministic_input_hash,
+    _dry_run_non_ultra_trail_plan,
     generate_non_ultra_trail_plan,
+    serialize_generation_input,
     serialize_workout_structure,
     validate_generated_plan,
 )
@@ -41,35 +59,116 @@ ATHLETE_TODAY = date(2026, 9, 3)
 BLOCK_START = date(2026, 9, 7)
 
 
-def _known(value: object) -> ProvenancedValue:
+def _digest(label: str) -> str:
+    return f"sha256:{hashlib.sha256(label.encode()).hexdigest()}"
+
+
+def _known(
+    value: object,
+    *,
+    label: str = "fixture",
+    provenance: str = "athlete_stated",
+    confirmed_assumption: bool = False,
+) -> ProvenancedValue:
+    revision = _digest(label)
     return ProvenancedValue(
+        state="known",
+        provenance=provenance,
+        source_revision=revision,
         value=value,
-        provenance="athlete_stated",
-        source_reference="owner-review",
-        source_timestamp=ATHLETE_TODAY,
-        athlete_confirmed=True,
+        assumption_confirmed_revision=(
+            revision if confirmed_assumption else None
+        ),
     )
 
 
-def _unknown() -> ProvenancedValue:
-    return ProvenancedValue(value=None, provenance="unknown")
+def _unknown(label: str = "unknown") -> ProvenancedValue:
+    return ProvenancedValue(
+        state="unknown",
+        provenance="unknown",
+        source_revision=_digest(label),
+    )
+
+
+def _optional_context() -> TrailOptionalContext:
+    return TrailOptionalContext(
+        environment=TrailEnvironmentContext(
+            maximum_altitude_m=_known(430, label="altitude"),
+            temperature_min_c=_known(10.5, label="temperature-min"),
+            temperature_max_c=_known(24.0, label="temperature-max"),
+            humidity_min_pct=_known(45, label="humidity-min"),
+            humidity_max_pct=_known(85, label="humidity-max"),
+            sun_exposure=_known("mixed", label="sun"),
+            wind_exposure=_known("mixed", label="wind"),
+            conditions_basis=_known(
+                "organizer_information", label="conditions-basis"
+            ),
+        ),
+        support=TrailSupportContext(
+            aid_support_mode=_known("organized_aid", label="aid-mode"),
+            aid_station_count=_known(4, label="aid-count"),
+            max_aid_station_gap_m=_known(6000, label="aid-gap"),
+            water_availability=_known("all_stations", label="water"),
+            food_availability=_known("some_stations", label="food"),
+            mandatory_gear=_known(
+                ("water_carry", "weather_shell"), label="gear"
+            ),
+        ),
+        fueling=TrailFuelingContext(
+            longest_practiced_duration_min=_known(180, label="fuel-duration"),
+            practice_sessions_last_42_days=_known(4, label="fuel-sessions"),
+            intake_form=_known("mixed_food_and_drink", label="intake"),
+            gastrointestinal_experience=_known(
+                "no_plan_altering_issue", label="gi"
+            ),
+        ),
+    )
 
 
 def _course() -> TrailCourseDemand:
     return TrailCourseDemand(
-        expected_duration_seconds=_known(10_800),
-        distance_meters=_known(24_700),
-        elevation_gain_meters=_known(618),
-        elevation_loss_meters=_known(620),
-        grade_distribution=_known({"reference": "course-profile-v1"}),
-        technicality=_known({"reference": "course-technicality-v1"}),
-        maximum_altitude_meters=_known(430),
-        environmental_demand=_known({"reference": "event-conditions-v1"}),
-        aid_and_support=_known({"reference": "event-support-v1"}),
-        training_terrain_access=_known({"reference": "owner-access-v1"}),
-        recent_downhill_exposure=_known({"reference": "history-v1"}),
-        fueling_practice_experience=_known({"reference": "practice-v1"}),
-        athlete_confirmed=True,
+        event_id="event-ninghai-2026",
+        event_date=_known(date(2026, 11, 15), label="event-date"),
+        distance_meters=_known(24700, label="distance"),
+        total_ascent_m=_known(618, label="ascent"),
+        total_descent_m=_known(620, label="descent"),
+        planning_duration_range=_known(
+            TrailPlanningDurationRange(180, 300), label="duration-range"
+        ),
+        event_format=_known("single_day", label="event-format"),
+        distance_family=_known("non_ultra", label="distance-family"),
+        planning_intent=_known("performance", label="intent"),
+        grade_distribution=_known(
+            TrailGradeDistribution(500, 1500, 4000, 3000, 1000),
+            label="grade",
+        ),
+        course_footing=_known(
+            ("firm_smooth", "loose_gravel"), label="course-footing"
+        ),
+        hands_assist=_known(False, label="hands"),
+        fixed_rope=_known(False, label="rope"),
+        optional_context=_optional_context(),
+    )
+
+
+def _constraints() -> TrailPlanGenerationConstraints:
+    return TrailPlanGenerationConstraints(
+        available_weekdays=_known((2, 4, 6), label="weekdays"),
+        weekly_time_limit_min=_known(240, label="weekly-time"),
+        maximum_session_duration_min=_known(70, label="session-time"),
+        unavailable_dates=_known((), label="unavailable"),
+        preferred_longest_weekday=6,
+        nontechnical_three_minute_uphill_access=_known(
+            True, label="uphill-access"
+        ),
+        controlled_downhill_access=_known(True, label="downhill-access"),
+        accessible_footing=_known(
+            ("firm_smooth", "loose_gravel", "mud"),
+            label="accessible-footing",
+        ),
+        adult_nonclinical_scope_confirmed=_known(True, label="adult"),
+        performance_intent_confirmed=_known(True, label="performance"),
+        current_symptom_stop=_known(False, label="symptom"),
     )
 
 
@@ -79,8 +178,7 @@ def _history() -> tuple[TrailRunningHistoryObservation, ...]:
     observations: list[TrailRunningHistoryObservation] = []
     for week in range(8):
         week_start = first_week_start + timedelta(weeks=week)
-        schedule = ((0, 40), (2, 50), (4, 60))
-        for index, (offset, duration) in enumerate(schedule):
+        for index, (offset, duration) in enumerate(((0, 40), (2, 50), (4, 60))):
             trail = index >= 1
             observed_date = week_start + timedelta(days=offset)
             observations.append(
@@ -90,13 +188,18 @@ def _history() -> tuple[TrailRunningHistoryObservation, ...]:
                     activity_type="trail_running" if trail else "running",
                     duration_min=float(duration),
                     distance_km=float(duration) / 6,
-                    elevation_gain_meters=(200 if index == 1 else 300) if trail else 50,
-                    elevation_loss_meters=(180 if index == 1 else 280) if trail else 40,
-                    source="garmin",
+                    elevation_gain_meters=(200 if index == 1 else 300)
+                    if trail
+                    else 50,
+                    elevation_loss_meters=(180 if index == 1 else 280)
+                    if trail
+                    else 40,
+                    observed_footing=("firm_smooth", "loose_gravel")
+                    if trail
+                    else None,
+                    source_revision=_digest(f"activity-{week}-{index}"),
                     source_timestamp=datetime.combine(
-                        observed_date,
-                        time(hour=12),
-                        tzinfo=timezone.utc,
+                        observed_date, time(hour=12), tzinfo=timezone.utc
                     ),
                     outdoor_confirmed=True,
                 )
@@ -104,12 +207,26 @@ def _history() -> tuple[TrailRunningHistoryObservation, ...]:
     return tuple(observations)
 
 
-def _generation_input(**changes: object) -> NonUltraTrailGenerationInput:
+def _generation_input(
+    *,
+    course: TrailCourseDemand | None = None,
+    constraints: TrailPlanGenerationConstraints | None = None,
+    statistics: RecentTrailHistoryStatistics | None = None,
+    workload_request: TrailWorkloadRequest | None = None,
+    **changes: object,
+) -> NonUltraTrailGenerationInput:
+    course = course or _course()
+    constraints = constraints or _constraints()
+    statistics = statistics or derive_recent_history_statistics(
+        _history(), athlete_today=ATHLETE_TODAY
+    )
     value = NonUltraTrailGenerationInput(
         policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        generator_version=NON_ULTRA_TRAIL_GENERATOR_VERSION,
         science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
         contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
         source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        ontology_version=NON_ULTRA_TRAIL_ONTOLOGY_VERSION,
         ontology_decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
         ontology_contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
         ontology_source_decision_digest=(
@@ -117,156 +234,92 @@ def _generation_input(**changes: object) -> NonUltraTrailGenerationInput:
         ),
         athlete_today=ATHLETE_TODAY,
         block_start=BLOCK_START,
-        goal=NonUltraTrailGoal(
-            intent="performance",
-            event_format="single_day",
-            distance_family="non_ultra",
-            target_event_date=date(2026, 11, 15),
-            event_confirmed=True,
+        course_demand=course,
+        history_statistics=statistics,
+        constraints=constraints,
+        revision_bindings=derive_revision_bindings(
+            course_demand=course,
+            constraints=constraints,
+            history_statistics=statistics,
         ),
-        course_demand=_course(),
-        history=_history(),
-        constraints=TrailPlanGenerationConstraints(
-            adult_confirmed=True,
-            current_symptom_stop=False,
-            available_weekdays=(1, 3, 5),
-            weekly_time_limit_min=240,
-            maximum_session_duration_min=70,
-            preferred_longest_easy_weekday=5,
-        ),
-        prevalidation=InternalTrailPrevalidation(
-            course_demand_eligible=True,
-            terrain_access_eligible=True,
-            nontechnical_uphill_accessible=True,
-            training_terrain_reference="owner-access-v1",
-            technical_terrain_module_supported=True,
-        ),
+        workload_request=workload_request,
+        synthetic_verification_only=True,
     )
     return replace(value, **changes)
 
 
-def test_contracts_are_exactly_bound_and_remain_inactive() -> None:
-    assert NON_ULTRA_TRAIL_CONTRACT.contract_digest == NON_ULTRA_TRAIL_CONTRACT_DIGEST
+def _reason_names(result: object) -> tuple[str, ...]:
+    return tuple(reason.namespaced for reason in result.matching_reasons)  # type: ignore[attr-defined]
+
+
+def test_exact_v2_contracts_are_accepted_but_remain_inactive() -> None:
+    assert NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID.endswith("-v2")
+    assert NON_ULTRA_TRAIL_SCIENCE_DECISION_ID.endswith("-v2")
+    assert NON_ULTRA_TRAIL_GENERATOR_VERSION.endswith("-v2")
+    assert NON_ULTRA_TRAIL_COURSE_SCHEMA_ID == "trail_course_demand_v2"
+    assert NON_ULTRA_TRAIL_CONSTRAINT_SCHEMA_ID == "non_ultra_trail_constraints_v2"
+    assert str(NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.decision_status) == "accepted"
+    assert str(NON_ULTRA_TRAIL_CONTRACT.decision_status) == "accepted"
+    assert str(NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.runtime_state) == "inactive"
+    assert str(NON_ULTRA_TRAIL_CONTRACT.runtime_state) == "inactive"
     assert (
         NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.contract_digest
-        == NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST
+        == "sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c"
     )
-    assert str(NON_ULTRA_TRAIL_CONTRACT.runtime_state) == "inactive"
-    assert str(NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.runtime_state) == "inactive"
-    assert NON_ULTRA_TRAIL_COURSE_SCHEMA_ID == "trail_course_demand_v1"
-    assert NON_ULTRA_TRAIL_GUARDRAILS.committed_proposal_days == 14
-    assert NON_ULTRA_TRAIL_GUARDRAILS.advisory_reassessment_after_completed_days == 7
+    assert (
+        NON_ULTRA_TRAIL_CONTRACT.contract_digest
+        == "sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9"
+    )
 
 
-def test_quality_template_is_exact_targetless_38_minute_contract() -> None:
-    assert CONTROLLED_UPHILL_TEMPLATE.total_minutes == 38
-    assert CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes == 26
-    input_value = _generation_input()
-    workout = generate_non_ultra_trail_plan(input_value).plan.weeks[0].workouts[1]
-    structure = serialize_workout_structure(workout)
-    assert workout.template_id == "trail-controlled-uphill-quality-v1"
-    assert structure["steps"][1]["repetitions"] == 4
+def test_v2_status_reason_and_module_catalog_is_exact_and_closed() -> None:
+    assert NON_ULTRA_TRAIL_STATUS_PRECEDENCE == (
+        "validation_failed",
+        "policy_unavailable",
+        "readiness_blocked",
+        "clarification_required",
+        "eligible_proposal",
+    )
+    assert len(NON_ULTRA_TRAIL_REASON_PAIRS) == 21
+    assert NON_ULTRA_TRAIL_DETAIL_REASON_CATALOG["eligible_proposal"] == ()
+    assert NON_ULTRA_TRAIL_MODULE_KEYS == (
+        "grade_specificity",
+        "technical_terrain",
+        "environment_altitude",
+        "fueling",
+    )
+
+
+def test_actual_inactive_entry_point_fails_closed_without_a_plan() -> None:
+    result = generate_non_ultra_trail_plan(
+        replace(_generation_input(), synthetic_verification_only=False)
+    )
+    assert result.status == "policy_unavailable"
+    assert result.detail_reason == "policy_inactive"
+    assert _reason_names(result) == ("policy_unavailable.policy_inactive",)
+    assert result.plan is None
+    assert result.inactive_dry_run is False
     assert all(
-        step.get("target", {}).get("metric") in {None, "none"}
-        for step in structure["steps"]
+        module.state == "not_evaluated"
+        and module.reason_target == "policy_unavailable.policy_inactive"
+        for module in result.module_availability
     )
 
 
-def test_history_uses_all_runs_but_only_unambiguous_trail_for_vertical() -> None:
-    history = list(_history())
-    history.append(
-        TrailRunningHistoryObservation(
-            activity_id="ambiguous",
-            observed_date=ATHLETE_TODAY - timedelta(days=2),
-            activity_type="running",
-            duration_min=60,
-            distance_km=8,
-            elevation_gain_meters=999,
-            elevation_loss_meters=999,
-            source="garmin",
-            source_timestamp=datetime(
-                2026,
-                9,
-                1,
-                12,
-                tzinfo=timezone.utc,
-            ),
-            outdoor_confirmed=True,
-        )
-    )
-    history.append(
-        TrailRunningHistoryObservation(
-            activity_id="unknown-loss",
-            observed_date=ATHLETE_TODAY - timedelta(days=1),
-            activity_type="trail_running",
-            duration_min=60,
-            distance_km=8,
-            elevation_gain_meters=999,
-            elevation_loss_meters=None,
-            source="garmin",
-            source_timestamp=datetime(
-                2026,
-                9,
-                2,
-                12,
-                tzinfo=timezone.utc,
-            ),
-            outdoor_confirmed=True,
-        )
-    )
-    statistics = derive_recent_history_statistics(history, athlete_today=ATHLETE_TODAY)
-    assert statistics.usable_completed_weeks == 8
-    assert statistics.recent_modal_running_frequency == 3
-    assert statistics.recent_median_usable_weekly_minutes == 150
-    assert statistics.recent_median_usable_weekly_ascent_meters == 500
-    assert statistics.recent_median_usable_weekly_descent_meters == 460
-    assert statistics.recent_maximum_session_ascent_meters == 300
-    assert statistics.latest_run_date == ATHLETE_TODAY - timedelta(days=1)
-    assert statistics.comparable_trail_sessions_within_window == 11
-
-
-def test_duplicate_activity_ids_cannot_inflate_history() -> None:
-    history = _history()
-    duplicate = replace(
-        history[-1],
-        observed_date=ATHLETE_TODAY - timedelta(days=1),
-    )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(history=(*history, duplicate))
-    )
-    assert result.code == "validation_failed"
-    assert result.uncertainty_or_missing_field == "history.duplicate_activity_id"
-
-
-def test_history_requires_typed_source_timestamp_and_outdoor_confirmation() -> None:
-    missing_timestamp = replace(
-        _history()[0],
-        source_timestamp=None,  # type: ignore[arg-type]
-    )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(history=(missing_timestamp, *_history()[1:]))
-    )
-    assert result.code == "validation_failed"
-    assert result.uncertainty_or_missing_field == "history_observation"
-
-    indoor_history = tuple(
-        replace(item, outdoor_confirmed=False) for item in _history()
-    )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(history=indoor_history)
-    )
-    assert result.code == "insufficient_comparable_history"
-    assert result.detail_reason == "insufficient_recent_history"
-
-
-def test_eligible_generation_is_deterministic_and_within_every_cap() -> None:
+def test_explicit_synthetic_dry_run_preserves_14_day_v1_envelope() -> None:
     generation_input = _generation_input()
-    first = generate_non_ultra_trail_plan(generation_input)
-    replay = generate_non_ultra_trail_plan(generation_input)
+    first = _dry_run_non_ultra_trail_plan(generation_input)
+    replay = _dry_run_non_ultra_trail_plan(generation_input)
     assert first == replay
-    assert first.code == "eligible_proposal"
-    assert first.detail_reason == "eligible_rolling_proposal"
+    assert first.status == "eligible_proposal"
+    assert first.detail_reason is None
+    assert first.matching_reasons == ()
+    assert first.inactive_dry_run is True
     assert first.plan is not None
+    assert first.contract_runtime_state == "inactive"
+    assert first.plan.contract_runtime_state == "inactive"
+    assert first.plan.synthetic_verification_only is True
+    assert first.plan.public_payload()["synthetic_verification_only"] is True
     assert first.plan.horizon_end == BLOCK_START + timedelta(days=13)
     assert first.plan.reassessment_dates == (BLOCK_START + timedelta(days=7),)
     assert validate_generated_plan(first.plan, generation_input) == ()
@@ -279,460 +332,516 @@ def test_eligible_generation_is_deterministic_and_within_every_cap() -> None:
         assert week.weekly_descent_ceiling_meters <= 460
         assert max(item.planned_duration_min for item in week.workouts) <= 60
         assert max(item.ascent_ceiling_meters for item in week.workouts) <= 300
+        assert max(item.descent_ceiling_meters for item in week.workouts) <= 280
+        assert all(item.activity_type == "trail_running" for item in week.workouts)
 
 
-def test_adjacent_running_days_fail_closed_across_schedule_units() -> None:
-    history = list(_history())
-    current_week_start = ATHLETE_TODAY - timedelta(days=ATHLETE_TODAY.weekday())
-    first_week_start = current_week_start - timedelta(weeks=8)
-    for week in range(8):
-        observed_date = first_week_start + timedelta(weeks=week, days=6)
-        history.append(
-            TrailRunningHistoryObservation(
-                activity_id=f"w{week}-extra",
-                observed_date=observed_date,
-                activity_type="running",
-                duration_min=1,
-                distance_km=0.1,
-                elevation_gain_meters=0,
-                elevation_loss_meters=0,
-                source="garmin",
-                source_timestamp=datetime.combine(
-                    observed_date,
-                    time(hour=12),
-                    tzinfo=timezone.utc,
-                ),
-                outdoor_confirmed=True,
-            )
+def test_synthetic_verification_is_private_and_requires_an_explicit_marker() -> None:
+    assert not hasattr(trail_generation, "dry_run_non_ultra_trail_plan")
+    unmarked = replace(
+        _generation_input(),
+        synthetic_verification_only=False,
+    )
+    with pytest.raises(ValueError, match="explicit marker"):
+        _dry_run_non_ultra_trail_plan(unmarked)
+
+
+def test_quality_template_is_exact_targetless_38_minutes() -> None:
+    assert CONTROLLED_UPHILL_TEMPLATE.total_minutes == 38
+    assert CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes == 26
+    result = _dry_run_non_ultra_trail_plan(_generation_input())
+    assert result.plan is not None
+    quality = result.plan.weeks[0].workouts[1]
+    structure = serialize_workout_structure(quality)
+    assert quality.template_id == "trail-controlled-uphill-quality-v1"
+    assert structure["steps"][1]["repetitions"] == 4
+    assert all(
+        step.get("target", {}).get("metric") in {None, "none"}
+        for step in structure["steps"]
+    )
+
+
+def test_history_snapshot_separates_ascent_descent_and_footing() -> None:
+    statistics = derive_recent_history_statistics(
+        _history(), athlete_today=ATHLETE_TODAY
+    )
+    assert statistics.usable_completed_weeks == 8
+    assert statistics.recent_modal_running_frequency == 3
+    assert statistics.recent_median_usable_weekly_minutes == 150
+    assert statistics.recent_median_usable_weekly_ascent_meters == 500
+    assert statistics.recent_median_usable_weekly_descent_meters == 460
+    assert statistics.recent_maximum_session_ascent_meters == 300
+    assert statistics.recent_maximum_session_descent_meters == 280
+    assert statistics.comparable_ascent_sessions_within_window > 2
+    assert statistics.comparable_descent_sessions_within_window > 2
+    assert statistics.recently_observed_footing == (
+        "firm_smooth",
+        "loose_gravel",
+    )
+    assert "activity_id" not in statistics.public_payload()
+
+
+def test_history_derivation_rejects_duplicate_unstamped_and_nonfinite_input() -> None:
+    history = _history()
+    with pytest.raises(ValueError, match="duplicate_activity_id"):
+        derive_recent_history_statistics(
+            (*history, history[-1]), athlete_today=ATHLETE_TODAY
         )
+    with pytest.raises(ValueError, match="history_observation"):
+        derive_recent_history_statistics(
+            (replace(history[0], source_timestamp=None), *history[1:]),  # type: ignore[arg-type]
+            athlete_today=ATHLETE_TODAY,
+        )
+    with pytest.raises(ValueError, match="history_observation"):
+        derive_recent_history_statistics(
+            (replace(history[0], duration_min=math.nan), *history[1:]),
+            athlete_today=ATHLETE_TODAY,
+        )
+
+
+def test_every_receipt_preserves_precedence_and_all_safe_matching_reasons() -> None:
+    course = replace(
+        _course(),
+        event_format=_known("multi_day", label="multi"),
+        hands_assist=_known(True, label="hands-true"),
+    )
     constraints = replace(
-        _generation_input().constraints,
-        available_weekdays=(0, 2, 4, 6),
-        preferred_longest_easy_weekday=6,
+        _constraints(),
+        current_symptom_stop=_known(True, label="symptom-true"),
+        controlled_downhill_access=_known(False, label="no-downhill"),
     )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(history=tuple(history), constraints=constraints)
+    statistics = replace(
+        derive_recent_history_statistics(_history(), athlete_today=ATHLETE_TODAY),
+        comparable_descent_sessions_within_window=0,
+        latest_comparable_descent_session_date=None,
     )
-    assert result.code == "validation_failed"
-    assert result.detail_reason == "no_schedule_within_envelope"
-
-
-def test_hash_is_order_independent_and_binds_ascent_and_descent_separately() -> None:
-    generation_input = _generation_input()
-    reordered = replace(
-        generation_input,
-        history=tuple(reversed(generation_input.history)),
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(
+            course=course, constraints=constraints, statistics=statistics
+        )
     )
-    assert deterministic_input_hash(generation_input) == deterministic_input_hash(
-        reordered
+    assert result.status == "policy_unavailable"
+    assert result.detail_reason == "unsupported_ultra_or_multiday"
+    assert _reason_names(result) == (
+        "policy_unavailable.unsupported_ultra_or_multiday",
+        "policy_unavailable.technical_features_outside_v2",
+        "readiness_blocked.insufficient_descent_history",
+        "readiness_blocked.insufficient_terrain_access",
+        "readiness_blocked.current_symptom_stop",
     )
-
-    changed_gain = replace(
-        generation_input,
-        course_demand=replace(
-            generation_input.course_demand,
-            elevation_gain_meters=_known(619),
-        ),
+    assert all(
+        item.reason_target
+        == "policy_unavailable.unsupported_ultra_or_multiday"
+        for item in result.module_availability
     )
-    changed_loss = replace(
-        generation_input,
-        course_demand=replace(
-            generation_input.course_demand,
-            elevation_loss_meters=_known(621),
-        ),
-    )
-    hashes = {
-        deterministic_input_hash(generation_input),
-        deterministic_input_hash(changed_gain),
-        deterministic_input_hash(changed_loss),
-    }
-    assert len(hashes) == 3
 
 
 @pytest.mark.parametrize(
-    ("prevalidation", "code"),
+    ("field_name", "value", "expected"),
     [
-        (
-            InternalTrailPrevalidation(None, True, True, "terrain"),
-            "material_course_demand_unknown",
-        ),
-        (
-            InternalTrailPrevalidation(False, True, True, "terrain"),
-            "course_clarification_required",
-        ),
-        (
-            InternalTrailPrevalidation(True, False, True, "terrain"),
-            "insufficient_terrain_access",
-        ),
-        (
-            InternalTrailPrevalidation(True, True, None, "terrain"),
-            "material_course_demand_unknown",
-        ),
+        ("event_format", "multi_day", "unsupported_ultra_or_multiday"),
+        ("distance_family", "ultra", "unsupported_ultra_or_multiday"),
+        ("planning_intent", "first_completion", "unsupported_population_or_intent"),
+        ("hands_assist", True, "technical_features_outside_v2"),
+        ("fixed_rope", True, "technical_features_outside_v2"),
     ],
 )
-def test_prevalidation_false_or_unknown_fails_closed(
-    prevalidation: InternalTrailPrevalidation,
-    code: str,
+def test_policy_scope_reasons_are_exact(
+    field_name: str, value: object, expected: str
 ) -> None:
-    result = generate_non_ultra_trail_plan(
-        _generation_input(prevalidation=prevalidation)
-    )
-    assert result.code == code
+    course = replace(_course(), **{field_name: _known(value, label=field_name)})
+    result = _dry_run_non_ultra_trail_plan(_generation_input(course=course))
+    assert result.status == "policy_unavailable"
+    assert result.detail_reason == expected
     assert result.plan is None
 
 
-def test_material_unknown_and_unconfirmed_assumption_fail_closed() -> None:
-    unknown = replace(_course(), elevation_loss_meters=_unknown())
-    result = generate_non_ultra_trail_plan(_generation_input(course_demand=unknown))
-    assert result.code == "material_course_demand_unknown"
-    assert result.uncertainty_or_missing_field == "elevation_loss_meters"
+def test_core_unknown_assumption_and_missing_constraints_are_distinct() -> None:
+    course = replace(_course(), total_descent_m=_unknown("unknown-descent"))
+    result = _dry_run_non_ultra_trail_plan(_generation_input(course=course))
+    assert result.status == "clarification_required"
+    assert result.detail_reason == "material_course_demand_unknown"
 
-    assumption = replace(
-        _course(),
-        technicality=ProvenancedValue(
-            value={"reference": "assumption"},
-            provenance="explicit_assumption",
-            athlete_confirmed=False,
-        ),
+    context = _optional_context()
+    assumption = _known(
+        "athlete_assumption",
+        label="assumed-conditions",
+        provenance="explicit_assumption",
     )
-    result = generate_non_ultra_trail_plan(_generation_input(course_demand=assumption))
-    assert result.code == "course_clarification_required"
-
-
-@pytest.mark.parametrize(
-    "field_name",
-    (
-        "maximum_altitude_meters",
-        "environmental_demand",
-        "fueling_practice_experience",
-    ),
-)
-def test_unconfirmed_assumption_fails_for_every_conditional_field(
-    field_name: str,
-) -> None:
-    assumed_value: object = (
-        430 if field_name == "maximum_altitude_meters" else {"reference": "x"}
+    context = replace(
+        context,
+        environment=replace(context.environment, conditions_basis=assumption),
     )
-    course = replace(
-        _course(),
-        **{
-            field_name: ProvenancedValue(
-                value=assumed_value,
-                provenance="explicit_assumption",
-                athlete_confirmed=False,
-            )
-        },
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(course=replace(_course(), optional_context=context))
     )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(course_demand=course)
-    )
-    assert result.code == "course_clarification_required"
-    assert result.failed_rule_id == "assumption_confirmation"
-    assert result.uncertainty_or_missing_field == field_name
+    assert result.detail_reason == "assumption_confirmation_required"
 
-
-def test_conditional_unknowns_limit_modules_without_inventing_values() -> None:
-    course = replace(
-        _course(),
-        maximum_altitude_meters=_unknown(),
-        environmental_demand=_unknown(),
-        fueling_practice_experience=_unknown(),
-    )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(
-            course_demand=course,
-            prevalidation=replace(
-                _generation_input().prevalidation,
-                technical_terrain_module_supported=None,
-            ),
-        )
-    )
-    assert result.code == "eligible_proposal"
-    assert result.limited_modules == (
-        "environment_module_limited",
-        "fueling_module_limited",
-        "technicality_module_limited",
-    )
-
-
-def test_product_detail_reasons_do_not_replace_canonical_science_codes() -> None:
-    short_history = _history()[:6]
-    result = generate_non_ultra_trail_plan(_generation_input(history=short_history))
-    assert result.code == "insufficient_comparable_history"
-    assert result.detail_reason == "insufficient_recent_history"
-
-    near_event = replace(
-        _generation_input().goal,
-        target_event_date=BLOCK_START + timedelta(days=14),
-    )
-    result = generate_non_ultra_trail_plan(_generation_input(goal=near_event))
-    assert result.code == "validation_failed"
-    assert result.detail_reason == "event_inside_unapproved_taper_window"
-
-
-def test_no_schedule_relaxes_no_guardrail() -> None:
     constraints = replace(
-        _generation_input().constraints,
-        maximum_session_duration_min=37,
+        _constraints(),
+        controlled_downhill_access=_unknown("unknown-downhill-access"),
     )
-    result = generate_non_ultra_trail_plan(
+    result = _dry_run_non_ultra_trail_plan(
         _generation_input(constraints=constraints)
     )
-    assert result.code == "validation_failed"
-    assert result.detail_reason == "no_schedule_within_envelope"
+    assert result.detail_reason == "training_constraints_missing"
+
+
+def test_non_core_unknowns_limit_exactly_four_modules() -> None:
+    context = _optional_context()
+    context = TrailOptionalContext(
+        environment=TrailEnvironmentContext(
+            *(_unknown(f"environment-{index}") for index in range(8))
+        ),
+        support=TrailSupportContext(
+            *(_unknown(f"support-{index}") for index in range(6))
+        ),
+        fueling=TrailFuelingContext(
+            *(_unknown(f"fueling-{index}") for index in range(4))
+        ),
+    )
+    course = replace(
+        _course(),
+        grade_distribution=_unknown("grade-unknown"),
+        course_footing=_unknown("footing-unknown"),
+        optional_context=context,
+    )
+    result = _dry_run_non_ultra_trail_plan(_generation_input(course=course))
+    assert result.status == "eligible_proposal"
+    assert result.limited_modules == (
+        "environment_altitude",
+        "fueling",
+        "grade_specificity",
+        "technical_terrain",
+    )
+    assert tuple(item.state for item in result.module_availability) == (
+        "limited",
+        "limited",
+        "limited",
+        "limited",
+    )
+    assert tuple(item.reason_target for item in result.module_availability) == (
+        "course.grade_distribution",
+        "course.course_footing",
+        "course.optional_context.environment",
+        "course.optional_context.support",
+    )
+
+
+def test_grade_and_footing_validation_is_strict_and_order_independent() -> None:
+    invalid_grade = replace(
+        _course(),
+        grade_distribution=_known(
+            TrailGradeDistribution(500, 1500, 4000, 3000, 999),
+            label="invalid-grade",
+        ),
+    )
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(course=invalid_grade)
+    )
+    assert result.status == "validation_failed"
+    assert result.detail_reason == "invalid_field_value"
+
+    first = _generation_input()
+    course = replace(
+        first.course_demand,
+        course_footing=_known(
+            ("loose_gravel", "firm_smooth"), label="course-footing"
+        ),
+    )
+    constraints = replace(
+        first.constraints,
+        available_weekdays=_known((6, 2, 4), label="weekdays"),
+        accessible_footing=_known(
+            ("mud", "loose_gravel", "firm_smooth"),
+            label="accessible-footing",
+        ),
+    )
+    reordered = _generation_input(
+        course=course,
+        constraints=constraints,
+        statistics=first.history_statistics,
+    )
+    assert deterministic_input_hash(first) == deterministic_input_hash(reordered)
+
+
+def test_footing_containment_distinguishes_access_from_observed_history() -> None:
+    rocky = replace(
+        _course(),
+        course_footing=_known(("rocks_or_roots",), label="rocky-course"),
+    )
+    result = _dry_run_non_ultra_trail_plan(_generation_input(course=rocky))
+    assert "readiness_blocked.insufficient_terrain_access" in _reason_names(result)
+    assert (
+        "readiness_blocked.insufficient_comparable_trail_history"
+        in _reason_names(result)
+    )
+
+    constraints = replace(
+        _constraints(),
+        accessible_footing=_known(
+            ("firm_smooth", "loose_gravel", "rocks_or_roots"),
+            label="rock-access",
+        ),
+    )
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(course=rocky, constraints=constraints)
+    )
+    assert "readiness_blocked.insufficient_terrain_access" not in _reason_names(
+        result
+    )
+    assert result.detail_reason == "insufficient_comparable_trail_history"
+
+
+def test_running_ascent_and_descent_history_have_separate_blockers() -> None:
+    base = derive_recent_history_statistics(_history(), athlete_today=ATHLETE_TODAY)
+    cases = (
+        (
+            replace(base, usable_completed_weeks=0, latest_run_date=None),
+            "insufficient_recent_running_history",
+        ),
+        (
+            replace(
+                base,
+                comparable_ascent_sessions_within_window=0,
+                latest_comparable_ascent_session_date=None,
+            ),
+            "insufficient_comparable_trail_history",
+        ),
+        (
+            replace(
+                base,
+                comparable_descent_sessions_within_window=0,
+                latest_comparable_descent_session_date=None,
+            ),
+            "insufficient_descent_history",
+        ),
+    )
+    for statistics, detail in cases:
+        result = _dry_run_non_ultra_trail_plan(
+            _generation_input(statistics=statistics)
+        )
+        assert result.status == "readiness_blocked"
+        assert detail in tuple(reason.detail_reason for reason in result.matching_reasons)
+
+
+def test_stale_revision_and_v1_v2_mix_fail_closed() -> None:
+    generation_input = _generation_input()
+    changed_course = replace(
+        generation_input.course_demand,
+        distance_meters=_known(24701, label="changed-distance"),
+    )
+    stale = replace(generation_input, course_demand=changed_course)
+    result = _dry_run_non_ultra_trail_plan(stale)
+    assert result.status == "clarification_required"
+    assert result.detail_reason == "stale_confirmation_or_source_revision"
+
+    mixed = replace(
+        _generation_input(),
+        policy_version="non-ultra-trail-plan-generation-policy-v1",
+        ontology_decision_id="sdr-trail-running-goal-ontology-v1",
+        course_demand=replace(_course(), schema_id="trail_course_demand_v1"),
+    )
+    result = _dry_run_non_ultra_trail_plan(mixed)
+    assert result.status == "validation_failed"
+    assert _reason_names(result)[:2] == (
+        "validation_failed.schema_version_mismatch",
+        "policy_unavailable.policy_inactive",
+    )
     assert result.plan is None
 
 
-def test_invariant_validator_rejects_a_tampered_week() -> None:
-    generation_input = _generation_input()
-    result = generate_non_ultra_trail_plan(generation_input)
-    assert result.plan is not None
-    first_week = result.plan.weeks[0]
-    tampered_week = replace(
-        first_week,
-        workouts=(
-            replace(
-                first_week.workouts[0],
-                activity_type="running",  # type: ignore[arg-type]
-            ),
-            *first_week.workouts[1:],
+def test_malformed_revision_preserves_safe_scope_and_inactive_reasons() -> None:
+    course = replace(
+        _course(),
+        event_format=_known("multi_day", label="malformed-multi-day"),
+    )
+    generation_input = _generation_input(course=course)
+    malformed = replace(
+        generation_input,
+        revision_bindings=replace(
+            generation_input.revision_bindings,
+            course_revision="malformed",
         ),
     )
-    tampered_plan: GeneratedNonUltraTrailPlan = replace(
-        result.plan,
-        weeks=(tampered_week, result.plan.weeks[1]),
+    synthetic = _dry_run_non_ultra_trail_plan(malformed)
+    assert synthetic.status == "validation_failed"
+    assert _reason_names(synthetic) == (
+        "validation_failed.invalid_field_value",
+        "policy_unavailable.unsupported_ultra_or_multiday",
     )
-    assert "activity_type" in {
-        violation.rule_id
-        for violation in validate_generated_plan(tampered_plan, generation_input)
-    }
+
+    actual = generate_non_ultra_trail_plan(
+        replace(malformed, synthetic_verification_only=False)
+    )
+    assert actual.status == "validation_failed"
+    assert actual.detail_reason == "invalid_field_value"
+    assert _reason_names(actual) == (
+        "validation_failed.invalid_field_value",
+        "policy_unavailable.policy_inactive",
+        "policy_unavailable.unsupported_ultra_or_multiday",
+    )
+    assert actual.plan is None
 
 
-def test_invariant_validator_rebinds_versions_course_modules_and_history() -> None:
+def test_adult_scope_unknown_and_contradictory_input_have_explicit_triggers() -> None:
+    constraints = replace(
+        _constraints(),
+        adult_nonclinical_scope_confirmed=_unknown("adult-unknown"),
+    )
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(constraints=constraints)
+    )
+    assert result.status == "clarification_required"
+    assert result.detail_reason == "adult_scope_or_constraints_unconfirmed"
+
+    contradictory = replace(
+        _constraints(),
+        preferred_longest_weekday=1,
+    )
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(constraints=contradictory)
+    )
+    assert result.status == "clarification_required"
+    assert result.detail_reason == "contradictory_input"
+
+
+def test_explicit_workload_above_history_is_clarification_not_progression() -> None:
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(
+            workload_request=TrailWorkloadRequest(weekly_running_minutes=999)
+        )
+    )
+    assert result.status == "clarification_required"
+    assert result.detail_reason == "training_constraints_outside_history_envelope"
+    assert result.plan is None
+
+
+def test_event_window_and_no_schedule_are_canonical_policy_and_readiness_results() -> None:
+    near_event = replace(
+        _course(),
+        event_date=_known(BLOCK_START + timedelta(days=14), label="near-event"),
+    )
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(course=near_event)
+    )
+    assert result.status == "policy_unavailable"
+    assert result.detail_reason == "event_inside_unapproved_taper_window"
+
+    constraints = replace(
+        _constraints(),
+        maximum_session_duration_min=_known(37, label="short-session"),
+    )
+    result = _dry_run_non_ultra_trail_plan(
+        _generation_input(constraints=constraints)
+    )
+    assert result.status == "readiness_blocked"
+    assert result.detail_reason == "no_schedule_within_envelope"
+
+
+def test_plan_validator_binds_contract_receipt_revisions_and_workouts() -> None:
     generation_input = _generation_input()
-    result = generate_non_ultra_trail_plan(generation_input)
+    result = _dry_run_non_ultra_trail_plan(generation_input)
     assert result.plan is not None
     plan = result.plan
-    tampered = (
-        (replace(plan, policy_version="other"), "policy_version"),
-        (replace(plan, generator_version="other"), "generator_version"),
-        (replace(plan, course_demand_fingerprint="0" * 64), "course_fingerprint"),
-        (replace(plan, limited_modules=("fueling_module_limited",)), "limited_modules"),
+    candidates: tuple[tuple[GeneratedNonUltraTrailPlan, str], ...] = (
+        (replace(plan, policy_version="v1"), "policy_version"),
+        (replace(plan, generator_version="v1"), "generator_version"),
         (
+            replace(plan, ontology_contract_digest="sha256:" + "0" * 64),
+            "ontology_contract_digest",
+        ),
+        (
+            replace(plan, readiness_receipt_digest="sha256:" + "0" * 64),
+            "readiness_receipt_digest",
+        ),
+        (
+            replace(plan, revision_bindings=replace(
+                plan.revision_bindings,
+                composite_revision="sha256:" + "0" * 64,
+            )),
+            "revision_bindings",
+        ),
+    )
+    for candidate, rule in candidates:
+        assert rule in {
+            value.rule_id
+            for value in validate_generated_plan(candidate, generation_input)
+        }
+    first_week = plan.weeks[0]
+    first_workout = first_week.workouts[0]
+    tampered = replace(
+        plan,
+        weeks=(
             replace(
-                plan,
-                history_statistics=replace(
-                    plan.history_statistics,
-                    usable_completed_weeks=99,
+                first_week,
+                workouts=(
+                    replace(first_workout, activity_type="running"),  # type: ignore[arg-type]
+                    *first_week.workouts[1:],
                 ),
             ),
-            "history_statistics",
+            plan.weeks[1],
         ),
     )
-    for candidate, expected_rule in tampered:
-        rules = {
-            violation.rule_id
-            for violation in validate_generated_plan(candidate, generation_input)
-        }
-        assert expected_rule in rules
-
-    ineligible_input = replace(
-        generation_input,
-        prevalidation=replace(
-            generation_input.prevalidation,
-            terrain_access_eligible=False,
-        ),
-    )
-    assert "eligibility:internal_terrain_prevalidation" in {
-        violation.rule_id
-        for violation in validate_generated_plan(plan, ineligible_input)
+    assert "activity_type" in {
+        value.rule_id for value in validate_generated_plan(tampered, generation_input)
     }
 
 
-def test_invariant_validator_binds_workout_and_longest_easy_semantics() -> None:
-    generation_input = _generation_input()
-    result = generate_non_ultra_trail_plan(generation_input)
-    assert result.plan is not None
-    week = result.plan.weeks[0]
-    ordinary_easy = next(
-        workout for workout in week.workouts if workout.workout_type == "easy"
-    )
-    changed_type = replace(ordinary_easy, workout_type="controlled_quality")
-    type_tampered_week = replace(
-        week,
-        workouts=tuple(
-            changed_type if workout == ordinary_easy else workout
-            for workout in week.workouts
+def test_replay_binds_course_ascent_descent_and_source_revisions_separately() -> None:
+    base = _generation_input()
+    hashes = {deterministic_input_hash(base)}
+    for field_name, value in (("total_ascent_m", 619), ("total_descent_m", 621)):
+        course = replace(
+            base.course_demand,
+            **{field_name: _known(value, label=f"changed-{field_name}")},
+        )
+        hashes.add(deterministic_input_hash(_generation_input(course=course)))
+    changed_source = replace(
+        base.course_demand,
+        distance_meters=replace(
+            base.course_demand.distance_meters,
+            source_revision=_digest("new-distance-source"),
         ),
     )
-    type_tampered_plan = replace(
-        result.plan,
-        weeks=(type_tampered_week, result.plan.weeks[1]),
-    )
-    assert "easy_workout_type" in {
-        violation.rule_id
-        for violation in validate_generated_plan(
-            type_tampered_plan,
-            generation_input,
+    hashes.add(deterministic_input_hash(_generation_input(course=changed_source)))
+    assert len(hashes) == 4
+
+
+def test_large_integer_and_decimal_context_do_not_escape_or_change_history() -> None:
+    history = _history()
+    original_precision = getcontext().prec
+    try:
+        getcontext().prec = 2
+        low_precision = derive_recent_history_statistics(
+            history, athlete_today=ATHLETE_TODAY
         )
-    }
-
-    longest = next(
-        workout
-        for workout in week.workouts
-        if workout.workout_type == "longest_easy"
-    )
-    removed_longest = replace(longest, workout_type="easy")
-    longest_tampered_week = replace(
-        week,
-        workouts=tuple(
-            removed_longest if workout == longest else workout
-            for workout in week.workouts
-        ),
-    )
-    longest_tampered_plan = replace(
-        result.plan,
-        weeks=(longest_tampered_week, result.plan.weeks[1]),
-    )
-    assert "longest_easy_date" in {
-        violation.rule_id
-        for violation in validate_generated_plan(
-            longest_tampered_plan,
-            generation_input,
+        getcontext().prec = 50
+        high_precision = derive_recent_history_statistics(
+            tuple(reversed(history)), athlete_today=ATHLETE_TODAY
         )
-    }
-
-    shortened_ordinary = replace(
-        ordinary_easy,
-        planned_duration_min=ordinary_easy.planned_duration_min - 1,
-        steps=(
-            replace(
-                ordinary_easy.steps[0],
-                duration_min=ordinary_easy.planned_duration_min - 1,
-            ),
-        ),
-    )
-    lengthened_longest = replace(
-        longest,
-        planned_duration_min=longest.planned_duration_min + 1,
-        steps=(
-            replace(
-                longest.steps[0],
-                duration_min=longest.planned_duration_min + 1,
-            ),
-        ),
-    )
-    duration_tampered_week = replace(
-        week,
-        workouts=tuple(
-            shortened_ordinary
-            if workout == ordinary_easy
-            else lengthened_longest
-            if workout == longest
-            else workout
-            for workout in week.workouts
-        ),
-    )
-    duration_tampered_plan = replace(
-        result.plan,
-        weeks=(duration_tampered_week, result.plan.weeks[1]),
-    )
-    assert "longest_easy_duration" in {
-        violation.rule_id
-        for violation in validate_generated_plan(
-            duration_tampered_plan,
-            generation_input,
-        )
-    }
-
-
-def test_nonfinite_history_is_a_typed_validation_failure() -> None:
-    invalid = replace(_history()[0], duration_min=float("nan"))
-    result = generate_non_ultra_trail_plan(
-        _generation_input(history=(invalid, *_history()[1:]))
-    )
-    assert result.code == "validation_failed"
-    assert result.detail_reason == "contradictory_input"
-    assert result.uncertainty_or_missing_field == "history.duration_min"
-    with pytest.raises(ValueError):
-        deterministic_input_hash(_generation_input(history=(invalid,)))
-
-
-def test_invalid_hash_distinguishes_each_nonfinite_representation() -> None:
-    hashes = set()
-    for value in (float("nan"), float("inf"), float("-inf")):
-        invalid = replace(_history()[0], duration_min=value)
-        result = generate_non_ultra_trail_plan(
-            _generation_input(history=(invalid, *_history()[1:]))
-        )
-        assert result.code == "validation_failed"
-        hashes.add(result.deterministic_input_hash)
-    assert len(hashes) == 3
-
-
-def test_very_large_vertical_values_remain_bounded_without_per_meter_work() -> None:
-    huge = 10**400
-    history = tuple(
-        replace(
-            item,
-            elevation_gain_meters=huge,
-            elevation_loss_meters=huge - 1,
-        )
-        if item.activity_type == "trail_running"
-        else item
-        for item in _history()
-    )
-    result = generate_non_ultra_trail_plan(
-        _generation_input(history=history)
-    )
-    assert result.code == "eligible_proposal"
-    assert result.plan is not None
-    for week in result.plan.weeks:
-        assert week.weekly_ascent_ceiling_meters == huge * 2
-        assert week.weekly_descent_ceiling_meters == (huge - 1) * 2
-
-
-def test_arbitrary_size_integer_duration_and_distance_do_not_overflow() -> None:
-    huge = 10**400
-    first = replace(
-        _history()[0],
-        duration_min=huge,
-        distance_km=huge,
-    )
-    generation_input = _generation_input(
-        history=(first, *_history()[1:])
-    )
-    result = generate_non_ultra_trail_plan(generation_input)
-    replay = generate_non_ultra_trail_plan(generation_input)
-    assert result == replay
-    assert result.code == "eligible_proposal"
-    assert deterministic_input_hash(generation_input) == (
-        result.deterministic_input_hash
-    )
-
-
-def test_duration_aggregation_is_order_and_decimal_context_independent() -> None:
-    huge = 10**400
-    history = list(_history())
-    history[0] = replace(
-        history[0],
-        duration_min=huge,
-        distance_km=huge,
-    )
-    history[1] = replace(history[1], duration_min=50.125)
-    generation_input = _generation_input(history=tuple(history))
-    reordered_input = replace(
-        generation_input,
-        history=tuple(reversed(history)),
-    )
-    with localcontext() as context:
-        context.prec = 28
-        low_precision = generate_non_ultra_trail_plan(generation_input)
-    with localcontext() as context:
-        context.prec = 500
-        high_precision = generate_non_ultra_trail_plan(reordered_input)
+    finally:
+        getcontext().prec = original_precision
     assert low_precision == high_precision
-    assert low_precision.history_statistics == high_precision.history_statistics
-    assert low_precision.deterministic_input_hash == (
-        high_precision.deterministic_input_hash
+
+    huge = 10**10000
+    generation_input = _generation_input()
+    course = replace(
+        generation_input.course_demand,
+        distance_meters=_known(huge, label="huge-distance"),
     )
+    result = _dry_run_non_ultra_trail_plan(
+        replace(generation_input, course_demand=course)
+    )
+    assert result.status == "validation_failed"
+    assert result.detail_reason == "invalid_field_value"
+
+
+def test_serialized_replay_contains_no_raw_history_or_provider_identifier() -> None:
+    payload = serialize_generation_input(_generation_input())
+    assert "history_statistics" in payload
+    assert "history" not in payload
+    rendered = repr(payload)
+    assert "activity_id" not in rendered
+    assert "provider" not in rendered
+    assert payload["generator_version"].endswith("-v2")

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -378,7 +378,48 @@ def test_history_snapshot_separates_ascent_descent_and_footing() -> None:
         "firm_smooth",
         "loose_gravel",
     )
+    assert statistics.observation_window_start is not None
+    assert statistics.observation_window_end == ATHLETE_TODAY - timedelta(days=1)
+    assert statistics.source_revision_fingerprint.startswith("sha256:")
     assert "activity_id" not in statistics.public_payload()
+
+
+def test_history_revision_changes_when_source_revision_changes_at_same_totals() -> None:
+    history = _history()
+    first = derive_recent_history_statistics(
+        history,
+        athlete_today=ATHLETE_TODAY,
+    )
+    corrected = (
+        replace(history[0], source_revision=_digest("corrected-source")),
+        *history[1:],
+    )
+    second = derive_recent_history_statistics(
+        corrected,
+        athlete_today=ATHLETE_TODAY,
+    )
+
+    assert first.source_revision_fingerprint != (
+        second.source_revision_fingerprint
+    )
+    assert replace(
+        first,
+        source_revision_fingerprint=second.source_revision_fingerprint,
+    ) == second
+    first_bindings = derive_revision_bindings(
+        course_demand=_course(),
+        constraints=_constraints(),
+        history_statistics=first,
+    )
+    second_bindings = derive_revision_bindings(
+        course_demand=_course(),
+        constraints=_constraints(),
+        history_statistics=second,
+    )
+    assert first_bindings.history_revision != second_bindings.history_revision
+    assert first_bindings.composite_revision != (
+        second_bindings.composite_revision
+    )
 
 
 def test_history_derivation_rejects_duplicate_unstamped_and_nonfinite_input() -> None:
@@ -649,6 +690,56 @@ def test_stale_revision_and_v1_v2_mix_fail_closed() -> None:
         "policy_unavailable.policy_inactive",
     )
     assert result.plan is None
+
+
+def test_assumption_confirmation_does_not_change_value_revision() -> None:
+    generation_input = _generation_input()
+    course = generation_input.course_demand
+    unconfirmed_basis = _known(
+        "athlete_assumption",
+        label="athlete-assumption",
+        provenance="explicit_assumption",
+    )
+    unconfirmed_course = replace(
+        course,
+        optional_context=replace(
+            course.optional_context,
+            environment=replace(
+                course.optional_context.environment,
+                conditions_basis=unconfirmed_basis,
+            ),
+        ),
+    )
+    confirmed_course = replace(
+        unconfirmed_course,
+        optional_context=replace(
+            unconfirmed_course.optional_context,
+            environment=replace(
+                unconfirmed_course.optional_context.environment,
+                conditions_basis=replace(
+                    unconfirmed_basis,
+                    assumption_confirmed_revision=(
+                        unconfirmed_basis.source_revision
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    before = derive_revision_bindings(
+        course_demand=unconfirmed_course,
+        constraints=generation_input.constraints,
+        history_statistics=generation_input.history_statistics,
+        confirmed=False,
+    )
+    after = derive_revision_bindings(
+        course_demand=confirmed_course,
+        constraints=generation_input.constraints,
+        history_statistics=generation_input.history_statistics,
+        confirmed=False,
+    )
+
+    assert before == after
 
 
 def test_malformed_revision_preserves_safe_scope_and_inactive_reasons() -> None:

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -398,6 +398,38 @@ def test_material_unknown_and_unconfirmed_assumption_fail_closed() -> None:
     assert result.code == "course_clarification_required"
 
 
+@pytest.mark.parametrize(
+    "field_name",
+    (
+        "maximum_altitude_meters",
+        "environmental_demand",
+        "fueling_practice_experience",
+    ),
+)
+def test_unconfirmed_assumption_fails_for_every_conditional_field(
+    field_name: str,
+) -> None:
+    assumed_value: object = (
+        430 if field_name == "maximum_altitude_meters" else {"reference": "x"}
+    )
+    course = replace(
+        _course(),
+        **{
+            field_name: ProvenancedValue(
+                value=assumed_value,
+                provenance="explicit_assumption",
+                athlete_confirmed=False,
+            )
+        },
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(course_demand=course)
+    )
+    assert result.code == "course_clarification_required"
+    assert result.failed_rule_id == "assumption_confirmation"
+    assert result.uncertainty_or_missing_field == field_name
+
+
 def test_conditional_unknowns_limit_modules_without_inventing_values() -> None:
     course = replace(
         _course(),
@@ -516,6 +548,103 @@ def test_invariant_validator_rebinds_versions_course_modules_and_history() -> No
     }
 
 
+def test_invariant_validator_binds_workout_and_longest_easy_semantics() -> None:
+    generation_input = _generation_input()
+    result = generate_non_ultra_trail_plan(generation_input)
+    assert result.plan is not None
+    week = result.plan.weeks[0]
+    ordinary_easy = next(
+        workout for workout in week.workouts if workout.workout_type == "easy"
+    )
+    changed_type = replace(ordinary_easy, workout_type="controlled_quality")
+    type_tampered_week = replace(
+        week,
+        workouts=tuple(
+            changed_type if workout == ordinary_easy else workout
+            for workout in week.workouts
+        ),
+    )
+    type_tampered_plan = replace(
+        result.plan,
+        weeks=(type_tampered_week, result.plan.weeks[1]),
+    )
+    assert "easy_workout_type" in {
+        violation.rule_id
+        for violation in validate_generated_plan(
+            type_tampered_plan,
+            generation_input,
+        )
+    }
+
+    longest = next(
+        workout
+        for workout in week.workouts
+        if workout.workout_type == "longest_easy"
+    )
+    removed_longest = replace(longest, workout_type="easy")
+    longest_tampered_week = replace(
+        week,
+        workouts=tuple(
+            removed_longest if workout == longest else workout
+            for workout in week.workouts
+        ),
+    )
+    longest_tampered_plan = replace(
+        result.plan,
+        weeks=(longest_tampered_week, result.plan.weeks[1]),
+    )
+    assert "longest_easy_date" in {
+        violation.rule_id
+        for violation in validate_generated_plan(
+            longest_tampered_plan,
+            generation_input,
+        )
+    }
+
+    shortened_ordinary = replace(
+        ordinary_easy,
+        planned_duration_min=ordinary_easy.planned_duration_min - 1,
+        steps=(
+            replace(
+                ordinary_easy.steps[0],
+                duration_min=ordinary_easy.planned_duration_min - 1,
+            ),
+        ),
+    )
+    lengthened_longest = replace(
+        longest,
+        planned_duration_min=longest.planned_duration_min + 1,
+        steps=(
+            replace(
+                longest.steps[0],
+                duration_min=longest.planned_duration_min + 1,
+            ),
+        ),
+    )
+    duration_tampered_week = replace(
+        week,
+        workouts=tuple(
+            shortened_ordinary
+            if workout == ordinary_easy
+            else lengthened_longest
+            if workout == longest
+            else workout
+            for workout in week.workouts
+        ),
+    )
+    duration_tampered_plan = replace(
+        result.plan,
+        weeks=(duration_tampered_week, result.plan.weeks[1]),
+    )
+    assert "longest_easy_duration" in {
+        violation.rule_id
+        for violation in validate_generated_plan(
+            duration_tampered_plan,
+            generation_input,
+        )
+    }
+
+
 def test_nonfinite_history_is_a_typed_validation_failure() -> None:
     invalid = replace(_history()[0], duration_min=float("nan"))
     result = generate_non_ultra_trail_plan(
@@ -541,7 +670,7 @@ def test_invalid_hash_distinguishes_each_nonfinite_representation() -> None:
 
 
 def test_very_large_vertical_values_remain_bounded_without_per_meter_work() -> None:
-    huge = 10**15
+    huge = 10**400
     history = tuple(
         replace(
             item,

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date, timedelta
+
+import pytest
+
+from analysis.non_ultra_trail_contract import (
+    NON_ULTRA_TRAIL_CONTRACT,
+    NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+    NON_ULTRA_TRAIL_COURSE_SCHEMA_ID,
+    NON_ULTRA_TRAIL_GUARDRAILS,
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT,
+    NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+    NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+    NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST,
+    NON_ULTRA_TRAIL_POLICY_VERSION,
+    NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+    NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+)
+from analysis.non_ultra_trail_plan_generation import (
+    CONTROLLED_UPHILL_TEMPLATE,
+    GeneratedNonUltraTrailPlan,
+    InternalTrailPrevalidation,
+    NonUltraTrailGenerationInput,
+    NonUltraTrailGoal,
+    ProvenancedValue,
+    TrailCourseDemand,
+    TrailPlanGenerationConstraints,
+    TrailRunningHistoryObservation,
+    derive_recent_history_statistics,
+    deterministic_input_hash,
+    generate_non_ultra_trail_plan,
+    serialize_workout_structure,
+    validate_generated_plan,
+)
+
+
+ATHLETE_TODAY = date(2026, 9, 3)
+BLOCK_START = date(2026, 9, 7)
+
+
+def _known(value: object) -> ProvenancedValue:
+    return ProvenancedValue(
+        value=value,
+        provenance="athlete_stated",
+        source_reference="owner-review",
+        source_timestamp=ATHLETE_TODAY,
+        athlete_confirmed=True,
+    )
+
+
+def _unknown() -> ProvenancedValue:
+    return ProvenancedValue(value=None, provenance="unknown")
+
+
+def _course() -> TrailCourseDemand:
+    return TrailCourseDemand(
+        expected_duration_seconds=_known(10_800),
+        distance_meters=_known(24_700),
+        elevation_gain_meters=_known(618),
+        elevation_loss_meters=_known(620),
+        grade_distribution=_known({"reference": "course-profile-v1"}),
+        technicality=_known({"reference": "course-technicality-v1"}),
+        maximum_altitude_meters=_known(430),
+        environmental_demand=_known({"reference": "event-conditions-v1"}),
+        aid_and_support=_known({"reference": "event-support-v1"}),
+        training_terrain_access=_known({"reference": "owner-access-v1"}),
+        recent_downhill_exposure=_known({"reference": "history-v1"}),
+        fueling_practice_experience=_known({"reference": "practice-v1"}),
+        athlete_confirmed=True,
+    )
+
+
+def _history() -> tuple[TrailRunningHistoryObservation, ...]:
+    current_week_start = ATHLETE_TODAY - timedelta(days=ATHLETE_TODAY.weekday())
+    first_week_start = current_week_start - timedelta(weeks=8)
+    observations: list[TrailRunningHistoryObservation] = []
+    for week in range(8):
+        week_start = first_week_start + timedelta(weeks=week)
+        schedule = ((0, 40), (2, 45), (4, 50), (6, 65))
+        for index, (offset, duration) in enumerate(schedule):
+            trail = index >= 2
+            observations.append(
+                TrailRunningHistoryObservation(
+                    activity_id=f"w{week}-{index}",
+                    observed_date=week_start + timedelta(days=offset),
+                    activity_type="trail_running" if trail else "running",
+                    duration_min=float(duration),
+                    distance_km=float(duration) / 6,
+                    elevation_gain_meters=(200 if index == 2 else 300) if trail else 50,
+                    elevation_loss_meters=(180 if index == 2 else 280) if trail else 40,
+                    source="garmin",
+                )
+            )
+    return tuple(observations)
+
+
+def _generation_input(**changes: object) -> NonUltraTrailGenerationInput:
+    value = NonUltraTrailGenerationInput(
+        policy_version=NON_ULTRA_TRAIL_POLICY_VERSION,
+        science_decision_id=NON_ULTRA_TRAIL_SCIENCE_DECISION_ID,
+        contract_digest=NON_ULTRA_TRAIL_CONTRACT_DIGEST,
+        source_decision_digest=NON_ULTRA_TRAIL_SOURCE_DECISION_DIGEST,
+        ontology_decision_id=NON_ULTRA_TRAIL_ONTOLOGY_DECISION_ID,
+        ontology_contract_digest=NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST,
+        ontology_source_decision_digest=(
+            NON_ULTRA_TRAIL_ONTOLOGY_SOURCE_DECISION_DIGEST
+        ),
+        athlete_today=ATHLETE_TODAY,
+        block_start=BLOCK_START,
+        goal=NonUltraTrailGoal(
+            intent="performance",
+            event_format="single_day",
+            distance_family="non_ultra",
+            target_event_date=date(2026, 11, 15),
+            event_confirmed=True,
+        ),
+        course_demand=_course(),
+        history=_history(),
+        constraints=TrailPlanGenerationConstraints(
+            adult_confirmed=True,
+            current_symptom_stop=False,
+            available_weekdays=(0, 2, 4, 6),
+            weekly_time_limit_min=240,
+            maximum_session_duration_min=70,
+            preferred_longest_easy_weekday=6,
+        ),
+        prevalidation=InternalTrailPrevalidation(
+            course_demand_eligible=True,
+            terrain_access_eligible=True,
+            nontechnical_uphill_accessible=True,
+            training_terrain_reference="owner-access-v1",
+            technical_terrain_module_supported=True,
+        ),
+    )
+    return replace(value, **changes)
+
+
+def test_contracts_are_exactly_bound_and_remain_inactive() -> None:
+    assert NON_ULTRA_TRAIL_CONTRACT.contract_digest == NON_ULTRA_TRAIL_CONTRACT_DIGEST
+    assert (
+        NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.contract_digest
+        == NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT_DIGEST
+    )
+    assert str(NON_ULTRA_TRAIL_CONTRACT.runtime_state) == "inactive"
+    assert str(NON_ULTRA_TRAIL_ONTOLOGY_CONTRACT.runtime_state) == "inactive"
+    assert NON_ULTRA_TRAIL_COURSE_SCHEMA_ID == "trail_course_demand_v1"
+    assert NON_ULTRA_TRAIL_GUARDRAILS.committed_proposal_days == 14
+    assert NON_ULTRA_TRAIL_GUARDRAILS.advisory_reassessment_after_completed_days == 7
+
+
+def test_quality_template_is_exact_targetless_38_minute_contract() -> None:
+    assert CONTROLLED_UPHILL_TEMPLATE.total_minutes == 38
+    assert CONTROLLED_UPHILL_TEMPLATE.low_intensity_minutes == 26
+    input_value = _generation_input()
+    workout = generate_non_ultra_trail_plan(input_value).plan.weeks[0].workouts[1]
+    structure = serialize_workout_structure(workout)
+    assert workout.template_id == "trail-controlled-uphill-quality-v1"
+    assert structure["steps"][1]["repetitions"] == 4
+    assert all(
+        step.get("target", {}).get("metric") in {None, "none"}
+        for step in structure["steps"]
+    )
+
+
+def test_history_uses_all_runs_but_only_unambiguous_trail_for_vertical() -> None:
+    history = list(_history())
+    history.append(
+        TrailRunningHistoryObservation(
+            activity_id="ambiguous",
+            observed_date=ATHLETE_TODAY - timedelta(days=2),
+            activity_type="running",
+            duration_min=60,
+            distance_km=8,
+            elevation_gain_meters=999,
+            elevation_loss_meters=999,
+            source="garmin",
+        )
+    )
+    history.append(
+        TrailRunningHistoryObservation(
+            activity_id="unknown-loss",
+            observed_date=ATHLETE_TODAY - timedelta(days=1),
+            activity_type="trail_running",
+            duration_min=60,
+            distance_km=8,
+            elevation_gain_meters=999,
+            elevation_loss_meters=None,
+            source="garmin",
+        )
+    )
+    statistics = derive_recent_history_statistics(history, athlete_today=ATHLETE_TODAY)
+    assert statistics.usable_completed_weeks == 8
+    assert statistics.recent_modal_running_frequency == 4
+    assert statistics.recent_median_usable_weekly_minutes == 200
+    assert statistics.recent_median_usable_weekly_ascent_meters == 500
+    assert statistics.recent_median_usable_weekly_descent_meters == 460
+    assert statistics.recent_maximum_session_ascent_meters == 300
+    assert statistics.latest_run_date == ATHLETE_TODAY - timedelta(days=1)
+    assert statistics.comparable_trail_sessions_within_window == 12
+
+
+def test_eligible_generation_is_deterministic_and_within_every_cap() -> None:
+    generation_input = _generation_input()
+    first = generate_non_ultra_trail_plan(generation_input)
+    replay = generate_non_ultra_trail_plan(generation_input)
+    assert first == replay
+    assert first.code == "eligible_proposal"
+    assert first.detail_reason == "eligible_rolling_proposal"
+    assert first.plan is not None
+    assert first.plan.horizon_end == BLOCK_START + timedelta(days=13)
+    assert first.plan.reassessment_dates == (BLOCK_START + timedelta(days=7),)
+    assert validate_generated_plan(first.plan, generation_input) == ()
+    assert len(first.plan.weeks) == 2
+    for week in first.plan.weeks:
+        assert len(week.workouts) == 4
+        assert sum(item.planned_duration_min for item in week.workouts) == 200
+        assert sum(item.intensity_bucket == "quality" for item in week.workouts) == 1
+        assert week.weekly_ascent_ceiling_meters <= 500
+        assert week.weekly_descent_ceiling_meters <= 460
+        assert max(item.planned_duration_min for item in week.workouts) <= 65
+        assert max(item.ascent_ceiling_meters for item in week.workouts) <= 300
+
+
+def test_hash_is_order_independent_and_binds_ascent_and_descent_separately() -> None:
+    generation_input = _generation_input()
+    reordered = replace(
+        generation_input,
+        history=tuple(reversed(generation_input.history)),
+    )
+    assert deterministic_input_hash(generation_input) == deterministic_input_hash(
+        reordered
+    )
+
+    changed_gain = replace(
+        generation_input,
+        course_demand=replace(
+            generation_input.course_demand,
+            elevation_gain_meters=_known(619),
+        ),
+    )
+    changed_loss = replace(
+        generation_input,
+        course_demand=replace(
+            generation_input.course_demand,
+            elevation_loss_meters=_known(621),
+        ),
+    )
+    hashes = {
+        deterministic_input_hash(generation_input),
+        deterministic_input_hash(changed_gain),
+        deterministic_input_hash(changed_loss),
+    }
+    assert len(hashes) == 3
+
+
+@pytest.mark.parametrize(
+    ("prevalidation", "code"),
+    [
+        (
+            InternalTrailPrevalidation(None, True, True, "terrain"),
+            "material_course_demand_unknown",
+        ),
+        (
+            InternalTrailPrevalidation(False, True, True, "terrain"),
+            "course_clarification_required",
+        ),
+        (
+            InternalTrailPrevalidation(True, False, True, "terrain"),
+            "insufficient_terrain_access",
+        ),
+        (
+            InternalTrailPrevalidation(True, True, None, "terrain"),
+            "material_course_demand_unknown",
+        ),
+    ],
+)
+def test_prevalidation_false_or_unknown_fails_closed(
+    prevalidation: InternalTrailPrevalidation,
+    code: str,
+) -> None:
+    result = generate_non_ultra_trail_plan(
+        _generation_input(prevalidation=prevalidation)
+    )
+    assert result.code == code
+    assert result.plan is None
+
+
+def test_material_unknown_and_unconfirmed_assumption_fail_closed() -> None:
+    unknown = replace(_course(), elevation_loss_meters=_unknown())
+    result = generate_non_ultra_trail_plan(_generation_input(course_demand=unknown))
+    assert result.code == "material_course_demand_unknown"
+    assert result.uncertainty_or_missing_field == "elevation_loss_meters"
+
+    assumption = replace(
+        _course(),
+        technicality=ProvenancedValue(
+            value={"reference": "assumption"},
+            provenance="explicit_assumption",
+            athlete_confirmed=False,
+        ),
+    )
+    result = generate_non_ultra_trail_plan(_generation_input(course_demand=assumption))
+    assert result.code == "course_clarification_required"
+
+
+def test_conditional_unknowns_limit_modules_without_inventing_values() -> None:
+    course = replace(
+        _course(),
+        maximum_altitude_meters=_unknown(),
+        environmental_demand=_unknown(),
+        fueling_practice_experience=_unknown(),
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(
+            course_demand=course,
+            prevalidation=replace(
+                _generation_input().prevalidation,
+                technical_terrain_module_supported=None,
+            ),
+        )
+    )
+    assert result.code == "eligible_proposal"
+    assert result.limited_modules == (
+        "environment_module_limited",
+        "fueling_module_limited",
+        "technicality_module_limited",
+    )
+
+
+def test_product_detail_reasons_do_not_replace_canonical_science_codes() -> None:
+    short_history = _history()[:6]
+    result = generate_non_ultra_trail_plan(_generation_input(history=short_history))
+    assert result.code == "insufficient_comparable_history"
+    assert result.detail_reason == "insufficient_recent_history"
+
+    near_event = replace(
+        _generation_input().goal,
+        target_event_date=BLOCK_START + timedelta(days=14),
+    )
+    result = generate_non_ultra_trail_plan(_generation_input(goal=near_event))
+    assert result.code == "validation_failed"
+    assert result.detail_reason == "event_inside_unapproved_taper_window"
+
+
+def test_no_schedule_relaxes_no_guardrail() -> None:
+    constraints = replace(
+        _generation_input().constraints,
+        maximum_session_duration_min=37,
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(constraints=constraints)
+    )
+    assert result.code == "validation_failed"
+    assert result.detail_reason == "no_schedule_within_envelope"
+    assert result.plan is None
+
+
+def test_invariant_validator_rejects_a_tampered_week() -> None:
+    generation_input = _generation_input()
+    result = generate_non_ultra_trail_plan(generation_input)
+    assert result.plan is not None
+    first_week = result.plan.weeks[0]
+    tampered_week = replace(
+        first_week,
+        workouts=(
+            replace(
+                first_week.workouts[0],
+                activity_type="running",  # type: ignore[arg-type]
+            ),
+            *first_week.workouts[1:],
+        ),
+    )
+    tampered_plan: GeneratedNonUltraTrailPlan = replace(
+        result.plan,
+        weeks=(tampered_week, result.plan.weeks[1]),
+    )
+    assert "activity_type" in {
+        violation.rule_id
+        for violation in validate_generated_plan(tampered_plan, generation_input)
+    }
+
+
+def test_nonfinite_history_is_a_typed_validation_failure() -> None:
+    invalid = replace(_history()[0], duration_min=float("nan"))
+    result = generate_non_ultra_trail_plan(
+        _generation_input(history=(invalid, *_history()[1:]))
+    )
+    assert result.code == "validation_failed"
+    assert result.detail_reason == "contradictory_input"
+    assert result.uncertainty_or_missing_field == "history.duration_min"
+    with pytest.raises(ValueError):
+        deterministic_input_hash(_generation_input(history=(invalid,)))

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import date, datetime, time, timedelta, timezone
+from decimal import localcontext
 
 import pytest
 
@@ -707,4 +708,31 @@ def test_arbitrary_size_integer_duration_and_distance_do_not_overflow() -> None:
     assert result.code == "eligible_proposal"
     assert deterministic_input_hash(generation_input) == (
         result.deterministic_input_hash
+    )
+
+
+def test_duration_aggregation_is_order_and_decimal_context_independent() -> None:
+    huge = 10**400
+    history = list(_history())
+    history[0] = replace(
+        history[0],
+        duration_min=huge,
+        distance_km=huge,
+    )
+    history[1] = replace(history[1], duration_min=50.125)
+    generation_input = _generation_input(history=tuple(history))
+    reordered_input = replace(
+        generation_input,
+        history=tuple(reversed(history)),
+    )
+    with localcontext() as context:
+        context.prec = 28
+        low_precision = generate_non_ultra_trail_plan(generation_input)
+    with localcontext() as context:
+        context.prec = 500
+        high_precision = generate_non_ultra_trail_plan(reordered_input)
+    assert low_precision == high_precision
+    assert low_precision.history_statistics == high_precision.history_statistics
+    assert low_precision.deterministic_input_hash == (
+        high_precision.deterministic_input_hash
     )

--- a/tests/test_non_ultra_trail_plan_generation.py
+++ b/tests/test_non_ultra_trail_plan_generation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
 
@@ -78,19 +78,26 @@ def _history() -> tuple[TrailRunningHistoryObservation, ...]:
     observations: list[TrailRunningHistoryObservation] = []
     for week in range(8):
         week_start = first_week_start + timedelta(weeks=week)
-        schedule = ((0, 40), (2, 45), (4, 50), (6, 65))
+        schedule = ((0, 40), (2, 50), (4, 60))
         for index, (offset, duration) in enumerate(schedule):
-            trail = index >= 2
+            trail = index >= 1
+            observed_date = week_start + timedelta(days=offset)
             observations.append(
                 TrailRunningHistoryObservation(
                     activity_id=f"w{week}-{index}",
-                    observed_date=week_start + timedelta(days=offset),
+                    observed_date=observed_date,
                     activity_type="trail_running" if trail else "running",
                     duration_min=float(duration),
                     distance_km=float(duration) / 6,
-                    elevation_gain_meters=(200 if index == 2 else 300) if trail else 50,
-                    elevation_loss_meters=(180 if index == 2 else 280) if trail else 40,
+                    elevation_gain_meters=(200 if index == 1 else 300) if trail else 50,
+                    elevation_loss_meters=(180 if index == 1 else 280) if trail else 40,
                     source="garmin",
+                    source_timestamp=datetime.combine(
+                        observed_date,
+                        time(hour=12),
+                        tzinfo=timezone.utc,
+                    ),
+                    outdoor_confirmed=True,
                 )
             )
     return tuple(observations)
@@ -121,10 +128,10 @@ def _generation_input(**changes: object) -> NonUltraTrailGenerationInput:
         constraints=TrailPlanGenerationConstraints(
             adult_confirmed=True,
             current_symptom_stop=False,
-            available_weekdays=(0, 2, 4, 6),
+            available_weekdays=(1, 3, 5),
             weekly_time_limit_min=240,
             maximum_session_duration_min=70,
-            preferred_longest_easy_weekday=6,
+            preferred_longest_easy_weekday=5,
         ),
         prevalidation=InternalTrailPrevalidation(
             course_demand_eligible=True,
@@ -176,6 +183,14 @@ def test_history_uses_all_runs_but_only_unambiguous_trail_for_vertical() -> None
             elevation_gain_meters=999,
             elevation_loss_meters=999,
             source="garmin",
+            source_timestamp=datetime(
+                2026,
+                9,
+                1,
+                12,
+                tzinfo=timezone.utc,
+            ),
+            outdoor_confirmed=True,
         )
     )
     history.append(
@@ -188,17 +203,59 @@ def test_history_uses_all_runs_but_only_unambiguous_trail_for_vertical() -> None
             elevation_gain_meters=999,
             elevation_loss_meters=None,
             source="garmin",
+            source_timestamp=datetime(
+                2026,
+                9,
+                2,
+                12,
+                tzinfo=timezone.utc,
+            ),
+            outdoor_confirmed=True,
         )
     )
     statistics = derive_recent_history_statistics(history, athlete_today=ATHLETE_TODAY)
     assert statistics.usable_completed_weeks == 8
-    assert statistics.recent_modal_running_frequency == 4
-    assert statistics.recent_median_usable_weekly_minutes == 200
+    assert statistics.recent_modal_running_frequency == 3
+    assert statistics.recent_median_usable_weekly_minutes == 150
     assert statistics.recent_median_usable_weekly_ascent_meters == 500
     assert statistics.recent_median_usable_weekly_descent_meters == 460
     assert statistics.recent_maximum_session_ascent_meters == 300
     assert statistics.latest_run_date == ATHLETE_TODAY - timedelta(days=1)
-    assert statistics.comparable_trail_sessions_within_window == 12
+    assert statistics.comparable_trail_sessions_within_window == 11
+
+
+def test_duplicate_activity_ids_cannot_inflate_history() -> None:
+    history = _history()
+    duplicate = replace(
+        history[-1],
+        observed_date=ATHLETE_TODAY - timedelta(days=1),
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(history=(*history, duplicate))
+    )
+    assert result.code == "validation_failed"
+    assert result.uncertainty_or_missing_field == "history.duplicate_activity_id"
+
+
+def test_history_requires_typed_source_timestamp_and_outdoor_confirmation() -> None:
+    missing_timestamp = replace(
+        _history()[0],
+        source_timestamp=None,  # type: ignore[arg-type]
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(history=(missing_timestamp, *_history()[1:]))
+    )
+    assert result.code == "validation_failed"
+    assert result.uncertainty_or_missing_field == "history_observation"
+
+    indoor_history = tuple(
+        replace(item, outdoor_confirmed=False) for item in _history()
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(history=indoor_history)
+    )
+    assert result.code == "insufficient_comparable_history"
+    assert result.detail_reason == "insufficient_recent_history"
 
 
 def test_eligible_generation_is_deterministic_and_within_every_cap() -> None:
@@ -214,13 +271,49 @@ def test_eligible_generation_is_deterministic_and_within_every_cap() -> None:
     assert validate_generated_plan(first.plan, generation_input) == ()
     assert len(first.plan.weeks) == 2
     for week in first.plan.weeks:
-        assert len(week.workouts) == 4
-        assert sum(item.planned_duration_min for item in week.workouts) == 200
+        assert len(week.workouts) == 3
+        assert sum(item.planned_duration_min for item in week.workouts) == 150
         assert sum(item.intensity_bucket == "quality" for item in week.workouts) == 1
         assert week.weekly_ascent_ceiling_meters <= 500
         assert week.weekly_descent_ceiling_meters <= 460
-        assert max(item.planned_duration_min for item in week.workouts) <= 65
+        assert max(item.planned_duration_min for item in week.workouts) <= 60
         assert max(item.ascent_ceiling_meters for item in week.workouts) <= 300
+
+
+def test_adjacent_running_days_fail_closed_across_schedule_units() -> None:
+    history = list(_history())
+    current_week_start = ATHLETE_TODAY - timedelta(days=ATHLETE_TODAY.weekday())
+    first_week_start = current_week_start - timedelta(weeks=8)
+    for week in range(8):
+        observed_date = first_week_start + timedelta(weeks=week, days=6)
+        history.append(
+            TrailRunningHistoryObservation(
+                activity_id=f"w{week}-extra",
+                observed_date=observed_date,
+                activity_type="running",
+                duration_min=1,
+                distance_km=0.1,
+                elevation_gain_meters=0,
+                elevation_loss_meters=0,
+                source="garmin",
+                source_timestamp=datetime.combine(
+                    observed_date,
+                    time(hour=12),
+                    tzinfo=timezone.utc,
+                ),
+                outdoor_confirmed=True,
+            )
+        )
+    constraints = replace(
+        _generation_input().constraints,
+        available_weekdays=(0, 2, 4, 6),
+        preferred_longest_easy_weekday=6,
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(history=tuple(history), constraints=constraints)
+    )
+    assert result.code == "validation_failed"
+    assert result.detail_reason == "no_schedule_within_envelope"
 
 
 def test_hash_is_order_independent_and_binds_ascent_and_descent_separately() -> None:
@@ -382,6 +475,47 @@ def test_invariant_validator_rejects_a_tampered_week() -> None:
     }
 
 
+def test_invariant_validator_rebinds_versions_course_modules_and_history() -> None:
+    generation_input = _generation_input()
+    result = generate_non_ultra_trail_plan(generation_input)
+    assert result.plan is not None
+    plan = result.plan
+    tampered = (
+        (replace(plan, policy_version="other"), "policy_version"),
+        (replace(plan, generator_version="other"), "generator_version"),
+        (replace(plan, course_demand_fingerprint="0" * 64), "course_fingerprint"),
+        (replace(plan, limited_modules=("fueling_module_limited",)), "limited_modules"),
+        (
+            replace(
+                plan,
+                history_statistics=replace(
+                    plan.history_statistics,
+                    usable_completed_weeks=99,
+                ),
+            ),
+            "history_statistics",
+        ),
+    )
+    for candidate, expected_rule in tampered:
+        rules = {
+            violation.rule_id
+            for violation in validate_generated_plan(candidate, generation_input)
+        }
+        assert expected_rule in rules
+
+    ineligible_input = replace(
+        generation_input,
+        prevalidation=replace(
+            generation_input.prevalidation,
+            terrain_access_eligible=False,
+        ),
+    )
+    assert "eligibility:internal_terrain_prevalidation" in {
+        violation.rule_id
+        for violation in validate_generated_plan(plan, ineligible_input)
+    }
+
+
 def test_nonfinite_history_is_a_typed_validation_failure() -> None:
     invalid = replace(_history()[0], duration_min=float("nan"))
     result = generate_non_ultra_trail_plan(
@@ -392,3 +526,37 @@ def test_nonfinite_history_is_a_typed_validation_failure() -> None:
     assert result.uncertainty_or_missing_field == "history.duration_min"
     with pytest.raises(ValueError):
         deterministic_input_hash(_generation_input(history=(invalid,)))
+
+
+def test_invalid_hash_distinguishes_each_nonfinite_representation() -> None:
+    hashes = set()
+    for value in (float("nan"), float("inf"), float("-inf")):
+        invalid = replace(_history()[0], duration_min=value)
+        result = generate_non_ultra_trail_plan(
+            _generation_input(history=(invalid, *_history()[1:]))
+        )
+        assert result.code == "validation_failed"
+        hashes.add(result.deterministic_input_hash)
+    assert len(hashes) == 3
+
+
+def test_very_large_vertical_values_remain_bounded_without_per_meter_work() -> None:
+    huge = 10**15
+    history = tuple(
+        replace(
+            item,
+            elevation_gain_meters=huge,
+            elevation_loss_meters=huge - 1,
+        )
+        if item.activity_type == "trail_running"
+        else item
+        for item in _history()
+    )
+    result = generate_non_ultra_trail_plan(
+        _generation_input(history=history)
+    )
+    assert result.code == "eligible_proposal"
+    assert result.plan is not None
+    for week in result.plan.weeks:
+        assert week.weekly_ascent_ceiling_meters == huge * 2
+        assert week.weekly_descent_ceiling_meters == (huge - 1) * 2

--- a/tests/test_science_approval_workflow.py
+++ b/tests/test_science_approval_workflow.py
@@ -677,6 +677,51 @@ def test_decision_cannot_be_accepted_without_linked_evidence_approval(
     assert registry.decisions[decision.id].status == RecordStatus.DRAFT
 
 
+def test_trail_v2_successor_lifecycle_keeps_exact_authenticated_approvals() -> None:
+    science_dir = Path("data/science")
+    registry = load_science_registry(science_dir)
+    approvals = {
+        approval.subject_id: approval
+        for approval in load_science_approvals(science_dir)
+        if approval.subject_id in {
+            "sdr-trail-running-goal-ontology-v2",
+            "sdr-non-ultra-trail-plan-generation-policy-v2",
+        }
+    }
+    expected = {
+        "sdr-trail-running-goal-ontology-v2": (
+            "sdr-trail-running-goal-ontology-v1",
+            "sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1",
+            "https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653482",
+        ),
+        "sdr-non-ultra-trail-plan-generation-policy-v2": (
+            "sdr-non-ultra-trail-plan-generation-policy-v1",
+            "sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe",
+            "https://github.com/praxys-run/praxys/pull/776#issuecomment-5534653739",
+        ),
+    }
+
+    assert set(approvals) == set(expected)
+    for decision_id, (predecessor_id, digest, source_ref) in expected.items():
+        decision = registry.decisions[decision_id]
+        predecessor = registry.decisions[predecessor_id]
+        approval = approvals[decision_id]
+        assert decision.status == RecordStatus.ACCEPTED
+        assert decision.supersedes == [predecessor_id]
+        assert predecessor.status == RecordStatus.SUPERSEDED
+        assert predecessor.superseded_by == decision_id
+        assert decision.artifact_policy is not None
+        assert decision.artifact_policy.runtime_state == ArtifactRuntimeState.INACTIVE
+        assert approval.role == ReviewRole.DECISION_APPROVER
+        assert approval.subject_digest == digest == science_decision_digest(decision)
+        assert approval.reviewer == "github:dddtc2005"
+        assert approval.reviewed_on == date(2026, 9, 4)
+        assert str(approval.source_ref) == source_ref
+        assert set(approval.scopes) == set(
+            required_review_scopes(ReviewRole.DECISION_APPROVER)
+        )
+
+
 def test_workflow_uses_trusted_code_and_rechecks_the_exact_pr_head() -> None:
     workflow = _WORKFLOW.read_text(encoding="utf-8").replace("\r\n", "\n")
 

--- a/tests/test_science_artifacts.py
+++ b/tests/test_science_artifacts.py
@@ -1124,3 +1124,30 @@ def test_marathon_packet_contains_exact_accepted_inactive_contract() -> None:
 def test_repository_generated_science_artifacts_are_current() -> None:
     registry = load_science_registry()
     assert sync_science_artifacts(registry, check=True) == []
+
+
+def test_trail_v2_successor_contracts_are_exact_and_inactive() -> None:
+    expected = {
+        "sdr-trail-running-goal-ontology-v1": (
+            "superseded",
+            "sha256:e341c379d8f60a27ee5919beab4800721c96b79458c861237d6e14800cdcd752",
+        ),
+        "sdr-trail-running-goal-ontology-v2": (
+            "accepted",
+            "sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c",
+        ),
+        "sdr-non-ultra-trail-plan-generation-policy-v1": (
+            "superseded",
+            "sha256:2035f855cea2c1c117bd092796615148e98e59f1536013f86fb2bba1cab73ce2",
+        ),
+        "sdr-non-ultra-trail-plan-generation-policy-v2": (
+            "accepted",
+            "sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9",
+        ),
+    }
+
+    for decision_id, (status, digest) in expected.items():
+        contract = load_policy_contract(decision_id, require_active=False)
+        assert str(contract.decision_status) == status
+        assert str(contract.runtime_state) == "inactive"
+        assert contract.contract_digest == digest

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -390,6 +390,95 @@ def test_get_settings_exposes_sync_interval_options(api_client):
     assert body["default_sync_interval_hours"] == 6
 
 
+def test_generic_settings_hides_and_preserves_reserved_trail_namespace(api_client):
+    """The ordinary/MCP-allowlisted settings surface cannot read Trail state."""
+    client, user_id = api_client
+    from db import session as db_session
+    from db.models import UserConfig
+
+    reserved = {
+        "namespace_version": 99,
+        "future": {"opaque": True},
+    }
+    with db_session.SessionLocal() as db:
+        row = db.get(UserConfig, user_id)
+        if row is None:
+            row = UserConfig(user_id=user_id)
+            db.add(row)
+        row.goal = {
+            "goal_kind": "race",
+            "race_date": "2026-11-15",
+            "trail_plan": reserved,
+        }
+        db.commit()
+
+    response = client.get("/api/settings")
+    assert response.status_code == 200, response.text
+    assert response.json()["config"]["goal"] == {
+        "goal_kind": "race",
+        "race_date": "2026-11-15",
+    }
+
+    updated = client.put("/api/settings", json={
+        "goal": {"target_time_sec": 14_400},
+    })
+    assert updated.status_code == 200, updated.text
+    assert "trail_plan" not in updated.json()["config"]["goal"]
+    with db_session.SessionLocal() as db:
+        assert db.get(UserConfig, user_id).goal["trail_plan"] == reserved
+
+
+def test_generic_settings_rejects_reserved_trail_namespace_writes(api_client):
+    client, user_id = api_client
+    from db import session as db_session
+    from db.models import UserConfig
+
+    response = client.put("/api/settings", json={
+        "goal": {
+            "trail_plan": {
+                "namespace_version": 1,
+                "course_demand": {"forged": True},
+            },
+        },
+    })
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+    with db_session.SessionLocal() as db:
+        row = db.get(UserConfig, user_id)
+        assert row is None or "trail_plan" not in (row.goal or {})
+
+
+def test_stale_generic_settings_snapshot_cannot_overwrite_trail_namespace(
+    api_client,
+    monkeypatch,
+):
+    client, user_id = api_client
+    from analysis.config import UserConfig as ConfigValue
+    from db import session as db_session
+    from db.models import UserConfig
+
+    reserved = {"namespace_version": 99, "opaque": "keep-current"}
+    with db_session.SessionLocal() as db:
+        db.add(UserConfig(
+            user_id=user_id,
+            language="en",
+            goal={"goal_kind": "race", "trail_plan": reserved},
+        ))
+        db.commit()
+
+    stale = ConfigValue(goal={"goal_kind": "race"}, language="en")
+    monkeypatch.setattr(
+        "api.routes.settings.load_config_from_db",
+        lambda _user_id, _db: stale,
+    )
+    response = client.put("/api/settings", json={"language": "zh"})
+    assert response.status_code == 200, response.text
+    with db_session.SessionLocal() as db:
+        row = db.get(UserConfig, user_id)
+        assert row.language == "zh"
+        assert row.goal["trail_plan"] == reserved
+
+
 def test_put_science_reloads_config_after_plan_write_lock(
     api_client,
     monkeypatch,

--- a/tests/test_trail_plan_routes.py
+++ b/tests/test_trail_plan_routes.py
@@ -1,0 +1,331 @@
+"""HTTP-boundary tests for the deliberately unregistered Trail v2 router."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+from api.routes import trail_plan as trail_routes
+from db.session import get_db
+from tests.test_trail_plan_service import _valid_request, trail_db
+
+
+@pytest.fixture
+def trail_route_client(trail_db, monkeypatch):
+    app = FastAPI()
+    app.include_router(trail_routes.router, prefix="/api")
+    actor = {
+        "credential_kind": "first_party_jwt",
+        "is_demo": False,
+        "is_active": True,
+        "is_superuser": False,
+    }
+
+    def authenticate(request, _db):
+        if request.headers.get("authorization") != "Bearer valid-owner":
+            raise HTTPException(401, "Not authenticated")
+        user = SimpleNamespace(
+            is_active=actor["is_active"],
+            is_superuser=actor["is_superuser"],
+        )
+        return SimpleNamespace(
+            user_id="trail-owner",
+            user=user,
+            claims={},
+            is_demo=actor["is_demo"],
+            credential_kind=actor["credential_kind"],
+        )
+
+    def override_db():
+        with trail_db.SessionLocal() as db:
+            yield db
+
+    monkeypatch.setattr(trail_routes, "get_authenticated_identity", authenticate)
+    monkeypatch.setattr(
+        trail_routes,
+        "user_has_current_legal_bundle_for_request",
+        lambda _db, _user_id, _request: True,
+    )
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app) as client:
+        yield client, actor
+
+
+def _headers(**extra: str) -> dict[str, str]:
+    return {
+        "Authorization": "Bearer valid-owner",
+        "Content-Type": "application/json",
+        **extra,
+    }
+
+
+def test_router_is_absent_from_main_and_every_isolated_route_is_hidden():
+    from api.main import app as main_app
+
+    assert all(
+        "/plan/trail" not in getattr(route, "path", "")
+        for route in main_app.routes
+    )
+    assert all(route.include_in_schema is False for route in trail_routes.router.routes)
+    assert not any("trail" in path for path in main_app.openapi()["paths"])
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"credential_kind": "mcp_session"},
+        {"credential_kind": "context_grant"},
+        {"is_demo": True},
+        {"is_active": False},
+        {"is_superuser": True},
+    ],
+)
+def test_authenticated_ineligible_actors_get_private_404_before_body_io(
+    trail_route_client,
+    change,
+):
+    client, actor = trail_route_client
+    actor.update(change)
+    response = client.put(
+        "/api/plan/trail/draft",
+        content=b"not-json" * 5000,
+        headers=_headers(**{"Content-Encoding": "gzip"}),
+    )
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not found"}
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+def test_missing_or_invalid_auth_stays_401_before_body_io(trail_route_client):
+    client, _ = trail_route_client
+    response = client.put(
+        "/api/plan/trail/draft",
+        content=b"not-json" * 5000,
+        headers={"Content-Type": "application/json", "Content-Encoding": "gzip"},
+    )
+    assert response.status_code == 401
+
+
+def test_manual_parser_rejects_compression_size_utf8_duplicates_and_exponents(
+    trail_route_client,
+):
+    client, _ = trail_route_client
+
+    compressed = client.put(
+        "/api/plan/trail/draft",
+        content=b"{}",
+        headers=_headers(**{"Content-Encoding": "gzip"}),
+    )
+    assert compressed.status_code == 415
+
+    oversized = client.put(
+        "/api/plan/trail/draft",
+        content=b"{" + (b" " * (trail_routes.MAX_TRAIL_REQUEST_BYTES + 1)),
+        headers=_headers(),
+    )
+    assert oversized.status_code == 413
+
+    exact = client.put(
+        "/api/plan/trail/draft",
+        content=b"{}" + b" " * (trail_routes.MAX_TRAIL_REQUEST_BYTES - 2),
+        headers=_headers(),
+    )
+    assert exact.status_code == 400
+    assert exact.json()["detail"]["code"] != "TRAIL_REQUEST_TOO_LARGE"
+
+    invalid_utf8 = client.put(
+        "/api/plan/trail/draft",
+        content=b"\xff",
+        headers=_headers(),
+    )
+    assert invalid_utf8.status_code == 400
+    assert invalid_utf8.json()["detail"]["code"] == "TRAIL_UTF8_INVALID"
+
+    duplicate = client.put(
+        "/api/plan/trail/draft",
+        content=(
+            b'{"course_demand":{},"course_demand":{},"constraints":{}}'
+        ),
+        headers=_headers(),
+    )
+    assert duplicate.status_code == 400
+    assert duplicate.json()["detail"]["code"] == "TRAIL_JSON_INVALID"
+
+    exponential = client.put(
+        "/api/plan/trail/draft",
+        content=b'{"value":2.47e4}',
+        headers=_headers(),
+    )
+    assert exponential.status_code == 400
+    assert exponential.json()["detail"]["code"] == "TRAIL_JSON_INVALID"
+
+
+def test_parser_rejects_deceptive_length_and_structural_depth():
+    messages = [{"type": "http.request", "body": b"{}", "more_body": False}]
+
+    async def receive():
+        return messages.pop(0)
+
+    request = Request({
+        "type": "http",
+        "method": "PUT",
+        "path": "/api/plan/trail/draft",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", b"1"),
+        ],
+    }, receive)
+    with pytest.raises(HTTPException) as mismatch:
+        asyncio.run(trail_routes.read_trail_json_body(request))
+    assert mismatch.value.status_code == 400
+    assert mismatch.value.detail["code"] == "TRAIL_CONTENT_LENGTH_MISMATCH"
+
+    deep = "0"
+    for _ in range(trail_routes.MAX_TRAIL_NESTING_DEPTH):
+        deep = f'{{"x":{deep}}}'
+    messages = [{
+        "type": "http.request",
+        "body": deep.encode(),
+        "more_body": False,
+    }]
+
+    async def receive_deep():
+        return messages.pop(0)
+
+    deep_request = Request({
+        "type": "http",
+        "method": "PUT",
+        "path": "/api/plan/trail/draft",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(deep.encode())).encode()),
+        ],
+    }, receive_deep)
+    with pytest.raises(HTTPException) as nested:
+        asyncio.run(trail_routes.read_trail_json_body(deep_request))
+    assert nested.value.detail["code"] == "TRAIL_JSON_INVALID"
+
+    recursive = "[" * 15_000 + "0" + "]" * 15_000
+    messages = [{
+        "type": "http.request",
+        "body": recursive.encode(),
+        "more_body": False,
+    }]
+
+    async def receive_recursive():
+        return messages.pop(0)
+
+    recursive_request = Request({
+        "type": "http",
+        "method": "PUT",
+        "path": "/api/plan/trail/draft",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(recursive)).encode()),
+        ],
+    }, receive_recursive)
+    with pytest.raises(HTTPException) as recursion:
+        asyncio.run(trail_routes.read_trail_json_body(recursive_request))
+    assert recursion.value.status_code == 400
+    assert recursion.value.detail["code"] == "TRAIL_JSON_INVALID"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "{" + ",".join(f'\"k{index}\":0' for index in range(65)) + "}",
+        '{"values":[' + ",".join("0" for _ in range(33)) + "]}",
+        '{"value":"' + ("x" * 129) + '"}',
+        '{"value":2147483648}',
+        '{"value":1.234}',
+        '{"value":12345678901234567}',
+    ],
+)
+def test_parser_rejects_every_structural_bound(trail_route_client, body):
+    client, _ = trail_route_client
+    response = client.put(
+        "/api/plan/trail/draft",
+        content=body.encode(),
+        headers=_headers(),
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "TRAIL_JSON_INVALID"
+
+
+def test_route_lifecycle_uses_strong_if_match_and_actual_inactive_readiness(
+    trail_route_client,
+):
+    client, _ = trail_route_client
+    initial = client.get("/api/plan/trail/draft", headers=_headers())
+    assert initial.status_code == 200
+    revision = initial.json()["composite_revision"]
+    assert initial.headers["etag"] == f'"{revision}"'
+
+    missing_precondition = client.put(
+        "/api/plan/trail/draft",
+        json=_valid_request(),
+        headers=_headers(),
+    )
+    assert missing_precondition.status_code == 428
+
+    saved = client.put(
+        "/api/plan/trail/draft",
+        json=_valid_request(),
+        headers=_headers(**{"If-Match": f'"{revision}"'}),
+    )
+    assert saved.status_code == 200, saved.text
+    saved_body = saved.json()
+    assert saved_body["course_demand"]["fields"]["event_date"]["provenance"] == "athlete_stated"
+    assert "owner_id" not in saved_body
+
+    stale = client.put(
+        "/api/plan/trail/draft",
+        json=_valid_request(),
+        headers=_headers(**{"If-Match": f'"{revision}"'}),
+    )
+    assert stale.status_code == 412
+
+    readiness = client.post(
+        "/api/plan/trail/readiness",
+        headers=_headers(),
+    )
+    assert readiness.status_code == 200, readiness.text
+    assert readiness.json()["readiness"]["detail_reason"] == "policy_inactive"
+    assert readiness.json()["readiness"]["plan"] is None
+    assert readiness.json()["readiness"]["inactive_dry_run"] is False
+
+
+def test_client_cannot_submit_authority_fields(trail_route_client):
+    client, _ = trail_route_client
+    initial = client.get("/api/plan/trail/draft", headers=_headers()).json()
+    body = _valid_request()
+    body["owner_id"] = "another-owner"
+    response = client.put(
+        "/api/plan/trail/draft",
+        json=body,
+        headers=_headers(**{"If-Match": f'"{initial["composite_revision"]}"'}),
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "TRAIL_INVALID_FIELD_VALUE"
+
+
+def test_legal_bundle_failure_remains_outside_product_readiness(
+    trail_route_client,
+    monkeypatch,
+):
+    client, _ = trail_route_client
+    monkeypatch.setattr(
+        trail_routes,
+        "user_has_current_legal_bundle_for_request",
+        lambda _db, _user_id, _request: False,
+    )
+    response = client.put(
+        "/api/plan/trail/draft",
+        content=b"not-json",
+        headers=_headers(**{"Content-Encoding": "gzip"}),
+    )
+    assert response.status_code == 428
+    assert response.json()["detail"]["code"] == "TERMS_ACCEPTANCE_REQUIRED"

--- a/tests/test_trail_plan_service.py
+++ b/tests/test_trail_plan_service.py
@@ -1,0 +1,572 @@
+"""Focused service tests for the inactive migration-free Trail v2 slice."""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import date, datetime, timedelta, timezone
+import os
+import tempfile
+
+import pytest
+from sqlalchemy import event
+
+from api.trail_plan_service import (
+    ABSENT_TRAIL_PLAN_REVISION,
+    TRAIL_EDITABLE_SECTION_KEYS,
+    TRAIL_PLAN_GOAL_NAMESPACE,
+    TrailPlanServiceError,
+    confirm_trail_plan_section,
+    delete_trail_plan_draft,
+    evaluate_trail_plan_readiness,
+    read_trail_plan_draft,
+    reset_trail_plan_draft,
+    save_trail_plan_draft,
+    validate_trail_draft_request,
+)
+
+
+TODAY = date(2026, 9, 4)
+NOW = datetime(2026, 9, 4, 8, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def trail_db(monkeypatch):
+    tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    monkeypatch.setenv("DATA_DIR", os.path.join(tmpdir.name, "data"))
+    from db import session as db_session
+
+    db_session.engine = None
+    db_session.SessionLocal = None
+    db_session.async_engine = None
+    db_session.AsyncSessionLocal = None
+    db_session.init_db()
+    from db.models import User, UserConfig
+
+    with db_session.SessionLocal() as db:
+        db.add(User(
+            id="trail-owner",
+            email="trail-owner@test.local",
+            hashed_password="x",
+            is_active=True,
+        ))
+        db.add(UserConfig(
+            user_id="trail-owner",
+            goal={
+                "goal_kind": "race",
+                "distance": "24.7k",
+                "race_date": "2026-11-15",
+                "target_time_sec": 0,
+            },
+            source_options={"athlete_timezone": "Asia/Shanghai"},
+        ))
+        db.commit()
+    try:
+        yield db_session
+    finally:
+        if db_session.engine is not None:
+            db_session.engine.dispose()
+        if db_session.async_engine is not None:
+            import asyncio
+
+            try:
+                asyncio.run(db_session.async_engine.dispose())
+            except RuntimeError:
+                pass
+        db_session.engine = None
+        db_session.SessionLocal = None
+        db_session.async_engine = None
+        db_session.AsyncSessionLocal = None
+        tmpdir.cleanup()
+
+
+def _known(value):
+    return {"state": "known", "value": value}
+
+
+def _unknown():
+    return {"state": "unknown"}
+
+
+def _valid_request() -> dict:
+    return {
+        "course_demand": {
+            "schema_id": "trail_course_demand_v2",
+            "fields": {
+                "event_date": _known("2026-11-15"),
+                "distance_meters": _known(24700),
+                "total_ascent_m": _known(618),
+                "total_descent_m": _known(620),
+                "planning_duration_range": _known({
+                    "minimum_min": 180,
+                    "maximum_min": 300,
+                }),
+                "event_format": _known("single_day"),
+                "distance_family": _known("non_ultra"),
+                "planning_intent": _known("performance"),
+                "grade_distribution": _known({
+                    "below_neg_10": 500,
+                    "neg_10_to_below_neg_3": 1500,
+                    "neg_3_to_below_pos_3": 4000,
+                    "pos_3_to_below_pos_10": 3000,
+                    "pos_10_and_above": 1000,
+                }),
+                "course_footing": _known([
+                    "firm_smooth",
+                    "rocks_or_roots",
+                ]),
+                "hands_assist": _known(False),
+                "fixed_rope": _known(False),
+                "optional_context": {
+                    "environment": {
+                        "maximum_altitude_m": _unknown(),
+                        "temperature_min_c": _unknown(),
+                        "temperature_max_c": _unknown(),
+                        "humidity_min_pct": _unknown(),
+                        "humidity_max_pct": _unknown(),
+                        "sun_exposure": _unknown(),
+                        "wind_exposure": _unknown(),
+                        "conditions_basis": _unknown(),
+                    },
+                    "support": {
+                        "aid_support_mode": _unknown(),
+                        "aid_station_count": _unknown(),
+                        "max_aid_station_gap_m": _known(None),
+                        "water_availability": _unknown(),
+                        "food_availability": _unknown(),
+                        "mandatory_gear": _known([]),
+                    },
+                    "fueling": {
+                        "longest_practiced_duration_min": _unknown(),
+                        "practice_sessions_last_42_days": _unknown(),
+                        "intake_form": _unknown(),
+                        "gastrointestinal_experience": _unknown(),
+                    },
+                },
+            },
+        },
+        "constraints": {
+            "schema_id": "non_ultra_trail_constraints_v2",
+            "available_weekdays": _known([2, 4, 6]),
+            "weekly_time_limit_min": _known(240),
+            "maximum_session_duration_min": _known(70),
+            "unavailable_dates": _known([]),
+            "preferred_longest_weekday": 6,
+            "nontechnical_three_minute_uphill_access": _known(True),
+            "controlled_downhill_access": _known(True),
+            "accessible_footing": _known([
+                "firm_smooth",
+                "rocks_or_roots",
+            ]),
+            "adult_nonclinical_scope_confirmed": _known(True),
+            "performance_intent_confirmed": _known(True),
+            "current_symptom_stop": _known(False),
+        },
+    }
+
+
+def _confirm_all(db, state: dict) -> dict:
+    current = state
+    for section_key in TRAIL_EDITABLE_SECTION_KEYS:
+        section = next(
+            item
+            for item in current["revision_bindings"]["section_confirmations"]
+            if item["section_key"] == section_key
+        )
+        current = confirm_trail_plan_section(
+            db,
+            user_id="trail-owner",
+            section_key=section_key,
+            section_revision=section["current_revision"],
+            expected_revision=current["composite_revision"],
+            athlete_today=TODAY,
+        )
+    return current
+
+
+def test_strict_request_contract_rejects_coercion_duplicates_and_extra_keys():
+    request = _valid_request()
+    assert validate_trail_draft_request(request)["constraints"][
+        "available_weekdays"
+    ]["value"] == (2, 4, 6)
+
+    extra = deepcopy(request)
+    extra["actor_id"] = "forged"
+    with pytest.raises(TrailPlanServiceError, match="Invalid Trail"):
+        validate_trail_draft_request(extra)
+
+    coerced = deepcopy(request)
+    coerced["course_demand"]["fields"]["distance_meters"] = _known("24700")
+    with pytest.raises(TrailPlanServiceError):
+        validate_trail_draft_request(coerced)
+
+    duplicate = deepcopy(request)
+    duplicate["constraints"]["available_weekdays"] = _known([2, 2, 6])
+    with pytest.raises(TrailPlanServiceError):
+        validate_trail_draft_request(duplicate)
+
+    bad_grade = deepcopy(request)
+    bad_grade["course_demand"]["fields"]["grade_distribution"]["value"][
+        "below_neg_10"
+    ] = 501
+    with pytest.raises(TrailPlanServiceError):
+        validate_trail_draft_request(bad_grade)
+
+    forged = deepcopy(request)
+    forged["course_demand"]["fields"]["event_date"]["provenance"] = (
+        "course_verified"
+    )
+    with pytest.raises(TrailPlanServiceError):
+        validate_trail_draft_request(forged)
+
+    explicit_null = deepcopy(request)
+    explicit_null["constraints"]["preferred_longest_weekday"] = None
+    with pytest.raises(TrailPlanServiceError):
+        validate_trail_draft_request(explicit_null)
+
+    omitted = deepcopy(request)
+    omitted["constraints"].pop("preferred_longest_weekday")
+    assert validate_trail_draft_request(omitted)["constraints"][
+        "preferred_longest_weekday"
+    ] is None
+
+
+def test_save_rejects_unavailable_dates_outside_current_14_day_horizon(trail_db):
+    request = _valid_request()
+    request["constraints"]["unavailable_dates"] = _known([
+        (TODAY + timedelta(days=14)).isoformat(),
+    ])
+    with trail_db.SessionLocal() as db:
+        with pytest.raises(TrailPlanServiceError) as invalid:
+            save_trail_plan_draft(
+                db,
+                user_id="trail-owner",
+                request=request,
+                expected_revision=ABSENT_TRAIL_PLAN_REVISION,
+                athlete_today=TODAY,
+                now=NOW,
+            )
+        assert invalid.value.code == "TRAIL_INVALID_FIELD_VALUE"
+
+
+def test_draft_confirmation_edit_reset_and_delete_are_revision_fenced(trail_db):
+    with trail_db.SessionLocal() as db:
+        absent = read_trail_plan_draft(
+            db, user_id="trail-owner", athlete_today=TODAY
+        )
+        assert absent == {
+            "state": "absent",
+            "composite_revision": ABSENT_TRAIL_PLAN_REVISION,
+        }
+        saved = save_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            request=_valid_request(),
+            expected_revision=absent["composite_revision"],
+            athlete_today=TODAY,
+            now=NOW,
+        )
+        assert saved["state"] == "current"
+        assert saved["course_demand"]["event_id"]
+        assert all(
+            item["confirmed_revision"] is None
+            for item in saved["revision_bindings"]["section_confirmations"]
+        )
+        confirmed = _confirm_all(db, saved)
+        assert all(
+            item["confirmed_revision"] == item["current_revision"]
+            for item in confirmed["revision_bindings"]["section_confirmations"]
+        )
+
+        changed_request = _valid_request()
+        changed_request["course_demand"]["fields"]["distance_meters"] = _known(24701)
+        changed = save_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            request=changed_request,
+            expected_revision=confirmed["composite_revision"],
+            athlete_today=TODAY,
+            now=NOW + timedelta(minutes=1),
+        )
+        confirmations = {
+            item["section_key"]: item
+            for item in changed["revision_bindings"]["section_confirmations"]
+        }
+        assert confirmations["section.event-duration"]["confirmed_revision"] is None
+        assert all(
+            confirmations[key]["confirmed_revision"]
+            == confirmations[key]["current_revision"]
+            for key in TRAIL_EDITABLE_SECTION_KEYS
+            if key != "section.event-duration"
+        )
+
+        with pytest.raises(TrailPlanServiceError) as stale:
+            reset_trail_plan_draft(
+                db,
+                user_id="trail-owner",
+                expected_revision=confirmed["composite_revision"],
+                athlete_today=TODAY,
+                now=NOW,
+            )
+        assert stale.value.status_code == 412
+
+        reset = reset_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            expected_revision=changed["composite_revision"],
+            athlete_today=TODAY,
+            now=NOW + timedelta(minutes=2),
+        )
+        assert reset["reset_is_erasure"] is False
+        assert reset["course_demand"]["fields"]["event_date"]["state"] == "unknown"
+        assert all(
+            item["confirmed_revision"] is None
+            for item in reset["revision_bindings"]["section_confirmations"]
+        )
+
+        deleted = delete_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            expected_revision=reset["composite_revision"],
+            athlete_today=TODAY,
+        )
+        assert deleted == {
+            "status": "deleted",
+            "composite_revision": ABSENT_TRAIL_PLAN_REVISION,
+        }
+        from db.models import UserConfig
+
+        row = db.get(UserConfig, "trail-owner")
+        assert TRAIL_PLAN_GOAL_NAMESPACE not in row.goal
+        assert row.goal["race_date"] == "2026-11-15"
+
+
+def test_confirmation_rejects_malformed_revision_before_stale_disclosure(
+    trail_db,
+):
+    with trail_db.SessionLocal() as db:
+        saved = save_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            request=_valid_request(),
+            expected_revision=ABSENT_TRAIL_PLAN_REVISION,
+            athlete_today=TODAY,
+            now=NOW,
+        )
+        with pytest.raises(TrailPlanServiceError) as malformed:
+            confirm_trail_plan_section(
+                db,
+                user_id="trail-owner",
+                section_key="section.event-duration",
+                section_revision="bogus",
+                expected_revision=saved["composite_revision"],
+                athlete_today=TODAY,
+            )
+        assert malformed.value.status_code == 400
+        assert malformed.value.code == "TRAIL_INVALID_FIELD_VALUE"
+        assert "current_section_revision" not in malformed.value.details
+
+
+def test_assumption_confirmation_binds_the_exact_visible_section_revision(
+    trail_db,
+):
+    request = _valid_request()
+    request["course_demand"]["fields"]["optional_context"]["environment"][
+        "conditions_basis"
+    ] = _known("athlete_assumption")
+
+    with trail_db.SessionLocal() as db:
+        saved = save_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            request=request,
+            expected_revision=ABSENT_TRAIL_PLAN_REVISION,
+            athlete_today=TODAY,
+            now=NOW,
+        )
+        before = next(
+            item
+            for item in saved["revision_bindings"]["section_confirmations"]
+            if item["section_key"] == "section.optional-context"
+        )
+        confirmed = confirm_trail_plan_section(
+            db,
+            user_id="trail-owner",
+            section_key="section.optional-context",
+            section_revision=before["current_revision"],
+            expected_revision=saved["composite_revision"],
+            athlete_today=TODAY,
+        )
+        after = next(
+            item
+            for item in confirmed["revision_bindings"][
+                "section_confirmations"
+            ]
+            if item["section_key"] == "section.optional-context"
+        )
+        basis = confirmed["course_demand"]["fields"]["optional_context"][
+            "environment"
+        ]["conditions_basis"]
+
+        assert after["current_revision"] == before["current_revision"]
+        assert after["confirmed_revision"] == before["current_revision"]
+        assert basis["assumption_confirmed_revision"] == basis[
+            "source_revision"
+        ]
+
+
+def test_unknown_namespace_round_trips_but_only_reset_or_delete_can_replace_it(trail_db):
+    from db.models import UserConfig
+
+    opaque = {
+        "namespace_version": 99,
+        "future": {"keep": ["exact", {"value": 7}]},
+    }
+    with trail_db.SessionLocal() as db:
+        row = db.get(UserConfig, "trail-owner")
+        row.goal = {**row.goal, TRAIL_PLAN_GOAL_NAMESPACE: opaque}
+        db.commit()
+        state = read_trail_plan_draft(db, user_id="trail-owner", athlete_today=TODAY)
+        assert state["state"] == "unknown_schema"
+        assert state["namespace"] == opaque
+        with pytest.raises(TrailPlanServiceError) as mismatch:
+            save_trail_plan_draft(
+                db,
+                user_id="trail-owner",
+                request=_valid_request(),
+                expected_revision=state["composite_revision"],
+                athlete_today=TODAY,
+                now=NOW,
+            )
+        assert mismatch.value.code == "TRAIL_SCHEMA_VERSION_MISMATCH"
+        assert db.get(UserConfig, "trail-owner").goal[TRAIL_PLAN_GOAL_NAMESPACE] == opaque
+
+        reset = reset_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            expected_revision=state["composite_revision"],
+            athlete_today=TODAY,
+            now=NOW,
+        )
+        assert reset["state"] == "current"
+        assert db.get(UserConfig, "trail-owner").goal[TRAIL_PLAN_GOAL_NAMESPACE][
+            "namespace_version"
+        ] == 1
+
+
+def test_readiness_is_no_write_uses_actual_inactive_core_and_invents_no_descent_or_footing(trail_db):
+    from db.models import Activity, PlanProposal, UserConfig
+
+    with trail_db.SessionLocal() as db:
+        db.add(Activity(
+            user_id="trail-owner",
+            activity_id="trail-observation",
+            date=TODAY - timedelta(days=3),
+            activity_type="trail_running",
+            duration_sec=3600.0,
+            distance_km=10.0,
+            elevation_gain_m=500.0,
+            avg_power=9999.0,
+            start_time=(NOW - timedelta(days=3)).isoformat(),
+            source="garmin",
+        ))
+        db.commit()
+        saved = save_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            request=_valid_request(),
+            expected_revision=ABSENT_TRAIL_PLAN_REVISION,
+            athlete_today=TODAY,
+            now=NOW,
+        )
+        confirmed = _confirm_all(db, saved)
+        before_goal = deepcopy(db.get(UserConfig, "trail-owner").goal)
+        statements: list[str] = []
+
+        def capture(_conn, _cursor, statement, _parameters, _context, _many):
+            statements.append(statement.strip().upper())
+
+        event.listen(trail_db.engine, "before_cursor_execute", capture)
+        try:
+            result = evaluate_trail_plan_readiness(
+                db,
+                user_id="trail-owner",
+                athlete_today=TODAY,
+            )
+        finally:
+            event.remove(trail_db.engine, "before_cursor_execute", capture)
+
+        readiness = result["readiness"]
+        assert readiness["status"] == "policy_unavailable"
+        assert readiness["detail_reason"] == "policy_inactive"
+        assert readiness["plan"] is None
+        assert readiness["inactive_dry_run"] is False
+        reasons = {
+            f"{item['status']}.{item['detail_reason']}"
+            for item in readiness["matching_reasons"]
+        }
+        assert "policy_unavailable.policy_inactive" in reasons
+        assert "readiness_blocked.insufficient_descent_history" in reasons
+        assert "readiness_blocked.insufficient_comparable_trail_history" in reasons
+        assert readiness["history_statistics"]["recent_maximum_session_descent_meters"] == 0
+        assert readiness["history_statistics"]["recently_observed_footing"] == []
+        assert db.get(UserConfig, "trail-owner").goal == before_goal
+        assert db.query(PlanProposal).count() == 0
+        assert not any(
+            statement.startswith(("INSERT", "UPDATE", "DELETE"))
+            for statement in statements
+        )
+        assert confirmed["composite_revision"] == result["draft"]["composite_revision"]
+
+
+def test_garmin_local_times_and_outdoor_runs_support_running_continuity(
+    trail_db,
+):
+    from db.models import Activity
+
+    current_week_start = TODAY - timedelta(days=TODAY.weekday())
+    with trail_db.SessionLocal() as db:
+        for week in range(1, 5):
+            week_start = current_week_start - timedelta(weeks=week)
+            for index, offset in enumerate((0, 2, 4)):
+                observed = week_start + timedelta(days=offset)
+                activity_type = "trail_running" if index == 2 else "running"
+                db.add(Activity(
+                    user_id="trail-owner",
+                    activity_id=f"garmin-{week}-{index}",
+                    date=observed,
+                    activity_type=activity_type,
+                    duration_sec=3600.0,
+                    distance_km=10.0,
+                    elevation_gain_m=300.0 if index == 2 else 50.0,
+                    start_time=f"{observed.isoformat()} 07:00:00",
+                    source="garmin",
+                ))
+        db.commit()
+        saved = save_trail_plan_draft(
+            db,
+            user_id="trail-owner",
+            request=_valid_request(),
+            expected_revision=ABSENT_TRAIL_PLAN_REVISION,
+            athlete_today=TODAY,
+            now=NOW,
+        )
+        _confirm_all(db, saved)
+
+        result = evaluate_trail_plan_readiness(
+            db,
+            user_id="trail-owner",
+            athlete_today=TODAY,
+        )["readiness"]
+        reasons = {
+            f"{item['status']}.{item['detail_reason']}"
+            for item in result["matching_reasons"]
+        }
+
+        assert result["history_statistics"]["usable_completed_weeks"] == 4
+        assert result["history_statistics"][
+            "recent_modal_running_frequency"
+        ] == 3
+        assert (
+            "readiness_blocked.insufficient_recent_running_history"
+            not in reasons
+        )
+        assert "readiness_blocked.insufficient_descent_history" in reasons

--- a/web/src/components/TrailCourseReview.tsx
+++ b/web/src/components/TrailCourseReview.tsx
@@ -1,0 +1,2269 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useLingui } from '@lingui/react/macro';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { apiFetch, extractErrorMessage } from '@/hooks/useApi';
+import {
+  TRAIL_API_ENDPOINTS,
+  TRAIL_EDITABLE_SECTION_KEYS,
+  TRAIL_MODULE_KEYS,
+  type TrailClientEnvelope,
+  type TrailCurrentDraft,
+  type TrailDraftResponse,
+  type TrailEditableSectionKey,
+  type TrailFixedFieldTarget,
+  type TrailFocusTarget,
+  type TrailModuleAvailability,
+  type TrailModuleKey,
+  type TrailReadinessReceipt,
+  type TrailSectionKey,
+  type TrailServerEnvelope,
+} from '@/types/trail-plan';
+import {
+  ConfirmBar,
+  DurationEditor,
+  EnumEditor,
+  FieldShell,
+  MultiSelectEditor,
+  NumberEditor,
+  SectionShell,
+  TriStateEditor,
+  UnknownButton,
+} from './trail-course-review/controls';
+import { useTrailCourseReviewCopy } from './trail-course-review/copy';
+import {
+  FIELD_ELEMENT_IDS,
+  FIELD_TARGET_SECTIONS,
+  GRADE_KEYS,
+  MODULE_LIMIT_TARGETS,
+  REVISION_PATTERN,
+  SECTION_ELEMENT_IDS,
+  buildValidatedRequest,
+  currentDraftFromResponse,
+  formatIsoDate,
+  known,
+  localIsoDate,
+  numericInputsFromDraft,
+  parseGradeBasisPoints,
+  provenanceMeta,
+  reasonCodeOf,
+  replaceConstraintField,
+  replaceCourseField,
+  replaceOptionalField,
+  requestFromDraft,
+  sectionConfirmation,
+  setOptionalGroupUnknown,
+  unknown,
+  type ConstraintEnvelopeKey,
+  type ConstraintFields,
+  type CourseEnvelopeKey,
+  type CourseFields,
+  type NumericInputKey,
+  type OpenSections,
+  type OptionalGroup,
+  type ValidationIssue,
+} from './trail-course-review/model';
+import {
+  TrailCourseReviewLoadError,
+  TrailCourseReviewSkeleton,
+  TrailUnknownVersion,
+} from './trail-course-review/states';
+import {
+  TrailMutationResponseError,
+  preservesPendingTrailEdits,
+} from './trail-course-review/mutation-error';
+import { usePrivateTrailDraft } from './trail-course-review/use-private-draft';
+import {
+  parseTrailDeleteResponse,
+  parseTrailReadinessResponse,
+} from './trail-course-review/validation';
+
+export default function TrailCourseReview() {
+  const {
+    data,
+    loading,
+    error,
+    errorStatus,
+    refetch,
+    fetchLatest,
+    replaceData,
+    clearData,
+    rejectData,
+  } = usePrivateTrailDraft();
+
+  if (loading || (!data && !error)) return <TrailCourseReviewSkeleton />;
+  if (!data) {
+    return <TrailCourseReviewLoadError status={errorStatus} onRetry={refetch} />;
+  }
+  if (data.state === 'unknown_schema') {
+    return (
+      <TrailUnknownVersion
+        draft={data}
+        onReload={refetch}
+        onClearData={clearData}
+        onRejectData={rejectData}
+      />
+    );
+  }
+  return (
+    <TrailCourseReviewWorkbench
+      remoteDraft={data}
+      onRefetch={refetch}
+      onFetchLatest={fetchLatest}
+      onReplaceRemote={replaceData}
+      onClearRemote={clearData}
+      onRejectRemote={rejectData}
+    />
+  );
+}
+
+function TrailCourseReviewWorkbench({
+  remoteDraft,
+  onRefetch,
+  onFetchLatest,
+  onReplaceRemote,
+  onClearRemote,
+  onRejectRemote,
+}: {
+  remoteDraft: TrailCurrentDraft | Extract<TrailDraftResponse, { state: 'absent' }>;
+  onRefetch: () => Promise<void>;
+  onFetchLatest: () => Promise<TrailDraftResponse>;
+  onReplaceRemote: (value: TrailDraftResponse) => void;
+  onClearRemote: () => void;
+  onRejectRemote: (message: string) => void;
+}) {
+  const { i18n, t } = useLingui();
+  const isZh = i18n.locale.toLowerCase().startsWith('zh');
+  const l = useCallback(
+    (english: string, chinese: string) => isZh ? chinese : english,
+    [isZh],
+  );
+  const errorSummaryRef = useRef<HTMLHeadingElement>(null);
+  const receiptErrorRef = useRef<HTMLDivElement>(null);
+  const remoteRevisionRef = useRef(remoteDraft.composite_revision);
+  const pendingRef = useRef(false);
+  const [serverDraft, setServerDraft] = useState(remoteDraft);
+  const [request, setRequest] = useState(() => requestFromDraft(remoteDraft));
+  const [numericInputs, setNumericInputs] = useState(() => numericInputsFromDraft(remoteDraft));
+  const [dirtySections, setDirtySections] = useState<Set<TrailEditableSectionKey>>(
+    () => new Set(),
+  );
+  const [openSections, setOpenSections] = useState<OpenSections>({
+    'section.event-duration': true,
+    'section.grade-footing': true,
+    'section.training-access': true,
+    'section.recent-experience': true,
+    'section.optional-context': false,
+    'section.policy-receipt': true,
+  });
+  const [optionalOpened, setOptionalOpened] = useState(false);
+  const [readiness, setReadiness] = useState<TrailReadinessReceipt | null>(null);
+  const [historyComparisonVisible, setHistoryComparisonVisible] = useState(false);
+  const [validationIssues, setValidationIssues] = useState<ValidationIssue[]>([]);
+  const [operationError, setOperationError] = useState<string | null>(null);
+  const [receiptTargetError, setReceiptTargetError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [slowAction, setSlowAction] = useState(false);
+  const [dialogAction, setDialogAction] = useState<'reset' | 'delete' | null>(null);
+  const [latestDraft, setLatestDraft] = useState<TrailDraftResponse | null>(null);
+  const [staleConflict, setStaleConflict] = useState(false);
+  const [online, setOnline] = useState(
+    () => typeof navigator === 'undefined' || navigator.onLine,
+  );
+  const [unavailableDateInput, setUnavailableDateInput] = useState('');
+
+  const pending = dirtySections.size > 0;
+
+  useEffect(() => {
+    pendingRef.current = pending;
+  }, [pending]);
+
+  const replaceWithServer = useCallback((draft: TrailDraftResponse) => {
+    if (draft.state === 'unknown_schema') return;
+    setServerDraft(draft);
+    setRequest(requestFromDraft(draft));
+    setNumericInputs(numericInputsFromDraft(draft));
+    setDirtySections(new Set());
+    setValidationIssues([]);
+    setReadiness(null);
+    setLatestDraft(null);
+    setStaleConflict(false);
+    setUnavailableDateInput('');
+    remoteRevisionRef.current = draft.composite_revision;
+  }, []);
+
+  useEffect(() => {
+    if (remoteDraft.composite_revision === remoteRevisionRef.current) return;
+    remoteRevisionRef.current = remoteDraft.composite_revision;
+    if (pendingRef.current) {
+      setLatestDraft(remoteDraft);
+      setStaleConflict(true);
+      return;
+    }
+    replaceWithServer(remoteDraft);
+  }, [remoteDraft, replaceWithServer]);
+
+  useEffect(() => {
+    if (!pending) return undefined;
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    return () => window.removeEventListener('beforeunload', warnBeforeUnload);
+  }, [pending]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setOnline(true);
+      if (pendingRef.current) {
+        setNotice(l(
+          t`Connection restored. Review the current server version before restoring pending changes.`,
+          t`连接已恢复。请先查看当前服务端版本，再恢复待保存更改。`,
+        ));
+      }
+    };
+    const handleOffline = () => setOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [l, t]);
+
+  const beginBusy = useCallback((action: string) => {
+    setBusyAction(action);
+    setSlowAction(false);
+    return window.setTimeout(() => setSlowAction(true), 8_000);
+  }, []);
+
+  const endBusy = useCallback((timer: number) => {
+    window.clearTimeout(timer);
+    setBusyAction(null);
+    setSlowAction(false);
+  }, []);
+
+  const invalidateReadiness = useCallback((section: TrailEditableSectionKey) => {
+    setDirtySections((current) => {
+      const next = new Set(current);
+      next.add(section);
+      return next;
+    });
+    setReadiness(null);
+    setValidationIssues([]);
+    setNotice(l(
+      t`Changed—confirm this section again after saving.`,
+      t`已更改，保存后请重新确认本节。`,
+    ));
+  }, [l, t]);
+
+  const updateNumeric = useCallback((
+    key: NumericInputKey,
+    value: string,
+    section: TrailEditableSectionKey,
+  ) => {
+    setNumericInputs((current) => ({ ...current, [key]: value }));
+    invalidateReadiness(section);
+  }, [invalidateReadiness]);
+
+  const updateCourse = useCallback(<K extends CourseEnvelopeKey,>(
+    key: K,
+    value: CourseFields[K],
+    section: TrailEditableSectionKey,
+  ) => {
+    setRequest((current) => replaceCourseField(current, key, value));
+    invalidateReadiness(section);
+  }, [invalidateReadiness]);
+
+  const updateConstraint = useCallback(<K extends ConstraintEnvelopeKey,>(
+    key: K,
+    value: ConstraintFields[K],
+  ) => {
+    setRequest((current) => replaceConstraintField(current, key, value));
+    invalidateReadiness('section.training-access');
+  }, [invalidateReadiness]);
+
+  const updateOptional = useCallback((
+    group: OptionalGroup,
+    key: string,
+    value: TrailClientEnvelope<unknown>,
+  ) => {
+    setRequest((current) => replaceOptionalField(current, group, key, value));
+    invalidateReadiness('section.optional-context');
+  }, [invalidateReadiness]);
+
+  const openSection = useCallback((sectionKey: TrailSectionKey) => {
+    setOpenSections((current) => ({ ...current, [sectionKey]: true }));
+  }, []);
+
+  const focusClosedTarget = useCallback((target: TrailFocusTarget) => {
+    setReceiptTargetError(null);
+    const failClosed = () => {
+      setReceiptTargetError(l(
+        t`Praxys did not provide a safe destination for this action. Review the receipt and retry after reloading.`,
+        t`Praxys 未提供可安全跳转的目标。请查看回执并重新加载后重试。`,
+      ));
+      requestAnimationFrame(() => receiptErrorRef.current?.focus());
+    };
+
+    if (target.startsWith('section.')) {
+      if (!(target in SECTION_ELEMENT_IDS)) {
+        failClosed();
+        return;
+      }
+      const section = target as TrailSectionKey;
+      openSection(section);
+      requestAnimationFrame(() => {
+        document.getElementById(SECTION_ELEMENT_IDS[section])?.focus();
+      });
+      return;
+    }
+    if (target.startsWith('field.')) {
+      if (!(target in FIELD_ELEMENT_IDS)) {
+        failClosed();
+        return;
+      }
+      const field = target as TrailFixedFieldTarget;
+      openSection(FIELD_TARGET_SECTIONS[field]);
+      requestAnimationFrame(() => {
+        document.getElementById(FIELD_ELEMENT_IDS[field])?.focus();
+      });
+      return;
+    }
+    failClosed();
+  }, [l, openSection, t]);
+
+  const reviewLatest = useCallback(async () => {
+    const timer = beginBusy('reload');
+    setOperationError(null);
+    try {
+      const latest = await onFetchLatest();
+      if (latest.state === 'unknown_schema') {
+        onReplaceRemote(latest);
+        return;
+      }
+      setLatestDraft(latest);
+      setStaleConflict(true);
+      setNotice(l(
+        t`The latest server version is ready to compare. Pending changes were not overwritten.`,
+        t`最新服务端版本已可对照。待保存更改未被覆盖。`,
+      ));
+    } catch (error) {
+      setOperationError(error instanceof Error ? error.message : l(
+        t`The latest version could not be loaded.`,
+        t`无法加载最新版本。`,
+      ));
+    } finally {
+      endBusy(timer);
+    }
+  }, [beginBusy, endBusy, l, onFetchLatest, onReplaceRemote, t]);
+
+  const handleSpecialTarget = useCallback(async (target: TrailFocusTarget) => {
+    if (target === 'action.reload-supported-version') {
+      await reviewLatest();
+      openSection('section.policy-receipt');
+      requestAnimationFrame(() => {
+        document.getElementById(SECTION_ELEMENT_IDS['section.policy-receipt'])?.focus();
+      });
+      return;
+    }
+    if (target === 'action.retry-readiness') {
+      if (pendingRef.current) {
+        setReceiptTargetError(l(
+          t`Save and confirm the current revision before retrying readiness.`,
+          t`请先保存并确认当前版本，再重新检查准备情况。`,
+        ));
+        requestAnimationFrame(() => receiptErrorRef.current?.focus());
+        return;
+      }
+      const readinessAction = document.getElementById('trail-readiness-action');
+      readinessAction?.focus();
+      readinessAction?.click();
+      return;
+    }
+    if (target === 'action.review-history-envelope') {
+      setHistoryComparisonVisible(true);
+      focusClosedTarget('section.recent-experience');
+      return;
+    }
+    focusClosedTarget(target);
+  }, [focusClosedTarget, l, openSection, reviewLatest, t]);
+
+  const handleResponseError = useCallback(async (
+    response: Response,
+    fallback: string,
+  ) => {
+    if (response.status === 412) {
+      setStaleConflict(true);
+      setNotice(l(
+        t`The server revision changed. Review the latest version before choosing whether to reapply pending changes.`,
+        t`服务端版本已更改。请查看最新版本，再决定是否重新应用待保存更改。`,
+      ));
+    }
+    throw new TrailMutationResponseError(
+      await extractErrorMessage(response, fallback),
+      response.status,
+    );
+  }, [l, t]);
+
+  const saveDraft = useCallback(async (leaveAfterSave = false) => {
+    if (!online) {
+      setOperationError(l(
+        t`Offline. Changes are kept only on this page and have not been saved.`,
+        t`当前离线。更改仅保留在此页面，尚未保存。`,
+      ));
+      return;
+    }
+    const validated = buildValidatedRequest(request, numericInputs);
+    setValidationIssues(validated.issues);
+    if (validated.issues.length > 0) {
+      setOperationError(l(
+        t`Review the linked fields before saving.`,
+        t`保存前请检查已链接的字段。`,
+      ));
+      requestAnimationFrame(() => errorSummaryRef.current?.focus());
+      return;
+    }
+    const timer = beginBusy('save');
+    setOperationError(null);
+    try {
+      const response = await apiFetch(TRAIL_API_ENDPOINTS.draft, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'If-Match': serverDraft.composite_revision,
+        },
+        body: JSON.stringify(validated.request),
+      });
+      if (!response.ok) {
+        await handleResponseError(response, l(
+          t`The Trail course review could not be saved.`,
+          t`无法保存越野赛道核对。`,
+        ));
+      }
+      const next = currentDraftFromResponse(await response.json());
+      if (!next) throw new Error(l(
+        t`The server returned an unsupported Trail draft.`,
+        t`服务端返回了不受支持的越野草稿。`,
+      ));
+      onReplaceRemote(next);
+      replaceWithServer(next);
+      setNotice(l(
+        t`Course review saved. Confirm each reviewed section at this revision.`,
+        t`赛道核对已保存。请按当前版本逐节确认。`,
+      ));
+      if (leaveAfterSave) window.location.assign('/training');
+    } catch (error) {
+      const failure = error instanceof Error ? error.message : l(
+        t`The Trail course review could not be saved.`,
+        t`无法保存越野赛道核对。`,
+      );
+      if (preservesPendingTrailEdits(error)) {
+        setOperationError(null);
+      } else {
+        setOperationError(failure);
+        onRejectRemote(failure);
+      }
+    } finally {
+      endBusy(timer);
+    }
+  }, [
+    beginBusy,
+    endBusy,
+    handleResponseError,
+    l,
+    numericInputs,
+    online,
+    onReplaceRemote,
+    onRejectRemote,
+    replaceWithServer,
+    request,
+    serverDraft.composite_revision,
+    t,
+  ]);
+
+  const confirmSection = useCallback(async (sectionKey: TrailEditableSectionKey) => {
+    if (serverDraft.state !== 'current' || dirtySections.has(sectionKey)) return;
+    const confirmation = sectionConfirmation(serverDraft, sectionKey);
+    if (!confirmation || !REVISION_PATTERN.test(confirmation.current_revision)) {
+      const failure = l(
+        t`This section has no safe revision to confirm. Reload and review it again.`,
+        t`本节没有可安全确认的版本。请重新加载并再次核对。`,
+      );
+      setOperationError(failure);
+      onRejectRemote(failure);
+      return;
+    }
+    const timer = beginBusy(`confirm:${sectionKey}`);
+    setOperationError(null);
+    try {
+      const response = await apiFetch(TRAIL_API_ENDPOINTS.confirm, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'If-Match': serverDraft.composite_revision,
+        },
+        body: JSON.stringify({
+          section_key: sectionKey,
+          section_revision: confirmation.current_revision,
+        }),
+      });
+      if (!response.ok) {
+        await handleResponseError(response, l(
+          t`This section could not be confirmed.`,
+          t`无法确认本节。`,
+        ));
+      }
+      const next = currentDraftFromResponse(await response.json());
+      if (!next) throw new Error(l(
+        t`The server returned an unsupported confirmation response.`,
+        t`服务端返回了不受支持的确认响应。`,
+      ));
+      onReplaceRemote(next);
+      replaceWithServer(next);
+      setNotice(l(
+        t`This exact section revision is confirmed. Confirmation does not attest safety or eligibility.`,
+        t`已确认本节的确切版本。确认不代表安全或符合生成条件。`,
+      ));
+    } catch (error) {
+      const failure = error instanceof Error ? error.message : l(
+        t`This section could not be confirmed.`,
+        t`无法确认本节。`,
+      );
+      if (preservesPendingTrailEdits(error)) {
+        setOperationError(null);
+      } else {
+        setOperationError(failure);
+        onRejectRemote(failure);
+      }
+    } finally {
+      endBusy(timer);
+    }
+  }, [
+    beginBusy,
+    dirtySections,
+    endBusy,
+    handleResponseError,
+    l,
+    onReplaceRemote,
+    onRejectRemote,
+    replaceWithServer,
+    serverDraft,
+    t,
+  ]);
+
+  const allConfirmed = serverDraft.state === 'current'
+    && TRAIL_EDITABLE_SECTION_KEYS.every((sectionKey) => {
+      const item = sectionConfirmation(serverDraft, sectionKey);
+      return item !== null
+        && item.confirmed_revision === item.current_revision
+        && !dirtySections.has(sectionKey);
+    });
+
+  const checkReadiness = useCallback(async () => {
+    if (!allConfirmed || pending || busyAction) return;
+    const timer = beginBusy('readiness');
+    setOperationError(null);
+    setReceiptTargetError(null);
+    setReadiness(null);
+    try {
+      const response = await apiFetch(TRAIL_API_ENDPOINTS.readiness, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        await handleResponseError(response, l(
+          t`Readiness could not be checked.`,
+          t`暂时无法检查准备情况。`,
+        ));
+      }
+      const payload = parseTrailReadinessResponse(
+        await response.json() as unknown,
+        serverDraft.composite_revision,
+      );
+      if (!payload) {
+        throw new Error(l(
+          t`The readiness response did not match the accepted inactive Trail contract. No result was applied.`,
+          t`准备情况响应与已接受的未启用越野合同不一致。未应用任何结果。`,
+        ));
+      }
+      setReadiness(payload.readiness);
+      setNotice(l(
+        t`Readiness updated for the current confirmed revision.`,
+        t`已按当前确认版本更新准备情况。`,
+      ));
+    } catch (error) {
+      const failure = error instanceof Error ? error.message : l(
+        t`Readiness could not be checked.`,
+        t`暂时无法检查准备情况。`,
+      );
+      setOperationError(preservesPendingTrailEdits(error) ? null : failure);
+    } finally {
+      endBusy(timer);
+    }
+  }, [
+    allConfirmed,
+    beginBusy,
+    busyAction,
+    endBusy,
+    handleResponseError,
+    l,
+    pending,
+    serverDraft.composite_revision,
+    t,
+  ]);
+
+  const resetOrDelete = useCallback(async (kind: 'reset' | 'delete') => {
+    const timer = beginBusy(kind);
+    setOperationError(null);
+    try {
+      const response = await apiFetch(
+        kind === 'reset' ? TRAIL_API_ENDPOINTS.reset : TRAIL_API_ENDPOINTS.draft,
+        {
+          method: kind === 'reset' ? 'POST' : 'DELETE',
+          headers: { 'If-Match': serverDraft.composite_revision },
+        },
+      );
+      if (!response.ok) {
+        await handleResponseError(response, l(
+          t`The requested Trail data action did not complete.`,
+          t`请求的越野数据操作未完成。`,
+        ));
+      }
+      const payload = await response.json() as unknown;
+      if (kind === 'reset') {
+        const next = currentDraftFromResponse(payload);
+        if (!next || next.reset_is_erasure !== false) throw new Error(l(
+          t`The reset response was not recognized.`,
+          t`无法识别重置响应。`,
+        ));
+        onReplaceRemote(next);
+        replaceWithServer(next);
+        setNotice(l(
+          t`The server reset editable answers to unknown and invalidated confirmations. Source activities and retained proposals were not erased.`,
+          t`服务端已把可编辑回答重置为未知并使确认失效。来源活动和已保留提案未被删除。`,
+        ));
+      } else {
+        const deletion = parseTrailDeleteResponse(payload);
+        if (!deletion) {
+          throw new Error(l(
+            t`The deletion response was not recognized.`,
+            t`无法识别删除响应。`,
+          ));
+        }
+        setNotice(deletion.status === 'deleted'
+          ? l(
+            t`The inactive Trail API reported the Trail draft deleted. Your Praxys account was not deleted.`,
+            t`未启用的越野 API 已报告删除越野草稿。你的 Praxys 账号未被删除。`,
+          )
+          : l(
+            t`The inactive Trail API reported no Trail draft to delete. Your Praxys account was not deleted.`,
+            t`未启用的越野 API 报告没有可删除的越野草稿。你的 Praxys 账号未被删除。`,
+          ));
+        pendingRef.current = false;
+        setDirtySections(new Set());
+        setReadiness(null);
+        onClearRemote();
+        await onRefetch();
+      }
+      setDialogAction(null);
+    } catch (error) {
+      const failure = error instanceof Error ? error.message : l(
+        t`The requested Trail data action did not complete.`,
+        t`请求的越野数据操作未完成。`,
+      );
+      if (preservesPendingTrailEdits(error)) {
+        setOperationError(null);
+      } else {
+        setOperationError(failure);
+        onRejectRemote(failure);
+      }
+    } finally {
+      endBusy(timer);
+    }
+  }, [
+    beginBusy,
+    endBusy,
+    handleResponseError,
+    l,
+    onRefetch,
+    onReplaceRemote,
+    onClearRemote,
+    onRejectRemote,
+    replaceWithServer,
+    serverDraft.composite_revision,
+    t,
+  ]);
+
+  const restoreAgainstLatest = useCallback(() => {
+    if (!latestDraft || latestDraft.state === 'unknown_schema') return;
+    onReplaceRemote(latestDraft);
+    setServerDraft(latestDraft);
+    remoteRevisionRef.current = latestDraft.composite_revision;
+    setLatestDraft(null);
+    setStaleConflict(false);
+    setReadiness(null);
+    setNotice(l(
+      t`Pending values were reapplied in memory to the latest revision. They have not been saved or confirmed.`,
+      t`待保存值已在页面内存中重新应用到最新版本；尚未保存或确认。`,
+    ));
+  }, [l, latestDraft, onReplaceRemote, t]);
+
+  const discardPending = useCallback(() => {
+    if (!latestDraft || latestDraft.state === 'unknown_schema') return;
+    onReplaceRemote(latestDraft);
+    replaceWithServer(latestDraft);
+    setNotice(l(
+      t`Pending changes were discarded.`,
+      t`已放弃待保存更改。`,
+    ));
+  }, [l, latestDraft, onReplaceRemote, replaceWithServer, t]);
+
+
+  const {
+    copy,
+    provenanceLabels,
+    eventFormatOptions,
+    distanceFamilyOptions,
+    planningIntentOptions,
+    footingOptions,
+    weekdayOptions,
+    sunOptions,
+    windOptions,
+    conditionsOptions,
+    supportOptions,
+    availabilityOptions,
+    gearOptions,
+    intakeOptions,
+    gutOptions,
+    gradeLabels,
+    reasonCatalog,
+    moduleLabels,
+  } = useTrailCourseReviewCopy();
+
+  const readinessHeadline = readiness?.status === 'validation_failed'
+    ? l(t`We couldn't check this information`, t`暂时无法检查这些信息`)
+    : readiness?.status === 'policy_unavailable'
+      ? l(t`Trail planning isn't available for this case`, t`此情况暂不支持越野计划`)
+      : readiness?.status === 'readiness_blocked'
+        ? l(
+          t`Your symptoms, schedule, history, or terrain access blocks a proposal for now`,
+          t`当前症状、时间安排、训练历史或场地条件暂时阻止生成计划`,
+        )
+        : readiness?.status === 'clarification_required'
+          ? l(
+            t`A few answers are needed before Praxys can check readiness`,
+            t`还需补充少量信息，Praxys 才能检查准备情况`,
+          )
+          : readiness?.status === 'eligible_proposal'
+            ? l(t`Ready to review a 14-day proposal`, t`可以查看 14 天计划提案`)
+            : copy.noReceipt;
+  const matchingReasons = readiness?.matching_reasons ?? [];
+  const recognizedReasons = matchingReasons.flatMap((reason) => {
+    const code = reasonCodeOf(reason.status, reason.detail_reason);
+    return code ? [{ code, copy: reasonCatalog[code] }] : [];
+  });
+  const hasUnknownReason = Boolean(readiness)
+    && recognizedReasons.length !== matchingReasons.length;
+  const moduleByKey = new Map<TrailModuleKey, TrailModuleAvailability>(
+    (readiness?.module_availability ?? []).flatMap((module) =>
+      TRAIL_MODULE_KEYS.includes(module.module) ? [[module.module, module]] : []),
+  );
+  const currentFields = serverDraft.state === 'current'
+    ? serverDraft.course_demand.fields
+    : null;
+  const currentConstraints = serverDraft.state === 'current'
+    ? serverDraft.constraints
+    : null;
+  const history = readiness?.history_statistics ?? null;
+  const historyRevision = readiness?.revision_bindings?.history_revision
+    ?? (serverDraft.state === 'current'
+      ? serverDraft.revision_bindings.history_revision
+      : null);
+  const gradeRawValues = [
+    numericInputs.gradeBelowNeg10,
+    numericInputs.gradeNeg10ToNeg3,
+    numericInputs.gradeNearLevel,
+    numericInputs.gradePos3ToPos10,
+    numericInputs.gradePos10AndAbove,
+  ].map(parseGradeBasisPoints);
+  const gradeTotal = gradeRawValues.some((value) => value === null)
+    ? null
+    : gradeRawValues.reduce<number>((sum, value) => sum + (value ?? 0), 0) / 100;
+  const gradeInputsAreBlank = [
+    numericInputs.gradeBelowNeg10,
+    numericInputs.gradeNeg10ToNeg3,
+    numericInputs.gradeNearLevel,
+    numericInputs.gradePos3ToPos10,
+    numericInputs.gradePos10AndAbove,
+  ].every((value) => value === '');
+  const sectionTitle: Record<TrailEditableSectionKey, string> = {
+    'section.event-duration': copy.eventSection,
+    'section.grade-footing': copy.gradeSection,
+    'section.training-access': copy.trainingSection,
+    'section.optional-context': copy.optionalSection,
+  };
+  const changedServerSections = serverDraft.state === 'current'
+    && latestDraft?.state === 'current'
+      ? TRAIL_EDITABLE_SECTION_KEYS.filter((sectionKey) => {
+        const earlier = sectionConfirmation(serverDraft, sectionKey);
+        const latest = sectionConfirmation(latestDraft, sectionKey);
+        return earlier?.current_revision !== latest?.current_revision;
+      })
+      : [];
+  const validationLabel = (issue: ValidationIssue) => {
+    const names: Record<string, string> = {
+      'event-date': copy.eventDate,
+      distance: copy.raceDistance,
+      ascent: copy.totalAscent,
+      descent: copy.totalDescent,
+      'planning-duration': copy.planningMinimum,
+      'grade-distribution': copy.gradeDistribution,
+      'course-footing': copy.footing,
+      'weekly-time': copy.weeklyTime,
+      'session-time': copy.longestSession,
+      'available-days': copy.availableDays,
+      'accessible-footing': copy.trainingFooting,
+      'preferred-day': copy.preferredDay,
+      'maximum-altitude': copy.maximumAltitude,
+      temperature_min_c: copy.temperatureRange,
+      temperature_max_c: copy.temperatureRange,
+      'temperature-range': copy.temperatureRange,
+      humidity_min_pct: copy.humidityRange,
+      humidity_max_pct: copy.humidityRange,
+      'humidity-range': copy.humidityRange,
+      'aid-count': copy.aidCount,
+      'aid-gap': copy.aidGap,
+      'fueling-duration': copy.fuelingDuration,
+      'fueling-sessions': copy.fuelingSessions,
+    };
+    return names[issue.id] ?? sectionTitle[issue.section];
+  };
+  const confirmationProps = (sectionKey: TrailEditableSectionKey) => {
+    const confirmation = sectionConfirmation(serverDraft, sectionKey);
+    return {
+      currentRevision: confirmation?.current_revision ?? null,
+      confirmedRevision: confirmation?.confirmed_revision ?? null,
+      dirty: dirtySections.has(sectionKey),
+      canConfirm: serverDraft.state === 'current'
+        && dirtySections.size === 0
+        && !dirtySections.has(sectionKey)
+        && confirmation !== null
+        && (sectionKey !== 'section.optional-context' || optionalOpened),
+    };
+  };
+
+  return (
+    <main
+      data-state={pending
+        ? 'memory-only-unsaved'
+        : !online
+          ? 'offline'
+          : serverDraft.state === 'absent'
+            ? 'absent'
+            : 'online-saved'}
+      className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8"
+    >
+      <header className="mb-6 flex min-w-0 flex-col gap-4 border-b border-border pb-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="break-words text-2xl font-semibold tracking-tight">{copy.title}</h1>
+          <p className="mt-2 max-w-[72ch] break-words text-sm leading-6 text-muted-foreground">
+            {copy.support}
+          </p>
+        </div>
+        <div className="max-w-xs sm:text-right">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="min-h-11 whitespace-normal motion-reduce:transition-none"
+                />
+              }
+            >
+              {copy.moreActions}
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-64 motion-reduce:animate-none">
+              <DropdownMenuItem className="min-h-11 whitespace-normal" onClick={() => setDialogAction('reset')}>
+                {copy.reset}
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled className="min-h-11 whitespace-normal">
+                <span className="flex min-w-0 flex-col gap-0.5 text-left">
+                  <span>{copy.export}</span>
+                  <span className="break-words text-xs text-muted-foreground">
+                    {copy.exportUnavailable}
+                  </span>
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem variant="destructive" className="min-h-11 whitespace-normal" onClick={() => setDialogAction('delete')}>
+                {copy.delete}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </header>
+
+      <div className="mb-5 min-h-6 space-y-1" aria-live="polite" aria-atomic="true">
+        <p className="break-words text-sm text-muted-foreground">
+          {!online
+            ? copy.offline
+            : slowAction
+              ? copy.slow
+              : pending
+                ? copy.pending
+                : notice ?? (serverDraft.state === 'absent' ? copy.notSaved : copy.onlineSaved)}
+        </p>
+        {!online && pending ? (
+          <p className="break-words text-sm font-semibold">{copy.pending}</p>
+        ) : null}
+      </div>
+
+      {operationError ? (
+        <Alert variant="destructive" className="mb-5">
+          <AlertTitle>{l(t`Trail action did not complete`, t`越野操作未完成`)}</AlertTitle>
+          <AlertDescription className="space-y-3">
+            <p className="break-words">{operationError}</p>
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11"
+              onClick={() => { void onRefetch().catch(() => undefined); }}
+            >
+              {copy.retry}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {validationIssues.length > 0 ? (
+        <Alert variant="destructive" className="mb-5">
+          <AlertTitle>
+            <h2 ref={errorSummaryRef} tabIndex={-1}>{copy.errorSummary}</h2>
+          </AlertTitle>
+          <AlertDescription>
+            <ul className="space-y-2">
+              {validationIssues.map((issue) => (
+                <li key={issue.id}>
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="h-auto min-h-11 max-w-full justify-start whitespace-normal px-0 text-left text-destructive"
+                    onClick={() => { void handleSpecialTarget(issue.target); }}
+                  >
+                    {validationLabel(issue)} — {copy.fieldError}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {staleConflict ? (
+        <Alert className="mb-5 border-accent-amber/60">
+          <AlertTitle>{copy.staleTitle}</AlertTitle>
+          <AlertDescription className="space-y-3">
+            <p>{copy.staleExplanation}</p>
+            {changedServerSections.length > 0 ? (
+              <ul className="list-disc space-y-1 pl-5">
+                {changedServerSections.map((sectionKey) => (
+                  <li key={sectionKey}>{sectionTitle[sectionKey]}</li>
+                ))}
+              </ul>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              {!latestDraft ? (
+                <Button type="button" variant="outline" className="min-h-11" onClick={() => { void reviewLatest(); }}>
+                  {copy.reviewLatest}
+                </Button>
+              ) : (
+                <>
+                  <Button type="button" variant="outline" className="min-h-11 whitespace-normal" onClick={restoreAgainstLatest}>
+                    {copy.restorePending}
+                  </Button>
+                  <Button type="button" variant="outline" className="min-h-11 whitespace-normal" onClick={discardPending}>
+                    {copy.discardPending}
+                  </Button>
+                </>
+              )}
+            </div>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="grid min-w-0 gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)] lg:items-start">
+        <div className="order-2 min-w-0 lg:order-1">
+          <SectionShell
+            sectionKey="section.event-duration"
+            title={copy.eventSection}
+            open={openSections['section.event-duration']}
+            onOpenChange={(open) => setOpenSections((current) => ({
+              ...current,
+              'section.event-duration': open,
+            }))}
+          >
+            <FieldShell id="trail-event-identity" label={copy.event}>
+              <div className="flex min-w-0 flex-wrap items-center gap-3">
+                <span className="break-words text-sm">{copy.currentEvent}</span>
+                <a
+                  href="/goal"
+                  className="inline-flex min-h-11 items-center rounded-lg px-2 text-sm text-primary underline-offset-4 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {copy.editGoal}
+                </a>
+              </div>
+            </FieldShell>
+            <FieldShell
+              id="trail-event-date"
+              label={copy.eventDate}
+              meta={provenanceMeta(
+                currentFields?.event_date as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <div className="space-y-2">
+                <Input
+                  id="trail-event-date"
+                  type="date"
+                  value={request.course_demand.fields.event_date.state === 'known'
+                    ? request.course_demand.fields.event_date.value
+                    : ''}
+                  onChange={(event) => updateCourse(
+                    'event_date',
+                    known(event.target.value),
+                    'section.event-duration',
+                  )}
+                  className="h-11 max-w-sm font-data"
+                />
+                <UnknownButton
+                  unknown={request.course_demand.fields.event_date.state === 'unknown'}
+                  label={copy.unknown}
+                  onChange={(value) => {
+                    if (value) updateCourse('event_date', unknown(), 'section.event-duration');
+                  }}
+                />
+              </div>
+            </FieldShell>
+            <FieldShell
+              id="trail-race-distance"
+              label={copy.raceDistance}
+              meta={provenanceMeta(
+                currentFields?.distance_meters as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <NumberEditor
+                id="trail-race-distance"
+                value={numericInputs.distanceKm}
+                unknown={request.course_demand.fields.distance_meters.state === 'unknown'}
+                unknownLabel={copy.unknown}
+                inputLabel={copy.raceDistance}
+                suffix="km"
+                onValueChange={(value) => updateNumeric('distanceKm', value, 'section.event-duration')}
+                onUnknownChange={(value) => {
+                  if (value) updateCourse('distance_meters', unknown(), 'section.event-duration');
+                }}
+              />
+            </FieldShell>
+            <div className="grid min-w-0 gap-5 sm:grid-cols-2">
+              <FieldShell
+                id="trail-total-ascent"
+                label={copy.totalAscent}
+                meta={provenanceMeta(
+                  currentFields?.total_ascent_m as TrailServerEnvelope<unknown> | null,
+                  provenanceLabels,
+                  copy.modelVersion,
+                )}
+              >
+                <NumberEditor
+                  id="trail-total-ascent"
+                  value={numericInputs.totalAscentM}
+                  unknown={request.course_demand.fields.total_ascent_m.state === 'unknown'}
+                  unknownLabel={copy.unknown}
+                  inputLabel={copy.totalAscent}
+                  suffix="m"
+                  onValueChange={(value) => updateNumeric('totalAscentM', value, 'section.event-duration')}
+                  onUnknownChange={(value) => {
+                    if (value) updateCourse('total_ascent_m', unknown(), 'section.event-duration');
+                  }}
+                />
+              </FieldShell>
+              <FieldShell
+                id="trail-total-descent"
+                label={copy.totalDescent}
+                meta={provenanceMeta(
+                  currentFields?.total_descent_m as TrailServerEnvelope<unknown> | null,
+                  provenanceLabels,
+                  copy.modelVersion,
+                )}
+              >
+                <NumberEditor
+                  id="trail-total-descent"
+                  value={numericInputs.totalDescentM}
+                  unknown={request.course_demand.fields.total_descent_m.state === 'unknown'}
+                  unknownLabel={copy.unknown}
+                  inputLabel={copy.totalDescent}
+                  suffix="m"
+                  onValueChange={(value) => updateNumeric('totalDescentM', value, 'section.event-duration')}
+                  onUnknownChange={(value) => {
+                    if (value) updateCourse('total_descent_m', unknown(), 'section.event-duration');
+                  }}
+                />
+              </FieldShell>
+            </div>
+            <FieldShell
+              id="trail-planning-minimum"
+              label={copy.planningMinimum}
+              description={copy.planningHelp}
+              meta={provenanceMeta(
+                currentFields?.planning_duration_range as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <DurationEditor
+                id="trail-planning-minimum"
+                unknown={request.course_demand.fields.planning_duration_range.state === 'unknown'}
+                hours={numericInputs.planningMinimumHours}
+                minutes={numericInputs.planningMinimumMinutes}
+                hoursLabel={`${copy.planningMinimum} · ${copy.hours}`}
+                minutesLabel={`${copy.planningMinimum} · ${copy.minutes}`}
+                unknownLabel={copy.unknown}
+                onHoursChange={(value) => updateNumeric('planningMinimumHours', value, 'section.event-duration')}
+                onMinutesChange={(value) => updateNumeric('planningMinimumMinutes', value, 'section.event-duration')}
+                onUnknownChange={(value) => {
+                  if (value) updateCourse('planning_duration_range', unknown(), 'section.event-duration');
+                }}
+              />
+            </FieldShell>
+            <FieldShell id="trail-planning-maximum" label={copy.planningMaximum}>
+              <DurationEditor
+                id="trail-planning-maximum"
+                unknown={request.course_demand.fields.planning_duration_range.state === 'unknown'}
+                hours={numericInputs.planningMaximumHours}
+                minutes={numericInputs.planningMaximumMinutes}
+                hoursLabel={`${copy.planningMaximum} · ${copy.hours}`}
+                minutesLabel={`${copy.planningMaximum} · ${copy.minutes}`}
+                unknownLabel={copy.unknown}
+                onHoursChange={(value) => updateNumeric('planningMaximumHours', value, 'section.event-duration')}
+                onMinutesChange={(value) => updateNumeric('planningMaximumMinutes', value, 'section.event-duration')}
+                onUnknownChange={(value) => {
+                  if (value) updateCourse('planning_duration_range', unknown(), 'section.event-duration');
+                }}
+              />
+            </FieldShell>
+            <FieldShell
+              id="trail-event-format"
+              label={copy.eventFormat}
+              meta={provenanceMeta(
+                currentFields?.event_format as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <EnumEditor
+                id="trail-event-format"
+                envelope={request.course_demand.fields.event_format}
+                options={eventFormatOptions}
+                unknownLabel={copy.unknown}
+                placeholder={copy.choose}
+                onChange={(value) => updateCourse('event_format', value, 'section.event-duration')}
+              />
+            </FieldShell>
+            <FieldShell id="trail-distance-category" label={copy.distanceCategory}>
+              <EnumEditor
+                id="trail-distance-category"
+                envelope={request.course_demand.fields.distance_family}
+                options={distanceFamilyOptions}
+                unknownLabel={copy.unknown}
+                placeholder={copy.choose}
+                onChange={(value) => updateCourse('distance_family', value, 'section.event-duration')}
+              />
+            </FieldShell>
+            <FieldShell id="trail-planning-goal" label={copy.planningGoal}>
+              <EnumEditor
+                id="trail-planning-goal"
+                envelope={request.course_demand.fields.planning_intent}
+                options={planningIntentOptions}
+                unknownLabel={copy.unknown}
+                placeholder={copy.choose}
+                onChange={(value) => updateCourse('planning_intent', value, 'section.event-duration')}
+              />
+            </FieldShell>
+            <ConfirmBar
+              sectionKey="section.event-duration"
+              {...confirmationProps('section.event-duration')}
+              busy={busyAction !== null}
+              confirmLabel={copy.confirmSection}
+              confirmedLabel={copy.confirmedRevision}
+              changedLabel={copy.changedConfirmAgain}
+              saveFirstLabel={copy.saveBeforeConfirming}
+              onConfirm={(key) => { void confirmSection(key); }}
+            />
+          </SectionShell>
+          <SectionShell
+            sectionKey="section.grade-footing"
+            title={copy.gradeSection}
+            open={openSections['section.grade-footing']}
+            onOpenChange={(open) => setOpenSections((current) => ({
+              ...current,
+              'section.grade-footing': open,
+            }))}
+          >
+            <FieldShell
+              id="trail-grade-below-neg-10"
+              label={copy.gradeDistribution}
+              description={copy.gradeExplanation}
+              meta={provenanceMeta(
+                currentFields?.grade_distribution as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <div className="space-y-3">
+                {GRADE_KEYS.map((key, index) => {
+                  const inputKeys: readonly NumericInputKey[] = [
+                    'gradeBelowNeg10',
+                    'gradeNeg10ToNeg3',
+                    'gradeNearLevel',
+                    'gradePos3ToPos10',
+                    'gradePos10AndAbove',
+                  ];
+                  const inputKey = inputKeys[index];
+                  return (
+                    <div key={key} className="grid min-w-0 gap-2 sm:grid-cols-[minmax(0,1fr)_9rem] sm:items-center">
+                      <Label htmlFor={`trail-grade-${key}`} className="whitespace-normal leading-5">
+                        {gradeLabels[key]}
+                      </Label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          id={`trail-grade-${key}`}
+                          inputMode="decimal"
+                          value={numericInputs[inputKey]}
+                          onChange={(event) => updateNumeric(
+                            inputKey,
+                            event.target.value,
+                            'section.grade-footing',
+                          )}
+                          className="h-11 font-data"
+                        />
+                        <span className="font-data text-sm text-muted-foreground">%</span>
+                      </div>
+                    </div>
+                  );
+                })}
+                <div className="flex min-h-11 items-center justify-between border-t border-border pt-2 text-sm font-semibold">
+                  <span>{copy.total}</span>
+                  <span className="font-data">{gradeTotal === null ? '—' : gradeTotal.toFixed(2)}%</span>
+                </div>
+                <UnknownButton
+                  unknown={request.course_demand.fields.grade_distribution.state === 'unknown'
+                    && gradeInputsAreBlank}
+                  label={copy.unknown}
+                  onChange={(value) => {
+                    if (value) {
+                      setNumericInputs((current) => ({
+                        ...current,
+                        gradeBelowNeg10: '',
+                        gradeNeg10ToNeg3: '',
+                        gradeNearLevel: '',
+                        gradePos3ToPos10: '',
+                        gradePos10AndAbove: '',
+                      }));
+                      updateCourse(
+                        'grade_distribution',
+                        unknown(),
+                        'section.grade-footing',
+                      );
+                    }
+                  }}
+                />
+              </div>
+            </FieldShell>
+            <FieldShell
+              id="trail-course-footing"
+              label={copy.footing}
+              meta={provenanceMeta(
+                currentFields?.course_footing as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <MultiSelectEditor
+                id="trail-course-footing"
+                envelope={request.course_demand.fields.course_footing}
+                options={footingOptions}
+                unknownLabel={copy.unknown}
+                onChange={(value) => updateCourse('course_footing', value, 'section.grade-footing')}
+              />
+            </FieldShell>
+            <FieldShell id="trail-hands-assist" label={copy.hands}>
+              <TriStateEditor
+                id="trail-hands-assist"
+                envelope={request.course_demand.fields.hands_assist}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateCourse('hands_assist', value, 'section.grade-footing')}
+              />
+            </FieldShell>
+            <FieldShell id="trail-fixed-rope" label={copy.rope}>
+              <TriStateEditor
+                id="trail-fixed-rope"
+                envelope={request.course_demand.fields.fixed_rope}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateCourse('fixed_rope', value, 'section.grade-footing')}
+              />
+            </FieldShell>
+            <ConfirmBar
+              sectionKey="section.grade-footing"
+              {...confirmationProps('section.grade-footing')}
+              busy={busyAction !== null}
+              confirmLabel={copy.confirmSection}
+              confirmedLabel={copy.confirmedRevision}
+              changedLabel={copy.changedConfirmAgain}
+              saveFirstLabel={copy.saveBeforeConfirming}
+              onConfirm={(key) => { void confirmSection(key); }}
+            />
+          </SectionShell>
+          <SectionShell
+            sectionKey="section.training-access"
+            title={copy.trainingSection}
+            open={openSections['section.training-access']}
+            onOpenChange={(open) => setOpenSections((current) => ({
+              ...current,
+              'section.training-access': open,
+            }))}
+          >
+            <FieldShell
+              id="trail-available-days"
+              label={copy.availableDays}
+              meta={provenanceMeta(
+                currentConstraints?.available_weekdays as TrailServerEnvelope<unknown> | null,
+                provenanceLabels,
+                copy.modelVersion,
+              )}
+            >
+              <MultiSelectEditor
+                id="trail-available-days"
+                envelope={request.constraints.available_weekdays}
+                options={weekdayOptions}
+                unknownLabel={copy.unknown}
+                onChange={(value) => updateConstraint('available_weekdays', value)}
+              />
+            </FieldShell>
+            <FieldShell id="trail-weekly-time" label={copy.weeklyTime}>
+              <DurationEditor
+                id="trail-weekly-time"
+                unknown={request.constraints.weekly_time_limit_min.state === 'unknown'}
+                hours={numericInputs.weeklyHours}
+                minutes={numericInputs.weeklyMinutes}
+                hoursLabel={`${copy.weeklyTime} · ${copy.hours}`}
+                minutesLabel={`${copy.weeklyTime} · ${copy.minutes}`}
+                unknownLabel={copy.unknown}
+                onHoursChange={(value) => updateNumeric('weeklyHours', value, 'section.training-access')}
+                onMinutesChange={(value) => updateNumeric('weeklyMinutes', value, 'section.training-access')}
+                onUnknownChange={(value) => {
+                  if (value) updateConstraint('weekly_time_limit_min', unknown());
+                }}
+              />
+            </FieldShell>
+            <FieldShell id="trail-session-time" label={copy.longestSession}>
+              <DurationEditor
+                id="trail-session-time"
+                unknown={request.constraints.maximum_session_duration_min.state === 'unknown'}
+                hours={numericInputs.sessionHours}
+                minutes={numericInputs.sessionMinutes}
+                hoursLabel={`${copy.longestSession} · ${copy.hours}`}
+                minutesLabel={`${copy.longestSession} · ${copy.minutes}`}
+                unknownLabel={copy.unknown}
+                onHoursChange={(value) => updateNumeric('sessionHours', value, 'section.training-access')}
+                onMinutesChange={(value) => updateNumeric('sessionMinutes', value, 'section.training-access')}
+                onUnknownChange={(value) => {
+                  if (value) updateConstraint('maximum_session_duration_min', unknown());
+                }}
+              />
+            </FieldShell>
+            <FieldShell
+              id="trail-unavailable-date"
+              label={copy.unavailableDates}
+              description={l(
+                t`Choose at most 14 dates inside the displayed 14-day horizon.`,
+                t`最多选择显示的 14 天范围内的 14 个日期。`,
+              )}
+            >
+              <div className="space-y-3">
+                <div className="flex min-w-0 flex-col gap-2 sm:flex-row">
+                  <Input
+                    id="trail-unavailable-date"
+                    type="date"
+                    min={localIsoDate()}
+                    max={localIsoDate(13)}
+                    value={unavailableDateInput}
+                    onChange={(event) => setUnavailableDateInput(event.target.value)}
+                    className="h-11 max-w-sm font-data"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="min-h-11"
+                    disabled={!unavailableDateInput}
+                    onClick={() => {
+                      const current = request.constraints.unavailable_dates.state === 'known'
+                        ? request.constraints.unavailable_dates.value
+                        : [];
+                      if (
+                        unavailableDateInput >= localIsoDate()
+                        && unavailableDateInput <= localIsoDate(13)
+                        && current.length < 14
+                        && !current.includes(unavailableDateInput)
+                      ) {
+                        updateConstraint(
+                          'unavailable_dates',
+                          known([...current, unavailableDateInput].sort()),
+                        );
+                        setUnavailableDateInput('');
+                      }
+                    }}
+                  >
+                    {copy.addDate}
+                  </Button>
+                </div>
+                {request.constraints.unavailable_dates.state === 'known' ? (
+                  request.constraints.unavailable_dates.value.length > 0 ? (
+                    <ul className="flex flex-wrap gap-2">
+                      {request.constraints.unavailable_dates.value.map((date) => (
+                        <li key={date}>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className="min-h-11 whitespace-normal font-data"
+                            aria-label={`${copy.removeDate}: ${formatIsoDate(date, i18n.locale)}`}
+                            onClick={() => updateConstraint(
+                              'unavailable_dates',
+                              known(request.constraints.unavailable_dates.state === 'known'
+                                ? request.constraints.unavailable_dates.value.filter((item) => item !== date)
+                                : []),
+                            )}
+                          >
+                            {formatIsoDate(date, i18n.locale)}
+                          </Button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : <p className="text-sm text-muted-foreground">{copy.noDates}</p>
+                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant={request.constraints.unavailable_dates.state === 'known'
+                      && request.constraints.unavailable_dates.value.length === 0
+                      ? 'secondary'
+                      : 'outline'}
+                    aria-pressed={request.constraints.unavailable_dates.state === 'known'
+                      && request.constraints.unavailable_dates.value.length === 0}
+                    className="min-h-11 min-w-11"
+                    onClick={() => updateConstraint('unavailable_dates', known([]))}
+                  >
+                    {copy.noDates}
+                  </Button>
+                  <UnknownButton
+                    unknown={request.constraints.unavailable_dates.state === 'unknown'}
+                    label={copy.unknown}
+                    onChange={(value) => {
+                      if (value) {
+                        setUnavailableDateInput('');
+                        updateConstraint('unavailable_dates', unknown());
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+            </FieldShell>
+            <FieldShell id="trail-preferred-day" label={copy.preferredDay}>
+              <Select
+                value={request.constraints.preferred_longest_weekday === undefined
+                  ? 'none'
+                  : String(request.constraints.preferred_longest_weekday)}
+                onValueChange={(value) => {
+                  setRequest((current) => {
+                    const next = { ...current, constraints: { ...current.constraints } };
+                    if (value === 'none' || value === null) {
+                      delete next.constraints.preferred_longest_weekday;
+                    } else {
+                      next.constraints.preferred_longest_weekday = Number(value);
+                    }
+                    return next;
+                  });
+                  invalidateReadiness('section.training-access');
+                }}
+              >
+                <SelectTrigger id="trail-preferred-day" className="min-h-11 w-full max-w-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="motion-reduce:animate-none">
+                  <SelectItem value="none" className="min-h-11">{copy.noPreference}</SelectItem>
+                  {weekdayOptions.map((option) => (
+                    <SelectItem key={option.value} value={String(option.value)} className="min-h-11">
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FieldShell>
+            <FieldShell id="trail-uphill-access" label={copy.uphillAccess}>
+              <TriStateEditor
+                id="trail-uphill-access"
+                envelope={request.constraints.nontechnical_three_minute_uphill_access}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateConstraint('nontechnical_three_minute_uphill_access', value)}
+              />
+            </FieldShell>
+            <FieldShell id="trail-downhill-access" label={copy.downhillAccess}>
+              <TriStateEditor
+                id="trail-downhill-access"
+                envelope={request.constraints.controlled_downhill_access}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateConstraint('controlled_downhill_access', value)}
+              />
+            </FieldShell>
+            <FieldShell id="trail-training-footing" label={copy.trainingFooting}>
+              <MultiSelectEditor
+                id="trail-training-footing"
+                envelope={request.constraints.accessible_footing}
+                options={footingOptions}
+                unknownLabel={copy.unknown}
+                onChange={(value) => updateConstraint('accessible_footing', value)}
+              />
+            </FieldShell>
+            <FieldShell id="trail-adult-scope" label={copy.adultScope}>
+              <TriStateEditor
+                id="trail-adult-scope"
+                envelope={request.constraints.adult_nonclinical_scope_confirmed}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateConstraint('adult_nonclinical_scope_confirmed', value)}
+              />
+            </FieldShell>
+            <FieldShell id="trail-performance-scope" label={copy.performanceScope}>
+              <TriStateEditor
+                id="trail-performance-scope"
+                envelope={request.constraints.performance_intent_confirmed}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateConstraint('performance_intent_confirmed', value)}
+              />
+            </FieldShell>
+            <FieldShell id="trail-symptom-stop" label={copy.symptoms}>
+              <TriStateEditor
+                id="trail-symptom-stop"
+                envelope={request.constraints.current_symptom_stop}
+                yesLabel={copy.yes}
+                noLabel={copy.no}
+                unknownLabel={copy.notSure}
+                onChange={(value) => updateConstraint('current_symptom_stop', value)}
+              />
+            </FieldShell>
+            <ConfirmBar
+              sectionKey="section.training-access"
+              {...confirmationProps('section.training-access')}
+              busy={busyAction !== null}
+              confirmLabel={copy.confirmSection}
+              confirmedLabel={copy.confirmedRevision}
+              changedLabel={copy.changedConfirmAgain}
+              saveFirstLabel={copy.saveBeforeConfirming}
+              onConfirm={(key) => { void confirmSection(key); }}
+            />
+          </SectionShell>
+          <SectionShell
+            sectionKey="section.recent-experience"
+            title={copy.recentSection}
+            description={l(
+              t`This server-derived receipt is read-only. Correct source activities from Activities; plan start does not accept replacement attestations.`,
+              t`此服务端推导回执为只读。请在活动记录中更正来源活动；计划开始流程不接受替代证明。`,
+            )}
+            open={openSections['section.recent-experience']}
+            onOpenChange={(open) => setOpenSections((current) => ({
+              ...current,
+              'section.recent-experience': open,
+            }))}
+          >
+            {[
+              {
+                id: 'trail-history-running',
+                label: copy.continuity,
+                value: history
+                  ? l(
+                    t`${history.usable_completed_weeks} completed weeks · ${history.recent_modal_running_frequency} runs per week`,
+                    t`${history.usable_completed_weeks} 个完整周 · 每周 ${history.recent_modal_running_frequency} 次跑步`,
+                  )
+                  : copy.notEvaluated,
+                freshness: history?.latest_run_date ?? null,
+              },
+              {
+                id: 'trail-history-ascent',
+                label: copy.ascentExposure,
+                value: history
+                  ? l(
+                    t`${history.comparable_ascent_sessions_within_window} comparable sessions · ${history.recent_maximum_session_ascent_meters} m maximum observed ascent`,
+                    t`${history.comparable_ascent_sessions_within_window} 次可比训练 · 单次已观察最大爬升 ${history.recent_maximum_session_ascent_meters} 米`,
+                  )
+                  : copy.notEvaluated,
+                freshness: history?.latest_comparable_ascent_session_date ?? null,
+              },
+              {
+                id: 'trail-history-descent',
+                label: copy.descentExposure,
+                value: history
+                  ? l(
+                    t`${history.comparable_descent_sessions_within_window} comparable sessions · ${history.recent_maximum_session_descent_meters} m maximum observed descent`,
+                    t`${history.comparable_descent_sessions_within_window} 次可比训练 · 单次已观察最大下降 ${history.recent_maximum_session_descent_meters} 米`,
+                  )
+                  : copy.notEvaluated,
+                freshness: history?.latest_comparable_descent_session_date ?? null,
+              },
+              {
+                id: 'trail-history-footing',
+                label: copy.observedFooting,
+                value: history
+                  ? history.recently_observed_footing.length > 0
+                    ? history.recently_observed_footing.map((value) => footingOptions.find((item) => item.value === value)?.label ?? '').filter(Boolean).join(', ')
+                    : l(t`No qualifying footing observed`, t`未观察到符合条件的路面`)
+                  : copy.notEvaluated,
+                freshness: history?.observation_window_end ?? null,
+              },
+            ].map((row) => (
+              <article key={row.id} id={row.id} tabIndex={-1} className="min-w-0 border-t border-border pt-4 first:border-t-0 first:pt-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                <h3 className="break-words text-sm font-semibold">{row.label}</h3>
+                <p className="mt-1 break-words font-data text-sm">{row.value}</p>
+                <dl className="mt-3 grid min-w-0 gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                  <div>
+                    <dt>{copy.observationWindow}</dt>
+                    <dd className="mt-1 break-words font-data">
+                      {history
+                        ? `${formatIsoDate(history.observation_window_start, i18n.locale)} – ${formatIsoDate(history.observation_window_end, i18n.locale)}`
+                        : copy.notEvaluated}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>{copy.freshness}</dt>
+                    <dd className="mt-1 font-data">{row.freshness ? formatIsoDate(row.freshness, i18n.locale) : copy.notEvaluated}</dd>
+                  </div>
+                  <div>
+                    <dt>{copy.serverSource}</dt>
+                    <dd className="mt-1">{copy.fromHistory}</dd>
+                  </div>
+                  <div>
+                    <dt>{copy.sourceRevision}</dt>
+                    <dd className="mt-1 break-all font-data">{historyRevision ?? '—'}</dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+            {historyComparisonVisible ? (
+              <div className="border-t border-border pt-4">
+                <h3 className="text-sm font-semibold text-accent-cobalt">{copy.compareHistory}</h3>
+                <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{copy.historyComparisonHelp}</p>
+                <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <dt className="text-xs text-muted-foreground">{copy.weeklyTime}</dt>
+                    <dd className="font-data text-sm">
+                      {request.constraints.weekly_time_limit_min.state === 'known'
+                        ? `${numericInputs.weeklyHours} h ${numericInputs.weeklyMinutes} min`
+                        : copy.unknown}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-muted-foreground">{copy.longestSession}</dt>
+                    <dd className="font-data text-sm">
+                      {request.constraints.maximum_session_duration_min.state === 'known'
+                        ? `${numericInputs.sessionHours} h ${numericInputs.sessionMinutes} min`
+                        : copy.unknown}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            ) : null}
+          </SectionShell>
+          <SectionShell
+            sectionKey="section.optional-context"
+            title={copy.optionalSection}
+            description={l(
+              t`Open and review this section before confirming it. Each group can be set to unknown without inventing defaults.`,
+              t`确认前请打开并核对本节。每组都可设为未知，不会虚构默认值。`,
+            )}
+            open={openSections['section.optional-context']}
+            onOpenChange={(open) => {
+              setOpenSections((current) => ({
+                ...current,
+                'section.optional-context': open,
+              }));
+              if (open) setOptionalOpened(true);
+            }}
+          >
+            <section aria-labelledby="trail-environment-heading" className="space-y-5 border-t border-border pt-5 first:border-t-0 first:pt-0">
+              <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <h3 id="trail-environment-heading" className="text-base font-semibold">{copy.environment}</h3>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="min-h-11 whitespace-normal"
+                  onClick={() => {
+                    setRequest((current) => setOptionalGroupUnknown(current, 'environment'));
+                    invalidateReadiness('section.optional-context');
+                  }}
+                >
+                  {copy.setGroupUnknown}
+                </Button>
+              </div>
+              <FieldShell id="trail-maximum-altitude" label={copy.maximumAltitude}>
+                <NumberEditor
+                  id="trail-maximum-altitude"
+                  value={numericInputs.maximumAltitudeM}
+                  unknown={request.course_demand.fields.optional_context.environment.maximum_altitude_m.state === 'unknown'}
+                  unknownLabel={copy.unknown}
+                  inputLabel={copy.maximumAltitude}
+                  suffix="m"
+                  onValueChange={(value) => updateNumeric('maximumAltitudeM', value, 'section.optional-context')}
+                  onUnknownChange={(value) => {
+                    if (value) updateOptional('environment', 'maximum_altitude_m', unknown());
+                  }}
+                />
+              </FieldShell>
+              <FieldShell id="trail-temperature-minimum" label={copy.temperatureRange}>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="trail-temperature-minimum">{copy.minimumTemperature}</Label>
+                    <NumberEditor
+                      id="trail-temperature-minimum"
+                      value={numericInputs.temperatureMinimumC}
+                      unknown={request.course_demand.fields.optional_context.environment.temperature_min_c.state === 'unknown'}
+                      unknownLabel={copy.unknown}
+                      inputLabel={copy.minimumTemperature}
+                      suffix="°C"
+                      onValueChange={(value) => updateNumeric('temperatureMinimumC', value, 'section.optional-context')}
+                      onUnknownChange={(value) => {
+                        if (value) updateOptional('environment', 'temperature_min_c', unknown());
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="trail-temperature-maximum">{copy.maximumTemperature}</Label>
+                    <NumberEditor
+                      id="trail-temperature-maximum"
+                      value={numericInputs.temperatureMaximumC}
+                      unknown={request.course_demand.fields.optional_context.environment.temperature_max_c.state === 'unknown'}
+                      unknownLabel={copy.unknown}
+                      inputLabel={copy.maximumTemperature}
+                      suffix="°C"
+                      onValueChange={(value) => updateNumeric('temperatureMaximumC', value, 'section.optional-context')}
+                      onUnknownChange={(value) => {
+                        if (value) updateOptional('environment', 'temperature_max_c', unknown());
+                      }}
+                    />
+                  </div>
+                </div>
+              </FieldShell>
+              <FieldShell id="trail-humidity-minimum" label={copy.humidityRange}>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="trail-humidity-minimum">{copy.minimumHumidity}</Label>
+                    <NumberEditor
+                      id="trail-humidity-minimum"
+                      value={numericInputs.humidityMinimumPct}
+                      unknown={request.course_demand.fields.optional_context.environment.humidity_min_pct.state === 'unknown'}
+                      unknownLabel={copy.unknown}
+                      inputLabel={copy.minimumHumidity}
+                      suffix="%"
+                      onValueChange={(value) => updateNumeric('humidityMinimumPct', value, 'section.optional-context')}
+                      onUnknownChange={(value) => {
+                        if (value) updateOptional('environment', 'humidity_min_pct', unknown());
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="trail-humidity-maximum">{copy.maximumHumidity}</Label>
+                    <NumberEditor
+                      id="trail-humidity-maximum"
+                      value={numericInputs.humidityMaximumPct}
+                      unknown={request.course_demand.fields.optional_context.environment.humidity_max_pct.state === 'unknown'}
+                      unknownLabel={copy.unknown}
+                      inputLabel={copy.maximumHumidity}
+                      suffix="%"
+                      onValueChange={(value) => updateNumeric('humidityMaximumPct', value, 'section.optional-context')}
+                      onUnknownChange={(value) => {
+                        if (value) updateOptional('environment', 'humidity_max_pct', unknown());
+                      }}
+                    />
+                  </div>
+                </div>
+              </FieldShell>
+              <FieldShell id="trail-sun-exposure" label={copy.sunExposure}>
+                <EnumEditor
+                  id="trail-sun-exposure"
+                  envelope={request.course_demand.fields.optional_context.environment.sun_exposure}
+                  options={sunOptions}
+                  unknownLabel={copy.unknown}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('environment', 'sun_exposure', value)}
+                />
+              </FieldShell>
+              <FieldShell id="trail-wind-exposure" label={copy.windExposure}>
+                <EnumEditor
+                  id="trail-wind-exposure"
+                  envelope={request.course_demand.fields.optional_context.environment.wind_exposure}
+                  options={windOptions}
+                  unknownLabel={copy.unknown}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('environment', 'wind_exposure', value)}
+                />
+              </FieldShell>
+              <FieldShell
+                id="trail-conditions-basis"
+                label={copy.conditionsBasis}
+                description={request.course_demand.fields.optional_context.environment.conditions_basis.state === 'known'
+                  && request.course_demand.fields.optional_context.environment.conditions_basis.value === 'athlete_assumption'
+                  ? copy.assumptionHelp
+                  : undefined}
+              >
+                <EnumEditor
+                  id="trail-conditions-basis"
+                  envelope={request.course_demand.fields.optional_context.environment.conditions_basis}
+                  options={conditionsOptions}
+                  unknownLabel={copy.unknown}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('environment', 'conditions_basis', value)}
+                />
+              </FieldShell>
+            </section>
+
+            <section aria-labelledby="trail-support-heading" className="space-y-5 border-t border-border pt-5">
+              <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <h3 id="trail-support-heading" className="text-base font-semibold">{copy.supportGroup}</h3>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="min-h-11 whitespace-normal"
+                  onClick={() => {
+                    setRequest((current) => setOptionalGroupUnknown(current, 'support'));
+                    invalidateReadiness('section.optional-context');
+                  }}
+                >
+                  {copy.setGroupUnknown}
+                </Button>
+              </div>
+              <FieldShell id="trail-support-setup" label={copy.supportSetup}>
+                <EnumEditor
+                  id="trail-support-setup"
+                  envelope={request.course_demand.fields.optional_context.support.aid_support_mode}
+                  options={supportOptions}
+                  unknownLabel={copy.unknown}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('support', 'aid_support_mode', value)}
+                />
+              </FieldShell>
+              <FieldShell id="trail-aid-count" label={copy.aidCount}>
+                <NumberEditor
+                  id="trail-aid-count"
+                  value={numericInputs.aidStationCount}
+                  unknown={request.course_demand.fields.optional_context.support.aid_station_count.state === 'unknown'}
+                  unknownLabel={copy.unknown}
+                  inputLabel={copy.aidCount}
+                  onValueChange={(value) => updateNumeric('aidStationCount', value, 'section.optional-context')}
+                  onUnknownChange={(value) => {
+                    if (value) updateOptional('support', 'aid_station_count', unknown());
+                  }}
+                />
+              </FieldShell>
+              <FieldShell id="trail-aid-gap" label={copy.aidGap}>
+                <div className="space-y-2">
+                  <div className="flex max-w-sm items-center gap-2">
+                    <Input
+                      id="trail-aid-gap"
+                      inputMode="decimal"
+                      value={numericInputs.aidStationGapKm}
+                      onChange={(event) => updateNumeric('aidStationGapKm', event.target.value, 'section.optional-context')}
+                      className="h-11 font-data"
+                    />
+                    <span className="font-data text-sm text-muted-foreground">km</span>
+                  </div>
+                  <ToggleGroup
+                    value={[
+                      numericInputs.aidStationGapKm !== ''
+                        ? 'value'
+                        : request.course_demand.fields.optional_context.support.max_aid_station_gap_m.state === 'unknown'
+                          ? 'unknown'
+                          : request.course_demand.fields.optional_context.support.max_aid_station_gap_m.value === null
+                            ? 'not-applicable'
+                            : 'value',
+                    ]}
+                    onValueChange={(values) => {
+                      const value = values.at(-1);
+                      if (value === 'unknown') {
+                        updateNumeric('aidStationGapKm', '', 'section.optional-context');
+                        updateOptional('support', 'max_aid_station_gap_m', unknown<number | null>());
+                      }
+                      if (value === 'not-applicable') {
+                        updateNumeric('aidStationGapKm', '', 'section.optional-context');
+                        updateOptional('support', 'max_aid_station_gap_m', known(null));
+                      }
+                      if (value === 'value') {
+                        document.getElementById('trail-aid-gap')?.focus();
+                      }
+                    }}
+                    variant="outline"
+                    spacing={2}
+                    className="flex w-full flex-wrap gap-2"
+                  >
+                    <ToggleGroupItem value="value" className="min-h-11 whitespace-normal px-3">{copy.enterDistance}</ToggleGroupItem>
+                    <ToggleGroupItem value="not-applicable" className="min-h-11 whitespace-normal px-3">{copy.notApplicable}</ToggleGroupItem>
+                    <ToggleGroupItem value="unknown" className="min-h-11 whitespace-normal px-3">{copy.notSure}</ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
+              </FieldShell>
+              <FieldShell id="trail-water" label={copy.water}>
+                <EnumEditor
+                  id="trail-water"
+                  envelope={request.course_demand.fields.optional_context.support.water_availability}
+                  options={availabilityOptions}
+                  unknownLabel={copy.notSure}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('support', 'water_availability', value)}
+                />
+              </FieldShell>
+              <FieldShell id="trail-food" label={copy.food}>
+                <EnumEditor
+                  id="trail-food"
+                  envelope={request.course_demand.fields.optional_context.support.food_availability}
+                  options={availabilityOptions}
+                  unknownLabel={copy.notSure}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('support', 'food_availability', value)}
+                />
+              </FieldShell>
+              <FieldShell id="trail-required-equipment" label={copy.requiredEquipment}>
+                <MultiSelectEditor
+                  id="trail-required-equipment"
+                  envelope={request.course_demand.fields.optional_context.support.mandatory_gear}
+                  options={gearOptions}
+                  unknownLabel={copy.unknown}
+                  emptyLabel={copy.noEquipment}
+                  allowKnownEmpty
+                  onChange={(value) => updateOptional('support', 'mandatory_gear', value)}
+                />
+              </FieldShell>
+            </section>
+
+            <section aria-labelledby="trail-fueling-heading" className="space-y-5 border-t border-border pt-5">
+              <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <h3 id="trail-fueling-heading" className="text-base font-semibold">{copy.fueling}</h3>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="min-h-11 whitespace-normal"
+                  onClick={() => {
+                    setRequest((current) => setOptionalGroupUnknown(current, 'fueling'));
+                    invalidateReadiness('section.optional-context');
+                  }}
+                >
+                  {copy.setGroupUnknown}
+                </Button>
+              </div>
+              <FieldShell id="trail-fueling-duration" label={copy.fuelingDuration}>
+                <DurationEditor
+                  id="trail-fueling-duration"
+                  unknown={request.course_demand.fields.optional_context.fueling.longest_practiced_duration_min.state === 'unknown'}
+                  hours={numericInputs.fuelingHours}
+                  minutes={numericInputs.fuelingMinutes}
+                  hoursLabel={`${copy.fuelingDuration} · ${copy.hours}`}
+                  minutesLabel={`${copy.fuelingDuration} · ${copy.minutes}`}
+                  unknownLabel={copy.unknown}
+                  onHoursChange={(value) => updateNumeric('fuelingHours', value, 'section.optional-context')}
+                  onMinutesChange={(value) => updateNumeric('fuelingMinutes', value, 'section.optional-context')}
+                  onUnknownChange={(value) => {
+                    if (value) updateOptional('fueling', 'longest_practiced_duration_min', unknown());
+                  }}
+                />
+              </FieldShell>
+              <FieldShell id="trail-fueling-sessions" label={copy.fuelingSessions}>
+                <NumberEditor
+                  id="trail-fueling-sessions"
+                  value={numericInputs.fuelingSessions}
+                  unknown={request.course_demand.fields.optional_context.fueling.practice_sessions_last_42_days.state === 'unknown'}
+                  unknownLabel={copy.unknown}
+                  inputLabel={copy.fuelingSessions}
+                  onValueChange={(value) => updateNumeric('fuelingSessions', value, 'section.optional-context')}
+                  onUnknownChange={(value) => {
+                    if (value) updateOptional('fueling', 'practice_sessions_last_42_days', unknown());
+                  }}
+                />
+              </FieldShell>
+              <FieldShell id="trail-intake" label={copy.intake}>
+                <EnumEditor
+                  id="trail-intake"
+                  envelope={request.course_demand.fields.optional_context.fueling.intake_form}
+                  options={intakeOptions}
+                  unknownLabel={copy.unknown}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('fueling', 'intake_form', value)}
+                />
+              </FieldShell>
+              <FieldShell
+                id="trail-gut-issue"
+                label={copy.gutIssue}
+                description={l(
+                  t`This answer is non-diagnostic and does not prescribe an intake quantity.`,
+                  t`此回答不用于诊断，也不提供摄入量处方。`,
+                )}
+              >
+                <EnumEditor
+                  id="trail-gut-issue"
+                  envelope={request.course_demand.fields.optional_context.fueling.gastrointestinal_experience}
+                  options={gutOptions}
+                  unknownLabel={copy.notSure}
+                  placeholder={copy.choose}
+                  onChange={(value) => updateOptional('fueling', 'gastrointestinal_experience', value)}
+                />
+              </FieldShell>
+            </section>
+            <ConfirmBar
+              sectionKey="section.optional-context"
+              {...confirmationProps('section.optional-context')}
+              busy={busyAction !== null}
+              confirmLabel={copy.confirmSection}
+              confirmedLabel={copy.confirmedRevision}
+              changedLabel={copy.changedConfirmAgain}
+              saveFirstLabel={optionalOpened ? copy.saveBeforeConfirming : l(
+                t`Open this section before confirming`,
+                t`确认前请先打开本节`,
+              )}
+              onConfirm={(key) => { void confirmSection(key); }}
+            />
+          </SectionShell>
+          <div className="flex min-w-0 flex-col gap-2 border-t border-border pt-6 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11 whitespace-normal"
+              disabled={busyAction !== null || !pending}
+              onClick={() => { void saveDraft(false); }}
+            >
+              {copy.save}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11 whitespace-normal"
+              disabled={busyAction !== null}
+              onClick={() => { void saveDraft(true); }}
+            >
+              {copy.saveLeave}
+            </Button>
+          </div>
+        </div>
+
+        <aside
+          id="trail-policy-receipt"
+          tabIndex={-1}
+          aria-labelledby="trail-readiness-heading"
+          className="order-1 min-w-0 border border-border bg-card p-4 outline-none focus-visible:ring-2 focus-visible:ring-ring lg:order-2 lg:sticky lg:top-6 lg:self-start"
+        >
+          <div className="border-b border-border pb-4">
+            <h2 id="trail-readiness-heading" className="text-base font-semibold text-accent-cobalt">
+              {copy.readinessTitle}
+            </h2>
+            <p className="mt-2 break-words text-sm font-semibold leading-6" aria-live="polite">
+              {readinessHeadline}
+            </p>
+            <Button
+              id="trail-readiness-action"
+              type="button"
+              className="mt-4 min-h-11 w-full whitespace-normal motion-reduce:transition-none"
+              disabled={!allConfirmed || pending || busyAction !== null}
+              onClick={() => { void checkReadiness(); }}
+            >
+              {copy.checkReadiness}
+            </Button>
+          </div>
+
+          <section aria-labelledby="trail-modules-heading" className="border-b border-border py-4">
+            <h3 id="trail-modules-heading" className="text-sm font-semibold text-accent-cobalt">
+              {copy.modules}
+            </h3>
+            <ul className="mt-3 space-y-3">
+              {TRAIL_MODULE_KEYS.map((moduleKey) => {
+                const module = moduleByKey.get(moduleKey) ?? {
+                  module: moduleKey,
+                  state: 'not_evaluated' as const,
+                  reason_target: null,
+                };
+                const stateLabel = module.state === 'available'
+                  ? copy.available
+                  : module.state === 'limited'
+                    ? copy.limited
+                    : copy.notEvaluated;
+                const explanation = module.state === 'available'
+                  ? copy.moduleAvailableHelp
+                  : module.state === 'limited'
+                    ? copy.moduleLimitedHelp
+                    : copy.moduleNotEvaluatedHelp;
+                const safeTarget = module.reason_target
+                  ? MODULE_LIMIT_TARGETS[module.reason_target] ?? null
+                  : null;
+                return (
+                  <li key={moduleKey} className="min-w-0 border-t border-border/70 pt-3 first:border-t-0 first:pt-0">
+                    <div className="flex min-w-0 items-start justify-between gap-3">
+                      <span className="break-words text-sm font-medium">{moduleLabels[moduleKey]}</span>
+                      <span className="shrink-0 text-xs font-semibold">{stateLabel}</span>
+                    </div>
+                    <p className="mt-1 break-words text-xs leading-5 text-muted-foreground">{explanation}</p>
+                    {module.state === 'limited' ? (
+                      <Button
+                        type="button"
+                        variant="link"
+                        className="mt-1 h-auto min-h-11 max-w-full justify-start whitespace-normal px-0 text-left text-accent-cobalt"
+                        onClick={() => {
+                          if (safeTarget) void handleSpecialTarget(safeTarget);
+                          else focusClosedTarget('action.first-conflicting-field');
+                        }}
+                      >
+                        {copy.nextAction}
+                      </Button>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+
+          <section aria-labelledby="trail-reasons-heading" className="pt-4">
+            <h3 id="trail-reasons-heading" className="text-sm font-semibold text-accent-cobalt">
+              {copy.finding}
+            </h3>
+            {recognizedReasons.length > 0 ? (
+              <ol className="mt-3 space-y-4">
+                {recognizedReasons.map((reason, index) => (
+                  <li key={`${reason.code}-${index}`} className="min-w-0 border-t border-border/70 pt-4 first:border-t-0 first:pt-0">
+                    <dl className="space-y-2 text-sm">
+                      <div>
+                        <dt className="text-xs font-semibold text-accent-cobalt">{copy.finding}</dt>
+                        <dd className="mt-1 break-words leading-5">{reason.copy.finding}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-semibold text-accent-cobalt">{copy.effect}</dt>
+                        <dd className="mt-1 break-words leading-5 text-muted-foreground">{reason.copy.effect}</dd>
+                      </div>
+                    </dl>
+                    <Button
+                      type="button"
+                      variant="link"
+                      className="mt-2 h-auto min-h-11 max-w-full justify-start whitespace-normal px-0 text-left text-accent-cobalt"
+                      onClick={() => { void handleSpecialTarget(reason.copy.target); }}
+                    >
+                      {copy.nextAction}: {reason.copy.action}
+                    </Button>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="mt-2 break-words text-xs leading-5 text-muted-foreground">
+                {copy.noReceipt}
+              </p>
+            )}
+            <div
+              ref={receiptErrorRef}
+              id="trail-receipt-error"
+              tabIndex={-1}
+              role={receiptTargetError || hasUnknownReason ? 'alert' : undefined}
+              className="mt-3 break-words text-xs leading-5 text-destructive outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {receiptTargetError
+                ?? (hasUnknownReason
+                  ? l(
+                    t`The receipt contained an unsupported reason. Praxys will not guess its meaning or destination.`,
+                    t`回执包含不受支持的原因。Praxys 不会猜测其含义或跳转目标。`,
+                  )
+                  : null)}
+            </div>
+          </section>
+        </aside>
+      </div>
+
+      <Dialog
+        open={dialogAction !== null}
+        onOpenChange={(open) => { if (!open) setDialogAction(null); }}
+      >
+        <DialogContent className="motion-reduce:animate-none sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogAction === 'reset' ? copy.resetTitle : copy.deleteTitle}
+            </DialogTitle>
+            <DialogDescription className="break-words leading-6">
+              {dialogAction === 'reset' ? copy.resetExplanation : copy.deleteExplanation}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11"
+              onClick={() => setDialogAction(null)}
+            >
+              {copy.cancel}
+            </Button>
+            <Button
+              type="button"
+              variant={dialogAction === 'delete' ? 'destructive' : 'outline'}
+              className="min-h-11 whitespace-normal"
+              disabled={dialogAction === null || busyAction !== null}
+              onClick={() => { if (dialogAction) void resetOrDelete(dialogAction); }}
+            >
+              {dialogAction === 'reset' ? copy.confirmReset : copy.confirmDelete}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/web/src/components/trail-course-review/controls.tsx
+++ b/web/src/components/trail-course-review/controls.tsx
@@ -1,0 +1,489 @@
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import type {
+  TrailClientEnvelope,
+  TrailEditableSectionKey,
+  TrailSectionKey,
+} from '@/types/trail-plan';
+import {
+  SECTION_ELEMENT_IDS,
+  type Option,
+} from './model';
+import {
+  applyUnknownIntent,
+  known,
+  toggleEnvelopeMember,
+  unknown,
+} from './transitions';
+
+interface FieldShellProps {
+  id: string;
+  label: ReactNode;
+  description?: ReactNode;
+  meta?: ReactNode;
+  children: ReactNode;
+}
+interface SectionShellProps {
+  sectionKey: TrailSectionKey;
+  title: ReactNode;
+  description?: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  status?: ReactNode;
+  children: ReactNode;
+}
+
+interface UnknownButtonProps {
+  unknown: boolean;
+  label: string;
+  onChange: (unknown: boolean) => void;
+  disabled?: boolean;
+}
+
+interface EnumEditorProps<T extends string> {
+  id: string;
+  envelope: TrailClientEnvelope<T>;
+  options: readonly Option<T>[];
+  unknownLabel: string;
+  placeholder: string;
+  onChange: (value: TrailClientEnvelope<T>) => void;
+  disabled?: boolean;
+}
+
+interface TriStateEditorProps {
+  id: string;
+  envelope: TrailClientEnvelope<boolean>;
+  yesLabel: string;
+  noLabel: string;
+  unknownLabel: string;
+  onChange: (value: TrailClientEnvelope<boolean>) => void;
+  disabled?: boolean;
+}
+
+interface MultiSelectEditorProps<T extends string | number> {
+  id: string;
+  envelope: TrailClientEnvelope<T[]>;
+  options: readonly Option<T>[];
+  unknownLabel: string;
+  emptyLabel?: string;
+  allowKnownEmpty?: boolean;
+  onChange: (value: TrailClientEnvelope<T[]>) => void;
+  disabled?: boolean;
+}
+
+interface DurationEditorProps {
+  id: string;
+  unknown: boolean;
+  hours: string;
+  minutes: string;
+  hoursLabel: string;
+  minutesLabel: string;
+  unknownLabel: string;
+  onUnknownChange: (unknown: boolean) => void;
+  onHoursChange: (value: string) => void;
+  onMinutesChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+interface NumberEditorProps {
+  id: string;
+  value: string;
+  unknown: boolean;
+  unknownLabel: string;
+  inputLabel: string;
+  suffix?: string;
+  onValueChange: (value: string) => void;
+  onUnknownChange: (unknown: boolean) => void;
+  disabled?: boolean;
+}
+
+interface ConfirmBarProps {
+  sectionKey: TrailEditableSectionKey;
+  currentRevision: string | null;
+  confirmedRevision: string | null;
+  dirty: boolean;
+  canConfirm: boolean;
+  busy: boolean;
+  confirmLabel: string;
+  confirmedLabel: string;
+  changedLabel: string;
+  saveFirstLabel: string;
+  onConfirm: (key: TrailEditableSectionKey) => void;
+}
+
+
+export function FieldShell({ id, label, description, meta, children }: FieldShellProps) {
+  return (
+    <div className="min-w-0 space-y-2 border-t border-border/70 pt-4 first:border-t-0 first:pt-0">
+      <Label id={`${id}-label`} htmlFor={id} className="block whitespace-normal text-sm leading-5">
+        {label}
+      </Label>
+      {description ? (
+        <p className="max-w-[72ch] break-words text-xs leading-5 text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+      <div className="min-w-0">{children}</div>
+      {meta ? <div className="text-xs leading-5 text-muted-foreground">{meta}</div> : null}
+    </div>
+  );
+}
+
+export function SectionShell({
+  sectionKey,
+  title,
+  description,
+  open,
+  onOpenChange,
+  status,
+  children,
+}: SectionShellProps) {
+  const contentId = `${SECTION_ELEMENT_IDS[sectionKey]}-content`;
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className="border-b border-border motion-reduce:transition-none"
+    >
+      <CollapsibleTrigger
+        id={SECTION_ELEMENT_IDS[sectionKey]}
+        aria-controls={contentId}
+        className="flex min-h-11 w-full min-w-0 items-center justify-between gap-3 py-4 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <span className="min-w-0 break-words text-base font-semibold leading-6">
+          {title}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {status ?? (open ? '−' : '+')}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        id={contentId}
+        className="pb-6 motion-reduce:transition-none"
+      >
+        {description ? (
+          <p className="mb-5 max-w-[72ch] break-words text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+        <div className="space-y-5">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function UnknownButton({
+  unknown: isUnknown,
+  label,
+  onChange,
+  disabled = false,
+}: UnknownButtonProps) {
+  return (
+    <Button
+      type="button"
+      variant={isUnknown ? 'secondary' : 'outline'}
+      aria-pressed={isUnknown}
+      disabled={disabled}
+      onClick={() => onChange(!isUnknown)}
+      className="min-h-11 max-w-full whitespace-normal text-left motion-reduce:transition-none"
+    >
+      {label}
+    </Button>
+  );
+}
+
+export function EnumEditor<T extends string>({
+  id,
+  envelope,
+  options,
+  unknownLabel,
+  placeholder,
+  onChange,
+  disabled = false,
+}: EnumEditorProps<T>) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start">
+      <Select
+        value={envelope.state === 'known' ? envelope.value : null}
+        onValueChange={(value) => {
+          if (typeof value === 'string') onChange(known(value as T));
+        }}
+        disabled={disabled}
+      >
+        <SelectTrigger
+          id={id}
+          aria-labelledby={`${id}-label`}
+          className="min-h-11 w-full min-w-0 whitespace-normal sm:max-w-sm motion-reduce:transition-none"
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent className="motion-reduce:animate-none">
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value} className="min-h-11 whitespace-normal">
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <UnknownButton
+        unknown={envelope.state === 'unknown'}
+        label={unknownLabel}
+        disabled={disabled}
+        onChange={(value) => {
+          const next = applyUnknownIntent(envelope, value);
+          if (next !== envelope) onChange(next);
+        }}
+      />
+    </div>
+  );
+}
+
+export function TriStateEditor({
+  id,
+  envelope,
+  yesLabel,
+  noLabel,
+  unknownLabel,
+  onChange,
+  disabled = false,
+}: TriStateEditorProps) {
+  const value = envelope.state === 'unknown'
+    ? 'unknown'
+    : envelope.value
+      ? 'yes'
+      : 'no';
+  return (
+    <ToggleGroup
+      value={[value]}
+      onValueChange={(values) => {
+        const selected = values.at(-1);
+        if (selected === 'yes') onChange(known(true));
+        if (selected === 'no') onChange(known(false));
+        if (selected === 'unknown') onChange(unknown<boolean>());
+      }}
+      aria-labelledby={`${id}-label`}
+      disabled={disabled}
+      variant="outline"
+      spacing={2}
+      className="flex w-full min-w-0 flex-wrap gap-2"
+    >
+      <ToggleGroupItem id={id} value="yes" className="min-h-11 min-w-16 whitespace-normal px-3">
+        {yesLabel}
+      </ToggleGroupItem>
+      <ToggleGroupItem value="no" className="min-h-11 min-w-16 whitespace-normal px-3">
+        {noLabel}
+      </ToggleGroupItem>
+      <ToggleGroupItem value="unknown" className="min-h-11 whitespace-normal px-3">
+        {unknownLabel}
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+}
+
+export function MultiSelectEditor<T extends string | number>({
+  id,
+  envelope,
+  options,
+  unknownLabel,
+  emptyLabel,
+  allowKnownEmpty = false,
+  onChange,
+  disabled = false,
+}: MultiSelectEditorProps<T>) {
+  const toggle = (value: T) => {
+    const next = toggleEnvelopeMember(envelope, value, allowKnownEmpty);
+    if (next !== envelope) onChange(next);
+  };
+  const values = envelope.state === 'known' ? envelope.value : [];
+  return (
+    <div className="space-y-2">
+      <div id={id} role="group" aria-labelledby={`${id}-label`} className="flex min-w-0 flex-wrap gap-2">
+        {options.map((option) => {
+          const selected = values.includes(option.value);
+          return (
+            <Button
+              key={String(option.value)}
+              type="button"
+              variant={selected ? 'secondary' : 'outline'}
+              aria-pressed={selected}
+              disabled={disabled}
+              onClick={() => toggle(option.value)}
+              className="min-h-11 max-w-full whitespace-normal text-left motion-reduce:transition-none"
+            >
+              {option.label}
+            </Button>
+          );
+        })}
+        {allowKnownEmpty && emptyLabel ? (
+          <Button
+            type="button"
+            variant={envelope.state === 'known' && values.length === 0 ? 'secondary' : 'outline'}
+            aria-pressed={envelope.state === 'known' && values.length === 0}
+            disabled={disabled}
+            onClick={() => onChange(known([]))}
+            className="min-h-11 max-w-full whitespace-normal text-left"
+          >
+            {emptyLabel}
+          </Button>
+        ) : null}
+      </div>
+      <UnknownButton
+        unknown={envelope.state === 'unknown'}
+        label={unknownLabel}
+        disabled={disabled}
+        onChange={(value) => {
+          const next = applyUnknownIntent(envelope, value);
+          if (next !== envelope) onChange(next);
+        }}
+      />
+    </div>
+  );
+}
+
+export function DurationEditor({
+  id,
+  unknown: isUnknown,
+  hours,
+  minutes,
+  hoursLabel,
+  minutesLabel,
+  unknownLabel,
+  onUnknownChange,
+  onHoursChange,
+  onMinutesChange,
+  disabled = false,
+}: DurationEditorProps) {
+  const visuallyUnknown = isUnknown && hours === '' && minutes === '';
+  return (
+    <div className="space-y-2">
+      <div className="grid min-w-0 grid-cols-2 gap-2 sm:max-w-sm">
+        <Input
+          id={id}
+          inputMode="numeric"
+          value={hours}
+          disabled={disabled}
+          aria-label={hoursLabel}
+          onChange={(event) => onHoursChange(event.target.value)}
+          className="h-11 font-data"
+        />
+        <Input
+          id={`${id}-minutes`}
+          inputMode="numeric"
+          value={minutes}
+          disabled={disabled}
+          aria-label={minutesLabel}
+          onChange={(event) => onMinutesChange(event.target.value)}
+          className="h-11 font-data"
+        />
+      </div>
+      <UnknownButton
+        unknown={visuallyUnknown}
+        label={unknownLabel}
+        disabled={disabled}
+        onChange={(value) => {
+          if (value) {
+            onHoursChange('');
+            onMinutesChange('');
+            onUnknownChange(true);
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+export function NumberEditor({
+  id,
+  value,
+  unknown: isUnknown,
+  unknownLabel,
+  inputLabel,
+  suffix,
+  onValueChange,
+  onUnknownChange,
+  disabled = false,
+}: NumberEditorProps) {
+  const visuallyUnknown = isUnknown && value === '';
+  return (
+    <div className="space-y-2">
+      <div className="flex max-w-sm items-center gap-2">
+        <Input
+          id={id}
+          inputMode="decimal"
+          value={value}
+          disabled={disabled}
+          aria-label={inputLabel}
+          onChange={(event) => onValueChange(event.target.value)}
+          className="h-11 font-data"
+        />
+        {suffix ? <span className="shrink-0 font-data text-sm text-muted-foreground">{suffix}</span> : null}
+      </div>
+      <UnknownButton
+        unknown={visuallyUnknown}
+        label={unknownLabel}
+        disabled={disabled}
+        onChange={(value) => {
+          if (value) {
+            onValueChange('');
+            onUnknownChange(true);
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+export function ConfirmBar({
+  sectionKey,
+  currentRevision,
+  confirmedRevision,
+  dirty,
+  canConfirm,
+  busy,
+  confirmLabel,
+  confirmedLabel,
+  changedLabel,
+  saveFirstLabel,
+  onConfirm,
+}: ConfirmBarProps) {
+  const confirmed = !dirty
+    && currentRevision !== null
+    && confirmedRevision === currentRevision;
+  return (
+    <div className="flex min-w-0 flex-col gap-2 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <p className="min-w-0 break-all text-xs text-muted-foreground" aria-live="polite">
+        {dirty
+          ? changedLabel
+          : confirmed
+            ? `${confirmedLabel} ${currentRevision}`
+            : canConfirm
+              ? confirmLabel
+              : saveFirstLabel}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        disabled={!canConfirm || busy || confirmed}
+        onClick={() => onConfirm(sectionKey)}
+        className="min-h-11 whitespace-normal"
+      >
+        {confirmLabel}
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/trail-course-review/copy.tsx
+++ b/web/src/components/trail-course-review/copy.tsx
@@ -1,0 +1,609 @@
+import { useCallback, useMemo } from 'react';
+import { useLingui } from '@lingui/react/macro';
+import type {
+  TrailAidAvailability,
+  TrailAidSupportMode,
+  TrailConditionsBasis,
+  TrailDistanceFamily,
+  TrailEventFormat,
+  TrailFooting,
+  TrailGastrointestinalExperience,
+  TrailIntakeForm,
+  TrailMandatoryGear,
+  TrailModuleKey,
+  TrailPlanningIntent,
+  TrailProvenance,
+  TrailReasonCode,
+  TrailSunExposure,
+  TrailWindExposure,
+} from '@/types/trail-plan';
+import type { GradeKey, Option, ReasonCopy } from './model';
+
+export function useTrailCourseReviewCopy() {
+  const { i18n, t } = useLingui();
+  const isZh = i18n.locale.toLowerCase().startsWith('zh');
+  const l = useCallback(
+    (english: string, chinese: string) => isZh ? chinese : english,
+    [isZh],
+  );
+
+  return useMemo(() => {
+
+  const copy = {
+    title: l(t`Review Trail event`, t`核对越野赛事`),
+    support: l(
+      t`Describe the course and where you can train. Praxys will keep unknowns visible.`,
+      t`填写赛道情况和可训练条件。Praxys 会明确保留未知项。`,
+    ),
+    eventSection: l(t`Event & planning duration`, t`赛事与计划用时`),
+    gradeSection: l(t`Grade & footing`, t`坡度与路面`),
+    trainingSection: l(t`When and where you can train`, t`可训练时间与场地`),
+    recentSection: l(t`Recent experience`, t`近期训练经历`),
+    optionalSection: l(t`Conditions, support, and fueling`, t`环境、支持与补给`),
+    unknown: l(t`I don't know yet`, t`目前不确定`),
+    yes: l(t`Yes`, t`是`),
+    no: l(t`No`, t`否`),
+    notSure: l(t`Not sure`, t`不确定`),
+    hours: l(t`Hours`, t`小时`),
+    minutes: l(t`Minutes`, t`分钟`),
+    choose: l(t`Choose one`, t`请选择`),
+    event: l(t`Event`, t`赛事`),
+    currentEvent: l(t`Current Trail race goal`, t`当前越野赛事目标`),
+    editGoal: l(t`Edit Goal`, t`编辑目标`),
+    eventDate: l(t`Event date`, t`比赛日期`),
+    raceDistance: l(t`Race distance`, t`比赛距离`),
+    totalAscent: l(t`Total ascent`, t`累计爬升`),
+    totalDescent: l(t`Total descent`, t`累计下降`),
+    planningMinimum: l(t`Minimum planning duration`, t`计划用时下限`),
+    planningMaximum: l(t`Maximum planning duration`, t`计划用时上限`),
+    planningHelp: l(
+      t`The range you want Praxys to plan around—not a finish-time prediction.`,
+      t`这是你希望 Praxys 用于制定计划的时长范围，并非完赛时间预测。`,
+    ),
+    eventFormat: l(t`Event format`, t`比赛形式`),
+    distanceCategory: l(t`Distance category`, t`距离类别`),
+    planningGoal: l(t`Planning goal`, t`计划目标`),
+    gradeDistribution: l(t`Course grade distribution`, t`赛道坡度分布`),
+    gradeExplanation: l(
+      t`Enter percentages for the five fixed grade bands. The total must be exactly 100.00%.`,
+      t`为五个固定坡度区间输入百分比，合计必须正好为 100.00%。`,
+    ),
+    total: l(t`Total`, t`合计`),
+    footing: l(t`Course footing`, t`赛道路面`),
+    hands: l(
+      t`Does any section require hands for progress?`,
+      t`是否有路段需要用手辅助通过？`,
+    ),
+    rope: l(
+      t`Does any section use fixed ropes?`,
+      t`是否有路段需要使用固定绳索？`,
+    ),
+    availableDays: l(t`Days available to run`, t`可跑步的星期`),
+    weeklyTime: l(t`Weekly training time available`, t`每周可训练时间`),
+    longestSession: l(t`Longest training session available`, t`单次最长可训练时间`),
+    unavailableDates: l(t`Dates you cannot train`, t`无法训练的日期`),
+    noDates: l(t`No dates`, t`无`),
+    addDate: l(t`Add date`, t`添加日期`),
+    removeDate: l(t`Remove date`, t`移除日期`),
+    preferredDay: l(
+      t`Preferred day for the longest easy session`,
+      t`最长轻松训练的首选星期`,
+    ),
+    noPreference: l(t`No preference`, t`无偏好`),
+    uphillAccess: l(
+      t`Can you access a continuous, nontechnical uphill for at least 3 minutes?`,
+      t`你能使用可连续进行至少 3 分钟、非技术性的上坡路线吗？`,
+    ),
+    downhillAccess: l(
+      t`Can you access terrain for controlled downhill training?`,
+      t`你能使用适合受控下坡训练的路线吗？`,
+    ),
+    trainingFooting: l(t`Footing available for training`, t`可用于训练的路面`),
+    adultScope: l(
+      t`I confirm I am 18 or older and this is not clinical or return-to-sport planning.`,
+      t`我确认本人已满 18 岁，且这不是医疗或重返运动计划。`,
+    ),
+    performanceScope: l(
+      t`I confirm the goal is race performance.`,
+      t`我确认目标是提升比赛表现。`,
+    ),
+    symptoms: l(
+      t`Do you currently have symptoms that should stop performance planning?`,
+      t`你目前是否有应停止竞速计划的症状？`,
+    ),
+    continuity: l(t`Recent running continuity`, t`近期跑步连续性`),
+    ascentExposure: l(t`Recent ascent exposure`, t`近期爬升训练`),
+    descentExposure: l(t`Recent descent exposure`, t`近期下降训练`),
+    observedFooting: l(t`Recently observed footing`, t`近期记录到的路面`),
+    observationWindow: l(t`Observation window`, t`观察窗口`),
+    freshness: l(t`Freshness`, t`新鲜度`),
+    serverSource: l(t`Server source`, t`服务端来源`),
+    sourceRevision: l(t`Source revision`, t`来源版本`),
+    notEvaluated: l(t`Not evaluated`, t`尚未评估`),
+    compareHistory: l(
+      t`Requested versus observed comparison`,
+      t`请求与已观察情况对照`,
+    ),
+    historyComparisonHelp: l(
+      t`The requested weekly and single-session limits are shown beside the server-observed history. This comparison does not increase the accepted history envelope.`,
+      t`请求的每周和单次训练上限与服务端观察历史并列显示。此对照不会提高已接受的历史边界。`,
+    ),
+    environment: l(t`Environment`, t`环境`),
+    supportGroup: l(t`Support`, t`支持`),
+    fueling: l(t`Fueling`, t`补给`),
+    setGroupUnknown: l(t`Set this group to unknown`, t`将本组设为未知`),
+    maximumAltitude: l(t`Maximum course altitude`, t`赛道最高海拔`),
+    temperatureRange: l(t`Expected temperature range`, t`预计气温范围`),
+    minimumTemperature: l(t`Minimum temperature`, t`最低气温`),
+    maximumTemperature: l(t`Maximum temperature`, t`最高气温`),
+    humidityRange: l(t`Expected humidity range`, t`预计湿度范围`),
+    minimumHumidity: l(t`Minimum humidity`, t`最低湿度`),
+    maximumHumidity: l(t`Maximum humidity`, t`最高湿度`),
+    sunExposure: l(t`Sun exposure`, t`日晒暴露`),
+    windExposure: l(t`Wind exposure`, t`风力暴露`),
+    conditionsBasis: l(t`Conditions based on`, t`环境信息依据`),
+    assumptionHelp: l(
+      t`Your assumption requires confirmation at this exact section revision.`,
+      t`你的假设需要按本节的确切版本确认。`,
+    ),
+    supportSetup: l(t`Support setup`, t`补给支持方式`),
+    aidCount: l(t`Number of aid stations`, t`补给站数量`),
+    aidGap: l(t`Longest gap between aid stations`, t`最长补给站间距`),
+    notApplicable: l(t`Not applicable`, t`不适用`),
+    enterDistance: l(t`Enter a distance`, t`输入距离`),
+    water: l(t`Water availability`, t`饮水供应`),
+    food: l(t`Food availability`, t`食物供应`),
+    requiredEquipment: l(t`Required equipment`, t`强制装备`),
+    noEquipment: l(t`No required equipment listed`, t`未列出强制装备`),
+    fuelingDuration: l(t`Longest practiced fueling duration`, t`最长补给练习时长`),
+    fuelingSessions: l(
+      t`Fueling practice sessions in the past 42 days`,
+      t`过去 42 天的补给练习次数`,
+    ),
+    intake: l(t`Practiced intake`, t`已练习的摄入形式`),
+    gutIssue: l(
+      t`Did stomach or gut issues change your plan?`,
+      t`胃肠不适是否曾让你改变计划？`,
+    ),
+    confirmSection: l(t`Confirm this section`, t`确认本节`),
+    confirmedRevision: l(t`Confirmed for revision`, t`已确认版本`),
+    changedConfirmAgain: l(t`Changed—confirm again`, t`已更改，请重新确认`),
+    saveBeforeConfirming: l(t`Save this section before confirming`, t`确认前请先保存本节`),
+    readinessTitle: l(t`Readiness receipt`, t`准备情况回执`),
+    checkReadiness: l(t`Check readiness`, t`检查准备情况`),
+    saveLeave: l(t`Save and leave`, t`保存并稍后继续`),
+    save: l(t`Save changes`, t`保存更改`),
+    pending: l(t`Pending changes`, t`待保存更改`),
+    onlineSaved: l(t`Online · saved`, t`在线 · 已保存`),
+    notSaved: l(t`No course review has been saved yet`, t`尚未保存赛道核对`),
+    offline: l(
+      t`Offline. Changes are kept only on this page and have not been saved.`,
+      t`当前离线。更改仅保留在此页面，尚未保存。`,
+    ),
+    slow: l(
+      t`This request is taking longer than usual. Do not close this page.`,
+      t`此请求用时较长，请勿关闭本页面。`,
+    ),
+    errorSummary: l(t`Review these fields`, t`请检查以下字段`),
+    fieldError: l(
+      t`This value is missing, outside the accepted range, or conflicts with another answer.`,
+      t`此值缺失、超出允许范围，或与另一项回答冲突。`,
+    ),
+    moreActions: l(t`More actions`, t`更多操作`),
+    reset: l(t`Reset course review`, t`重置赛道核对`),
+    export: l(t`Export my Trail plan data`, t`导出我的越野计划数据`),
+    exportUnavailable: l(
+      t`Export isn't available in this private preview yet.`,
+      t`当前私密预览暂不支持导出。`,
+    ),
+    delete: l(t`Delete Trail goal`, t`删除越野目标`),
+    resetTitle: l(t`Reset course review?`, t`重置赛道核对？`),
+    resetExplanation: l(
+      t`Reset replaces the current editable answers with unknowns. It does not erase source activities or retained proposal records.`,
+      t`重置会把当前可编辑回答改为未知；不会删除来源活动或已保留的提案记录。`,
+    ),
+    deleteTitle: l(t`Delete Trail goal?`, t`删除越野目标？`),
+    deleteExplanation: l(
+      t`Deleting the Trail goal is different from deleting your account. This requests removal of its owned draft, snapshots, proposals, audits, indexes, and caches. Praxys reports completion only from the server response; rollback or cleanup-pending must remain visible.`,
+      t`删除越野目标不同于删除账号。此操作请求移除该目标拥有的草稿、快照、提案、审计、索引和缓存。Praxys 只依据服务端响应报告完成；回滚或清理待处理状态必须保持可见。`,
+    ),
+    cancel: l(t`Cancel`, t`取消`),
+    confirmReset: l(t`Confirm reset`, t`确认重置`),
+    confirmDelete: l(t`Confirm deletion`, t`确认删除`),
+    reviewLatest: l(t`Review latest version`, t`查看最新版本`),
+    restorePending: l(t`Restore pending changes`, t`恢复待保存更改`),
+    discardPending: l(t`Discard pending changes`, t`放弃待保存更改`),
+    staleTitle: l(t`The Trail course review changed`, t`越野赛道核对已更改`),
+    staleExplanation: l(
+      t`Pending edits were kept only in this page. Compare the latest server version, then reapply or discard them. Reapplying does not save or confirm.`,
+      t`待保存编辑仅保留在本页面。请对照最新服务端版本，再重新应用或放弃。重新应用不会保存或确认。`,
+    ),
+    noReceipt: l(
+      t`Confirm every visible editable section to check readiness. Confirmation is review, not proof of safety or eligibility.`,
+      t`请确认每个可见可编辑分段后检查准备情况。确认表示已核对，不代表安全或符合生成条件。`,
+    ),
+    finding: l(t`Finding`, t`发现`),
+    effect: l(t`Effect`, t`影响`),
+    nextAction: l(t`Next action`, t`下一步`),
+    modules: l(t`Authoritative readiness modules`, t`权威准备情况模块`),
+    available: l(t`Available`, t`可用于生成`),
+    limited: l(t`Limited`, t`受限`),
+    moduleLimitedHelp: l(
+      t`This module would be omitted from generation unless its linked reason is resolved.`,
+      t`如未解决所链接原因，生成时将省略此模块。`,
+    ),
+    moduleAvailableHelp: l(
+      t`Generation may consider this module. It is not yet included in a proposal.`,
+      t`生成时可考虑此模块；它尚未包含在任何提案中。`,
+    ),
+    moduleNotEvaluatedHelp: l(
+      t`This module has not been evaluated for the current revision.`,
+      t`尚未针对当前版本评估此模块。`,
+    ),
+    retry: l(t`Retry`, t`重试`),
+    fromHistory: l(t`From your activity history`, t`来自你的活动历史`),
+    modelVersion: l(t`Model version`, t`模型版本`),
+  };
+
+  const provenanceLabels: Record<TrailProvenance, string> = {
+    athlete_stated: l(t`You entered this`, t`由你填写`),
+    course_verified: l(t`Verified course information`, t`已核实的赛道信息`),
+    history_observed: l(t`From your activity history`, t`来自你的活动历史`),
+    model_inferred: l(t`Estimated by Praxys`, t`由 Praxys 推断`),
+    explicit_assumption: l(
+      t`Your assumption—confirmation required`,
+      t`你的假设—需要确认`,
+    ),
+    unknown: l(t`Unknown`, t`未知`),
+  };
+
+  const eventFormatOptions: readonly Option<TrailEventFormat>[] = [
+    { value: 'single_day', label: l(t`One-day event`, t`单日赛事`) },
+    { value: 'multi_day', label: l(t`Multi-day event`, t`多日赛事`) },
+  ];
+  const distanceFamilyOptions: readonly Option<TrailDistanceFamily>[] = [
+    { value: 'non_ultra', label: l(t`Non-ultra Trail`, t`非超长距离越野`) },
+    { value: 'ultra', label: l(t`Ultra-distance Trail`, t`超长距离越野`) },
+  ];
+  const planningIntentOptions: readonly Option<TrailPlanningIntent>[] = [
+    { value: 'performance', label: l(t`Improve race performance`, t`提升比赛表现`) },
+    { value: 'first_completion', label: l(t`Finish the event`, t`完成赛事`) },
+    { value: 'return_to_consistency', label: l(t`Rebuild training consistency`, t`恢复训练规律`) },
+  ];
+  const footingOptions: readonly Option<TrailFooting>[] = [
+    { value: 'firm_smooth', label: l(t`Firm, smooth trail`, t`坚实平整路面`) },
+    { value: 'loose_gravel', label: l(t`Loose gravel`, t`松散碎石`) },
+    { value: 'mud', label: l(t`Mud`, t`泥地`) },
+    { value: 'rocks_or_roots', label: l(t`Rocks or roots`, t`岩石或树根`) },
+    { value: 'built_steps', label: l(t`Built steps`, t`人工台阶`) },
+    { value: 'water_crossing', label: l(t`Water crossings`, t`涉水路段`) },
+  ];
+  const weekdayOptions: readonly Option<number>[] = [
+    { value: 1, label: l(t`Monday`, t`星期一`) },
+    { value: 2, label: l(t`Tuesday`, t`星期二`) },
+    { value: 3, label: l(t`Wednesday`, t`星期三`) },
+    { value: 4, label: l(t`Thursday`, t`星期四`) },
+    { value: 5, label: l(t`Friday`, t`星期五`) },
+    { value: 6, label: l(t`Saturday`, t`星期六`) },
+    { value: 7, label: l(t`Sunday`, t`星期日`) },
+  ];
+  const sunOptions: readonly Option<TrailSunExposure>[] = [
+    { value: 'low', label: l(t`Low`, t`低`) },
+    { value: 'mixed', label: l(t`Mixed`, t`混合`) },
+    { value: 'high', label: l(t`High`, t`高`) },
+  ];
+  const windOptions: readonly Option<TrailWindExposure>[] = [
+    { value: 'sheltered', label: l(t`Sheltered`, t`遮蔽`) },
+    { value: 'mixed', label: l(t`Mixed`, t`混合`) },
+    { value: 'exposed', label: l(t`Exposed`, t`暴露`) },
+  ];
+  const conditionsOptions: readonly Option<TrailConditionsBasis>[] = [
+    { value: 'organizer_information', label: l(t`Organizer information`, t`赛事方信息`) },
+    { value: 'seasonal_expectation', label: l(t`Seasonal expectation`, t`季节预期`) },
+    { value: 'athlete_assumption', label: l(t`My assumption`, t`我的假设`) },
+  ];
+  const supportOptions: readonly Option<TrailAidSupportMode>[] = [
+    { value: 'organized_aid', label: l(t`Organized aid`, t`赛事补给`) },
+    { value: 'mixed', label: l(t`Mixed`, t`混合`) },
+    { value: 'self_supported', label: l(t`Self-supported`, t`自助`) },
+  ];
+  const availabilityOptions: readonly Option<TrailAidAvailability>[] = [
+    { value: 'none', label: l(t`None`, t`无`) },
+    { value: 'some_stations', label: l(t`Some stations`, t`部分站点`) },
+    { value: 'all_stations', label: l(t`Every station`, t`每个站点`) },
+  ];
+  const gearOptions: readonly Option<TrailMandatoryGear>[] = [
+    { value: 'water_carry', label: l(t`Carry water`, t`携水`) },
+    { value: 'food_carry', label: l(t`Carry food`, t`携带食物`) },
+    { value: 'weather_shell', label: l(t`Weather shell`, t`防风雨外套`) },
+    { value: 'lighting', label: l(t`Lighting`, t`照明`) },
+    { value: 'navigation_device', label: l(t`Navigation device`, t`导航设备`) },
+    { value: 'other_required', label: l(t`Other required`, t`其他必需装备`) },
+  ];
+  const intakeOptions: readonly Option<TrailIntakeForm>[] = [
+    { value: 'none', label: l(t`None`, t`无`) },
+    { value: 'fluids_only', label: l(t`Fluids only`, t`仅液体`) },
+    { value: 'carbohydrate_drink', label: l(t`Carbohydrate drink`, t`碳水饮料`) },
+    { value: 'mixed_food_and_drink', label: l(t`Mixed food and drink`, t`食物与饮品混合`) },
+  ];
+  const gutOptions: readonly Option<TrailGastrointestinalExperience>[] = [
+    { value: 'no_plan_altering_issue', label: l(t`No plan-altering issue`, t`未影响计划`) },
+    { value: 'plan_altering_issue', label: l(t`Plan-altering issue`, t`曾影响计划`) },
+  ];
+
+  const gradeLabels: Record<GradeKey, string> = {
+    below_neg_10: l(t`Steep downhill (below −10%)`, t`陡下坡（低于 −10%）`),
+    neg_10_to_below_neg_3: l(t`Downhill (−10% to below −3%)`, t`下坡（−10% 至低于 −3%）`),
+    neg_3_to_below_pos_3: l(t`Near level (−3% to below 3%)`, t`近似平缓（−3% 至低于 3%）`),
+    pos_3_to_below_pos_10: l(t`Uphill (3% to below 10%)`, t`上坡（3% 至低于 10%）`),
+    pos_10_and_above: l(t`Steep uphill (10% and above)`, t`陡上坡（10% 及以上）`),
+  };
+
+  const reasonCatalog = {
+    'validation_failed.invalid_field_value': {
+      finding: l(
+        t`One or more values is outside the accepted format or range.`,
+        t`一项或多项数据不符合格式或范围要求。`,
+      ),
+      effect: l(
+        t`Praxys cannot interpret this revision safely.`,
+        t`Praxys 无法安全解释当前版本。`,
+      ),
+      target: 'action.first-invalid-field',
+      action: l(t`Review the first invalid value`, t`查看首个无效值`),
+    },
+    'validation_failed.schema_version_mismatch': {
+      finding: l(
+        t`This course review was created with an unsupported version.`,
+        t`此赛道核对使用了不受支持的版本。`,
+      ),
+      effect: l(
+        t`Praxys will not guess how old or future fields map to v2.`,
+        t`Praxys 不会猜测旧版或未来字段如何映射到 v2。`,
+      ),
+      target: 'action.reload-supported-version',
+      action: l(t`Reload the supported version`, t`重新加载受支持版本`),
+    },
+    'validation_failed.deterministic_invariant_failed': {
+      finding: l(
+        t`Praxys could not reproduce the same readiness receipt.`,
+        t`Praxys 无法复现同一份准备情况回执。`,
+      ),
+      effect: l(
+        t`No proposal can be trusted from this result.`,
+        t`无法信任基于此结果生成的提案。`,
+      ),
+      target: 'action.retry-readiness',
+      action: l(t`Retry the readiness check`, t`重新检查准备情况`),
+    },
+    'policy_unavailable.policy_inactive': {
+      finding: l(t`This Trail policy is not active.`, t`此越野策略尚未启用。`),
+      effect: l(
+        t`No proposal is available from this inactive slice.`,
+        t`此未启用切片不能生成提案。`,
+      ),
+      target: 'section.policy-receipt',
+      action: l(t`Review policy status`, t`查看策略状态`),
+    },
+    'policy_unavailable.event_inside_unapproved_taper_window': {
+      finding: l(
+        t`The event is inside a period without an accepted taper policy.`,
+        t`比赛已进入尚无获批减量策略的阶段。`,
+      ),
+      effect: l(
+        t`This policy cannot organize the event-near period.`,
+        t`此策略无法安排临赛阶段。`,
+      ),
+      target: 'field.event-date',
+      action: l(t`Review the event date`, t`查看比赛日期`),
+    },
+    'policy_unavailable.unsupported_ultra_or_multiday': {
+      finding: l(
+        t`This event is ultra-distance or multiday.`,
+        t`此赛事属于超长距离或多日赛。`,
+      ),
+      effect: l(
+        t`It is outside the non-ultra, one-day policy.`,
+        t`它超出非超长距离单日策略范围。`,
+      ),
+      target: 'field.event-scope',
+      action: l(t`Review event scope`, t`查看赛事范围`),
+    },
+    'policy_unavailable.unsupported_population_or_intent': {
+      finding: l(
+        t`The confirmed context or goal is outside this performance policy.`,
+        t`已确认的适用场景或目标不在此竞速策略范围内。`,
+      ),
+      effect: l(
+        t`Praxys will not substitute another population or intent.`,
+        t`Praxys 不会替换为其他人群或目标。`,
+      ),
+      target: 'field.adult-performance-scope',
+      action: l(t`Review planning scope`, t`查看计划适用范围`),
+    },
+    'policy_unavailable.technical_features_outside_v2': {
+      finding: l(
+        t`The course requires hands assistance or fixed ropes.`,
+        t`赛道需要用手辅助或使用固定绳索。`,
+      ),
+      effect: l(t`Those technical features are outside v2.`, t`这些技术特征超出 v2 范围。`),
+      target: 'action.first-confirmed-hazard',
+      action: l(t`Review the technical feature`, t`查看技术特征`),
+    },
+    'readiness_blocked.insufficient_recent_running_history': {
+      finding: l(
+        t`Recent running continuity is below the accepted history gate.`,
+        t`近期跑步连续性未达到已接受的历史门槛。`,
+      ),
+      effect: l(
+        t`Praxys cannot anchor a proposal to enough recent running.`,
+        t`Praxys 无法用足够的近期跑步记录约束提案。`,
+      ),
+      target: 'field.history-running',
+      action: l(t`Review recent running`, t`查看近期跑步记录`),
+    },
+    'readiness_blocked.insufficient_comparable_trail_history': {
+      finding: l(
+        t`Comparable Trail, ascent, or footing history is insufficient.`,
+        t`可比的越野、爬升或路面训练历史不足。`,
+      ),
+      effect: l(
+        t`Course-specific work cannot be bounded from observed experience.`,
+        t`无法依据已观察经历约束赛道专项训练。`,
+      ),
+      target: 'field.history-comparable-trail',
+      action: l(t`Review comparable experience`, t`查看可比训练经历`),
+    },
+    'readiness_blocked.insufficient_descent_history': {
+      finding: l(
+        t`Recent descent exposure is insufficient.`,
+        t`近期下降训练经历不足。`,
+      ),
+      effect: l(
+        t`Downhill work cannot be bounded from observed history.`,
+        t`无法依据已观察历史约束下坡训练。`,
+      ),
+      target: 'field.history-descent',
+      action: l(t`Review descent experience`, t`查看下降训练经历`),
+    },
+    'readiness_blocked.insufficient_terrain_access': {
+      finding: l(
+        t`Required uphill, downhill, or footing access is unavailable.`,
+        t`缺少所需的上坡、下坡或路面训练条件。`,
+      ),
+      effect: l(
+        t`Praxys will not replace the course demand with road training.`,
+        t`Praxys 不会用公路训练替代赛道需求。`,
+      ),
+      target: 'section.training-access',
+      action: l(t`Review training access`, t`查看训练场地条件`),
+    },
+    'readiness_blocked.current_symptom_stop': {
+      finding: l(
+        t`You confirmed a current symptom that should stop performance planning.`,
+        t`你确认目前有应停止竞速计划的症状。`,
+      ),
+      effect: l(
+        t`Performance planning stops; Praxys makes no diagnosis.`,
+        t`竞速计划将停止；Praxys 不作诊断。`,
+      ),
+      target: 'field.symptom-stop',
+      action: l(t`Review your response`, t`查看你的回答`),
+    },
+    'readiness_blocked.no_schedule_within_envelope': {
+      finding: l(
+        t`No 14-day schedule fits the confirmed availability and accepted limits.`,
+        t`没有 14 天安排能同时满足已确认时间和已接受限制。`,
+      ),
+      effect: l(
+        t`Praxys will not compress, stack, or substitute sessions.`,
+        t`Praxys 不会压缩、堆叠或替换训练。`,
+      ),
+      target: 'section.training-access',
+      action: l(t`Review your schedule`, t`查看训练时间安排`),
+    },
+    'clarification_required.material_course_demand_unknown': {
+      finding: l(t`A core course detail is still unknown.`, t`仍有核心赛道信息未知。`),
+      effect: l(
+        t`Readiness cannot be decided without that detail.`,
+        t`缺少该信息时无法判断准备情况。`,
+      ),
+      target: 'action.first-unknown-core-field',
+      action: l(t`Complete the next course detail`, t`补充下一项赛道信息`),
+    },
+    'clarification_required.assumption_confirmation_required': {
+      finding: l(
+        t`A course or conditions assumption has not been confirmed.`,
+        t`一项赛道或环境假设尚未确认。`,
+      ),
+      effect: l(
+        t`Praxys will not treat an assumption as reviewed fact.`,
+        t`Praxys 不会把未确认假设当作已核对事实。`,
+      ),
+      target: 'action.first-unconfirmed-assumption',
+      action: l(t`Review the assumption`, t`查看该假设`),
+    },
+    'clarification_required.adult_scope_or_constraints_unconfirmed': {
+      finding: l(
+        t`Adult, non-clinical performance scope is not confirmed.`,
+        t`尚未确认成人、非医疗的竞速适用范围。`,
+      ),
+      effect: l(t`This policy cannot be applied yet.`, t`暂时无法应用此策略。`),
+      target: 'field.adult-performance-scope',
+      action: l(t`Confirm planning scope`, t`确认计划适用范围`),
+    },
+    'clarification_required.training_constraints_missing': {
+      finding: l(
+        t`A required schedule, access, or symptom answer is missing.`,
+        t`缺少必填的时间、场地或症状回答。`,
+      ),
+      effect: l(
+        t`Praxys cannot evaluate the complete planning envelope.`,
+        t`Praxys 无法评估完整计划边界。`,
+      ),
+      target: 'action.first-missing-training-field',
+      action: l(t`Complete the next training detail`, t`补充下一项训练信息`),
+    },
+    'clarification_required.training_constraints_outside_history_envelope': {
+      finding: l(
+        t`A requested workload or edit is above recent observed history.`,
+        t`请求的训练量或编辑超出近期已观察历史。`,
+      ),
+      effect: l(
+        t`Praxys will not increase the accepted history envelope.`,
+        t`Praxys 不会提高已接受的历史边界。`,
+      ),
+      target: 'action.review-history-envelope',
+      action: l(t`Compare the request with recent history`, t`对照近期历史查看请求`),
+    },
+    'clarification_required.stale_confirmation_or_source_revision': {
+      finding: l(
+        t`A confirmed section or source changed after review.`,
+        t`已确认的分段或来源在核对后发生变化。`,
+      ),
+      effect: l(
+        t`Readiness is stale and cannot be silently rebound.`,
+        t`准备情况已过期，不能静默重新绑定。`,
+      ),
+      target: 'action.first-stale-section',
+      action: l(t`Review the latest revision`, t`查看最新版本`),
+    },
+    'clarification_required.contradictory_input': {
+      finding: l(t`Two otherwise valid answers conflict.`, t`两项各自有效的回答彼此冲突。`),
+      effect: l(
+        t`Praxys cannot choose which answer should govern the plan.`,
+        t`Praxys 无法自行选择哪项回答应约束计划。`,
+      ),
+      target: 'action.first-conflicting-field',
+      action: l(t`Resolve the first conflict`, t`处理首个冲突`),
+    },
+  } satisfies Record<TrailReasonCode, ReasonCopy>;
+
+  const moduleLabels: Record<TrailModuleKey, string> = {
+    grade_specificity: l(t`Grade-specific training`, t`坡度专项训练`),
+    technical_terrain: l(t`Technical terrain`, t`技术路面训练`),
+    environment_altitude: l(t`Environment and altitude`, t`环境与海拔适应`),
+    fueling: l(t`Fueling practice`, t`补给练习`),
+  };
+    return {
+    copy,
+    provenanceLabels,
+    eventFormatOptions,
+    distanceFamilyOptions,
+    planningIntentOptions,
+    footingOptions,
+    weekdayOptions,
+    sunOptions,
+    windOptions,
+    conditionsOptions,
+    supportOptions,
+    availabilityOptions,
+    gearOptions,
+    intakeOptions,
+    gutOptions,
+    gradeLabels,
+    reasonCatalog,
+    moduleLabels,
+    };
+  }, [l, t]);
+}

--- a/web/src/components/trail-course-review/model.tsx
+++ b/web/src/components/trail-course-review/model.tsx
@@ -1,0 +1,831 @@
+import type { ReactNode } from 'react';
+import {
+  TRAIL_REASON_CODES,
+  TRAIL_SCHEMA_IDS,
+  type TrailClientEnvelope,
+  type TrailCurrentDraft,
+  type TrailDraftRequest,
+  type TrailDraftResponse,
+  type TrailEditableSectionKey,
+  type TrailFixedFieldTarget,
+  type TrailFocusTarget,
+  type TrailProvenance,
+  type TrailReasonCode,
+  type TrailSectionKey,
+  type TrailServerEnvelope,
+} from '@/types/trail-plan';
+import {
+  decimalEnvelopeFromExplicitInput,
+  durationEnvelopeFromExplicitInputs,
+  gradeEnvelopeFromExplicitInputs,
+  integerEnvelopeFromExplicitInput,
+  known,
+  metresEnvelopeFromExplicitKilometres,
+  unknown,
+} from './transitions';
+import { parseTrailDraftResponse } from './validation';
+
+export { known, parseGradeBasisPoints, unknown } from './transitions';
+
+export const GRADE_KEYS = [
+  'below_neg_10',
+  'neg_10_to_below_neg_3',
+  'neg_3_to_below_pos_3',
+  'pos_3_to_below_pos_10',
+  'pos_10_and_above',
+] as const;
+
+export const REVISION_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export const SECTION_ELEMENT_IDS: Record<TrailSectionKey, string> = {
+  'section.event-duration': 'trail-section-event-duration',
+  'section.grade-footing': 'trail-section-grade-footing',
+  'section.training-access': 'trail-section-training-access',
+  'section.recent-experience': 'trail-section-recent-experience',
+  'section.optional-context': 'trail-section-optional-context',
+  'section.policy-receipt': 'trail-policy-receipt',
+};
+
+export const FIELD_ELEMENT_IDS: Record<TrailFixedFieldTarget, string> = {
+  'field.event-date': 'trail-event-date',
+  'field.event-scope': 'trail-event-format',
+  'field.adult-performance-scope': 'trail-adult-scope',
+  'field.symptom-stop': 'trail-symptom-stop',
+  'field.history-running': 'trail-history-running',
+  'field.history-comparable-trail': 'trail-history-ascent',
+  'field.history-descent': 'trail-history-descent',
+};
+
+export const FIELD_TARGET_SECTIONS: Record<TrailFixedFieldTarget, TrailSectionKey> = {
+  'field.event-date': 'section.event-duration',
+  'field.event-scope': 'section.event-duration',
+  'field.adult-performance-scope': 'section.training-access',
+  'field.symptom-stop': 'section.training-access',
+  'field.history-running': 'section.recent-experience',
+  'field.history-comparable-trail': 'section.recent-experience',
+  'field.history-descent': 'section.recent-experience',
+};
+
+export const MODULE_LIMIT_TARGETS: Readonly<Record<string, TrailFocusTarget>> = {
+  'course.grade_distribution': 'section.grade-footing',
+  'course.course_footing': 'section.grade-footing',
+  'course.optional_context.environment': 'section.optional-context',
+  'course.optional_context.support': 'section.optional-context',
+  'course.optional_context.fueling': 'section.optional-context',
+};
+
+export type GradeKey = (typeof GRADE_KEYS)[number];
+
+export type NumericInputKey =
+  | 'distanceKm'
+  | 'totalAscentM'
+  | 'totalDescentM'
+  | 'planningMinimumHours'
+  | 'planningMinimumMinutes'
+  | 'planningMaximumHours'
+  | 'planningMaximumMinutes'
+  | 'gradeBelowNeg10'
+  | 'gradeNeg10ToNeg3'
+  | 'gradeNearLevel'
+  | 'gradePos3ToPos10'
+  | 'gradePos10AndAbove'
+  | 'weeklyHours'
+  | 'weeklyMinutes'
+  | 'sessionHours'
+  | 'sessionMinutes'
+  | 'maximumAltitudeM'
+  | 'temperatureMinimumC'
+  | 'temperatureMaximumC'
+  | 'humidityMinimumPct'
+  | 'humidityMaximumPct'
+  | 'aidStationCount'
+  | 'aidStationGapKm'
+  | 'fuelingHours'
+  | 'fuelingMinutes'
+  | 'fuelingSessions';
+
+export type NumericInputs = Record<NumericInputKey, string>;
+
+export type OpenSections = Record<TrailSectionKey, boolean>;
+
+export type OptionalGroup = 'environment' | 'support' | 'fueling';
+
+export interface ValidationIssue {
+  id: string;
+  target: TrailFocusTarget;
+  section: TrailEditableSectionKey;
+}
+export interface ReasonCopy {
+  finding: string;
+  effect: string;
+  target: TrailFocusTarget;
+  action: string;
+}
+
+export interface Option<T extends string | number> {
+  value: T;
+  label: string;
+}
+
+
+export const EMPTY_NUMERIC_INPUTS: NumericInputs = {
+  distanceKm: '',
+  totalAscentM: '',
+  totalDescentM: '',
+  planningMinimumHours: '',
+  planningMinimumMinutes: '',
+  planningMaximumHours: '',
+  planningMaximumMinutes: '',
+  gradeBelowNeg10: '',
+  gradeNeg10ToNeg3: '',
+  gradeNearLevel: '',
+  gradePos3ToPos10: '',
+  gradePos10AndAbove: '',
+  weeklyHours: '',
+  weeklyMinutes: '',
+  sessionHours: '',
+  sessionMinutes: '',
+  maximumAltitudeM: '',
+  temperatureMinimumC: '',
+  temperatureMaximumC: '',
+  humidityMinimumPct: '',
+  humidityMaximumPct: '',
+  aidStationCount: '',
+  aidStationGapKm: '',
+  fuelingHours: '',
+  fuelingMinutes: '',
+  fuelingSessions: '',
+};
+
+export function projectEnvelope<T>(
+  envelope: TrailServerEnvelope<T>,
+): TrailClientEnvelope<T> {
+  return envelope.state === 'known' ? known(envelope.value) : unknown<T>();
+}
+
+export function emptyDraftRequest(): TrailDraftRequest {
+  return {
+    course_demand: {
+      schema_id: TRAIL_SCHEMA_IDS.course,
+      fields: {
+        event_date: unknown(),
+        distance_meters: unknown(),
+        total_ascent_m: unknown(),
+        total_descent_m: unknown(),
+        planning_duration_range: unknown(),
+        event_format: unknown(),
+        distance_family: unknown(),
+        planning_intent: unknown(),
+        grade_distribution: unknown(),
+        course_footing: unknown(),
+        hands_assist: unknown(),
+        fixed_rope: unknown(),
+        optional_context: {
+          environment: {
+            maximum_altitude_m: unknown(),
+            temperature_min_c: unknown(),
+            temperature_max_c: unknown(),
+            humidity_min_pct: unknown(),
+            humidity_max_pct: unknown(),
+            sun_exposure: unknown(),
+            wind_exposure: unknown(),
+            conditions_basis: unknown(),
+          },
+          support: {
+            aid_support_mode: unknown(),
+            aid_station_count: unknown(),
+            max_aid_station_gap_m: unknown(),
+            water_availability: unknown(),
+            food_availability: unknown(),
+            mandatory_gear: unknown(),
+          },
+          fueling: {
+            longest_practiced_duration_min: unknown(),
+            practice_sessions_last_42_days: unknown(),
+            intake_form: unknown(),
+            gastrointestinal_experience: unknown(),
+          },
+        },
+      },
+    },
+    constraints: {
+      schema_id: TRAIL_SCHEMA_IDS.constraints,
+      available_weekdays: unknown(),
+      weekly_time_limit_min: unknown(),
+      maximum_session_duration_min: unknown(),
+      unavailable_dates: unknown(),
+      nontechnical_three_minute_uphill_access: unknown(),
+      controlled_downhill_access: unknown(),
+      accessible_footing: unknown(),
+      adult_nonclinical_scope_confirmed: unknown(),
+      performance_intent_confirmed: unknown(),
+      current_symptom_stop: unknown(),
+    },
+  };
+}
+
+export function requestFromDraft(draft: TrailDraftResponse): TrailDraftRequest {
+  if (draft.state !== 'current') return emptyDraftRequest();
+  const fields = draft.course_demand.fields;
+  const constraints = draft.constraints;
+  return {
+    course_demand: {
+      schema_id: TRAIL_SCHEMA_IDS.course,
+      fields: {
+        event_date: projectEnvelope(fields.event_date),
+        distance_meters: projectEnvelope(fields.distance_meters),
+        total_ascent_m: projectEnvelope(fields.total_ascent_m),
+        total_descent_m: projectEnvelope(fields.total_descent_m),
+        planning_duration_range: projectEnvelope(fields.planning_duration_range),
+        event_format: projectEnvelope(fields.event_format),
+        distance_family: projectEnvelope(fields.distance_family),
+        planning_intent: projectEnvelope(fields.planning_intent),
+        grade_distribution: projectEnvelope(fields.grade_distribution),
+        course_footing: projectEnvelope(fields.course_footing),
+        hands_assist: projectEnvelope(fields.hands_assist),
+        fixed_rope: projectEnvelope(fields.fixed_rope),
+        optional_context: {
+          environment: {
+            maximum_altitude_m: projectEnvelope(
+              fields.optional_context.environment.maximum_altitude_m,
+            ),
+            temperature_min_c: projectEnvelope(
+              fields.optional_context.environment.temperature_min_c,
+            ),
+            temperature_max_c: projectEnvelope(
+              fields.optional_context.environment.temperature_max_c,
+            ),
+            humidity_min_pct: projectEnvelope(
+              fields.optional_context.environment.humidity_min_pct,
+            ),
+            humidity_max_pct: projectEnvelope(
+              fields.optional_context.environment.humidity_max_pct,
+            ),
+            sun_exposure: projectEnvelope(
+              fields.optional_context.environment.sun_exposure,
+            ),
+            wind_exposure: projectEnvelope(
+              fields.optional_context.environment.wind_exposure,
+            ),
+            conditions_basis: projectEnvelope(
+              fields.optional_context.environment.conditions_basis,
+            ),
+          },
+          support: {
+            aid_support_mode: projectEnvelope(
+              fields.optional_context.support.aid_support_mode,
+            ),
+            aid_station_count: projectEnvelope(
+              fields.optional_context.support.aid_station_count,
+            ),
+            max_aid_station_gap_m: projectEnvelope(
+              fields.optional_context.support.max_aid_station_gap_m,
+            ),
+            water_availability: projectEnvelope(
+              fields.optional_context.support.water_availability,
+            ),
+            food_availability: projectEnvelope(
+              fields.optional_context.support.food_availability,
+            ),
+            mandatory_gear: projectEnvelope(
+              fields.optional_context.support.mandatory_gear,
+            ),
+          },
+          fueling: {
+            longest_practiced_duration_min: projectEnvelope(
+              fields.optional_context.fueling.longest_practiced_duration_min,
+            ),
+            practice_sessions_last_42_days: projectEnvelope(
+              fields.optional_context.fueling.practice_sessions_last_42_days,
+            ),
+            intake_form: projectEnvelope(
+              fields.optional_context.fueling.intake_form,
+            ),
+            gastrointestinal_experience: projectEnvelope(
+              fields.optional_context.fueling.gastrointestinal_experience,
+            ),
+          },
+        },
+      },
+    },
+    constraints: {
+      schema_id: TRAIL_SCHEMA_IDS.constraints,
+      available_weekdays: projectEnvelope(constraints.available_weekdays),
+      weekly_time_limit_min: projectEnvelope(constraints.weekly_time_limit_min),
+      maximum_session_duration_min: projectEnvelope(
+        constraints.maximum_session_duration_min,
+      ),
+      unavailable_dates: projectEnvelope(constraints.unavailable_dates),
+      ...(constraints.preferred_longest_weekday === null
+        ? {}
+        : { preferred_longest_weekday: constraints.preferred_longest_weekday }),
+      nontechnical_three_minute_uphill_access: projectEnvelope(
+        constraints.nontechnical_three_minute_uphill_access,
+      ),
+      controlled_downhill_access: projectEnvelope(
+        constraints.controlled_downhill_access,
+      ),
+      accessible_footing: projectEnvelope(constraints.accessible_footing),
+      adult_nonclinical_scope_confirmed: projectEnvelope(
+        constraints.adult_nonclinical_scope_confirmed,
+      ),
+      performance_intent_confirmed: projectEnvelope(
+        constraints.performance_intent_confirmed,
+      ),
+      current_symptom_stop: projectEnvelope(constraints.current_symptom_stop),
+    },
+  };
+}
+
+function decimalText(value: number): string {
+  return Number.isFinite(value) ? String(value) : '';
+}
+
+function meterKilometreText(value: number): string {
+  return decimalText(value / 1000);
+}
+
+function durationParts(value: number): readonly [string, string] {
+  return [String(Math.floor(value / 60)), String(value % 60)] as const;
+}
+
+export function numericInputsFromDraft(draft: TrailDraftResponse): NumericInputs {
+  if (draft.state !== 'current') return { ...EMPTY_NUMERIC_INPUTS };
+  const fields = draft.course_demand.fields;
+  const constraints = draft.constraints;
+  const optional = fields.optional_context;
+  const duration = fields.planning_duration_range.state === 'known'
+    ? fields.planning_duration_range.value
+    : null;
+  const minimumDuration = duration
+    ? durationParts(duration.minimum_min)
+    : ['', ''] as const;
+  const maximumDuration = duration
+    ? durationParts(duration.maximum_min)
+    : ['', ''] as const;
+  const weekly = constraints.weekly_time_limit_min.state === 'known'
+    ? durationParts(constraints.weekly_time_limit_min.value)
+    : ['', ''] as const;
+  const session = constraints.maximum_session_duration_min.state === 'known'
+    ? durationParts(constraints.maximum_session_duration_min.value)
+    : ['', ''] as const;
+  const fueling = optional.fueling.longest_practiced_duration_min.state === 'known'
+    ? durationParts(optional.fueling.longest_practiced_duration_min.value)
+    : ['', ''] as const;
+  const grade = fields.grade_distribution.state === 'known'
+    ? fields.grade_distribution.value
+    : null;
+  return {
+    distanceKm: fields.distance_meters.state === 'known'
+      ? meterKilometreText(fields.distance_meters.value)
+      : '',
+    totalAscentM: fields.total_ascent_m.state === 'known'
+      ? String(fields.total_ascent_m.value)
+      : '',
+    totalDescentM: fields.total_descent_m.state === 'known'
+      ? String(fields.total_descent_m.value)
+      : '',
+    planningMinimumHours: minimumDuration[0],
+    planningMinimumMinutes: minimumDuration[1],
+    planningMaximumHours: maximumDuration[0],
+    planningMaximumMinutes: maximumDuration[1],
+    gradeBelowNeg10: grade ? decimalText(grade.below_neg_10 / 100) : '',
+    gradeNeg10ToNeg3: grade
+      ? decimalText(grade.neg_10_to_below_neg_3 / 100)
+      : '',
+    gradeNearLevel: grade
+      ? decimalText(grade.neg_3_to_below_pos_3 / 100)
+      : '',
+    gradePos3ToPos10: grade
+      ? decimalText(grade.pos_3_to_below_pos_10 / 100)
+      : '',
+    gradePos10AndAbove: grade
+      ? decimalText(grade.pos_10_and_above / 100)
+      : '',
+    weeklyHours: weekly[0],
+    weeklyMinutes: weekly[1],
+    sessionHours: session[0],
+    sessionMinutes: session[1],
+    maximumAltitudeM: optional.environment.maximum_altitude_m.state === 'known'
+      ? String(optional.environment.maximum_altitude_m.value)
+      : '',
+    temperatureMinimumC: optional.environment.temperature_min_c.state === 'known'
+      ? decimalText(optional.environment.temperature_min_c.value)
+      : '',
+    temperatureMaximumC: optional.environment.temperature_max_c.state === 'known'
+      ? decimalText(optional.environment.temperature_max_c.value)
+      : '',
+    humidityMinimumPct: optional.environment.humidity_min_pct.state === 'known'
+      ? decimalText(optional.environment.humidity_min_pct.value)
+      : '',
+    humidityMaximumPct: optional.environment.humidity_max_pct.state === 'known'
+      ? decimalText(optional.environment.humidity_max_pct.value)
+      : '',
+    aidStationCount: optional.support.aid_station_count.state === 'known'
+      ? String(optional.support.aid_station_count.value)
+      : '',
+    aidStationGapKm:
+      optional.support.max_aid_station_gap_m.state === 'known'
+      && optional.support.max_aid_station_gap_m.value !== null
+        ? meterKilometreText(optional.support.max_aid_station_gap_m.value)
+        : '',
+    fuelingHours: fueling[0],
+    fuelingMinutes: fueling[1],
+    fuelingSessions:
+      optional.fueling.practice_sessions_last_42_days.state === 'known'
+        ? String(optional.fueling.practice_sessions_last_42_days.value)
+        : '',
+  };
+}
+
+function cloneDraftRequest(request: TrailDraftRequest): TrailDraftRequest {
+  const optional = request.course_demand.fields.optional_context;
+  return {
+    course_demand: {
+      ...request.course_demand,
+      fields: {
+        ...request.course_demand.fields,
+        optional_context: {
+          environment: { ...optional.environment },
+          support: { ...optional.support },
+          fueling: { ...optional.fueling },
+        },
+      },
+    },
+    constraints: { ...request.constraints },
+  };
+}
+
+export function buildValidatedRequest(
+  request: TrailDraftRequest,
+  inputs: NumericInputs,
+): { request: TrailDraftRequest; issues: ValidationIssue[] } {
+  const next = cloneDraftRequest(request);
+  const fields = next.course_demand.fields;
+  const constraints = next.constraints;
+  const optional = fields.optional_context;
+  const issues: ValidationIssue[] = [];
+  const add = (
+    id: string,
+    target: TrailFocusTarget,
+    section: TrailEditableSectionKey,
+  ) => issues.push({ id, target, section });
+
+  if (fields.event_date.state === 'known'
+    && !/^\d{4}-\d{2}-\d{2}$/.test(fields.event_date.value)) {
+    add('event-date', 'field.event-date', 'section.event-duration');
+  }
+
+  if (fields.distance_meters.state === 'known' || inputs.distanceKm !== '') {
+    const value = metresEnvelopeFromExplicitKilometres(inputs.distanceKm, 1, 49999);
+    if (value.state === 'unknown') add('distance', 'section.event-duration', 'section.event-duration');
+    else fields.distance_meters = value;
+  }
+  if (fields.total_ascent_m.state === 'known' || inputs.totalAscentM !== '') {
+    const value = integerEnvelopeFromExplicitInput(inputs.totalAscentM, 0, 20000);
+    if (value.state === 'unknown') add('ascent', 'section.event-duration', 'section.event-duration');
+    else fields.total_ascent_m = value;
+  }
+  if (fields.total_descent_m.state === 'known' || inputs.totalDescentM !== '') {
+    const value = integerEnvelopeFromExplicitInput(inputs.totalDescentM, 0, 20000);
+    if (value.state === 'unknown') add('descent', 'section.event-duration', 'section.event-duration');
+    else fields.total_descent_m = value;
+  }
+  if (fields.planning_duration_range.state === 'known' || [
+    inputs.planningMinimumHours,
+    inputs.planningMinimumMinutes,
+    inputs.planningMaximumHours,
+    inputs.planningMaximumMinutes,
+  ].some((value) => value !== '')) {
+    const minimum = durationEnvelopeFromExplicitInputs(
+      inputs.planningMinimumHours,
+      inputs.planningMinimumMinutes,
+      1,
+      1440,
+    );
+    const maximum = durationEnvelopeFromExplicitInputs(
+      inputs.planningMaximumHours,
+      inputs.planningMaximumMinutes,
+      1,
+      1440,
+    );
+    if (minimum.state === 'unknown'
+      || maximum.state === 'unknown'
+      || minimum.value >= maximum.value) {
+      add('planning-duration', 'section.event-duration', 'section.event-duration');
+    } else {
+      fields.planning_duration_range = known({
+        minimum_min: minimum.value,
+        maximum_min: maximum.value,
+      });
+    }
+  }
+
+  const rawGrade = [
+    inputs.gradeBelowNeg10,
+    inputs.gradeNeg10ToNeg3,
+    inputs.gradeNearLevel,
+    inputs.gradePos3ToPos10,
+    inputs.gradePos10AndAbove,
+  ] as const;
+  if (fields.grade_distribution.state === 'known'
+    || rawGrade.some((value) => value !== '')) {
+    const grade = gradeEnvelopeFromExplicitInputs(rawGrade);
+    if (grade.state === 'unknown') {
+      add('grade-distribution', 'section.grade-footing', 'section.grade-footing');
+    } else {
+      fields.grade_distribution = grade;
+    }
+  }
+  if (fields.course_footing.state === 'known' && fields.course_footing.value.length === 0) {
+    add('course-footing', 'section.grade-footing', 'section.grade-footing');
+  }
+
+  let weekly: number | null = null;
+  if (constraints.weekly_time_limit_min.state === 'known'
+    || inputs.weeklyHours !== ''
+    || inputs.weeklyMinutes !== '') {
+    const value = durationEnvelopeFromExplicitInputs(
+      inputs.weeklyHours,
+      inputs.weeklyMinutes,
+      1,
+      10080,
+    );
+    if (value.state === 'unknown') {
+      add('weekly-time', 'section.training-access', 'section.training-access');
+    } else {
+      weekly = value.value;
+      constraints.weekly_time_limit_min = value;
+    }
+  }
+  if (constraints.maximum_session_duration_min.state === 'known'
+    || inputs.sessionHours !== ''
+    || inputs.sessionMinutes !== '') {
+    const session = durationEnvelopeFromExplicitInputs(
+      inputs.sessionHours,
+      inputs.sessionMinutes,
+      1,
+      1440,
+    );
+    if (session.state === 'unknown'
+      || (weekly !== null && session.value > weekly)) {
+      add('session-time', 'section.training-access', 'section.training-access');
+    } else {
+      constraints.maximum_session_duration_min = session;
+    }
+  }
+  if (constraints.available_weekdays.state === 'known'
+    && constraints.available_weekdays.value.length === 0) {
+    add('available-days', 'section.training-access', 'section.training-access');
+  }
+  if (constraints.accessible_footing.state === 'known'
+    && constraints.accessible_footing.value.length === 0) {
+    add('accessible-footing', 'section.training-access', 'section.training-access');
+  }
+  if (
+    constraints.preferred_longest_weekday !== undefined
+    && constraints.available_weekdays.state === 'known'
+    && !constraints.available_weekdays.value.includes(
+      constraints.preferred_longest_weekday,
+    )
+  ) {
+    add('preferred-day', 'section.training-access', 'section.training-access');
+  }
+
+  if (optional.environment.maximum_altitude_m.state === 'known'
+    || inputs.maximumAltitudeM !== '') {
+    const value = integerEnvelopeFromExplicitInput(inputs.maximumAltitudeM, -500, 9000);
+    if (value.state === 'unknown') add('maximum-altitude', 'section.optional-context', 'section.optional-context');
+    else optional.environment.maximum_altitude_m = value;
+  }
+  const decimalOptional = [
+    ['temperatureMinimumC', 'temperature_min_c', -30, 55],
+    ['temperatureMaximumC', 'temperature_max_c', -30, 55],
+    ['humidityMinimumPct', 'humidity_min_pct', 0, 100],
+    ['humidityMaximumPct', 'humidity_max_pct', 0, 100],
+  ] as const;
+  for (const [inputKey, fieldKey, minimum, maximum] of decimalOptional) {
+    const envelope = optional.environment[fieldKey];
+    if (envelope.state !== 'known' && inputs[inputKey] === '') continue;
+    const value = decimalEnvelopeFromExplicitInput(inputs[inputKey], 2, minimum, maximum);
+    if (value.state === 'unknown') add(fieldKey, 'section.optional-context', 'section.optional-context');
+    else optional.environment[fieldKey] = value;
+  }
+  const temperatureMinimum = optional.environment.temperature_min_c;
+  const temperatureMaximum = optional.environment.temperature_max_c;
+  if (
+    temperatureMinimum.state === 'known'
+    && temperatureMaximum.state === 'known'
+    && temperatureMinimum.value > temperatureMaximum.value
+  ) {
+    add('temperature-range', 'section.optional-context', 'section.optional-context');
+  }
+  const humidityMinimum = optional.environment.humidity_min_pct;
+  const humidityMaximum = optional.environment.humidity_max_pct;
+  if (
+    humidityMinimum.state === 'known'
+    && humidityMaximum.state === 'known'
+    && humidityMinimum.value > humidityMaximum.value
+  ) {
+    add('humidity-range', 'section.optional-context', 'section.optional-context');
+  }
+  if (optional.support.aid_station_count.state === 'known'
+    || inputs.aidStationCount !== '') {
+    const value = integerEnvelopeFromExplicitInput(inputs.aidStationCount, 0, 50);
+    if (value.state === 'unknown') add('aid-count', 'section.optional-context', 'section.optional-context');
+    else optional.support.aid_station_count = value;
+  }
+  if (
+    inputs.aidStationGapKm !== ''
+    || (optional.support.max_aid_station_gap_m.state === 'known'
+      && optional.support.max_aid_station_gap_m.value !== null)
+  ) {
+    const value = metresEnvelopeFromExplicitKilometres(inputs.aidStationGapKm, 100, 50000);
+    if (value.state === 'unknown') add('aid-gap', 'section.optional-context', 'section.optional-context');
+    else optional.support.max_aid_station_gap_m = value;
+  }
+  if (optional.fueling.longest_practiced_duration_min.state === 'known'
+    || inputs.fuelingHours !== ''
+    || inputs.fuelingMinutes !== '') {
+    const value = durationEnvelopeFromExplicitInputs(
+      inputs.fuelingHours,
+      inputs.fuelingMinutes,
+      0,
+      1440,
+    );
+    if (value.state === 'unknown') add('fueling-duration', 'section.optional-context', 'section.optional-context');
+    else optional.fueling.longest_practiced_duration_min = value;
+  }
+  if (optional.fueling.practice_sessions_last_42_days.state === 'known'
+    || inputs.fuelingSessions !== '') {
+    const value = integerEnvelopeFromExplicitInput(inputs.fuelingSessions, 0, 84);
+    if (value.state === 'unknown') add('fueling-sessions', 'section.optional-context', 'section.optional-context');
+    else optional.fueling.practice_sessions_last_42_days = value;
+  }
+  return { request: next, issues };
+}
+
+
+export type CourseFields = TrailDraftRequest['course_demand']['fields'];
+export type CourseEnvelopeKey = Exclude<keyof CourseFields, 'optional_context'>;
+export type ConstraintFields = TrailDraftRequest['constraints'];
+export type ConstraintEnvelopeKey = Exclude<
+  keyof ConstraintFields,
+  'schema_id' | 'preferred_longest_weekday'
+>;
+
+export function replaceCourseField<K extends CourseEnvelopeKey>(
+  request: TrailDraftRequest,
+  key: K,
+  value: CourseFields[K],
+): TrailDraftRequest {
+  return {
+    ...request,
+    course_demand: {
+      ...request.course_demand,
+      fields: {
+        ...request.course_demand.fields,
+        [key]: value,
+      },
+    },
+  };
+}
+
+export function replaceConstraintField<K extends ConstraintEnvelopeKey>(
+  request: TrailDraftRequest,
+  key: K,
+  value: ConstraintFields[K],
+): TrailDraftRequest {
+  return {
+    ...request,
+    constraints: {
+      ...request.constraints,
+      [key]: value,
+    },
+  };
+}
+
+export function replaceOptionalField(
+  request: TrailDraftRequest,
+  group: OptionalGroup,
+  key: string,
+  value: TrailClientEnvelope<unknown>,
+): TrailDraftRequest {
+  const optional = request.course_demand.fields.optional_context;
+  const groupFields = optional[group] as unknown as Record<
+    string,
+    TrailClientEnvelope<unknown>
+  >;
+  return {
+    ...request,
+    course_demand: {
+      ...request.course_demand,
+      fields: {
+        ...request.course_demand.fields,
+        optional_context: {
+          ...optional,
+          [group]: {
+            ...groupFields,
+            [key]: value,
+          },
+        },
+      },
+    },
+  } as TrailDraftRequest;
+}
+
+export function setOptionalGroupUnknown(
+  request: TrailDraftRequest,
+  group: OptionalGroup,
+): TrailDraftRequest {
+  const keys: Record<OptionalGroup, readonly string[]> = {
+    environment: [
+      'maximum_altitude_m',
+      'temperature_min_c',
+      'temperature_max_c',
+      'humidity_min_pct',
+      'humidity_max_pct',
+      'sun_exposure',
+      'wind_exposure',
+      'conditions_basis',
+    ],
+    support: [
+      'aid_support_mode',
+      'aid_station_count',
+      'max_aid_station_gap_m',
+      'water_availability',
+      'food_availability',
+      'mandatory_gear',
+    ],
+    fueling: [
+      'longest_practiced_duration_min',
+      'practice_sessions_last_42_days',
+      'intake_form',
+      'gastrointestinal_experience',
+    ],
+  };
+  return keys[group].reduce(
+    (current, key) => replaceOptionalField(current, group, key, unknown()),
+    request,
+  );
+}
+
+export function sectionConfirmation(
+  draft: TrailDraftResponse,
+  sectionKey: TrailEditableSectionKey,
+) {
+  if (draft.state !== 'current') return null;
+  return draft.revision_bindings.section_confirmations.find(
+    (item) => item.section_key === sectionKey,
+  ) ?? null;
+}
+
+export function currentDraftFromResponse(value: unknown): TrailCurrentDraft | null {
+  const candidate = parseTrailDraftResponse(value);
+  return candidate?.state === 'current' ? candidate : null;
+}
+
+export function reasonCodeOf(status: string, detailReason: string): TrailReasonCode | null {
+  const candidate = `${status}.${detailReason}`;
+  return (TRAIL_REASON_CODES as readonly string[]).includes(candidate)
+    ? candidate as TrailReasonCode
+    : null;
+}
+
+export function formatIsoDate(value: string | null, locale: string): string {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return '—';
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+export function localIsoDate(offsetDays = 0): string {
+  const value = new Date();
+  value.setHours(12, 0, 0, 0);
+  value.setDate(value.getDate() + offsetDays);
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function provenanceMeta(
+  envelope: TrailServerEnvelope<unknown> | null,
+  labels: Record<TrailProvenance, string>,
+  modelLabel: string,
+): ReactNode {
+  if (!envelope) return null;
+  return (
+    <span className="break-words">
+      {labels[envelope.provenance]}
+      {envelope.provenance === 'model_inferred' && envelope.model_version
+        ? ` · ${modelLabel} ${envelope.model_version}`
+        : ''}
+    </span>
+  );
+}

--- a/web/src/components/trail-course-review/mutation-error.ts
+++ b/web/src/components/trail-course-review/mutation-error.ts
@@ -1,0 +1,13 @@
+export class TrailMutationResponseError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'TrailMutationResponseError';
+    this.status = status;
+  }
+}
+
+export function preservesPendingTrailEdits(error: unknown): boolean {
+  return error instanceof TrailMutationResponseError && error.status === 412;
+}

--- a/web/src/components/trail-course-review/private-draft-state.ts
+++ b/web/src/components/trail-course-review/private-draft-state.ts
@@ -1,0 +1,47 @@
+import type { TrailDraftResponse } from '../../types/trail-plan.ts';
+
+export interface PrivateTrailDraftState {
+  data: TrailDraftResponse | null;
+  loading: boolean;
+  error: string | null;
+  errorStatus: number | null;
+}
+
+export type PrivateTrailDraftAction =
+  | { type: 'begin' }
+  | { type: 'success'; data: TrailDraftResponse }
+  | { type: 'failure'; message: string; status: number | null }
+  | { type: 'clear' };
+
+export const INITIAL_PRIVATE_TRAIL_DRAFT_STATE: PrivateTrailDraftState = {
+  data: null,
+  loading: true,
+  error: null,
+  errorStatus: null,
+};
+
+export function reducePrivateTrailDraftState(
+  _state: PrivateTrailDraftState,
+  action: PrivateTrailDraftAction,
+): PrivateTrailDraftState {
+  if (action.type === 'begin') {
+    return { data: null, loading: true, error: null, errorStatus: null };
+  }
+  if (action.type === 'success') {
+    return {
+      data: action.data,
+      loading: false,
+      error: null,
+      errorStatus: null,
+    };
+  }
+  if (action.type === 'failure') {
+    return {
+      data: null,
+      loading: false,
+      error: action.message,
+      errorStatus: action.status,
+    };
+  }
+  return { data: null, loading: false, error: null, errorStatus: null };
+}

--- a/web/src/components/trail-course-review/states.tsx
+++ b/web/src/components/trail-course-review/states.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react';
+import { useLingui } from '@lingui/react/macro';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { apiFetch, extractErrorMessage } from '@/hooks/useApi';
+import {
+  TRAIL_API_ENDPOINTS,
+  type TrailUnknownSchemaDraft,
+} from '@/types/trail-plan';
+import {
+  parseTrailDeleteResponse,
+  parseTrailDraftResponse,
+} from './validation';
+
+export function TrailCourseReviewSkeleton() {
+  const { i18n, t } = useLingui();
+  const isZh = i18n.locale.toLowerCase().startsWith('zh');
+  const loadingLabel = isZh
+    ? t`正在加载越野赛道核对`
+    : t`Loading Trail course review`;
+  return (
+    <div
+      aria-label={loadingLabel}
+      aria-busy="true"
+      className="mx-auto w-full max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8"
+    >
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-64 max-w-full" />
+        <Skeleton className="h-4 w-[34rem] max-w-full" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)]">
+        <div className="space-y-5">
+          {[1, 2, 3, 4, 5].map((item) => (
+            <div key={item} className="space-y-3 border-b border-border pb-5">
+              <Skeleton className="h-6 w-56 max-w-full" />
+              <Skeleton className="h-11 w-full" />
+              <Skeleton className="h-11 w-4/5" />
+            </div>
+          ))}
+        </div>
+        <div className="space-y-3 lg:sticky lg:top-6 lg:self-start">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-11 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+export function TrailCourseReviewLoadError({
+  status,
+  onRetry,
+}: {
+  status: number | null;
+  onRetry: () => Promise<void>;
+}) {
+  const { i18n, t } = useLingui();
+  const isZh = i18n.locale.toLowerCase().startsWith('zh');
+  const title = status === 404
+    ? isZh
+      ? t`未找到此私密越野赛道核对`
+      : t`This private Trail course review was not found`
+    : isZh
+      ? t`暂时无法加载越野赛道核对`
+      : t`Trail course review could not be loaded`;
+  const description = status === 404
+    ? isZh
+      ? t`请确认已登录赛事目标的所有者账号。Praxys 不会透露其他账号是否有此数据。`
+      : t`Sign in as the owner of the event goal. Praxys does not reveal whether another account has this data.`
+    : isZh
+      ? t`请重试。未加载的数据不会被猜测或替换。`
+      : t`Retry the request. Unavailable data will not be guessed or replaced.`;
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <Alert variant="destructive">
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>{description}</p>
+          {status === 404 ? null : (
+            <Button
+              type="button"
+              variant="outline"
+              className="min-h-11"
+              onClick={() => { void onRetry().catch(() => undefined); }}
+            >
+              {isZh ? t`重试` : t`Retry`}
+            </Button>
+          )}
+        </AlertDescription>
+      </Alert>
+    </main>
+  );
+}
+
+export function TrailUnknownVersion({
+  draft,
+  onReload,
+  onClearData,
+  onRejectData,
+}: {
+  draft: TrailUnknownSchemaDraft;
+  onReload: () => Promise<void>;
+  onClearData: () => void;
+  onRejectData: (message: string) => void;
+}) {
+  const { i18n, t } = useLingui();
+  const isZh = i18n.locale.toLowerCase().startsWith('zh');
+  const [dialog, setDialog] = useState<'reset' | 'delete' | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const mutate = async (kind: 'reset' | 'delete') => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const response = await apiFetch(
+        kind === 'reset' ? TRAIL_API_ENDPOINTS.reset : TRAIL_API_ENDPOINTS.draft,
+        {
+          method: kind === 'reset' ? 'POST' : 'DELETE',
+          headers: { 'If-Match': draft.composite_revision },
+        },
+      );
+      if (!response.ok) {
+        throw new Error(await extractErrorMessage(response, 'Request failed.'));
+      }
+      const payload = await response.json() as unknown;
+      if (kind === 'delete') {
+        if (!parseTrailDeleteResponse(payload)) {
+          throw new Error('The Trail deletion response was not recognized.');
+        }
+      } else {
+        const reset = parseTrailDraftResponse(payload);
+        if (!reset || reset.state !== 'current' || reset.reset_is_erasure !== false) {
+          throw new Error('The Trail reset response was not recognized.');
+        }
+      }
+      setDialog(null);
+      onClearData();
+      await onReload();
+    } catch (error) {
+      const failure = error instanceof Error
+        ? error.message
+        : isZh
+          ? t`操作未完成。`
+          : t`The action did not complete.`;
+      setMessage(failure);
+      onRejectData(failure);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl space-y-5 px-4 py-8 sm:px-6 lg:px-8">
+      <Alert variant="destructive">
+        <AlertTitle>
+          {isZh
+            ? t`此赛道核对使用了不受支持的版本`
+            : t`This course review uses an unsupported version`}
+        </AlertTitle>
+        <AlertDescription>
+          {isZh
+            ? t`Praxys 不会猜测旧版或未来字段如何映射到 v2。你可以重新加载、重置赛道核对，或删除这份越野草稿。`
+            : t`Praxys will not guess how old or future fields map to v2. Reload, reset the course review, or delete this Trail draft.`}
+        </AlertDescription>
+      </Alert>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="min-h-11"
+          onClick={() => { void onReload().catch(() => undefined); }}
+        >
+          {isZh ? t`重新加载受支持版本` : t`Reload the supported version`}
+        </Button>
+        <Button type="button" variant="outline" className="min-h-11" onClick={() => setDialog('reset')}>
+          {isZh ? t`重置赛道核对` : t`Reset course review`}
+        </Button>
+        <Button type="button" variant="destructive" className="min-h-11" onClick={() => setDialog('delete')}>
+          {isZh ? t`删除越野目标` : t`Delete Trail goal`}
+        </Button>
+      </div>
+      <p aria-live="polite" className="break-words text-sm text-muted-foreground">
+        {message}
+      </p>
+      <Dialog open={dialog !== null} onOpenChange={(open) => { if (!open) setDialog(null); }}>
+        <DialogContent className="motion-reduce:animate-none sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {dialog === 'reset'
+                ? isZh ? t`重置赛道核对？` : t`Reset course review?`
+                : isZh ? t`删除越野目标？` : t`Delete Trail goal?`}
+            </DialogTitle>
+            <DialogDescription className="break-words leading-6">
+              {dialog === 'reset'
+                ? isZh
+                  ? t`重置会把当前可编辑回答改为未知；不会删除来源活动或已保留的提案记录。`
+                  : t`Reset replaces the current editable answers with unknowns. It does not erase source activities or retained proposal records.`
+                : isZh
+                  ? t`删除越野目标不同于删除账号。系统会请求移除该目标拥有的草稿、快照、提案、审计、索引和缓存；只有服务端确认的结果才会显示为完成。`
+                  : t`Deleting the Trail goal is different from deleting your account. This requests removal of its owned draft, snapshots, proposals, audits, indexes, and caches; only the server-confirmed result will be reported as complete.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" className="min-h-11" onClick={() => setDialog(null)}>
+              {isZh ? t`取消` : t`Cancel`}
+            </Button>
+            <Button
+              type="button"
+              variant={dialog === 'delete' ? 'destructive' : 'outline'}
+              className="min-h-11"
+              disabled={busy || dialog === null}
+              onClick={() => { if (dialog) void mutate(dialog); }}
+            >
+              {busy
+                ? isZh ? t`正在处理…` : t`Working…`
+                : dialog === 'reset'
+                  ? isZh ? t`确认重置` : t`Confirm reset`
+                  : isZh ? t`确认删除` : t`Confirm deletion`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}

--- a/web/src/components/trail-course-review/transitions.ts
+++ b/web/src/components/trail-course-review/transitions.ts
@@ -1,0 +1,116 @@
+import type {
+  TrailClientEnvelope,
+  TrailGradeDistribution,
+} from '../../types/trail-plan.ts';
+
+export function unknown<T>(): TrailClientEnvelope<T> {
+  return { state: 'unknown' };
+}
+
+export function known<T>(value: T): TrailClientEnvelope<T> {
+  return { state: 'known', value };
+}
+
+export function applyUnknownIntent<T>(
+  current: TrailClientEnvelope<T>,
+  makeUnknown: boolean,
+): TrailClientEnvelope<T> {
+  return makeUnknown ? unknown<T>() : current;
+}
+
+export function toggleEnvelopeMember<T extends string | number>(
+  current: TrailClientEnvelope<T[]>,
+  value: T,
+  allowKnownEmpty: boolean,
+): TrailClientEnvelope<T[]> {
+  const values = current.state === 'known' ? current.value : [];
+  const next = values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value];
+  return next.length > 0 || allowKnownEmpty ? known(next) : current;
+}
+
+export function parseGradeBasisPoints(raw: string): number | null {
+  if (!/^\d+(?:\.\d{1,2})?$/.test(raw)) return null;
+  const [whole, fraction = ''] = raw.split('.');
+  const value = Number(whole) * 100 + Number(fraction.padEnd(2, '0'));
+  return Number.isSafeInteger(value) && value >= 0 && value <= 10000
+    ? value
+    : null;
+}
+
+export function gradeEnvelopeFromExplicitInputs(
+  raw: readonly [string, string, string, string, string],
+): TrailClientEnvelope<TrailGradeDistribution> {
+  const values = raw.map(parseGradeBasisPoints);
+  if (values.some((value) => value === null)
+    || values.reduce<number>((total, value) => total + (value ?? 0), 0) !== 10000) {
+    return unknown();
+  }
+  const [a, b, c, d, e] = values as [number, number, number, number, number];
+  return known({
+    below_neg_10: a,
+    neg_10_to_below_neg_3: b,
+    neg_3_to_below_pos_3: c,
+    pos_3_to_below_pos_10: d,
+    pos_10_and_above: e,
+  });
+}
+
+export function integerEnvelopeFromExplicitInput(
+  raw: string,
+  minimum: number,
+  maximum: number,
+): TrailClientEnvelope<number> {
+  if (!/^-?\d+$/.test(raw)) return unknown();
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= minimum && value <= maximum
+    ? known(value)
+    : unknown();
+}
+
+export function decimalEnvelopeFromExplicitInput(
+  raw: string,
+  fractionalDigits: number,
+  minimum: number,
+  maximum: number,
+): TrailClientEnvelope<number> {
+  const expression = new RegExp(`^-?\\d+(?:\\.\\d{1,${fractionalDigits}})?$`);
+  if (!expression.test(raw)) return unknown();
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= minimum && value <= maximum
+    ? known(value)
+    : unknown();
+}
+
+export function metresEnvelopeFromExplicitKilometres(
+  raw: string,
+  minimum: number,
+  maximum: number,
+): TrailClientEnvelope<number> {
+  if (!/^\d+(?:\.\d{1,3})?$/.test(raw)) return unknown();
+  const [whole, fraction = ''] = raw.split('.');
+  const value = Number(whole) * 1000 + Number(fraction.padEnd(3, '0'));
+  return Number.isSafeInteger(value) && value >= minimum && value <= maximum
+    ? known(value)
+    : unknown();
+}
+
+export function durationEnvelopeFromExplicitInputs(
+  hours: string,
+  minutes: string,
+  minimum: number,
+  maximum: number,
+): TrailClientEnvelope<number> {
+  const parsedHours = integerEnvelopeFromExplicitInput(
+    hours,
+    0,
+    Math.ceil(maximum / 60),
+  );
+  const parsedMinutes = integerEnvelopeFromExplicitInput(minutes, 0, 59);
+  if (parsedHours.state === 'unknown' || parsedMinutes.state === 'unknown') {
+    return unknown();
+  }
+  const value = parsedHours.value * 60 + parsedMinutes.value;
+  return value >= minimum && value <= maximum ? known(value) : unknown();
+}

--- a/web/src/components/trail-course-review/use-private-draft.ts
+++ b/web/src/components/trail-course-review/use-private-draft.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { apiFetcher } from '@/hooks/useApi';
+import { ApiResponseError } from '@/lib/api-error';
+import { TRAIL_API_ENDPOINTS, type TrailDraftResponse } from '@/types/trail-plan';
+import { parseTrailDraftResponse } from './validation';
+import {
+  INITIAL_PRIVATE_TRAIL_DRAFT_STATE,
+  reducePrivateTrailDraftState,
+} from './private-draft-state';
+
+interface PrivateTrailDraftResult {
+  data: TrailDraftResponse | null;
+  loading: boolean;
+  error: string | null;
+  errorStatus: number | null;
+  refetch: () => Promise<void>;
+  fetchLatest: () => Promise<TrailDraftResponse>;
+  replaceData: (value: TrailDraftResponse) => void;
+  clearData: () => void;
+  rejectData: (message: string) => void;
+}
+
+export function usePrivateTrailDraft(): PrivateTrailDraftResult {
+  const mountedRef = useRef(false);
+  const controllerRef = useRef<AbortController | null>(null);
+  const [state, dispatch] = useReducer(
+    reducePrivateTrailDraftState,
+    INITIAL_PRIVATE_TRAIL_DRAFT_STATE,
+  );
+
+  const replaceData = useCallback((value: TrailDraftResponse) => {
+    dispatch({ type: 'success', data: value });
+  }, []);
+
+  const clearData = useCallback(() => {
+    dispatch({ type: 'clear' });
+  }, []);
+
+  const rejectData = useCallback((message: string) => {
+    dispatch({ type: 'failure', message, status: null });
+  }, []);
+
+  const fetchLatest = useCallback(async () => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const raw = await apiFetcher<unknown>(
+      TRAIL_API_ENDPOINTS.draft,
+      controller.signal,
+      15_000,
+    );
+    const result = parseTrailDraftResponse(raw);
+    if (!result) throw new Error('The Trail draft response was not recognized.');
+    return result;
+  }, []);
+
+  const refetch = useCallback(async () => {
+    dispatch({ type: 'begin' });
+    try {
+      const result = await fetchLatest();
+      if (!mountedRef.current) return;
+      replaceData(result);
+    } catch (reason) {
+      if (!mountedRef.current) return;
+      const responseError = reason instanceof ApiResponseError ? reason : null;
+      dispatch({
+        type: 'failure',
+        message: reason instanceof Error
+          ? reason.message
+          : 'Trail course review could not be loaded.',
+        status: responseError?.status ?? null,
+      });
+      throw reason;
+    }
+  }, [fetchLatest, replaceData]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    queueMicrotask(() => {
+      if (mountedRef.current) void refetch().catch(() => undefined);
+    });
+    return () => {
+      mountedRef.current = false;
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, [refetch]);
+
+  return {
+    ...state,
+    refetch,
+    fetchLatest,
+    replaceData,
+    clearData,
+    rejectData,
+  };
+}

--- a/web/src/components/trail-course-review/validation.ts
+++ b/web/src/components/trail-course-review/validation.ts
@@ -1,0 +1,689 @@
+import {
+  TRAIL_EDITABLE_SECTION_KEYS,
+  TRAIL_MODULE_KEYS,
+  TRAIL_REASON_CODES,
+  TRAIL_SCHEMA_IDS,
+  type TrailDraftResponse,
+  type TrailDeleteResponse,
+  type TrailReadinessResponse,
+} from '../../types/trail-plan.ts';
+
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const ABSENT_TRAIL_PLAN_REVISION = 'sha256:8adaaec35fb1a6ff05f212e69fc57c9e41bceaa30b65b95a8b3f90120ef5a321';
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const STATUS_PRECEDENCE = [
+  'validation_failed',
+  'policy_unavailable',
+  'readiness_blocked',
+  'clarification_required',
+  'eligible_proposal',
+] as const;
+const EXPECTED_METADATA = {
+  policy_version: 'non-ultra-trail-plan-generation-policy-v2',
+  generator_version: 'non-ultra-trail-deterministic-generator-v2',
+  science_decision_id: 'sdr-non-ultra-trail-plan-generation-policy-v2',
+  contract_digest: 'sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9',
+  source_decision_digest: 'sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe',
+  ontology_version: 'trail-course-demand-v2',
+  ontology_decision_id: 'sdr-trail-running-goal-ontology-v2',
+  ontology_contract_digest: 'sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c',
+  ontology_source_decision_digest: 'sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1',
+  course_schema_id: TRAIL_SCHEMA_IDS.course,
+  constraint_schema_id: TRAIL_SCHEMA_IDS.constraints,
+  contract_runtime_state: 'inactive',
+} as const;
+const READINESS_KEYS = [
+  ...Object.keys(EXPECTED_METADATA),
+  'inactive_dry_run',
+  'status',
+  'detail_reason',
+  'matching_reasons',
+  'module_availability',
+  'limited_modules',
+  'deterministic_input_hash',
+  'readiness_receipt_digest',
+  'revision_bindings',
+  'plan',
+  'history_statistics',
+] as const;
+const HISTORY_NUMBER_KEYS = [
+  'usable_completed_weeks',
+  'recent_modal_running_frequency',
+  'recent_median_usable_weekly_minutes',
+  'recent_maximum_usable_weekly_minutes',
+  'recent_maximum_session_minutes',
+  'recent_median_usable_weekly_ascent_meters',
+  'recent_maximum_usable_weekly_ascent_meters',
+  'recent_median_usable_weekly_descent_meters',
+  'recent_maximum_usable_weekly_descent_meters',
+  'recent_maximum_session_ascent_meters',
+  'recent_maximum_session_descent_meters',
+  'comparable_ascent_sessions_within_window',
+  'comparable_descent_sessions_within_window',
+] as const;
+const HISTORY_DATE_KEYS = [
+  'latest_run_date',
+  'latest_comparable_ascent_session_date',
+  'latest_comparable_descent_session_date',
+  'observation_window_start',
+  'observation_window_end',
+] as const;
+const FOOTING = new Set([
+  'firm_smooth',
+  'loose_gravel',
+  'mud',
+  'rocks_or_roots',
+  'built_steps',
+  'water_crossing',
+]);
+const PROVENANCE = new Set([
+  'athlete_stated',
+  'course_verified',
+  'history_observed',
+  'model_inferred',
+  'explicit_assumption',
+  'unknown',
+]);
+const ENVELOPE_KEYS = new Set([
+  'state',
+  'provenance',
+  'source_revision',
+  'value',
+  'source_timestamp',
+  'model_version',
+  'assumption_confirmed_revision',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRealIsoDate(value: unknown): value is string {
+  if (typeof value !== 'string' || !ISO_DATE_PATTERN.test(value)) return false;
+  const [year, month, day] = value.split('-').map(Number);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+  return year >= 1 && year <= 9999
+    && month >= 1
+    && month <= 12
+    && day >= 1
+    && daysInMonth !== undefined
+    && day <= daysInMonth;
+}
+
+function isoDayDifference(later: string, earlier: string): number {
+  return (Date.parse(`${later}T00:00:00Z`) - Date.parse(`${earlier}T00:00:00Z`))
+    / 86_400_000;
+}
+
+function isTimezoneAwareIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-](\d{2}):(\d{2}))$/.exec(value);
+  if (!match || !isRealIsoDate(match[1])) return false;
+  const hour = Number(match[2]);
+  const minute = Number(match[3]);
+  const second = Number(match[4]);
+  if (hour > 23 || minute > 59 || second > 59) return false;
+  if (match[5] !== 'Z') {
+    const offsetHour = Number(match[6]);
+    const offsetMinute = Number(match[7]);
+    if (offsetHour > 23 || offsetMinute > 59) return false;
+  }
+  return true;
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length
+    && actual.every((key, index) => key === wanted[index]);
+}
+
+function isInteger(value: unknown, minimum: number, maximum: number): boolean {
+  return Number.isInteger(value) && Number(value) >= minimum && Number(value) <= maximum;
+}
+
+function isFiniteNumber(value: unknown, minimum: number, maximum: number): boolean {
+  return typeof value === 'number'
+    && Number.isFinite(value)
+    && value >= minimum
+    && value <= maximum;
+}
+
+function isClosedString(value: unknown, allowed: readonly string[]): boolean {
+  return typeof value === 'string' && allowed.includes(value);
+}
+
+function isClosedSet(
+  value: unknown,
+  allowed: ReadonlySet<string>,
+  allowEmpty: boolean,
+): boolean {
+  return Array.isArray(value)
+    && (allowEmpty || value.length > 0)
+    && new Set(value).size === value.length
+    && value.every((item) => typeof item === 'string' && allowed.has(item));
+}
+
+function isServerEnvelope(
+  value: unknown,
+  knownValue: (candidate: unknown) => boolean,
+): boolean {
+  if (!isRecord(value)
+    || Object.keys(value).some((key) => !ENVELOPE_KEYS.has(key))
+    || (value.state !== 'known' && value.state !== 'unknown')
+    || typeof value.provenance !== 'string'
+    || !PROVENANCE.has(value.provenance)
+    || typeof value.source_revision !== 'string'
+    || !SHA256_PATTERN.test(value.source_revision)) return false;
+  if (value.source_timestamp !== undefined && !isTimezoneAwareIsoTimestamp(value.source_timestamp)) {
+    return false;
+  }
+  if (value.model_version !== undefined
+    && (typeof value.model_version !== 'string'
+      || value.model_version.length === 0
+      || value.model_version.length > 128)) return false;
+  if (value.assumption_confirmed_revision !== undefined
+    && (typeof value.assumption_confirmed_revision !== 'string'
+      || !SHA256_PATTERN.test(value.assumption_confirmed_revision))) return false;
+  if (value.state === 'unknown' && value.provenance !== 'unknown') return false;
+  if (value.state === 'known' && value.provenance === 'unknown') return false;
+  if (value.provenance === 'model_inferred'
+    && (typeof value.model_version !== 'string' || value.model_version.length === 0)) {
+    return false;
+  }
+  return value.state === 'known'
+    ? Object.hasOwn(value, 'value') && knownValue(value.value)
+    : !Object.hasOwn(value, 'value');
+}
+
+function isOptionalContext(value: unknown): boolean {
+  if (!isRecord(value) || !hasExactKeys(value, ['environment', 'support', 'fueling'])
+    || !isRecord(value.environment)
+    || !hasExactKeys(value.environment, [
+      'maximum_altitude_m',
+      'temperature_min_c',
+      'temperature_max_c',
+      'humidity_min_pct',
+      'humidity_max_pct',
+      'sun_exposure',
+      'wind_exposure',
+      'conditions_basis',
+    ])
+    || !isRecord(value.support)
+    || !hasExactKeys(value.support, [
+      'aid_support_mode',
+      'aid_station_count',
+      'max_aid_station_gap_m',
+      'water_availability',
+      'food_availability',
+      'mandatory_gear',
+    ])
+    || !isRecord(value.fueling)
+    || !hasExactKeys(value.fueling, [
+      'longest_practiced_duration_min',
+      'practice_sessions_last_42_days',
+      'intake_form',
+      'gastrointestinal_experience',
+    ])) return false;
+  const environment = value.environment;
+  const support = value.support;
+  const fueling = value.fueling;
+  if (isRecord(environment.temperature_min_c)
+    && isRecord(environment.temperature_max_c)
+    && environment.temperature_min_c.state === 'known'
+    && environment.temperature_max_c.state === 'known'
+    && Number(environment.temperature_min_c.value) > Number(environment.temperature_max_c.value)) {
+    return false;
+  }
+  if (isRecord(environment.humidity_min_pct)
+    && isRecord(environment.humidity_max_pct)
+    && environment.humidity_min_pct.state === 'known'
+    && environment.humidity_max_pct.state === 'known'
+    && Number(environment.humidity_min_pct.value) > Number(environment.humidity_max_pct.value)) {
+    return false;
+  }
+  if (isRecord(environment.conditions_basis)
+    && environment.conditions_basis.state === 'known') {
+    const isAssumption = environment.conditions_basis.value === 'athlete_assumption';
+    if (isAssumption !== (environment.conditions_basis.provenance === 'explicit_assumption')) {
+      return false;
+    }
+  }
+  return isServerEnvelope(environment.maximum_altitude_m, (item) => isInteger(item, -500, 9000))
+    && isServerEnvelope(environment.temperature_min_c, (item) => isFiniteNumber(item, -30, 55))
+    && isServerEnvelope(environment.temperature_max_c, (item) => isFiniteNumber(item, -30, 55))
+    && isServerEnvelope(environment.humidity_min_pct, (item) => isFiniteNumber(item, 0, 100))
+    && isServerEnvelope(environment.humidity_max_pct, (item) => isFiniteNumber(item, 0, 100))
+    && isServerEnvelope(environment.sun_exposure, (item) => isClosedString(item, ['low', 'mixed', 'high']))
+    && isServerEnvelope(environment.wind_exposure, (item) => isClosedString(item, ['sheltered', 'mixed', 'exposed']))
+    && isServerEnvelope(environment.conditions_basis, (item) => isClosedString(item, [
+      'organizer_information',
+      'seasonal_expectation',
+      'athlete_assumption',
+    ]))
+    && isServerEnvelope(support.aid_support_mode, (item) => isClosedString(item, [
+      'organized_aid',
+      'mixed',
+      'self_supported',
+    ]))
+    && isServerEnvelope(support.aid_station_count, (item) => isInteger(item, 0, 50))
+    && isServerEnvelope(support.max_aid_station_gap_m, (item) => item === null || isInteger(item, 100, 50000))
+    && isServerEnvelope(support.water_availability, (item) => isClosedString(item, ['none', 'some_stations', 'all_stations']))
+    && isServerEnvelope(support.food_availability, (item) => isClosedString(item, ['none', 'some_stations', 'all_stations']))
+    && isServerEnvelope(support.mandatory_gear, (item) => isClosedSet(item, new Set([
+      'water_carry',
+      'food_carry',
+      'weather_shell',
+      'lighting',
+      'navigation_device',
+      'other_required',
+    ]), true))
+    && isServerEnvelope(fueling.longest_practiced_duration_min, (item) => isInteger(item, 0, 1440))
+    && isServerEnvelope(fueling.practice_sessions_last_42_days, (item) => isInteger(item, 0, 84))
+    && isServerEnvelope(fueling.intake_form, (item) => isClosedString(item, [
+      'none',
+      'fluids_only',
+      'carbohydrate_drink',
+      'mixed_food_and_drink',
+    ]))
+    && isServerEnvelope(fueling.gastrointestinal_experience, (item) => isClosedString(item, [
+      'no_plan_altering_issue',
+      'plan_altering_issue',
+    ]));
+}
+
+function isCurrentDraft(value: Record<string, unknown>): boolean {
+  const allowedRootKeys = new Set([
+    'state',
+    'namespace_version',
+    'course_demand',
+    'constraints',
+    'revision_bindings',
+    'composite_revision',
+    'reset_is_erasure',
+  ]);
+  if (Object.keys(value).some((key) => !allowedRootKeys.has(key))
+    || value.state !== 'current'
+    || value.namespace_version !== 1
+    || typeof value.composite_revision !== 'string'
+    || !SHA256_PATTERN.test(value.composite_revision)
+    || (value.reset_is_erasure !== undefined && value.reset_is_erasure !== false)
+    || !isRevisionBindings(value.revision_bindings, value.composite_revision)
+    || !isRecord(value.course_demand)
+    || !hasExactKeys(value.course_demand, ['schema_id', 'event_id', 'fields'])
+    || value.course_demand.schema_id !== TRAIL_SCHEMA_IDS.course
+    || typeof value.course_demand.event_id !== 'string'
+    || value.course_demand.event_id.length === 0
+    || value.course_demand.event_id.length > 128
+    || !isRecord(value.course_demand.fields)
+    || !hasExactKeys(value.course_demand.fields, [
+      'event_date',
+      'distance_meters',
+      'total_ascent_m',
+      'total_descent_m',
+      'planning_duration_range',
+      'event_format',
+      'distance_family',
+      'planning_intent',
+      'grade_distribution',
+      'course_footing',
+      'hands_assist',
+      'fixed_rope',
+      'optional_context',
+    ])) return false;
+  const fields = value.course_demand.fields;
+  const grade = (item: unknown) => isRecord(item)
+    && hasExactKeys(item, [
+      'below_neg_10',
+      'neg_10_to_below_neg_3',
+      'neg_3_to_below_pos_3',
+      'pos_3_to_below_pos_10',
+      'pos_10_and_above',
+    ])
+    && Object.values(item).every((share) => isInteger(share, 0, 10000))
+    && Object.values(item).reduce<number>((sum, share) => sum + Number(share), 0) === 10000;
+  const duration = (item: unknown) => isRecord(item)
+    && hasExactKeys(item, ['minimum_min', 'maximum_min'])
+    && isInteger(item.minimum_min, 1, 1440)
+    && isInteger(item.maximum_min, 1, 1440)
+    && Number(item.minimum_min) < Number(item.maximum_min);
+  if (!isServerEnvelope(fields.event_date, isRealIsoDate)
+    || !isServerEnvelope(fields.distance_meters, (item) => isInteger(item, 1, 49999))
+    || !isServerEnvelope(fields.total_ascent_m, (item) => isInteger(item, 0, 20000))
+    || !isServerEnvelope(fields.total_descent_m, (item) => isInteger(item, 0, 20000))
+    || !isServerEnvelope(fields.planning_duration_range, duration)
+    || !isServerEnvelope(fields.event_format, (item) => isClosedString(item, ['single_day', 'multi_day']))
+    || !isServerEnvelope(fields.distance_family, (item) => isClosedString(item, ['non_ultra', 'ultra']))
+    || !isServerEnvelope(fields.planning_intent, (item) => isClosedString(item, [
+      'performance',
+      'first_completion',
+      'return_to_consistency',
+    ]))
+    || !isServerEnvelope(fields.grade_distribution, grade)
+    || !isServerEnvelope(fields.course_footing, (item) => isClosedSet(item, FOOTING, false))
+    || !isServerEnvelope(fields.hands_assist, (item) => typeof item === 'boolean')
+    || !isServerEnvelope(fields.fixed_rope, (item) => typeof item === 'boolean')
+    || !isOptionalContext(fields.optional_context)
+    || !isRecord(value.constraints)
+    || !hasExactKeys(value.constraints, [
+      'schema_id',
+      'available_weekdays',
+      'weekly_time_limit_min',
+      'maximum_session_duration_min',
+      'unavailable_dates',
+      'preferred_longest_weekday',
+      'nontechnical_three_minute_uphill_access',
+      'controlled_downhill_access',
+      'accessible_footing',
+      'adult_nonclinical_scope_confirmed',
+      'performance_intent_confirmed',
+      'current_symptom_stop',
+    ])
+    || value.constraints.schema_id !== TRAIL_SCHEMA_IDS.constraints) return false;
+  if (isRecord(fields.grade_distribution)
+    && fields.grade_distribution.state === 'known'
+    && !['athlete_stated', 'course_verified'].includes(String(fields.grade_distribution.provenance))) {
+    return false;
+  }
+  const constraints = value.constraints;
+  if (isRecord(constraints.weekly_time_limit_min)
+    && isRecord(constraints.maximum_session_duration_min)
+    && constraints.weekly_time_limit_min.state === 'known'
+    && constraints.maximum_session_duration_min.state === 'known'
+    && Number(constraints.maximum_session_duration_min.value)
+      > Number(constraints.weekly_time_limit_min.value)) return false;
+  if (constraints.preferred_longest_weekday !== null
+    && isRecord(constraints.available_weekdays)
+    && constraints.available_weekdays.state === 'known'
+    && (!Array.isArray(constraints.available_weekdays.value)
+      || !constraints.available_weekdays.value.includes(constraints.preferred_longest_weekday))) {
+    return false;
+  }
+  return isServerEnvelope(constraints.available_weekdays, (item) => Array.isArray(item)
+      && item.length > 0
+      && new Set(item).size === item.length
+      && item.every((day) => isInteger(day, 1, 7))
+      && item.every((day, index) => index === 0 || Number(item[index - 1]) < Number(day)))
+    && isServerEnvelope(constraints.weekly_time_limit_min, (item) => isInteger(item, 1, 10080))
+    && isServerEnvelope(constraints.maximum_session_duration_min, (item) => isInteger(item, 1, 1440))
+    && isServerEnvelope(constraints.unavailable_dates, (item) => Array.isArray(item)
+      && item.length <= 14
+      && new Set(item).size === item.length
+      && item.every(isRealIsoDate)
+      && item.every((date, index) => index === 0 || String(item[index - 1]) < String(date)))
+    && (constraints.preferred_longest_weekday === null
+      || isInteger(constraints.preferred_longest_weekday, 1, 7))
+    && isServerEnvelope(constraints.nontechnical_three_minute_uphill_access, (item) => typeof item === 'boolean')
+    && isServerEnvelope(constraints.controlled_downhill_access, (item) => typeof item === 'boolean')
+    && isServerEnvelope(constraints.accessible_footing, (item) => isClosedSet(item, FOOTING, false))
+    && isServerEnvelope(constraints.adult_nonclinical_scope_confirmed, (item) => typeof item === 'boolean')
+    && isServerEnvelope(constraints.performance_intent_confirmed, (item) => typeof item === 'boolean')
+    && isServerEnvelope(constraints.current_symptom_stop, (item) => typeof item === 'boolean');
+}
+
+export function parseTrailDraftResponse(value: unknown): TrailDraftResponse | null {
+  if (!isRecord(value) || typeof value.composite_revision !== 'string'
+    || !SHA256_PATTERN.test(value.composite_revision)) return null;
+  if (value.state === 'absent') {
+    return hasExactKeys(value, ['state', 'composite_revision'])
+      ? value as unknown as TrailDraftResponse
+      : null;
+  }
+  if (value.state === 'unknown_schema') {
+    return hasExactKeys(value, ['state', 'namespace', 'composite_revision'])
+      ? value as unknown as TrailDraftResponse
+      : null;
+  }
+  return value.state === 'current' && isCurrentDraft(value)
+    ? value as unknown as TrailDraftResponse
+    : null;
+}
+
+export function parseTrailDeleteResponse(value: unknown): TrailDeleteResponse | null {
+  if (!isRecord(value)
+    || !hasExactKeys(value, ['status', 'composite_revision'])
+    || (value.status !== 'deleted' && value.status !== 'absent')
+    || value.composite_revision !== ABSENT_TRAIL_PLAN_REVISION) return null;
+  return value as unknown as TrailDeleteResponse;
+}
+
+function isRevisionBindings(value: unknown, expectedComposite: string): boolean {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    'course_revision',
+    'planning_context_revision',
+    'history_revision',
+    'composite_revision',
+    'section_confirmations',
+  ])) return false;
+  if (value.composite_revision !== expectedComposite) return false;
+  for (const key of [
+    'course_revision',
+    'planning_context_revision',
+    'history_revision',
+    'composite_revision',
+  ]) {
+    if (typeof value[key] !== 'string' || !SHA256_PATTERN.test(value[key])) return false;
+  }
+  if (!Array.isArray(value.section_confirmations)) return false;
+  const seen = new Set<string>();
+  for (const item of value.section_confirmations) {
+    if (!isRecord(item) || !hasExactKeys(item, [
+      'section_key',
+      'current_revision',
+      'confirmed_revision',
+    ])) return false;
+    if (!(TRAIL_EDITABLE_SECTION_KEYS as readonly string[]).includes(String(item.section_key))) {
+      return false;
+    }
+    if (seen.has(String(item.section_key))) return false;
+    seen.add(String(item.section_key));
+    if (typeof item.current_revision !== 'string' || !SHA256_PATTERN.test(item.current_revision)) {
+      return false;
+    }
+    if (item.confirmed_revision !== null
+      && (typeof item.confirmed_revision !== 'string'
+        || !SHA256_PATTERN.test(item.confirmed_revision))) return false;
+  }
+  return seen.size === TRAIL_EDITABLE_SECTION_KEYS.length;
+}
+
+function isHistoryStatistics(value: unknown): boolean {
+  if (!isRecord(value) || !hasExactKeys(value, [
+    ...HISTORY_NUMBER_KEYS,
+    ...HISTORY_DATE_KEYS,
+    'recently_observed_footing',
+    'source_revision_fingerprint',
+    'evaluator_schema_id',
+  ])) return false;
+  for (const key of HISTORY_NUMBER_KEYS) {
+    if (!Number.isInteger(value[key]) || Number(value[key]) < 0) return false;
+  }
+  if (Number(value.usable_completed_weeks) > 8) return false;
+  for (const key of HISTORY_DATE_KEYS) {
+    if (value[key] !== null
+      && !isRealIsoDate(value[key])) return false;
+  }
+  if (!Array.isArray(value.recently_observed_footing)) return false;
+  const footing = value.recently_observed_footing;
+  if (new Set(footing).size !== footing.length
+    || footing.some((item) => typeof item !== 'string' || !FOOTING.has(item))) return false;
+  if (value.evaluator_schema_id !== 'trail-running-history-statistics-v2') return false;
+  const start = value.observation_window_start;
+  const end = value.observation_window_end;
+  if (typeof start !== 'string' || typeof end !== 'string') return false;
+  const observationDays = isoDayDifference(end, start);
+  if (!Number.isInteger(observationDays)
+    || observationDays < 55
+    || observationDays > 61) return false;
+  if (typeof start === 'string' && typeof end === 'string') {
+    for (const dateKey of [
+      'latest_run_date',
+      'latest_comparable_ascent_session_date',
+      'latest_comparable_descent_session_date',
+    ]) {
+      const date = value[dateKey];
+      if (typeof date === 'string' && (date < start || date > end)) return false;
+    }
+    for (const dateKey of [
+      'latest_comparable_ascent_session_date',
+      'latest_comparable_descent_session_date',
+    ]) {
+      const date = value[dateKey];
+      if (typeof date === 'string') {
+        const completedDaysBeforeEnd = isoDayDifference(end, date);
+        if (!Number.isInteger(completedDaysBeforeEnd)
+          || completedDaysBeforeEnd < 0
+          || completedDaysBeforeEnd > 41) return false;
+      }
+    }
+  }
+  if ((Number(value.comparable_ascent_sessions_within_window) === 0)
+    !== (value.latest_comparable_ascent_session_date === null)) return false;
+  if ((Number(value.comparable_descent_sessions_within_window) === 0)
+    !== (value.latest_comparable_descent_session_date === null)) return false;
+  if (Number(value.recent_median_usable_weekly_minutes)
+      > Number(value.recent_maximum_usable_weekly_minutes)
+    || Number(value.recent_maximum_session_minutes)
+      > Number(value.recent_maximum_usable_weekly_minutes)
+    || Number(value.recent_median_usable_weekly_ascent_meters)
+      > Number(value.recent_maximum_usable_weekly_ascent_meters)
+    || Number(value.recent_maximum_session_ascent_meters)
+      > Number(value.recent_maximum_usable_weekly_ascent_meters)
+    || Number(value.recent_median_usable_weekly_descent_meters)
+      > Number(value.recent_maximum_usable_weekly_descent_meters)
+    || Number(value.recent_maximum_session_descent_meters)
+      > Number(value.recent_maximum_usable_weekly_descent_meters)) return false;
+  return typeof value.source_revision_fingerprint === 'string'
+    && SHA256_PATTERN.test(value.source_revision_fingerprint)
+    && typeof value.evaluator_schema_id === 'string';
+}
+
+export function parseTrailReadinessResponse(
+  value: unknown,
+  expectedCompositeRevision: string,
+): TrailReadinessResponse | null {
+  if (!SHA256_PATTERN.test(expectedCompositeRevision)
+    || !isRecord(value)
+    || !hasExactKeys(value, ['draft', 'readiness'])
+    || !isRecord(value.readiness)
+    || !hasExactKeys(value.readiness, READINESS_KEYS)) return null;
+  const draft = parseTrailDraftResponse(value.draft);
+  if (!draft || draft.state !== 'current'
+    || draft.composite_revision !== expectedCompositeRevision) return null;
+
+  const readiness = value.readiness;
+  for (const [key, expected] of Object.entries(EXPECTED_METADATA)) {
+    if (readiness[key] !== expected) return null;
+  }
+  if (readiness.inactive_dry_run !== false || readiness.plan !== null) return null;
+  if (typeof readiness.deterministic_input_hash !== 'string'
+    || !SHA256_PATTERN.test(readiness.deterministic_input_hash)
+    || typeof readiness.readiness_receipt_digest !== 'string'
+    || !SHA256_PATTERN.test(readiness.readiness_receipt_digest)
+    || !isRevisionBindings(readiness.revision_bindings, expectedCompositeRevision)
+    || !isHistoryStatistics(readiness.history_statistics)) return null;
+  const draftBindings = draft.revision_bindings as unknown as Record<string, unknown>;
+  const readinessBindings = readiness.revision_bindings as Record<string, unknown>;
+  for (const key of [
+    'course_revision',
+    'planning_context_revision',
+    'history_revision',
+    'composite_revision',
+  ]) {
+    if (draftBindings[key] !== readinessBindings[key]) return null;
+  }
+  if (JSON.stringify(draftBindings.section_confirmations)
+    !== JSON.stringify(readinessBindings.section_confirmations)) return null;
+  if (!(readinessBindings.section_confirmations as unknown[]).every((item) =>
+    isRecord(item) && item.confirmed_revision === item.current_revision)) return null;
+  const conditionsBasis = draft.course_demand.fields.optional_context.environment.conditions_basis;
+  if (conditionsBasis.provenance === 'explicit_assumption'
+    && conditionsBasis.assumption_confirmed_revision !== conditionsBasis.source_revision) {
+    return null;
+  }
+
+  if (typeof readiness.status !== 'string'
+    || !(STATUS_PRECEDENCE as readonly string[]).includes(readiness.status)) return null;
+  const status = readiness.status;
+  if (status !== 'policy_unavailable'
+    || readiness.detail_reason !== 'policy_inactive') return null;
+  const matching = readiness.matching_reasons;
+  if (!Array.isArray(matching)) return null;
+  const codes: string[] = [];
+  for (const reason of matching) {
+    if (!isRecord(reason)
+      || !hasExactKeys(reason, ['status', 'detail_reason'])
+      || typeof reason.status !== 'string'
+      || typeof reason.detail_reason !== 'string') return null;
+    const code = `${reason.status}.${reason.detail_reason}`;
+    if (!(TRAIL_REASON_CODES as readonly string[]).includes(code)) return null;
+    codes.push(code);
+  }
+  if (new Set(codes).size !== codes.length) return null;
+  const indexes = codes.map((code) => (TRAIL_REASON_CODES as readonly string[]).indexOf(code));
+  if (indexes.some((index, position) => position > 0 && index <= indexes[position - 1])) {
+    return null;
+  }
+
+  if (typeof readiness.detail_reason !== 'string') return null;
+  const primaryReason = `${status}.${readiness.detail_reason}`;
+  if (!(TRAIL_REASON_CODES as readonly string[]).includes(primaryReason)
+    || codes[0] !== primaryReason) return null;
+
+  const history = readiness.history_statistics as Record<string, unknown>;
+  const historyEnd = String(history.observation_window_end);
+  const requiredHistoryReasons: string[] = [];
+  const latestRun = history.latest_run_date;
+  const insufficientRecentRunning = Number(history.usable_completed_weeks) < 4
+    || typeof latestRun !== 'string'
+    || isoDayDifference(historyEnd, latestRun) > 9;
+  if (insufficientRecentRunning) {
+    requiredHistoryReasons.push('readiness_blocked.insufficient_recent_running_history');
+  }
+  const latestAscent = history.latest_comparable_ascent_session_date;
+  const courseFooting = draft.course_demand.fields.course_footing;
+  const observedFooting = history.recently_observed_footing as string[];
+  const footingMismatch = courseFooting.state === 'known'
+    && courseFooting.value.some((footing) => !observedFooting.includes(footing));
+  const insufficientComparableHistory = Number(history.comparable_ascent_sessions_within_window) < 2
+    || typeof latestAscent !== 'string'
+    || isoDayDifference(historyEnd, latestAscent) > 20
+    || footingMismatch;
+  if (insufficientComparableHistory) {
+    requiredHistoryReasons.push('readiness_blocked.insufficient_comparable_trail_history');
+  }
+  const latestDescent = history.latest_comparable_descent_session_date;
+  const insufficientDescentHistory = Number(history.comparable_descent_sessions_within_window) < 2
+    || typeof latestDescent !== 'string'
+    || isoDayDifference(historyEnd, latestDescent) > 20;
+  if (insufficientDescentHistory) {
+    requiredHistoryReasons.push('readiness_blocked.insufficient_descent_history');
+  }
+  if (requiredHistoryReasons.some((reason) => !codes.includes(reason))) return null;
+  if (codes.includes('readiness_blocked.insufficient_recent_running_history')
+    !== insufficientRecentRunning) return null;
+  if (codes.includes('readiness_blocked.insufficient_comparable_trail_history')
+    !== insufficientComparableHistory) return null;
+  if (codes.includes('readiness_blocked.insufficient_descent_history')
+    !== insufficientDescentHistory) return null;
+
+  if (!Array.isArray(readiness.module_availability)
+    || readiness.module_availability.length !== TRAIL_MODULE_KEYS.length) return null;
+  for (const [index, module] of readiness.module_availability.entries()) {
+    if (!isRecord(module)
+      || !hasExactKeys(module, ['module', 'state', 'reason_target'])
+      || module.module !== TRAIL_MODULE_KEYS[index]
+      || !['not_evaluated', 'available', 'limited'].includes(String(module.state))) return null;
+    if (module.state !== 'not_evaluated'
+      || module.reason_target !== primaryReason) return null;
+  }
+
+  if (!Array.isArray(readiness.limited_modules)
+    || readiness.limited_modules.some((item) => typeof item !== 'string')) return null;
+  if (readiness.limited_modules.length !== 0) return null;
+  return value as unknown as TrailReadinessResponse;
+}

--- a/web/src/types/trail-plan.ts
+++ b/web/src/types/trail-plan.ts
@@ -1,0 +1,448 @@
+export const TRAIL_API_ENDPOINTS = {
+  draft: '/api/plan/trail/draft',
+  confirm: '/api/plan/trail/confirm',
+  reset: '/api/plan/trail/reset',
+  readiness: '/api/plan/trail/readiness',
+} as const;
+
+export const TRAIL_SCHEMA_IDS = {
+  course: 'trail_course_demand_v2',
+  constraints: 'non_ultra_trail_constraints_v2',
+} as const;
+
+export const TRAIL_EDITABLE_SECTION_KEYS = [
+  'section.event-duration',
+  'section.grade-footing',
+  'section.training-access',
+  'section.optional-context',
+] as const;
+
+export const TRAIL_SECTION_KEYS = [
+  ...TRAIL_EDITABLE_SECTION_KEYS.slice(0, 3),
+  'section.recent-experience',
+  'section.optional-context',
+  'section.policy-receipt',
+] as const;
+
+export const TRAIL_MODULE_KEYS = [
+  'grade_specificity',
+  'technical_terrain',
+  'environment_altitude',
+  'fueling',
+] as const;
+
+export const TRAIL_REASON_CODES = [
+  'validation_failed.invalid_field_value',
+  'validation_failed.schema_version_mismatch',
+  'validation_failed.deterministic_invariant_failed',
+  'policy_unavailable.policy_inactive',
+  'policy_unavailable.event_inside_unapproved_taper_window',
+  'policy_unavailable.unsupported_ultra_or_multiday',
+  'policy_unavailable.unsupported_population_or_intent',
+  'policy_unavailable.technical_features_outside_v2',
+  'readiness_blocked.insufficient_recent_running_history',
+  'readiness_blocked.insufficient_comparable_trail_history',
+  'readiness_blocked.insufficient_descent_history',
+  'readiness_blocked.insufficient_terrain_access',
+  'readiness_blocked.current_symptom_stop',
+  'readiness_blocked.no_schedule_within_envelope',
+  'clarification_required.material_course_demand_unknown',
+  'clarification_required.assumption_confirmation_required',
+  'clarification_required.adult_scope_or_constraints_unconfirmed',
+  'clarification_required.training_constraints_missing',
+  'clarification_required.training_constraints_outside_history_envelope',
+  'clarification_required.stale_confirmation_or_source_revision',
+  'clarification_required.contradictory_input',
+] as const;
+
+export type TrailEditableSectionKey =
+  (typeof TRAIL_EDITABLE_SECTION_KEYS)[number];
+export type TrailSectionKey = (typeof TRAIL_SECTION_KEYS)[number];
+export type TrailModuleKey = (typeof TRAIL_MODULE_KEYS)[number];
+export type TrailReasonCode = (typeof TRAIL_REASON_CODES)[number];
+
+export type TrailProvenance =
+  | 'athlete_stated'
+  | 'course_verified'
+  | 'history_observed'
+  | 'model_inferred'
+  | 'explicit_assumption'
+  | 'unknown';
+
+interface TrailServerEnvelopeMetadata {
+  provenance: TrailProvenance;
+  source_revision: string;
+  source_timestamp?: string;
+  model_version?: string;
+  assumption_confirmed_revision?: string;
+}
+
+export type TrailServerEnvelope<T> =
+  | (TrailServerEnvelopeMetadata & { state: 'known'; value: T })
+  | (TrailServerEnvelopeMetadata & { state: 'unknown'; value?: never });
+
+export type TrailClientEnvelope<T> =
+  | { state: 'known'; value: T }
+  | { state: 'unknown'; value?: never };
+
+export type TrailEventFormat = 'single_day' | 'multi_day';
+export type TrailDistanceFamily = 'non_ultra' | 'ultra';
+export type TrailPlanningIntent =
+  | 'performance'
+  | 'first_completion'
+  | 'return_to_consistency';
+export type TrailFooting =
+  | 'firm_smooth'
+  | 'loose_gravel'
+  | 'mud'
+  | 'rocks_or_roots'
+  | 'built_steps'
+  | 'water_crossing';
+export type TrailSunExposure = 'low' | 'mixed' | 'high';
+export type TrailWindExposure = 'sheltered' | 'mixed' | 'exposed';
+export type TrailConditionsBasis =
+  | 'organizer_information'
+  | 'seasonal_expectation'
+  | 'athlete_assumption';
+export type TrailAidSupportMode =
+  | 'organized_aid'
+  | 'mixed'
+  | 'self_supported';
+export type TrailAidAvailability = 'none' | 'some_stations' | 'all_stations';
+export type TrailMandatoryGear =
+  | 'water_carry'
+  | 'food_carry'
+  | 'weather_shell'
+  | 'lighting'
+  | 'navigation_device'
+  | 'other_required';
+export type TrailIntakeForm =
+  | 'none'
+  | 'fluids_only'
+  | 'carbohydrate_drink'
+  | 'mixed_food_and_drink';
+export type TrailGastrointestinalExperience =
+  | 'no_plan_altering_issue'
+  | 'plan_altering_issue';
+
+export interface TrailPlanningDurationRange {
+  minimum_min: number;
+  maximum_min: number;
+}
+
+export interface TrailGradeDistribution {
+  below_neg_10: number;
+  neg_10_to_below_neg_3: number;
+  neg_3_to_below_pos_3: number;
+  pos_3_to_below_pos_10: number;
+  pos_10_and_above: number;
+}
+
+export interface TrailOptionalContext<TEnvelope> {
+  environment: {
+    maximum_altitude_m: TEnvelope;
+    temperature_min_c: TEnvelope;
+    temperature_max_c: TEnvelope;
+    humidity_min_pct: TEnvelope;
+    humidity_max_pct: TEnvelope;
+    sun_exposure: TEnvelope;
+    wind_exposure: TEnvelope;
+    conditions_basis: TEnvelope;
+  };
+  support: {
+    aid_support_mode: TEnvelope;
+    aid_station_count: TEnvelope;
+    max_aid_station_gap_m: TEnvelope;
+    water_availability: TEnvelope;
+    food_availability: TEnvelope;
+    mandatory_gear: TEnvelope;
+  };
+  fueling: {
+    longest_practiced_duration_min: TEnvelope;
+    practice_sessions_last_42_days: TEnvelope;
+    intake_form: TEnvelope;
+    gastrointestinal_experience: TEnvelope;
+  };
+}
+
+export interface TrailServerOptionalContext {
+  environment: {
+    maximum_altitude_m: TrailServerEnvelope<number>;
+    temperature_min_c: TrailServerEnvelope<number>;
+    temperature_max_c: TrailServerEnvelope<number>;
+    humidity_min_pct: TrailServerEnvelope<number>;
+    humidity_max_pct: TrailServerEnvelope<number>;
+    sun_exposure: TrailServerEnvelope<TrailSunExposure>;
+    wind_exposure: TrailServerEnvelope<TrailWindExposure>;
+    conditions_basis: TrailServerEnvelope<TrailConditionsBasis>;
+  };
+  support: {
+    aid_support_mode: TrailServerEnvelope<TrailAidSupportMode>;
+    aid_station_count: TrailServerEnvelope<number>;
+    max_aid_station_gap_m: TrailServerEnvelope<number | null>;
+    water_availability: TrailServerEnvelope<TrailAidAvailability>;
+    food_availability: TrailServerEnvelope<TrailAidAvailability>;
+    mandatory_gear: TrailServerEnvelope<TrailMandatoryGear[]>;
+  };
+  fueling: {
+    longest_practiced_duration_min: TrailServerEnvelope<number>;
+    practice_sessions_last_42_days: TrailServerEnvelope<number>;
+    intake_form: TrailServerEnvelope<TrailIntakeForm>;
+    gastrointestinal_experience:
+      TrailServerEnvelope<TrailGastrointestinalExperience>;
+  };
+}
+
+export interface TrailClientOptionalContext {
+  environment: {
+    maximum_altitude_m: TrailClientEnvelope<number>;
+    temperature_min_c: TrailClientEnvelope<number>;
+    temperature_max_c: TrailClientEnvelope<number>;
+    humidity_min_pct: TrailClientEnvelope<number>;
+    humidity_max_pct: TrailClientEnvelope<number>;
+    sun_exposure: TrailClientEnvelope<TrailSunExposure>;
+    wind_exposure: TrailClientEnvelope<TrailWindExposure>;
+    conditions_basis: TrailClientEnvelope<TrailConditionsBasis>;
+  };
+  support: {
+    aid_support_mode: TrailClientEnvelope<TrailAidSupportMode>;
+    aid_station_count: TrailClientEnvelope<number>;
+    max_aid_station_gap_m: TrailClientEnvelope<number | null>;
+    water_availability: TrailClientEnvelope<TrailAidAvailability>;
+    food_availability: TrailClientEnvelope<TrailAidAvailability>;
+    mandatory_gear: TrailClientEnvelope<TrailMandatoryGear[]>;
+  };
+  fueling: {
+    longest_practiced_duration_min: TrailClientEnvelope<number>;
+    practice_sessions_last_42_days: TrailClientEnvelope<number>;
+    intake_form: TrailClientEnvelope<TrailIntakeForm>;
+    gastrointestinal_experience:
+      TrailClientEnvelope<TrailGastrointestinalExperience>;
+  };
+}
+
+export interface TrailCourseDemandResponse {
+  schema_id: typeof TRAIL_SCHEMA_IDS.course;
+  event_id: string;
+  fields: {
+    event_date: TrailServerEnvelope<string>;
+    distance_meters: TrailServerEnvelope<number>;
+    total_ascent_m: TrailServerEnvelope<number>;
+    total_descent_m: TrailServerEnvelope<number>;
+    planning_duration_range:
+      TrailServerEnvelope<TrailPlanningDurationRange>;
+    event_format: TrailServerEnvelope<TrailEventFormat>;
+    distance_family: TrailServerEnvelope<TrailDistanceFamily>;
+    planning_intent: TrailServerEnvelope<TrailPlanningIntent>;
+    grade_distribution: TrailServerEnvelope<TrailGradeDistribution>;
+    course_footing: TrailServerEnvelope<TrailFooting[]>;
+    hands_assist: TrailServerEnvelope<boolean>;
+    fixed_rope: TrailServerEnvelope<boolean>;
+    optional_context: TrailServerOptionalContext;
+  };
+}
+
+export interface TrailConstraintsResponse {
+  schema_id: typeof TRAIL_SCHEMA_IDS.constraints;
+  available_weekdays: TrailServerEnvelope<number[]>;
+  weekly_time_limit_min: TrailServerEnvelope<number>;
+  maximum_session_duration_min: TrailServerEnvelope<number>;
+  unavailable_dates: TrailServerEnvelope<string[]>;
+  preferred_longest_weekday: number | null;
+  nontechnical_three_minute_uphill_access: TrailServerEnvelope<boolean>;
+  controlled_downhill_access: TrailServerEnvelope<boolean>;
+  accessible_footing: TrailServerEnvelope<TrailFooting[]>;
+  adult_nonclinical_scope_confirmed: TrailServerEnvelope<boolean>;
+  performance_intent_confirmed: TrailServerEnvelope<boolean>;
+  current_symptom_stop: TrailServerEnvelope<boolean>;
+}
+
+export interface TrailDraftRequest {
+  course_demand: {
+    schema_id: typeof TRAIL_SCHEMA_IDS.course;
+    fields: {
+      event_date: TrailClientEnvelope<string>;
+      distance_meters: TrailClientEnvelope<number>;
+      total_ascent_m: TrailClientEnvelope<number>;
+      total_descent_m: TrailClientEnvelope<number>;
+      planning_duration_range:
+        TrailClientEnvelope<TrailPlanningDurationRange>;
+      event_format: TrailClientEnvelope<TrailEventFormat>;
+      distance_family: TrailClientEnvelope<TrailDistanceFamily>;
+      planning_intent: TrailClientEnvelope<TrailPlanningIntent>;
+      grade_distribution: TrailClientEnvelope<TrailGradeDistribution>;
+      course_footing: TrailClientEnvelope<TrailFooting[]>;
+      hands_assist: TrailClientEnvelope<boolean>;
+      fixed_rope: TrailClientEnvelope<boolean>;
+      optional_context: TrailClientOptionalContext;
+    };
+  };
+  constraints: {
+    schema_id: typeof TRAIL_SCHEMA_IDS.constraints;
+    available_weekdays: TrailClientEnvelope<number[]>;
+    weekly_time_limit_min: TrailClientEnvelope<number>;
+    maximum_session_duration_min: TrailClientEnvelope<number>;
+    unavailable_dates: TrailClientEnvelope<string[]>;
+    preferred_longest_weekday?: number;
+    nontechnical_three_minute_uphill_access: TrailClientEnvelope<boolean>;
+    controlled_downhill_access: TrailClientEnvelope<boolean>;
+    accessible_footing: TrailClientEnvelope<TrailFooting[]>;
+    adult_nonclinical_scope_confirmed: TrailClientEnvelope<boolean>;
+    performance_intent_confirmed: TrailClientEnvelope<boolean>;
+    current_symptom_stop: TrailClientEnvelope<boolean>;
+  };
+}
+
+export interface TrailSectionConfirmation {
+  section_key: TrailEditableSectionKey;
+  current_revision: string;
+  confirmed_revision: string | null;
+}
+
+export interface TrailRevisionBindings {
+  course_revision: string;
+  planning_context_revision: string;
+  history_revision: string;
+  composite_revision: string;
+  section_confirmations: TrailSectionConfirmation[];
+}
+
+export interface TrailCurrentDraft {
+  state: 'current';
+  namespace_version: 1;
+  course_demand: TrailCourseDemandResponse;
+  constraints: TrailConstraintsResponse;
+  revision_bindings: TrailRevisionBindings;
+  composite_revision: string;
+  reset_is_erasure?: false;
+}
+
+export interface TrailAbsentDraft {
+  state: 'absent';
+  composite_revision: string;
+}
+
+export interface TrailUnknownSchemaDraft {
+  state: 'unknown_schema';
+  namespace: unknown;
+  composite_revision: string;
+}
+
+export type TrailDraftResponse =
+  | TrailCurrentDraft
+  | TrailAbsentDraft
+  | TrailUnknownSchemaDraft;
+
+export type TrailReadinessStatus =
+  | 'validation_failed'
+  | 'policy_unavailable'
+  | 'readiness_blocked'
+  | 'clarification_required'
+  | 'eligible_proposal';
+
+type TrailMatchingReasonFromCode<T extends TrailReasonCode> =
+  T extends `${infer TStatus}.${infer TDetail}`
+    ? { status: TStatus; detail_reason: TDetail }
+    : never;
+
+export type TrailMatchingReason = TrailMatchingReasonFromCode<TrailReasonCode>;
+
+export type TrailModuleReasonTarget =
+  | TrailReasonCode
+  | 'course.grade_distribution'
+  | 'course.course_footing'
+  | 'course.optional_context.environment'
+  | 'course.optional_context.support'
+  | 'course.optional_context.fueling';
+
+export interface TrailModuleAvailability {
+  module: TrailModuleKey;
+  state: 'not_evaluated' | 'available' | 'limited';
+  reason_target: TrailModuleReasonTarget | null;
+}
+
+export interface TrailHistoryStatistics {
+  usable_completed_weeks: number;
+  recent_modal_running_frequency: number;
+  recent_median_usable_weekly_minutes: number;
+  recent_maximum_usable_weekly_minutes: number;
+  recent_maximum_session_minutes: number;
+  recent_median_usable_weekly_ascent_meters: number;
+  recent_maximum_usable_weekly_ascent_meters: number;
+  recent_median_usable_weekly_descent_meters: number;
+  recent_maximum_usable_weekly_descent_meters: number;
+  recent_maximum_session_ascent_meters: number;
+  recent_maximum_session_descent_meters: number;
+  latest_run_date: string | null;
+  comparable_ascent_sessions_within_window: number;
+  latest_comparable_ascent_session_date: string | null;
+  comparable_descent_sessions_within_window: number;
+  latest_comparable_descent_session_date: string | null;
+  recently_observed_footing: TrailFooting[];
+  observation_window_start: string | null;
+  observation_window_end: string | null;
+  source_revision_fingerprint: string;
+  evaluator_schema_id: string;
+}
+
+export interface TrailReadinessReceipt {
+  policy_version: string;
+  generator_version: string;
+  science_decision_id: string;
+  contract_digest: string;
+  source_decision_digest: string;
+  ontology_version: string;
+  ontology_decision_id: string;
+  ontology_contract_digest: string;
+  ontology_source_decision_digest: string;
+  course_schema_id: typeof TRAIL_SCHEMA_IDS.course;
+  constraint_schema_id: typeof TRAIL_SCHEMA_IDS.constraints;
+  contract_runtime_state: 'inactive';
+  inactive_dry_run: false;
+  status: TrailReadinessStatus;
+  detail_reason: string | null;
+  matching_reasons: TrailMatchingReason[];
+  module_availability: TrailModuleAvailability[];
+  limited_modules: TrailModuleKey[];
+  deterministic_input_hash: string;
+  readiness_receipt_digest: string;
+  revision_bindings: TrailRevisionBindings | null;
+  plan: null;
+  history_statistics: TrailHistoryStatistics;
+}
+
+export interface TrailReadinessResponse {
+  draft: TrailCurrentDraft;
+  readiness: TrailReadinessReceipt;
+}
+
+export interface TrailDeleteResponse {
+  status: 'deleted' | 'absent';
+  composite_revision: string;
+}
+
+export type TrailFixedFieldTarget =
+  | 'field.event-date'
+  | 'field.event-scope'
+  | 'field.adult-performance-scope'
+  | 'field.symptom-stop'
+  | 'field.history-running'
+  | 'field.history-comparable-trail'
+  | 'field.history-descent';
+
+export type TrailGenericActionTarget =
+  | 'action.first-invalid-field'
+  | 'action.first-unknown-core-field'
+  | 'action.first-unconfirmed-assumption'
+  | 'action.first-missing-training-field'
+  | 'action.first-conflicting-field'
+  | 'action.first-confirmed-hazard'
+  | 'action.first-stale-section'
+  | 'action.reload-supported-version'
+  | 'action.retry-readiness'
+  | 'action.review-history-envelope';
+
+export type TrailFocusTarget =
+  | TrailSectionKey
+  | TrailFixedFieldTarget
+  | TrailGenericActionTarget;

--- a/web/tests/trail-course-review.test.mjs
+++ b/web/tests/trail-course-review.test.mjs
@@ -1,0 +1,786 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+import test from 'node:test';
+
+import {
+  TRAIL_API_ENDPOINTS,
+  TRAIL_EDITABLE_SECTION_KEYS,
+  TRAIL_MODULE_KEYS,
+  TRAIL_REASON_CODES,
+  TRAIL_SCHEMA_IDS,
+  TRAIL_SECTION_KEYS,
+} from '../src/types/trail-plan.ts';
+import {
+  applyUnknownIntent,
+  decimalEnvelopeFromExplicitInput,
+  durationEnvelopeFromExplicitInputs,
+  gradeEnvelopeFromExplicitInputs,
+  integerEnvelopeFromExplicitInput,
+  known,
+  metresEnvelopeFromExplicitKilometres,
+  toggleEnvelopeMember,
+  unknown,
+} from '../src/components/trail-course-review/transitions.ts';
+import {
+  parseTrailDraftResponse,
+  parseTrailDeleteResponse,
+  parseTrailReadinessResponse,
+} from '../src/components/trail-course-review/validation.ts';
+import {
+  INITIAL_PRIVATE_TRAIL_DRAFT_STATE,
+  reducePrivateTrailDraftState,
+} from '../src/components/trail-course-review/private-draft-state.ts';
+import {
+  TrailMutationResponseError,
+  preservesPendingTrailEdits,
+} from '../src/components/trail-course-review/mutation-error.ts';
+
+const read = (path) => readFile(new URL(path, import.meta.url), 'utf8');
+
+const TRAIL_IMPLEMENTATION_PATHS = [
+  '../src/components/TrailCourseReview.tsx',
+  '../src/components/trail-course-review/controls.tsx',
+  '../src/components/trail-course-review/copy.tsx',
+  '../src/components/trail-course-review/model.tsx',
+  '../src/components/trail-course-review/mutation-error.ts',
+  '../src/components/trail-course-review/private-draft-state.ts',
+  '../src/components/trail-course-review/states.tsx',
+  '../src/components/trail-course-review/transitions.ts',
+  '../src/components/trail-course-review/use-private-draft.ts',
+  '../src/components/trail-course-review/validation.ts',
+];
+
+const readTrailImplementation = async () => (
+  await Promise.all(TRAIL_IMPLEMENTATION_PATHS.map(read))
+).join('\n');
+
+const EXPECTED_REASONS = [
+  'validation_failed.invalid_field_value',
+  'validation_failed.schema_version_mismatch',
+  'validation_failed.deterministic_invariant_failed',
+  'policy_unavailable.policy_inactive',
+  'policy_unavailable.event_inside_unapproved_taper_window',
+  'policy_unavailable.unsupported_ultra_or_multiday',
+  'policy_unavailable.unsupported_population_or_intent',
+  'policy_unavailable.technical_features_outside_v2',
+  'readiness_blocked.insufficient_recent_running_history',
+  'readiness_blocked.insufficient_comparable_trail_history',
+  'readiness_blocked.insufficient_descent_history',
+  'readiness_blocked.insufficient_terrain_access',
+  'readiness_blocked.current_symptom_stop',
+  'readiness_blocked.no_schedule_within_envelope',
+  'clarification_required.material_course_demand_unknown',
+  'clarification_required.assumption_confirmation_required',
+  'clarification_required.adult_scope_or_constraints_unconfirmed',
+  'clarification_required.training_constraints_missing',
+  'clarification_required.training_constraints_outside_history_envelope',
+  'clarification_required.stale_confirmation_or_source_revision',
+  'clarification_required.contradictory_input',
+];
+
+const SHA_A = `sha256:${'a'.repeat(64)}`;
+const SHA_B = `sha256:${'b'.repeat(64)}`;
+const SHA_C = `sha256:${'c'.repeat(64)}`;
+const SHA_D = `sha256:${'d'.repeat(64)}`;
+const SECTION_CONFIRMATIONS = TRAIL_EDITABLE_SECTION_KEYS.map((sectionKey) => ({
+  section_key: sectionKey,
+  current_revision: SHA_D,
+  confirmed_revision: SHA_D,
+}));
+const REVISION_BINDINGS = {
+  course_revision: SHA_A,
+  planning_context_revision: SHA_B,
+  history_revision: SHA_C,
+  composite_revision: SHA_D,
+  section_confirmations: SECTION_CONFIRMATIONS,
+};
+
+function inactiveReadinessResponse() {
+  const unknownValue = () => ({
+    state: 'unknown',
+    provenance: 'unknown',
+    source_revision: SHA_A,
+  });
+  return {
+    draft: {
+      state: 'current',
+      namespace_version: 1,
+      course_demand: {
+        schema_id: TRAIL_SCHEMA_IDS.course,
+        event_id: 'synthetic-event',
+        fields: {
+          event_date: unknownValue(),
+          distance_meters: unknownValue(),
+          total_ascent_m: unknownValue(),
+          total_descent_m: unknownValue(),
+          planning_duration_range: unknownValue(),
+          event_format: unknownValue(),
+          distance_family: unknownValue(),
+          planning_intent: unknownValue(),
+          grade_distribution: unknownValue(),
+          course_footing: unknownValue(),
+          hands_assist: unknownValue(),
+          fixed_rope: unknownValue(),
+          optional_context: {
+            environment: {
+              maximum_altitude_m: unknownValue(),
+              temperature_min_c: unknownValue(),
+              temperature_max_c: unknownValue(),
+              humidity_min_pct: unknownValue(),
+              humidity_max_pct: unknownValue(),
+              sun_exposure: unknownValue(),
+              wind_exposure: unknownValue(),
+              conditions_basis: unknownValue(),
+            },
+            support: {
+              aid_support_mode: unknownValue(),
+              aid_station_count: unknownValue(),
+              max_aid_station_gap_m: unknownValue(),
+              water_availability: unknownValue(),
+              food_availability: unknownValue(),
+              mandatory_gear: unknownValue(),
+            },
+            fueling: {
+              longest_practiced_duration_min: unknownValue(),
+              practice_sessions_last_42_days: unknownValue(),
+              intake_form: unknownValue(),
+              gastrointestinal_experience: unknownValue(),
+            },
+          },
+        },
+      },
+      constraints: {
+        schema_id: TRAIL_SCHEMA_IDS.constraints,
+        available_weekdays: unknownValue(),
+        weekly_time_limit_min: unknownValue(),
+        maximum_session_duration_min: unknownValue(),
+        unavailable_dates: unknownValue(),
+        preferred_longest_weekday: null,
+        nontechnical_three_minute_uphill_access: unknownValue(),
+        controlled_downhill_access: unknownValue(),
+        accessible_footing: unknownValue(),
+        adult_nonclinical_scope_confirmed: unknownValue(),
+        performance_intent_confirmed: unknownValue(),
+        current_symptom_stop: unknownValue(),
+      },
+      revision_bindings: structuredClone(REVISION_BINDINGS),
+      composite_revision: SHA_D,
+    },
+    readiness: {
+      policy_version: 'non-ultra-trail-plan-generation-policy-v2',
+      generator_version: 'non-ultra-trail-deterministic-generator-v2',
+      science_decision_id: 'sdr-non-ultra-trail-plan-generation-policy-v2',
+      contract_digest: 'sha256:1952421299cb59ddfea00115b6824d3116bd6e5f9175741916aa6f1015f8f9f9',
+      source_decision_digest: 'sha256:9e4eef184a94d3f646b9483b569a4751ab2a9939ac509e55b888af6548c888fe',
+      ontology_version: 'trail-course-demand-v2',
+      ontology_decision_id: 'sdr-trail-running-goal-ontology-v2',
+      ontology_contract_digest: 'sha256:0d3e4056e081e07bb52cbda15fc161ff9584a50f25f97f39fd513e1dad404c9c',
+      ontology_source_decision_digest: 'sha256:363d5970c2ad6f7d4a18ced426d4a2996aef3ff116e6a6b112232c9eccaeeca1',
+      course_schema_id: TRAIL_SCHEMA_IDS.course,
+      constraint_schema_id: TRAIL_SCHEMA_IDS.constraints,
+      contract_runtime_state: 'inactive',
+      inactive_dry_run: false,
+      status: 'policy_unavailable',
+      detail_reason: 'policy_inactive',
+      matching_reasons: [{
+        status: 'policy_unavailable',
+        detail_reason: 'policy_inactive',
+      }],
+      module_availability: TRAIL_MODULE_KEYS.map((module) => ({
+        module,
+        state: 'not_evaluated',
+        reason_target: 'policy_unavailable.policy_inactive',
+      })),
+      limited_modules: [],
+      deterministic_input_hash: SHA_A,
+      readiness_receipt_digest: SHA_B,
+      revision_bindings: structuredClone(REVISION_BINDINGS),
+      plan: null,
+      history_statistics: {
+        usable_completed_weeks: 4,
+        recent_modal_running_frequency: 4,
+        recent_median_usable_weekly_minutes: 180,
+        recent_maximum_usable_weekly_minutes: 210,
+        recent_maximum_session_minutes: 90,
+        recent_median_usable_weekly_ascent_meters: 500,
+        recent_maximum_usable_weekly_ascent_meters: 650,
+        recent_median_usable_weekly_descent_meters: 500,
+        recent_maximum_usable_weekly_descent_meters: 650,
+        recent_maximum_session_ascent_meters: 300,
+        recent_maximum_session_descent_meters: 300,
+        latest_run_date: '2026-09-03',
+        comparable_ascent_sessions_within_window: 2,
+        latest_comparable_ascent_session_date: '2026-09-01',
+        comparable_descent_sessions_within_window: 2,
+        latest_comparable_descent_session_date: '2026-09-01',
+        recently_observed_footing: ['firm_smooth'],
+        observation_window_start: '2026-07-10',
+        observation_window_end: '2026-09-03',
+        source_revision_fingerprint: SHA_C,
+        evaluator_schema_id: 'trail-running-history-statistics-v2',
+      },
+    },
+  };
+}
+
+test('Trail constants close the inactive v2 API, section, module, and reason contracts', () => {
+  assert.deepEqual(TRAIL_API_ENDPOINTS, {
+    draft: '/api/plan/trail/draft',
+    confirm: '/api/plan/trail/confirm',
+    reset: '/api/plan/trail/reset',
+    readiness: '/api/plan/trail/readiness',
+  });
+  assert.deepEqual(TRAIL_SCHEMA_IDS, {
+    course: 'trail_course_demand_v2',
+    constraints: 'non_ultra_trail_constraints_v2',
+  });
+  assert.deepEqual(TRAIL_EDITABLE_SECTION_KEYS, [
+    'section.event-duration',
+    'section.grade-footing',
+    'section.training-access',
+    'section.optional-context',
+  ]);
+  assert.deepEqual(TRAIL_SECTION_KEYS, [
+    'section.event-duration',
+    'section.grade-footing',
+    'section.training-access',
+    'section.recent-experience',
+    'section.optional-context',
+    'section.policy-receipt',
+  ]);
+  assert.deepEqual(TRAIL_MODULE_KEYS, [
+    'grade_specificity',
+    'technical_terrain',
+    'environment_altitude',
+    'fueling',
+  ]);
+  assert.deepEqual(TRAIL_REASON_CODES, EXPECTED_REASONS);
+  assert.equal(new Set(TRAIL_REASON_CODES).size, 21);
+});
+
+test('the private implementation uses an isolated draft read and exact revision-fenced mutations', async () => {
+  const [implementation, route] = await Promise.all([
+    readTrailImplementation(),
+    read('../../api/routes/trail_plan.py'),
+  ]);
+
+  assert.match(implementation, /usePrivateTrailDraft/);
+  assert.match(implementation, /apiFetcher<unknown>/);
+  assert.match(implementation, /method: 'PUT'/);
+  assert.match(implementation, /method: 'POST'/);
+  assert.match(implementation, /method: kind === 'reset' \? 'POST' : 'DELETE'/);
+  assert.match(implementation, /'If-Match': serverDraft\.composite_revision/);
+  assert.match(implementation, /'If-Match': draft\.composite_revision/);
+  assert.match(implementation, /section_key: sectionKey/);
+  assert.match(implementation, /section_revision: confirmation\.current_revision/);
+  assert.match(implementation, /TRAIL_API_ENDPOINTS\.readiness/);
+  assert.doesNotMatch(implementation, /ownerExport|\/api\/me\/export|downloadOwnerExport/);
+  assert.match(route, /@router\.get\("\/draft"/);
+  assert.match(route, /@router\.post\("\/confirm"/);
+  assert.match(route, /@router\.post\("\/reset"/);
+  assert.match(route, /@router\.delete\("\/draft"/);
+  assert.match(route, /@router\.post\("\/readiness"/);
+  assert.doesNotMatch(implementation, /If-None-Match|If-Unmodified-Since/);
+});
+
+test('the Trail review remains unreachable and carries no provider or browser persistence surface', async () => {
+  const [implementation, component, app, training, sidebar, registry, apiMain, miniapp] = await Promise.all([
+    readTrailImplementation(),
+    read('../src/components/TrailCourseReview.tsx'),
+    read('../src/App.tsx'),
+    read('../src/pages/Training.tsx'),
+    read('../src/components/AppSidebar.tsx'),
+    read('../src/components/platform-registry.ts'),
+    read('../../api/main.py'),
+    read('../../miniapp/app.json'),
+  ]);
+
+  for (const registeredSurface of [app, training, sidebar, registry, miniapp, apiMain]) {
+    assert.doesNotMatch(
+      registeredSurface,
+      /TrailCourseReview|trail-course-review|trail\/course-review/,
+    );
+  }
+  assert.doesNotMatch(apiMain, /include_router\([^\n]*trail_plan/);
+  assert.match(component, /\.\/trail-course-review\/controls/);
+  assert.match(component, /\.\/trail-course-review\/copy/);
+  assert.match(component, /\.\/trail-course-review\/model/);
+  assert.match(component, /\.\/trail-course-review\/states/);
+  assert.match(component, /\.\/trail-course-review\/use-private-draft/);
+  assert.match(component, /\.\/trail-course-review\/validation/);
+  const sourcePaths = await readdir(new URL('../src/', import.meta.url), {
+    recursive: true,
+  });
+  const otherSourceFiles = sourcePaths.filter((path) => {
+    const normalized = path.replaceAll('\\', '/');
+    return /\.[cm]?[jt]sx?$/.test(normalized)
+      && normalized !== 'components/TrailCourseReview.tsx'
+      && !normalized.startsWith('components/trail-course-review/');
+  });
+  for (const path of otherSourceFiles) {
+    const source = await read(`../src/${path.replaceAll('\\', '/')}`);
+    assert.doesNotMatch(
+      source,
+      /TrailCourseReview|components\/trail-course-review/,
+      `${path} must not import or register the inactive Trail review`,
+    );
+  }
+  assert.doesNotMatch(implementation, /localStorage|sessionStorage/);
+  assert.doesNotMatch(implementation, /useApi<|useQuery|useQueryClient|queryKey/);
+  assert.match(implementation, /controllerRef\.current\?\.abort\(\)/);
+  assert.doesNotMatch(implementation, /dataRef/);
+  assert.equal((component.match(/onReplaceRemote\(next\)/g) ?? []).length, 3);
+  assert.match(component, /onClearRemote\(\);\s*await onRefetch\(\)/);
+  assert.match(implementation, /onClearData\(\);\s*await onReload\(\)/);
+  assert.doesNotMatch(implementation, /void on(?:Reload|Refetch)\(\);/);
+  assert.match(implementation, /void onReload\(\)\.catch\(\(\) => undefined\)/);
+  assert.match(implementation, /void onRefetch\(\)\.catch\(\(\) => undefined\)/);
+  assert.doesNotMatch(implementation, /pushState|replaceState|location\.hash|URLSearchParams/);
+  assert.doesNotMatch(implementation, /encodeURIComponent|\/plan\/trail\/\$\{/);
+  assert.doesNotMatch(implementation, /garmin|provider|credential|tokenstore|consent/i);
+  assert.doesNotMatch(implementation, /TRAIL_API_ENDPOINTS\.(?:send|schedule|reconcile|connect)/);
+  assert.match(implementation, /window\.location\.assign\('\/training'\)/);
+  assert.match(implementation, /href="\/goal"/);
+});
+
+test('unknown fields stay unknown until an explicit value is entered', async () => {
+  const unknownEnum = unknown();
+  assert.strictEqual(applyUnknownIntent(unknownEnum, false), unknownEnum);
+  assert.deepEqual(applyUnknownIntent(known('single_day'), true), unknown());
+  assert.deepEqual(
+    toggleEnvelopeMember(unknown(), 'rocks_or_roots', false),
+    known(['rocks_or_roots']),
+  );
+  assert.deepEqual(integerEnvelopeFromExplicitInput('', 0, 10), unknown());
+  assert.deepEqual(integerEnvelopeFromExplicitInput('0', 0, 10), known(0));
+  assert.deepEqual(decimalEnvelopeFromExplicitInput('1.', 2, 0, 10), unknown());
+  assert.deepEqual(decimalEnvelopeFromExplicitInput('1.25', 2, 0, 10), known(1.25));
+  assert.deepEqual(metresEnvelopeFromExplicitKilometres('', 100, 50000), unknown());
+  assert.deepEqual(metresEnvelopeFromExplicitKilometres('0.1', 100, 50000), known(100));
+  assert.deepEqual(durationEnvelopeFromExplicitInputs('1', '', 1, 1440), unknown());
+  assert.deepEqual(durationEnvelopeFromExplicitInputs('1', '30', 1, 1440), known(90));
+  assert.deepEqual(
+    gradeEnvelopeFromExplicitInputs(['25', '', '', '', '']),
+    unknown(),
+    'one entered grade band must not synthesize zeroes for the other four',
+  );
+  assert.deepEqual(
+    gradeEnvelopeFromExplicitInputs(['10', '15', '50', '15', '10']),
+    known({
+      below_neg_10: 1000,
+      neg_10_to_below_neg_3: 1500,
+      neg_3_to_below_pos_3: 5000,
+      pos_3_to_below_pos_10: 1500,
+      pos_10_and_above: 1000,
+    }),
+  );
+  const controls = await read('../src/components/trail-course-review/controls.tsx');
+  const component = await read('../src/components/TrailCourseReview.tsx');
+  assert.doesNotMatch(controls, /options\[0\]/);
+  assert.doesNotMatch(component, /neg_3_to_below_pos_3:\s*10000/);
+  assert.doesNotMatch(component, /known\((?:0|1|100)\)|known\(\{\s*minimum_min/);
+});
+
+test('private draft state drops prior values on begin, failure, replacement, and clear', () => {
+  const first = { state: 'absent', composite_revision: SHA_A };
+  const second = { state: 'absent', composite_revision: SHA_B };
+  const loaded = reducePrivateTrailDraftState(
+    INITIAL_PRIVATE_TRAIL_DRAFT_STATE,
+    { type: 'success', data: first },
+  );
+  assert.strictEqual(loaded.data, first);
+  const begun = reducePrivateTrailDraftState(loaded, { type: 'begin' });
+  assert.equal(begun.data, null);
+  const failed = reducePrivateTrailDraftState(loaded, {
+    type: 'failure',
+    message: 'failed',
+    status: 503,
+  });
+  assert.deepEqual(failed, {
+    data: null,
+    loading: false,
+    error: 'failed',
+    errorStatus: 503,
+  });
+  const replaced = reducePrivateTrailDraftState(loaded, {
+    type: 'success',
+    data: second,
+  });
+  assert.strictEqual(replaced.data, second);
+  assert.notStrictEqual(replaced.data, first);
+  assert.equal(reducePrivateTrailDraftState(loaded, { type: 'clear' }).data, null);
+});
+
+test('HTTP 412 preserves pending state while other mutation failures clear it', () => {
+  const pending = reducePrivateTrailDraftState(
+    INITIAL_PRIVATE_TRAIL_DRAFT_STATE,
+    { type: 'success', data: { state: 'absent', composite_revision: SHA_A } },
+  );
+  const stale = new TrailMutationResponseError('stale', 412);
+  assert.equal(stale.status, 412);
+  assert.equal(preservesPendingTrailEdits(stale), true);
+  const afterStale = preservesPendingTrailEdits(stale)
+    ? pending
+    : reducePrivateTrailDraftState(pending, {
+        type: 'failure', message: stale.message, status: stale.status,
+      });
+  assert.strictEqual(afterStale.data, pending.data);
+
+  const unavailable = new TrailMutationResponseError('unavailable', 503);
+  assert.equal(preservesPendingTrailEdits(unavailable), false);
+  const afterUnavailable = preservesPendingTrailEdits(unavailable)
+    ? pending
+    : reducePrivateTrailDraftState(pending, {
+        type: 'failure', message: unavailable.message, status: unavailable.status,
+      });
+  assert.equal(afterUnavailable.data, null);
+});
+
+test('HTTP 412 renders stale recovery with intentional discard but no generic retry', async () => {
+  const [component, copy] = await Promise.all([
+    read('../src/components/TrailCourseReview.tsx'),
+    read('../src/components/trail-course-review/copy.tsx'),
+  ]);
+  assert.match(component, /if \(preservesPendingTrailEdits\(error\)\) \{\s*setOperationError\(null\)/);
+  assert.match(component, /staleConflict/);
+  assert.match(component, /copy\.reviewLatest/);
+  assert.match(component, /copy\.restorePending/);
+  assert.match(component, /const discardPending = useCallback/);
+  assert.match(component, /onClick=\{discardPending\}/);
+  assert.match(component, /copy\.discardPending/);
+  assert.match(copy, /t`Discard pending changes`/);
+  assert.match(copy, /t`放弃待保存更改`/);
+  assert.match(component, /if \(!latestDraft \|\| latestDraft\.state === 'unknown_schema'\) return;/);
+  assert.doesNotMatch(component, /preservesPendingTrailEdits\(error\)[\s\S]{0,160}onRefetch/);
+  assert.match(component, /<DropdownMenuItem disabled[^>]*>[\s\S]*?copy\.export[\s\S]*?copy\.exportUnavailable/);
+  assert.match(copy, /t`Export my Trail plan data`/);
+  assert.match(copy, /t`导出我的越野计划数据`/);
+  assert.match(copy, /t`Export isn't available in this private preview yet\.`/);
+  assert.match(copy, /t`当前私密预览暂不支持导出。`/);
+  assert.doesNotMatch(`${component}\n${copy}`, /\/api\/me\/export|ownerExport|downloadOwnerExport/);
+});
+
+test('Trail delete responses accept only the exact absent revision receipt', () => {
+  const absentRevision = 'sha256:8adaaec35fb1a6ff05f212e69fc57c9e41bceaa30b65b95a8b3f90120ef5a321';
+  assert.deepEqual(parseTrailDeleteResponse({
+    status: 'deleted',
+    composite_revision: absentRevision,
+  }), {
+    status: 'deleted',
+    composite_revision: absentRevision,
+  });
+  for (const value of [
+    { status: 'deleted', composite_revision: SHA_A },
+    { status: 'absent', composite_revision: absentRevision, leaked: 'value' },
+    { status: 'complete', composite_revision: absentRevision },
+    { status: 'deleted' },
+  ]) {
+    assert.equal(parseTrailDeleteResponse(value), null);
+  }
+});
+
+test('the unknown-schema delete path uses the same closed response parser', async () => {
+  const states = await read('../src/components/trail-course-review/states.tsx');
+  assert.match(states, /kind === 'delete'/);
+  assert.match(states, /parseTrailDeleteResponse\(payload\)/);
+  assert.match(states, /throw new Error\('The Trail deletion response was not recognized\.'\)/);
+  assert.equal(parseTrailDeleteResponse({
+    status: 'deleted',
+    composite_revision: 'sha256:8adaaec35fb1a6ff05f212e69fc57c9e41bceaa30b65b95a8b3f90120ef5a321',
+    private_payload: { value: 'must-not-pass' },
+  }), null);
+});
+
+test('readiness validation accepts only the exact inactive contract receipt', () => {
+  const valid = inactiveReadinessResponse();
+  assert.notEqual(parseTrailDraftResponse(valid.draft), null);
+  assert.notEqual(parseTrailReadinessResponse(valid, SHA_D), null);
+
+  const confirmedAssumption = inactiveReadinessResponse();
+  confirmedAssumption.draft.course_demand.fields.optional_context.environment.conditions_basis = {
+    state: 'known',
+    value: 'athlete_assumption',
+    provenance: 'explicit_assumption',
+    source_revision: SHA_A,
+    assumption_confirmed_revision: SHA_A,
+  };
+  assert.notEqual(parseTrailReadinessResponse(confirmedAssumption, SHA_D), null);
+
+  for (const spuriousReason of [
+    'insufficient_comparable_trail_history',
+    'insufficient_descent_history',
+  ]) {
+    const spurious = inactiveReadinessResponse();
+    spurious.readiness.matching_reasons.push({
+      status: 'readiness_blocked',
+      detail_reason: spuriousReason,
+    });
+    assert.equal(parseTrailReadinessResponse(spurious, SHA_D), null);
+  }
+
+  const footingMismatch = inactiveReadinessResponse();
+  footingMismatch.draft.course_demand.fields.course_footing = {
+    state: 'known',
+    value: ['rocks_or_roots'],
+    provenance: 'athlete_stated',
+    source_revision: SHA_A,
+  };
+  footingMismatch.readiness.matching_reasons.push({
+    status: 'readiness_blocked',
+    detail_reason: 'insufficient_comparable_trail_history',
+  });
+  assert.notEqual(parseTrailReadinessResponse(footingMismatch, SHA_D), null);
+
+  const invalidCases = [
+    (value) => { value.readiness.contract_runtime_state = 'active'; },
+    (value) => { value.readiness.inactive_dry_run = true; },
+    (value) => { value.readiness.plan = {}; },
+    (value) => { value.readiness.contract_digest = SHA_A; },
+    (value) => { value.readiness.status = 'ready'; },
+    (value) => {
+      value.readiness.status = 'eligible_proposal';
+      value.readiness.detail_reason = null;
+      value.readiness.matching_reasons = [];
+      value.readiness.module_availability = TRAIL_MODULE_KEYS.map((module) => ({
+        module,
+        state: 'available',
+        reason_target: null,
+      }));
+    },
+    (value) => { value.readiness.matching_reasons = [{ status: 'future', detail_reason: 'reason' }]; },
+    (value) => { value.readiness.matching_reasons = [
+      { status: 'policy_unavailable', detail_reason: 'policy_inactive' },
+      { status: 'policy_unavailable', detail_reason: 'policy_inactive' },
+    ]; },
+    (value) => { value.readiness.module_availability.pop(); },
+    (value) => { value.readiness.module_availability[1].module = 'grade_specificity'; },
+    (value) => { value.readiness.module_availability[0].state = 'available'; },
+    (value) => { value.readiness.module_availability[0].reason_target = 'course.course_footing'; },
+    (value) => { value.readiness.limited_modules = ['grade_specificity']; },
+    (value) => { value.readiness.revision_bindings.history_revision = SHA_D; },
+    (value) => { delete value.readiness.history_statistics.latest_run_date; },
+    (value) => {
+      value.draft.course_demand.fields.optional_context.environment.temperature_min_c = {
+        state: 'known', value: 30, provenance: 'athlete_stated', source_revision: SHA_A,
+      };
+      value.draft.course_demand.fields.optional_context.environment.temperature_max_c = {
+        state: 'known', value: 20, provenance: 'athlete_stated', source_revision: SHA_A,
+      };
+    },
+    (value) => {
+      value.draft.constraints.weekly_time_limit_min = {
+        state: 'known', value: 100, provenance: 'athlete_stated', source_revision: SHA_A,
+      };
+      value.draft.constraints.maximum_session_duration_min = {
+        state: 'known', value: 200, provenance: 'athlete_stated', source_revision: SHA_A,
+      };
+    },
+    (value) => {
+      value.draft.constraints.available_weekdays = {
+        state: 'known', value: [1], provenance: 'athlete_stated', source_revision: SHA_A,
+      };
+      value.draft.constraints.preferred_longest_weekday = 2;
+    },
+    (value) => {
+      value.draft.course_demand.fields.grade_distribution = {
+        state: 'known',
+        value: {
+          below_neg_10: 1000,
+          neg_10_to_below_neg_3: 1000,
+          neg_3_to_below_pos_3: 6000,
+          pos_3_to_below_pos_10: 1000,
+          pos_10_and_above: 1000,
+        },
+        provenance: 'model_inferred',
+        source_revision: SHA_A,
+        model_version: 'forbidden-grade-model',
+      };
+    },
+    (value) => {
+      value.draft.course_demand.fields.optional_context.environment.conditions_basis = {
+        state: 'known',
+        value: 'athlete_assumption',
+        provenance: 'explicit_assumption',
+        source_revision: SHA_A,
+      };
+    },
+    (value) => { value.readiness.history_statistics.evaluator_schema_id = 'future-history'; },
+    (value) => { value.readiness.history_statistics.usable_completed_weeks = 9; },
+    (value) => { value.readiness.history_statistics.usable_completed_weeks = 3; },
+    (value) => {
+      value.readiness.history_statistics.observation_window_start = '2026-09-04';
+      value.readiness.history_statistics.observation_window_end = '2026-09-03';
+    },
+    (value) => {
+      value.readiness.history_statistics.comparable_ascent_sessions_within_window = 0;
+    },
+    (value) => {
+      value.readiness.history_statistics.latest_comparable_ascent_session_date = '2026-08-01';
+    },
+    (value) => {
+      value.draft.course_demand.fields.event_date = {
+        state: 'known', value: '2026-02-30', provenance: 'athlete_stated', source_revision: SHA_A,
+      };
+    },
+    (value) => {
+      value.draft.course_demand.fields.event_date = {
+        state: 'known',
+        value: '2026-11-15',
+        provenance: 'athlete_stated',
+        source_revision: SHA_A,
+        source_timestamp: '2026-09-04T12:00:00',
+      };
+    },
+    (value) => {
+      value.draft.course_demand.fields.event_date = {
+        state: 'known',
+        value: '2026-11-15',
+        provenance: 'athlete_stated',
+        source_revision: SHA_A,
+        source_timestamp: '2026-02-30T12:00:00+08:00',
+      };
+    },
+    (value) => {
+      value.draft.course_demand.fields.event_date = {
+        state: 'known',
+        value: '2026-11-15',
+        provenance: 'athlete_stated',
+        source_revision: SHA_A,
+        model_version: '',
+      };
+    },
+    (value) => {
+      value.readiness.matching_reasons.push({
+        status: 'readiness_blocked',
+        detail_reason: 'insufficient_recent_running_history',
+      });
+    },
+    (value) => { delete value.draft.course_demand.fields.optional_context.support; },
+  ];
+  for (const mutate of invalidCases) {
+    const candidate = inactiveReadinessResponse();
+    mutate(candidate);
+    assert.equal(parseTrailReadinessResponse(candidate, SHA_D), null);
+  }
+  assert.equal(parseTrailReadinessResponse(valid, SHA_A), null);
+});
+
+test('all five ordered ledger sections and only four server confirmations are implemented', async () => {
+  const [component, implementation] = await Promise.all([
+    read('../src/components/TrailCourseReview.tsx'),
+    readTrailImplementation(),
+  ]);
+  const sectionTitles = [
+    'Event & planning duration',
+    'Grade & footing',
+    'When and where you can train',
+    'Recent experience',
+    'Conditions, support, and fueling',
+  ];
+  for (const title of sectionTitles) assert.match(implementation, new RegExp(title.replaceAll('&', '\\&')));
+  const renderedSectionOrder = [
+    'section.event-duration',
+    'section.grade-footing',
+    'section.training-access',
+    'section.recent-experience',
+    'section.optional-context',
+  ].map((section) => component.indexOf(`sectionKey="${section}"`));
+  assert.ok(renderedSectionOrder.every((position) => position >= 0));
+  assert.deepEqual(renderedSectionOrder, [...renderedSectionOrder].sort((a, b) => a - b));
+  assert.equal((component.match(/<ConfirmBar\b/g) ?? []).length, 4);
+  assert.doesNotMatch(implementation, /Confirm all|确认全部/);
+  assert.match(component, /'section\.optional-context': false/);
+  assert.match(component, /optionalOpened/);
+  assert.match(component, /read-only|只读/);
+
+  const requiredFields = [
+    'event_date', 'distance_meters', 'total_ascent_m', 'total_descent_m',
+    'planning_duration_range', 'event_format', 'distance_family',
+    'planning_intent', 'grade_distribution', 'course_footing', 'hands_assist',
+    'fixed_rope', 'available_weekdays', 'weekly_time_limit_min',
+    'maximum_session_duration_min', 'unavailable_dates',
+    'preferred_longest_weekday', 'nontechnical_three_minute_uphill_access',
+    'controlled_downhill_access', 'accessible_footing',
+    'adult_nonclinical_scope_confirmed', 'performance_intent_confirmed',
+    'current_symptom_stop', 'maximum_altitude_m', 'temperature_min_c',
+    'temperature_max_c', 'humidity_min_pct', 'humidity_max_pct',
+    'sun_exposure', 'wind_exposure', 'conditions_basis', 'aid_support_mode',
+    'aid_station_count', 'max_aid_station_gap_m', 'water_availability',
+    'food_availability', 'mandatory_gear', 'longest_practiced_duration_min',
+    'practice_sessions_last_42_days', 'intake_form',
+    'gastrointestinal_experience',
+  ];
+  for (const field of requiredFields) assert.match(implementation, new RegExp(`\\b${field}\\b`));
+});
+
+test('reason and module rendering is exhaustive, natural-language only, and fail closed', async () => {
+  const component = await readTrailImplementation();
+  for (const code of EXPECTED_REASONS) {
+    assert.match(component, new RegExp(`['"]${code.replaceAll('.', '\\.')}['"]`));
+  }
+  for (const phrase of [
+    'Finding', 'Effect', 'Next action',
+    'Grade-specific training', 'Technical terrain',
+    'Environment and altitude', 'Fueling practice',
+    'Not evaluated', 'Available', 'Limited',
+  ]) {
+    assert.match(component, new RegExp(phrase));
+  }
+  assert.match(component, /reasonCodeOf/);
+  assert.match(component, /hasUnknownReason/);
+  assert.match(component, /did not provide a safe destination/);
+  assert.match(component, /MODULE_LIMIT_TARGETS/);
+  assert.doesNotMatch(component, />\s*\{reason\.code\}\s*</);
+  assert.doesNotMatch(component, />\s*\{readiness\.status\}\s*</);
+  assert.doesNotMatch(component, />\s*\{reason\.detail_reason\}\s*</);
+});
+
+test('Lingui locale-only copy includes the accepted English and Simplified Chinese contracts', async () => {
+  const component = await readTrailImplementation();
+  assert.match(component, /useLingui/);
+  assert.match(component, /i18n\.locale\.toLowerCase\(\)\.startsWith\('zh'\)/);
+  assert.match(component, /t`Review Trail event`/);
+  assert.match(component, /t`核对越野赛事`/);
+  assert.match(component, /t`Describe the course and where you can train\. Praxys will keep unknowns visible\.`/);
+  assert.match(component, /t`填写赛道情况和可训练条件。Praxys 会明确保留未知项。`/);
+  assert.match(component, /t`I don't know yet`/);
+  assert.match(component, /t`目前不确定`/);
+  assert.match(component, /t`Offline\. Changes are kept only on this page and have not been saved\.`/);
+  assert.match(component, /t`当前离线。更改仅保留在此页面，尚未保存。`/);
+  assert.match(component, /Reset replaces the current editable answers with unknowns/);
+  assert.match(component, /重置会把当前可编辑回答改为未知/);
+  assert.doesNotMatch(component, /Review Trail event\s*\/\s*核对越野赛事/);
+});
+
+test('state, accessibility, and responsive markers cover the approved workbench contract', async () => {
+  const component = await readTrailImplementation();
+  for (const marker of [
+    'TrailCourseReviewSkeleton', 'unknown_schema', 'errorStatus', 'status === 404',
+    'memory-only-unsaved', 'beforeunload', 'navigator.onLine', 'slowAction',
+    'validationIssues', 'staleConflict', 'Review latest version',
+    'Restore pending changes', 'Discard pending changes', 'aria-live',
+    'aria-busy', 'aria-atomic', 'tabIndex={-1}', 'role="group"',
+    'motion-reduce', 'min-h-11', 'break-words', 'font-data',
+    'lg:grid-cols-', 'lg:sticky', 'Collapsible',
+  ]) {
+    assert.match(component, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(component, /response\.status === 412/);
+  assert.match(component, /requestAnimationFrame\(\(\) => errorSummaryRef\.current\?\.focus\(\)\)/);
+  assert.match(component, /requestAnimationFrame\(\(\) => receiptErrorRef\.current\?\.focus\(\)\)/);
+  assert.doesNotMatch(component, /<(?:button|input|select)\b/);
+  assert.doesNotMatch(component, /shadow-(?:sm|md|lg|xl|2xl)|bg-gradient|border-l-[2-9]/);
+});
+
+test('types preserve strict unknown envelopes and closed response targets', async () => {
+  const types = await read('../src/types/trail-plan.ts');
+  assert.match(types, /\{ state: 'known'; value: T \}/);
+  assert.match(types, /\{ state: 'unknown'; value\?: never \}/);
+  assert.match(types, /namespace: unknown/);
+  assert.match(types, /TrailMatchingReasonFromCode<T extends TrailReasonCode>/);
+  assert.match(types, /TrailModuleReasonTarget/);
+  assert.match(types, /'course\.optional_context\.fueling'/);
+  assert.match(types, /plan: null/);
+  assert.match(types, /inactive_dry_run: false/);
+  assert.doesNotMatch(types, /\bany\b/);
+});


### PR DESCRIPTION
## Summary

Stacked on #759. This change prepares only the accepted, inactive non-ultra
Trail v2 core and an unregistered Praxys Web course-review implementation.

- applies the approved atomic v1 superseded / v2 accepted lifecycle while both
  v2 contracts remain inactive;
- adds the deterministic inactive readiness core and private, unregistered
  draft/readiness API implementation;
- adds the complete Web course ledger, strict DTO validation, bilingual copy,
  stale-revision recovery, and data-rights boundary;
- keeps capability discovery, Web and miniapp navigation, proposal adoption,
  production data, owner dogfood, and provider delivery absent.

## Work Contract

- Classification: `sha256:d0a83117e8cd681435229fb7fb2c8ddddf4ac8ad8acaba24590079ba1e200607`
- Route: `sha256:6a022077cd4d910007c63241ee7c4b98773cd587c92450c6acecc778943fe168`
- Primary loop: Delivery
- Lead/executor: Engineering
- Verifier: Quality
- Contributors: Product, Science, Design, Architecture, Trust
- Decision Review: agent-resolved for strict inactive implementation

The residual-UI-only reclassification was not adopted: this is the same
digest-bound implementation iteration and remains bound to the approved
Product, Science, Design, Architecture, and Trust decisions.

## Runtime boundary

Both Trail v2 contracts are accepted but `inactive`. This PR does not:

- include the Trail router in `api/main.py`;
- import the Trail page from App, Training, sidebar, capability discovery, or
  the miniapp;
- add a migration, proposal/adoption path, production-data path, provider
  credential read, Garmin/COROS call, delivery ledger, or deployment switch;
- create an activation or discovery escape hatch.

The production Web build tree-shakes the unregistered Trail UI. All rendered
verification used synthetic data in a temporary local harness.

## Implementation Impact Map

This is the cumulative #776 diff relative to its stacked base, #759:

- Governance and Science lifecycle:
  `docs/dev/trail-running-plan-*-v2.md`,
  `data/science/decisions/*trail*-v2.yaml`, approval ledgers, generated
  contracts/review packets, and `data/science/REGISTRY.md` bind the approved
  Product, Design, Architecture, Trust, Science, and atomic v1->superseded /
  v2->accepted transition. Both v2 machine contracts remain inactive.
- Deterministic analysis:
  `analysis/non_ultra_trail_contract.py` and
  `analysis/non_ultra_trail_plan_generation.py` implement the strict pure
  inactive core, synthetic-only dry-run boundary, five statuses, 21 reasons,
  four module receipts, and no provider/runtime reachability.
- Private API and owner data lifecycle:
  `api/trail_plan_service.py`, the deliberately unregistered
  `api/routes/trail_plan.py`, and the reserved namespace handling in
  `api/routes/settings.py` implement bounded draft/readiness operations,
  revision fencing, actor isolation, export/account-deletion coverage, and
  fail-closed history derivation inside existing `UserConfig` storage.
- Web:
  `web/src/components/TrailCourseReview.tsx` and its private
  `trail-course-review/` modules implement the unregistered ledger, strict
  response validation, isolated sensitive-draft lifecycle, offline/stale
  recovery, and bilingual states. `web/src/types/trail-plan.ts` closes the
  DTO surface.
- Verification:
  Trail analysis/API/settings/export/deletion/Science tests plus
  `web/tests/trail-course-review.test.mjs` cover deterministic behavior,
  lifecycle, privacy, data rights, unreachability, unknown preservation,
  strict receipts, and accessibility contracts.
- No sync/data-pipeline write, database model or migration, operations/deploy
  setting, miniapp editor, provider adapter, credential, consent, or delivery
  implementation is added.

## UI quality

- Impeccable: `polish web/src/components/TrailCourseReview.tsx`
- Visual review: desktop 1440x900; mobile 390x844 and 320x800; light and dark
- Primary journey: private Trail review -> edit/offline/stale recovery -> inactive readiness receipt
- Reviewer handoff: local-only - head-bound
  `test-screenshots/ui-quality/pr-776/report.json` plus native screenshots
- States checked: saved, policy inactive, offline memory-only edits, stale 412 compare/reapply/discard, private 404, English, Simplified Chinese
- Accessibility: keyboard Tab/Enter/Escape and restored trigger focus, visible
  focus ring, named controls, 44x44 touch targets, reduced-motion media query,
  320px wrapping and no horizontal overflow
- Design system impact: none - existing Field Lab tokens and components cover this change
- Miniapp parity: not applicable - this inactive slice is undiscoverable on both clients; no partial miniapp editor is exposed
- Exceptions: Browser plugin unavailable; regular Playwright used. The evidence
  report binds commit `a6809406f2617e945e41e762da47583553315860`, every
  reviewed source digest, and every screenshot digest. Console contains only
  the deliberately induced 412 and 404 network responses, with no unexpected
  app errors.

## Verification

Exact candidate commit: `a6809406`.

- full Web test/build: `118 passed`, TypeScript and Vite production build passed;
- focused Trail/backend/settings/export/deletion suite: `140 passed`;
- Trail UI behavioral/static suite: `15 passed`;
- synthetic Playwright: desktop/mobile, EN/zh, light/dark, offline, 412, 404,
  keyboard, touch, overflow, and console checks passed;
- `python3 scripts/check_ui_quality.py --base origin/codex/trail-ninghai-science --head HEAD --skip-evidence`: passed;
- Codex/Copilot static runtime parity: passed;
- Science artifact and registry deterministic checks: passed;
- independent Science conformance: PASS;
- independent Trust conformance: PASS;
- independent rendered Design conformance: PASS.

Focused ESLint for every changed Trail Web file passes. Repository-wide
`npm run lint` currently reports 29 errors and 3 warnings in existing files
outside the new Trail UI; this draft PR does not claim to repair that separate
baseline.

Independent Quality verifies the immutable pushed head separately.

## Authority boundary

This PR remains draft. The existing approvals authorize only preparation and
review of inactive implementation. They do not authorize merge, deployment,
route or catalog registration, activation, production data, owner dogfood,
proposal adoption, miniapp exposure, provider consent, credentials, Garmin
delivery, or any other provider I/O.
