### PR TITLE
Fix Garmin import of Stryd running power

### DIFF
--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -1962,14 +1962,14 @@ def _sync_garmin_locked(
     # quietly lose intensity metrics, so we surface an aggregate warning.
     activity_ids = [str(a.get("activityId", "")) for a in raw_activities]
     total = len(activity_ids)
-    all_splits = []
+    split_payloads: dict[str, object] = {}
     split_failures = 0
     for idx, aid in enumerate(activity_ids):
         with _sync_lock:
             status["garmin"]["progress"] = f"Fetching splits: {idx + 1}/{total}"
         try:
             splits_data = client.get_activity_splits(aid) or {}
-            all_splits.extend(parse_splits(aid, splits_data))
+            split_payloads[aid] = splits_data
             time.sleep(RATE_LIMIT_DELAY)
         except Exception as e:
             split_failures += 1
@@ -1980,20 +1980,22 @@ def _sync_garmin_locked(
             "intensity analysis will be missing for those runs",
             split_failures, total, user_id,
         )
-    split_count = sync_writer.write_splits(user_id, all_splits, db)
 
     # Fetch per-second streams and write to activity_samples. One extra API
     # call per activity (get_activity_details). Rate-limited the same as splits.
-    # Power is not available in the Garmin stream for ConnectIQ-based devices
-    # (Stryd pod) — it only surfaces in lap splits via the CIQ developer field.
+    # Standard and explicitly recognized Stryd ConnectIQ power also enriches
+    # laps that do not carry their own power aggregate.
     all_samples = []
+    samples_by_activity: dict[str, list[dict]] = {}
     stream_failures = 0
     for idx, aid in enumerate(activity_ids):
         with _sync_lock:
             status["garmin"]["progress"] = f"Fetching streams: {idx + 1}/{total}"
         try:
             details = client.get_activity_details(aid, maxchart=GARMIN_MAX_CHART_SIZE) or {}
-            all_samples.extend(parse_activity_stream(aid, details))
+            parsed_samples = parse_activity_stream(aid, details)
+            samples_by_activity[aid] = parsed_samples
+            all_samples.extend(parsed_samples)
             time.sleep(RATE_LIMIT_DELAY)
         except Exception as e:
             stream_failures += 1
@@ -2003,6 +2005,15 @@ def _sync_garmin_locked(
             "Garmin stream fetch failed for %d of %d activities (user %s)",
             stream_failures, total, user_id,
         )
+
+    all_splits = []
+    for aid in activity_ids:
+        all_splits.extend(parse_splits(
+            aid,
+            split_payloads.get(aid, {}),
+            activity_samples=samples_by_activity.get(aid),
+        ))
+    split_count = sync_writer.write_splits(user_id, all_splits, db)
     sample_count = sync_writer.write_samples(user_id, all_samples, db)
     logger.debug("Garmin sync: %d splits, %d samples written", split_count, sample_count)
 

--- a/api/routes/sync.py
+++ b/api/routes/sync.py
@@ -1974,13 +1974,6 @@ def _sync_garmin_locked(
         except Exception as e:
             split_failures += 1
             logger.debug("Splits for %s: skipped (%s)", aid, e)
-    if total and split_failures >= max(3, total // 2):
-        logger.warning(
-            "Garmin splits fetch failed for %d of %d activities (user %s) — "
-            "intensity analysis will be missing for those runs",
-            split_failures, total, user_id,
-        )
-
     # Fetch per-second streams and write to activity_samples. One extra API
     # call per activity (get_activity_details). Rate-limited the same as splits.
     # Standard and explicitly recognized Stryd ConnectIQ power also enriches
@@ -2008,11 +2001,21 @@ def _sync_garmin_locked(
 
     all_splits = []
     for aid in activity_ids:
-        all_splits.extend(parse_splits(
-            aid,
-            split_payloads.get(aid, {}),
-            activity_samples=samples_by_activity.get(aid),
-        ))
+        try:
+            all_splits.extend(parse_splits(
+                aid,
+                split_payloads.get(aid, {}),
+                activity_samples=samples_by_activity.get(aid),
+            ))
+        except Exception as e:
+            split_failures += 1
+            logger.debug("Splits for %s: skipped (%s)", aid, e)
+    if total and split_failures >= max(3, total // 2):
+        logger.warning(
+            "Garmin splits fetch or parse failed for %d of %d activities "
+            "(user %s) — intensity analysis will be missing for those runs",
+            split_failures, total, user_id,
+        )
     split_count = sync_writer.write_splits(user_id, all_splits, db)
     sample_count = sync_writer.write_samples(user_id, all_samples, db)
     logger.debug("Garmin sync: %d splits, %d samples written", split_count, sample_count)

--- a/db/models.py
+++ b/db/models.py
@@ -280,8 +280,9 @@ class ActivitySample(Base):
 
     One row per second per activity. Columns cover the union of all connector
     field sets; connector-specific fields are NULL for other sources. The
-    unique constraint on (user_id, activity_id, t_sec) makes re-syncs idempotent —
-    duplicate writes are silently ignored via INSERT OR IGNORE.
+    unique constraint on (user_id, activity_id, t_sec) makes re-syncs idempotent.
+    Conflicts fill power and its source only when stored power is NULL;
+    existing watts remain authoritative.
 
     Storage estimate: ~3,600 rows/hour of running. At SQLite scale for
     personal use this is negligible; multi-user growth is managed by the

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -746,10 +746,11 @@ _SAMPLE_BATCH_SIZE = 500
 def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
     """Upsert per-second activity samples. Returns count of rows written.
 
-    Uses an idempotent INSERT ... ON CONFLICT DO NOTHING keyed on
-    (user_id, activity_id, t_sec) so re-syncing an
-    activity is idempotent — existing rows are left untouched. Inserts are
-    batched to avoid oversized transactions for long activities.
+    Inserts are keyed on ``(user_id, activity_id, t_sec)``. A conflict may
+    fill power and its provider only when the stored sample has no power; an
+    existing non-null observation remains authoritative. This lets a re-sync
+    recover power added by a newer parser without changing prior data.
+    Inserts are batched to avoid oversized transactions for long activities.
     """
     if not rows:
         return 0
@@ -799,7 +800,17 @@ def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
         if not records:
             continue
         stmt = _dialect_insert(ActivitySample).values(records)
-        stmt = stmt.on_conflict_do_nothing(index_elements=["user_id", "activity_id", "t_sec"])
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["user_id", "activity_id", "t_sec"],
+            set_={
+                "power_watts": stmt.excluded.power_watts,
+                "source": stmt.excluded.source,
+            },
+            where=(
+                ActivitySample.power_watts.is_(None)
+                & stmt.excluded.power_watts.is_not(None)
+            ),
+        )
         result = db.execute(stmt)
         total += result.rowcount
     if total > 0:

--- a/db/sync_writer.py
+++ b/db/sync_writer.py
@@ -756,9 +756,8 @@ def write_samples(user_id: str, rows: list[dict], db: Session) -> int:
         return 0
     lock_revision_writes(db, user_id)
 
-    # Dialect-agnostic upsert: SQLite and PostgreSQL both expose
-    # on_conflict_do_nothing(index_elements=...) on their INSERT construct,
-    # but via dialect-specific modules (#360).
+    # SQLite and PostgreSQL expose conditional on_conflict_do_update() through
+    # dialect-specific INSERT constructs (#360).
     if db.bind.dialect.name == "postgresql":
         from sqlalchemy.dialects.postgresql import insert as _dialect_insert
     else:

--- a/docs/dev/gotchas.md
+++ b/docs/dev/gotchas.md
@@ -12,16 +12,22 @@ Non-obvious traps this codebase has hit in production. The severe, always-releva
 - The Settings page shows region read-only. To change region, the user disconnects and reconnects with the other account's credentials.
 - If these two values drift (old bug: an editable region toggle in Settings updated `source_options` but not `is_cn`), the sync client hits the wrong SSO domain and Garmin rate-limits the account with 429s.
 
-### ConnectIQ field 10 is Stryd's convention, not a standard
+### ConnectIQ field numbers require an app identity
 
-Garmin lap DTOs expose a `connectIQMeasurement` array. Each entry has `developerFieldNumber`, `developerFieldName`, and `value`. **Field number 10 is Stryd's convention for power** — but any CIQ app can register a field with number 10 for anything (e.g., Leg Spring Stiffness). `parse_splits` in `sync/garmin_sync.py` checks `developerFieldName` before accepting a field-10 value as power.
+Garmin's JSON identifies ConnectIQ data with `appID` and an app-scoped
+`developerFieldNumber`; real split/detail payloads do not reliably include a
+developer field name. Praxys accepts only the observed Stryd identities:
 
-Priority order in `parse_splits`:
-1. Native `lap.averagePower` — present on modern Garmin watches (Fenix 6+, FR 255+/955+/965, Epix) and when HRM-Pro / Stryd pod is paired via ANT+.
-2. ConnectIQ field 10 with a name that contains "power" (or no name — Stryd's historical payload).
-3. Otherwise empty.
+- legacy Stryd app `660a581e-5301-460c-8f2f-034c8b6dc90f`: record field 0 is
+  power; lap payloads have no power aggregate;
+- Stryd Power Zone `18fb2cf0-1a4b-430d-ad66-988c847421f4`: record field 0 is
+  power and lap field 10 is Lap Power.
 
-Same priority applies to activity-level `averagePower` / `maxPower` in `parse_activities`.
+`parse_splits` prefers native `lap.averagePower`, then the exact Power Zone lap
+field, then averages recognized record power within the lap's GMT boundary.
+An unknown app using field 10 (or claiming a Stryd-like display name) is not
+power evidence. Activity-list native power is `avgPower` / `maxPower`;
+`averagePower` remains a compatibility fallback for detailed summaries.
 
 ### Garmin CN still needs one workaround in the 0.3.x library
 

--- a/sync/garmin_sync.py
+++ b/sync/garmin_sync.py
@@ -4,12 +4,24 @@ import hashlib
 import json
 import math
 from collections.abc import Mapping
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Any
 
 RATE_LIMIT_DELAY = 0.5  # seconds between per-activity API calls
 GARMIN_CALENDAR_DAYS_BACK = 2
 GARMIN_CALENDAR_DAYS_AHEAD = 31
+
+# Garmin identifies ConnectIQ fields by the app UUID plus an app-scoped field
+# number. Public Stryd FIT/Garmin payload pairs show two Stryd apps: the legacy
+# data field and the current Stryd Power Zone field. Both write record power in
+# field 0; only Power Zone writes a lap-level aggregate in field 10.
+_STRYD_CONNECTIQ_RECORD_POWER_FIELDS = frozenset({
+    ("660a581e-5301-460c-8f2f-034c8b6dc90f", 0),
+    ("18fb2cf0-1a4b-430d-ad66-988c847421f4", 0),
+})
+_STRYD_CONNECTIQ_LAP_POWER_FIELDS = frozenset({
+    ("18fb2cf0-1a4b-430d-ad66-988c847421f4", 10),
+})
 
 
 def garmin_provider_account_id(
@@ -526,6 +538,136 @@ def _garmin_speed_to_pace_sec_km(speed_value: float) -> float | None:
     return round(1000.0 / speed_ms)
 
 
+def _finite_number(value: object) -> float | None:
+    """Return one finite numeric value without trusting provider coercions."""
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _connectiq_field_identity(
+    field: object,
+) -> tuple[str, int] | None:
+    if not isinstance(field, Mapping):
+        return None
+    app_id = field.get("appID")
+    field_number = field.get("developerFieldNumber")
+    if (
+        not isinstance(app_id, str)
+        or isinstance(field_number, bool)
+        or not isinstance(field_number, int)
+    ):
+        return None
+    return app_id.strip().casefold(), field_number
+
+
+def _connectiq_power_value(
+    fields: object,
+    *,
+    accepted_fields: frozenset[tuple[str, int]],
+) -> float | None:
+    """Read one unambiguous power value from explicitly accepted fields."""
+    if not isinstance(fields, list):
+        return None
+    found = None
+    for field in fields:
+        if (
+            _connectiq_field_identity(field) not in accepted_fields
+            or not isinstance(field, Mapping)
+        ):
+            continue
+        value = _finite_number(field.get("value"))
+        if value is None:
+            continue
+        if found is not None and not math.isclose(found, value, abs_tol=1e-6):
+            return None
+        found = value
+    return found
+
+
+def _stryd_record_power_metric_index(descriptors: object) -> int | None:
+    """Return the sole metric index for an observed Stryd record-power field."""
+    if not isinstance(descriptors, list):
+        return None
+    indexes: set[int] = set()
+    for descriptor in descriptors:
+        if (
+            _connectiq_field_identity(descriptor)
+            not in _STRYD_CONNECTIQ_RECORD_POWER_FIELDS
+            or not isinstance(descriptor, Mapping)
+        ):
+            continue
+        index = descriptor.get("metricsIndex")
+        if isinstance(index, int) and not isinstance(index, bool) and index >= 0:
+            indexes.add(index)
+    if len(indexes) != 1:
+        return None
+    return next(iter(indexes))
+
+
+def _garmin_lap_start_epoch(lap: Mapping[str, Any]) -> float | None:
+    raw_timestamp = lap.get("startTimeGMT")
+    if not isinstance(raw_timestamp, str) or not raw_timestamp.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(
+            raw_timestamp.strip().replace("Z", "+00:00")
+        )
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed.timestamp()
+
+
+def _stream_power_for_lap(
+    lap: Mapping[str, Any],
+    next_lap: Mapping[str, Any] | None,
+    activity_samples: object,
+) -> tuple[str, str] | None:
+    """Average parsed record power inside one lap's UTC time boundary."""
+    if not isinstance(activity_samples, list):
+        return None
+    start = _garmin_lap_start_epoch(lap)
+    if start is None:
+        return None
+
+    end = _garmin_lap_start_epoch(next_lap) if next_lap is not None else None
+    if end is None or end <= start:
+        elapsed = _finite_number(lap.get("elapsedDuration"))
+        if elapsed is None or elapsed <= 0:
+            elapsed = _finite_number(lap.get("duration"))
+        if elapsed is None or elapsed <= 0:
+            return None
+        end = start + elapsed
+
+    values: list[float] = []
+    for sample in activity_samples:
+        if not isinstance(sample, Mapping):
+            continue
+        if sample.get("source") != "stryd":
+            continue
+        sample_time = _finite_number(sample.get("t_sec"))
+        power = _finite_number(sample.get("power_watts"))
+        if (
+            sample_time is None
+            or power is None
+            or not start <= sample_time < end
+        ):
+            continue
+        values.append(power)
+    if not values:
+        return None
+    average_power = sum(values) / len(values)
+    return str(int(round(average_power))), "stryd"
+
+
 def parse_activities(raw_activities: list[dict]) -> list[dict]:
     """Transform Garmin activity list data into our CSV schema.
 
@@ -560,12 +702,12 @@ def parse_activities(raw_activities: list[dict]) -> list[dict]:
             val = a.get(f"hrTimeInZone_{z}")
             hr_zones[f"hr_zone{z}_sec"] = str(int(val)) if val is not None else ""
 
-        # Native Garmin running power is present on modern watches (Fenix 6+,
-        # FR 255/955/965, Epix) and when an HRM-Pro or Stryd pod is paired via
-        # ANT+. Older watches may only surface power through ConnectIQ (handled
-        # at the lap level in parse_splits).
-        avg_power_raw = a.get("averagePower")
-        max_power_raw = a.get("maxPower")
+        # get_activities_by_date() uses avgPower. Detailed activity summaries
+        # use averagePower, so retain that as a compatibility fallback.
+        avg_power = _finite_number(a.get("avgPower"))
+        if avg_power is None:
+            avg_power = _finite_number(a.get("averagePower"))
+        max_power = _finite_number(a.get("maxPower"))
 
         rows.append({
             "activity_id": str(a.get("activityId", "")),
@@ -575,8 +717,8 @@ def parse_activities(raw_activities: list[dict]) -> list[dict]:
             "distance_km": str(round(distance_m / 1000, 1)) if distance_m else "",
             "duration_sec": str(int(duration)) if duration else "",
             "avg_pace_min_km": avg_pace,
-            "avg_power": str(round(float(avg_power_raw), 1)) if avg_power_raw is not None else "",
-            "max_power": str(round(float(max_power_raw), 1)) if max_power_raw is not None else "",
+            "avg_power": str(round(avg_power, 1)) if avg_power is not None else "",
+            "max_power": str(round(max_power, 1)) if max_power is not None else "",
             "avg_hr": str(int(a["averageHR"])) if a.get("averageHR") else "",
             "max_hr": str(int(a["maxHR"])) if a.get("maxHR") else "",
             "elevation_gain_m": str(a["elevationGain"]) if a.get("elevationGain") else "",
@@ -589,24 +731,31 @@ def parse_activities(raw_activities: list[dict]) -> list[dict]:
     return rows
 
 
-def parse_splits(activity_id: str, splits_data: dict) -> list[dict]:
+def parse_splits(
+    activity_id: str,
+    splits_data: object,
+    *,
+    activity_samples: list[dict] | None = None,
+) -> list[dict]:
     """Parse per-lap split data from get_activity_splits() response.
 
-    Garmin returns laps as lapDTOs. Power comes from one of two sources, in
-    priority order:
+    Garmin returns laps as lapDTOs. Power comes from these sources, in order:
     1. Native Garmin running power (lap["averagePower"]) — present on modern
-       watches and when HRM-Pro / Stryd pod is paired via ANT+.
-    2. ConnectIQ developer field 10 — Stryd's ConnectIQ data-field convention,
-       used when the watch doesn't expose power natively. Field numbers are
-       defined per-app, so the `developerFieldName` must explicitly identify
-       both Stryd and power before it establishes provenance.
+       watches and standardized sensor integrations.
+    2. Stryd Power Zone's app-scoped lap-power field 10.
+    3. Parsed native/Stryd record power averaged within the lap boundary. This
+       covers the legacy Stryd app, whose Garmin lap payload has no aggregate.
     """
     rows = []
+    if not isinstance(splits_data, Mapping):
+        return rows
     laps = splits_data.get("lapDTOs", [])
-    if not laps:
+    if not isinstance(laps, list) or not laps:
         return rows
 
     for i, lap in enumerate(laps, start=1):
+        if not isinstance(lap, Mapping):
+            continue
         distance_m = lap.get("distance", 0) or 0
         duration_sec = lap.get("duration", 0) or 0
 
@@ -617,33 +766,32 @@ def parse_splits(activity_id: str, splits_data: dict) -> list[dict]:
             secs = int(pace_sec_per_km % 60)
             avg_pace = f"{mins}:{secs:02d}"
 
-        # Prefer native Garmin power; fall back to ConnectIQ field 10.
+        # Standard Garmin power wins over app-specific and derived fallbacks.
         avg_power = ""
         power_source = ""
-        native_power = lap.get("averagePower")
+        native_power = _finite_number(lap.get("averagePower"))
         if native_power is not None:
-            try:
-                avg_power = str(int(float(native_power)))
-                power_source = "garmin"
-            except (ValueError, TypeError):
-                pass
+            avg_power = str(int(native_power))
+            power_source = "garmin"
         if not avg_power:
-            for ciq in lap.get("connectIQMeasurement", []):
-                if ciq.get("developerFieldNumber") != 10:
-                    continue
-                # Developer field numbers are app-scoped. A generic "power"
-                # name identifies a metric, not the app that produced it.
-                field_name = str(
-                    ciq.get("developerFieldName") or ciq.get("fieldName") or ""
-                ).lower()
-                if "stryd" not in field_name or "power" not in field_name:
-                    continue
-                try:
-                    avg_power = str(int(float(ciq["value"])))
-                    power_source = "stryd"
-                except (ValueError, KeyError, TypeError):
-                    pass
-                break
+            stryd_lap_power = _connectiq_power_value(
+                lap.get("connectIQMeasurement"),
+                accepted_fields=_STRYD_CONNECTIQ_LAP_POWER_FIELDS,
+            )
+            if stryd_lap_power is not None:
+                avg_power = str(int(stryd_lap_power))
+                power_source = "stryd"
+        if not avg_power:
+            next_lap = laps[i] if i < len(laps) else None
+            if not isinstance(next_lap, Mapping):
+                next_lap = None
+            stream_power = _stream_power_for_lap(
+                lap,
+                next_lap,
+                activity_samples,
+            )
+            if stream_power is not None:
+                avg_power, power_source = stream_power
 
         elev_gain = lap.get("elevationGain")
         elev_loss = lap.get("elevationLoss", 0)
@@ -683,8 +831,9 @@ def parse_activity_stream(activity_id: str, details: dict) -> list[dict]:
 
     Timestamps are in milliseconds; sampling is typically every 2 seconds
     (half the row count of a 1Hz Stryd stream for the same activity duration).
-    Power is not available in the stream for ConnectIQ-based devices — it only
-    appears in lap splits via the CIQ developer field.
+    Stryd ConnectIQ power uses an app-scoped developer descriptor; only
+    observed Stryd app/field identities are accepted, because field numbers
+    and display names are not global.
 
     Returns an empty list and logs a warning when the response was truncated
     (metricsCount < totalMetricsCount), which would indicate GARMIN_MAX_CHART_SIZE
@@ -693,8 +842,12 @@ def parse_activity_stream(activity_id: str, details: dict) -> list[dict]:
     import logging as _log
     _logger = _log.getLogger(__name__)
 
+    if not isinstance(details, Mapping):
+        return []
     descriptors = details.get("metricDescriptors") or []
     rows = details.get("activityDetailMetrics") or []
+    if not isinstance(descriptors, list) or not isinstance(rows, list):
+        return []
     if not descriptors or not rows:
         return []
 
@@ -708,32 +861,47 @@ def parse_activity_stream(activity_id: str, details: dict) -> list[dict]:
         )
 
     key_idx: dict[str, int] = {
-        m["key"]: m["metricsIndex"]
-        for m in descriptors
-        if "key" in m and "metricsIndex" in m
+        descriptor["key"]: descriptor["metricsIndex"]
+        for descriptor in descriptors
+        if isinstance(descriptor, Mapping)
+        and isinstance(descriptor.get("key"), str)
+        and isinstance(descriptor.get("metricsIndex"), int)
+        and not isinstance(descriptor.get("metricsIndex"), bool)
+        and descriptor["metricsIndex"] >= 0
     }
+    stryd_power_idx = _stryd_record_power_metric_index(descriptors)
 
     ts_idx = key_idx.get("directTimestamp")
     if ts_idx is None:
         return []
 
-    def _val(metrics: list, key: str) -> float | None:
-        idx = key_idx.get(key)
-        if idx is None or idx >= len(metrics):
+    def _metric_value(metrics: object, idx: int | None) -> float | None:
+        if (
+            idx is None
+            or not isinstance(metrics, list)
+            or idx >= len(metrics)
+        ):
             return None
-        v = metrics[idx]
-        return float(v) if v is not None else None
+        return _finite_number(metrics[idx])
+
+    def _val(metrics: object, key: str) -> float | None:
+        return _metric_value(metrics, key_idx.get(key))
 
     samples = []
     for row in rows:
+        if not isinstance(row, Mapping):
+            continue
         metrics = row.get("metrics") or []
-        if ts_idx >= len(metrics) or metrics[ts_idx] is None:
+        timestamp_ms = _metric_value(metrics, ts_idx)
+        if timestamp_ms is None:
             continue
         speed = _val(metrics, "directSpeed")
+        stryd_power = _metric_value(metrics, stryd_power_idx)
         samples.append({
             "activity_id": str(activity_id),
-            "source": "garmin",
-            "t_sec": int(metrics[ts_idx] / 1000),
+            "source": "stryd" if stryd_power is not None else "garmin",
+            "t_sec": int(timestamp_ms / 1000),
+            "power_watts": stryd_power,
             "hr_bpm": _val(metrics, "directHeartRate"),
             "cadence_spm": _val(metrics, "directDoubleCadence"),
             "speed_ms": speed,

--- a/sync/garmin_sync.py
+++ b/sync/garmin_sync.py
@@ -581,7 +581,7 @@ def _connectiq_power_value(
         ):
             continue
         value = _finite_number(field.get("value"))
-        if value is None:
+        if value is None or value < 0:
             continue
         if found is not None and not math.isclose(found, value, abs_tol=1e-6):
             return None
@@ -658,6 +658,7 @@ def _stream_power_for_lap(
         if (
             sample_time is None
             or power is None
+            or power < 0
             or not start <= sample_time < end
         ):
             continue
@@ -897,6 +898,8 @@ def parse_activity_stream(activity_id: str, details: dict) -> list[dict]:
             continue
         speed = _val(metrics, "directSpeed")
         stryd_power = _metric_value(metrics, stryd_power_idx)
+        if stryd_power is not None and stryd_power < 0:
+            stryd_power = None
         samples.append({
             "activity_id": str(activity_id),
             "source": "stryd" if stryd_power is not None else "garmin",

--- a/sync/garmin_sync.py
+++ b/sync/garmin_sync.py
@@ -549,6 +549,11 @@ def _finite_number(value: object) -> float | None:
     return number if math.isfinite(number) else None
 
 
+def _nonnegative_power(value: object) -> float | None:
+    number = _finite_number(value)
+    return number if number is not None and number >= 0 else None
+
+
 def _connectiq_field_identity(
     field: object,
 ) -> tuple[str, int] | None:
@@ -580,8 +585,8 @@ def _connectiq_power_value(
             or not isinstance(field, Mapping)
         ):
             continue
-        value = _finite_number(field.get("value"))
-        if value is None or value < 0:
+        value = _nonnegative_power(field.get("value"))
+        if value is None:
             continue
         if found is not None and not math.isclose(found, value, abs_tol=1e-6):
             return None
@@ -654,11 +659,10 @@ def _stream_power_for_lap(
         if sample.get("source") != "stryd":
             continue
         sample_time = _finite_number(sample.get("t_sec"))
-        power = _finite_number(sample.get("power_watts"))
+        power = _nonnegative_power(sample.get("power_watts"))
         if (
             sample_time is None
             or power is None
-            or power < 0
             or not start <= sample_time < end
         ):
             continue
@@ -705,10 +709,10 @@ def parse_activities(raw_activities: list[dict]) -> list[dict]:
 
         # get_activities_by_date() uses avgPower. Detailed activity summaries
         # use averagePower, so retain that as a compatibility fallback.
-        avg_power = _finite_number(a.get("avgPower"))
+        avg_power = _nonnegative_power(a.get("avgPower"))
         if avg_power is None:
-            avg_power = _finite_number(a.get("averagePower"))
-        max_power = _finite_number(a.get("maxPower"))
+            avg_power = _nonnegative_power(a.get("averagePower"))
+        max_power = _nonnegative_power(a.get("maxPower"))
 
         rows.append({
             "activity_id": str(a.get("activityId", "")),
@@ -770,7 +774,7 @@ def parse_splits(
         # Standard Garmin power wins over app-specific and derived fallbacks.
         avg_power = ""
         power_source = ""
-        native_power = _finite_number(lap.get("averagePower"))
+        native_power = _nonnegative_power(lap.get("averagePower"))
         if native_power is not None:
             avg_power = str(int(native_power))
             power_source = "garmin"
@@ -897,9 +901,9 @@ def parse_activity_stream(activity_id: str, details: dict) -> list[dict]:
         if timestamp_ms is None:
             continue
         speed = _val(metrics, "directSpeed")
-        stryd_power = _metric_value(metrics, stryd_power_idx)
-        if stryd_power is not None and stryd_power < 0:
-            stryd_power = None
+        stryd_power = _nonnegative_power(
+            _metric_value(metrics, stryd_power_idx)
+        )
         samples.append({
             "activity_id": str(activity_id),
             "source": "stryd" if stryd_power is not None else "garmin",

--- a/tests/test_garmin_activity_stream.py
+++ b/tests/test_garmin_activity_stream.py
@@ -1,6 +1,12 @@
 """Tests for parse_activity_stream() in sync/garmin_sync.py."""
 import pytest
-from sync.garmin_sync import parse_activity_stream
+from sync.garmin_sync import parse_activity_stream, parse_splits
+
+
+STRYD_CONNECTIQ_APP_IDS = (
+    "660a581e-5301-460c-8f2f-034c8b6dc90f",
+    "18fb2cf0-1a4b-430d-ad66-988c847421f4",
+)
 
 
 def _make_details(
@@ -42,6 +48,27 @@ def _make_details(
         ]
         rows.append({"metrics": metrics})
     return {"metricDescriptors": descriptors, "activityDetailMetrics": rows}
+
+
+def _add_metric(
+    details: dict,
+    *,
+    key: str,
+    values: list[object],
+    app_id: str | None = None,
+    developer_field_number: int | None = None,
+) -> None:
+    """Append one descriptor and its values to a synthetic details payload."""
+    assert len(values) == len(details["activityDetailMetrics"])
+    metrics_index = len(details["activityDetailMetrics"][0]["metrics"])
+    descriptor = {"metricsIndex": metrics_index, "key": key}
+    if app_id is not None:
+        descriptor["appID"] = app_id
+    if developer_field_number is not None:
+        descriptor["developerFieldNumber"] = developer_field_number
+    details["metricDescriptors"].append(descriptor)
+    for row, value in zip(details["activityDetailMetrics"], values, strict=True):
+        row["metrics"].append(value)
 
 
 def test_returns_one_sample_per_row():
@@ -104,11 +131,96 @@ def test_dynamics_populated():
     assert s["vertical_ratio"] == pytest.approx(6.8)
 
 
-def test_no_power_in_output():
-    """power_watts is not in the sample dict — unavailable in Garmin stream."""
+def test_no_power_in_output_without_supported_descriptor():
+    """A stream without a supported power descriptor remains power-empty."""
     details = _make_details(n=1)
     s = parse_activity_stream("act-8", details)[0]
-    assert "power_watts" not in s
+    assert s["power_watts"] is None
+    assert s["source"] == "garmin"
+
+
+@pytest.mark.parametrize("app_id", STRYD_CONNECTIQ_APP_IDS)
+def test_stryd_connectiq_record_power_is_mapped(app_id):
+    """Both observed Stryd apps record watts in developer field 0."""
+    details = _make_details(n=3)
+    _add_metric(
+        details,
+        key="connectIQDeveloperField00",
+        values=[240, 250, 260],
+        app_id=app_id,
+        developer_field_number=0,
+    )
+
+    samples = parse_activity_stream("stryd-run", details)
+
+    assert [sample["power_watts"] for sample in samples] == [240, 250, 260]
+    assert {sample["source"] for sample in samples} == {"stryd"}
+
+
+@pytest.mark.parametrize(
+    ("app_id", "field_number", "value"),
+    [
+        ("00000000-0000-0000-0000-000000000000", 0, 250),
+        (STRYD_CONNECTIQ_APP_IDS[1], 8, 250),
+        (STRYD_CONNECTIQ_APP_IDS[1], 0, "not-a-number"),
+        (STRYD_CONNECTIQ_APP_IDS[1], 0, "nan"),
+    ],
+)
+def test_unrelated_or_malformed_connectiq_power_is_ignored(
+    app_id, field_number, value,
+):
+    details = _make_details(n=1)
+    _add_metric(
+        details,
+        key="connectIQDeveloperField00",
+        values=[value],
+        app_id=app_id,
+        developer_field_number=field_number,
+    )
+
+    sample = parse_activity_stream("untrusted-run", details)[0]
+
+    assert sample["power_watts"] is None
+    assert sample["source"] == "garmin"
+
+
+def test_stream_power_fills_only_laps_without_native_power():
+    """Record power is averaged into laps while native lap power stays first."""
+    details = _make_details(
+        n=4,
+        start_ms=1_700_000_000_000,
+        step_ms=2000,
+    )
+    _add_metric(
+        details,
+        key="connectIQDeveloperField00",
+        values=[200, 220, 300, 320],
+        app_id=STRYD_CONNECTIQ_APP_IDS[0],
+        developer_field_number=0,
+    )
+    samples = parse_activity_stream("mixed-run", details)
+    splits = parse_splits(
+        "mixed-run",
+        {
+            "lapDTOs": [
+                {
+                    "startTimeGMT": "2023-11-14T22:13:20.0",
+                    "duration": 4,
+                    "averagePower": 250,
+                },
+                {
+                    "startTimeGMT": "2023-11-14T22:13:24.0",
+                    "duration": 4,
+                },
+            ],
+        },
+        activity_samples=samples,
+    )
+
+    assert splits[0]["avg_power"] == "250"
+    assert splits[0]["power_source"] == "garmin"
+    assert splits[1]["avg_power"] == "310"
+    assert splits[1]["power_source"] == "stryd"
 
 
 def test_dynamic_descriptor_order():

--- a/tests/test_garmin_activity_stream.py
+++ b/tests/test_garmin_activity_stream.py
@@ -164,6 +164,7 @@ def test_stryd_connectiq_record_power_is_mapped(app_id):
         (STRYD_CONNECTIQ_APP_IDS[1], 8, 250),
         (STRYD_CONNECTIQ_APP_IDS[1], 0, "not-a-number"),
         (STRYD_CONNECTIQ_APP_IDS[1], 0, "nan"),
+        (STRYD_CONNECTIQ_APP_IDS[1], 0, -25),
     ],
 )
 def test_unrelated_or_malformed_connectiq_power_is_ignored(

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -28,6 +28,9 @@ from sync.garmin_sync import (
 )
 
 
+STRYD_POWER_ZONE_APP_ID = "18fb2cf0-1a4b-430d-ad66-988c847421f4"
+
+
 def _garmin_connection_error(status_code):
     return GarminConnectConnectionError(
         f"API call client error ({status_code}): API Error {status_code}",
@@ -443,11 +446,13 @@ def test_parse_activity_weather_requires_a_valid_complete_pair(payload):
     assert parse_activity_weather(payload) == {}
 
 
-def test_sync_garmin_enriches_only_outdoor_runs_with_weather(
+def test_sync_garmin_wires_weather_and_stryd_stream_power(
     tmp_path, monkeypatch,
 ):
     weather_calls = []
     written_rows = []
+    written_splits = []
+    written_samples = []
     raw_activities = [
         {
             "activityId": 1000,
@@ -468,6 +473,7 @@ def test_sync_garmin_enriches_only_outdoor_runs_with_weather(
             "activityId": 1003,
             "startTimeLocal": "2026-07-22 07:00:00",
             "activityType": {"typeKey": "treadmill_running"},
+            "avgPower": 250,
         },
     ]
 
@@ -488,9 +494,30 @@ def test_sync_garmin_enriches_only_outdoor_runs_with_weather(
             return {"temp": 86, "relativeHumidity": 72}
 
         def get_activity_splits(self, activity_id):
+            if str(activity_id) == "1003":
+                return {"lapDTOs": [{
+                    "startTimeGMT": "2023-11-14T22:13:20.0",
+                    "duration": 4,
+                }]}
             return {}
 
         def get_activity_details(self, activity_id, maxchart):
+            if str(activity_id) == "1003":
+                return {
+                    "metricDescriptors": [
+                        {"metricsIndex": 0, "key": "directTimestamp"},
+                        {
+                            "metricsIndex": 1,
+                            "key": "connectIQDeveloperField00",
+                            "appID": "660a581e-5301-460c-8f2f-034c8b6dc90f",
+                            "developerFieldNumber": 0,
+                        },
+                    ],
+                    "activityDetailMetrics": [
+                        {"metrics": [1_700_000_000_000, 260]},
+                        {"metrics": [1_700_000_002_000, 280]},
+                    ],
+                }
             return {}
 
         def get_lactate_threshold(self, **kwargs):
@@ -524,13 +551,21 @@ def test_sync_garmin_enriches_only_outdoor_runs_with_weather(
         written_rows.extend(rows)
         return len(rows)
 
+    def capture_splits(user_id, rows, db):
+        written_splits.extend(rows)
+        return len(rows)
+
+    def capture_samples(user_id, rows, db):
+        written_samples.extend(rows)
+        return len(rows)
+
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     monkeypatch.setattr("garminconnect.Garmin", FakeGarmin)
     monkeypatch.setattr("sync.garmin_sync.RATE_LIMIT_DELAY", 0)
     monkeypatch.setattr("db.sync_writer.write_activities", capture_activities)
+    monkeypatch.setattr("db.sync_writer.write_splits", capture_splits)
+    monkeypatch.setattr("db.sync_writer.write_samples", capture_samples)
     for name in (
-        "write_splits",
-        "write_samples",
         "write_lactate_threshold",
         "write_daily_metrics",
         "write_recovery",
@@ -588,6 +623,11 @@ def test_sync_garmin_enriches_only_outdoor_runs_with_weather(
     assert "temperature_c" not in rows_by_id["1000"]
     assert "temperature_c" not in rows_by_id["1002"]
     assert "temperature_c" not in rows_by_id["1003"]
+    assert rows_by_id["1003"]["avg_power"] == "250.0"
+    assert written_splits[0]["avg_power"] == "270"
+    assert written_splits[0]["power_source"] == "stryd"
+    assert [row["power_watts"] for row in written_samples] == [260, 280]
+    assert {row["source"] for row in written_samples} == {"stryd"}
 
 
 @pytest.mark.parametrize(
@@ -728,8 +768,8 @@ SAMPLE_LAP_DTOS = {
             "elevationLoss": 5.0,
             "connectIQMeasurement": [
                 {
+                    "appID": STRYD_POWER_ZONE_APP_ID,
                     "developerFieldNumber": 10,
-                    "developerFieldName": "Stryd Power",
                     "value": "265.0",
                 },
             ],
@@ -855,15 +895,27 @@ def test_parse_daily_metrics_empty():
 
 
 def test_parse_activities_native_power():
-    """Activity-level averagePower/maxPower from native running power."""
+    """The activity-list endpoint exposes native running power as avgPower."""
     act = {
         **SAMPLE_ACTIVITY,
-        "averagePower": 252.4,
+        "avgPower": 252.4,
         "maxPower": 410,
     }
     rows = parse_activities([act])
     assert rows[0]["avg_power"] == "252.4"
     assert rows[0]["max_power"] == "410.0"
+
+
+def test_parse_activities_accepts_average_power_compatibility_shape():
+    """Detailed activity summaries may use averagePower instead of avgPower."""
+    act = {
+        **SAMPLE_ACTIVITY,
+        "averagePower": 251.4,
+        "maxPower": 409,
+    }
+    rows = parse_activities([act])
+    assert rows[0]["avg_power"] == "251.4"
+    assert rows[0]["max_power"] == "409.0"
 
 
 def test_parse_activities_no_power_when_missing():
@@ -882,7 +934,11 @@ def test_parse_splits_prefers_native_power_over_connectiq():
             "elevationGain": 0.0, "elevationLoss": 0.0,
             "averagePower": 245.0,
             "connectIQMeasurement": [
-                {"developerFieldNumber": 10, "value": "999.0"},
+                {
+                    "appID": STRYD_POWER_ZONE_APP_ID,
+                    "developerFieldNumber": 10,
+                    "value": "999.0",
+                },
             ],
         }],
     }
@@ -892,14 +948,14 @@ def test_parse_splits_prefers_native_power_over_connectiq():
 
 
 def test_parse_splits_connectiq_fallback_when_native_absent():
-    """ConnectIQ field 10 picks up when native power isn't present."""
+    """Stryd Power Zone lap field 10 is used when native power is absent."""
     data = {
         "lapDTOs": [{
             "distance": 1000.0, "duration": 300.0,
             "connectIQMeasurement": [
                 {
+                    "appID": STRYD_POWER_ZONE_APP_ID,
                     "developerFieldNumber": 10,
-                    "developerFieldName": "Stryd Power",
                     "value": "270.0",
                 },
             ],
@@ -910,34 +966,17 @@ def test_parse_splits_connectiq_fallback_when_native_absent():
     assert rows[0]["power_source"] == "stryd"
 
 
-def test_parse_splits_ignores_unnamed_connectiq_field():
-    """An app-scoped field number alone cannot establish Stryd provenance."""
-    data = {
-        "lapDTOs": [{
-            "distance": 1000.0,
-            "duration": 300.0,
-            "connectIQMeasurement": [
-                {"developerFieldNumber": 10, "value": "270.0"},
-            ],
-        }],
-    }
-
-    rows = parse_splits("a1", data)
-
-    assert rows[0]["avg_power"] == ""
-    assert rows[0]["power_source"] == ""
-
-
-def test_parse_splits_ignores_generic_connectiq_power_field():
-    """A power metric without an explicit Stryd identity has unknown provenance."""
+def test_parse_splits_ignores_connectiq_field_from_unknown_app():
+    """A field number or attacker-controlled name cannot establish provenance."""
     data = {
         "lapDTOs": [{
             "distance": 1000.0,
             "duration": 300.0,
             "connectIQMeasurement": [
                 {
+                    "appID": "00000000-0000-0000-0000-000000000000",
                     "developerFieldNumber": 10,
-                    "developerFieldName": "Running Power",
+                    "developerFieldName": "Stryd Power",
                     "value": "270.0",
                 },
             ],
@@ -950,23 +989,46 @@ def test_parse_splits_ignores_generic_connectiq_power_field():
     assert rows[0]["power_source"] == ""
 
 
-def test_parse_splits_ignores_connectiq_non_power_field():
-    """ConnectIQ field 10 from an unrelated app (by name) is skipped."""
+def test_parse_splits_ignores_wrong_field_from_stryd_app():
+    """Record power field 0 is not a lap-power aggregate."""
+    data = {
+        "lapDTOs": [{
+            "distance": 1000.0,
+            "duration": 300.0,
+            "connectIQMeasurement": [
+                {
+                    "appID": STRYD_POWER_ZONE_APP_ID,
+                    "developerFieldNumber": 0,
+                    "value": "270.0",
+                },
+            ],
+        }],
+    }
+
+    rows = parse_splits("a1", data)
+
+    assert rows[0]["avg_power"] == ""
+    assert rows[0]["power_source"] == ""
+
+
+@pytest.mark.parametrize("value", [None, "not-a-number", "nan", "inf", []])
+def test_parse_splits_ignores_malformed_stryd_lap_power(value):
+    """Malformed values from an otherwise-recognized Stryd field fail closed."""
     data = {
         "lapDTOs": [{
             "distance": 1000.0, "duration": 300.0,
             "connectIQMeasurement": [
                 {
+                    "appID": STRYD_POWER_ZONE_APP_ID,
                     "developerFieldNumber": 10,
-                    "developerFieldName": "Leg Spring Stiffness",
-                    "value": "11.5",
+                    "value": value,
                 },
             ],
         }],
     }
     rows = parse_splits("a1", data)
-    # Non-power field 10 must not be mis-read as power.
     assert rows[0]["avg_power"] == ""
+    assert rows[0]["power_source"] == ""
 
 
 # --- User profile (LTHR + max HR thresholds) ---

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -446,7 +446,7 @@ def test_parse_activity_weather_requires_a_valid_complete_pair(payload):
     assert parse_activity_weather(payload) == {}
 
 
-def test_sync_garmin_wires_weather_and_stryd_stream_power(
+def test_sync_garmin_isolates_bad_split_and_wires_valid_enrichment(
     tmp_path, monkeypatch,
 ):
     weather_calls = []
@@ -494,6 +494,8 @@ def test_sync_garmin_wires_weather_and_stryd_stream_power(
             return {"temp": 86, "relativeHumidity": 72}
 
         def get_activity_splits(self, activity_id):
+            if str(activity_id) == "1002":
+                return {"lapDTOs": [{"distance": "invalid", "duration": 300}]}
             if str(activity_id) == "1003":
                 return {"lapDTOs": [{
                     "startTimeGMT": "2023-11-14T22:13:20.0",
@@ -1011,7 +1013,10 @@ def test_parse_splits_ignores_wrong_field_from_stryd_app():
     assert rows[0]["power_source"] == ""
 
 
-@pytest.mark.parametrize("value", [None, "not-a-number", "nan", "inf", []])
+@pytest.mark.parametrize(
+    "value",
+    [None, "not-a-number", "nan", "inf", [], -25],
+)
 def test_parse_splits_ignores_malformed_stryd_lap_power(value):
     """Malformed values from an otherwise-recognized Stryd field fail closed."""
     data = {

--- a/tests/test_garmin_sync.py
+++ b/tests/test_garmin_sync.py
@@ -927,6 +927,20 @@ def test_parse_activities_no_power_when_missing():
     assert rows[0]["max_power"] == ""
 
 
+@pytest.mark.parametrize("power_key", ["avgPower", "averagePower"])
+def test_parse_activities_rejects_negative_native_power(power_key):
+    act = {
+        **SAMPLE_ACTIVITY,
+        power_key: -25,
+        "maxPower": -50,
+    }
+
+    rows = parse_activities([act])
+
+    assert rows[0]["avg_power"] == ""
+    assert rows[0]["max_power"] == ""
+
+
 def test_parse_splits_prefers_native_power_over_connectiq():
     """Native lap averagePower wins over ConnectIQ field 10."""
     data = {
@@ -964,6 +978,26 @@ def test_parse_splits_connectiq_fallback_when_native_absent():
         }],
     }
     rows = parse_splits("a1", data)
+    assert rows[0]["avg_power"] == "270"
+    assert rows[0]["power_source"] == "stryd"
+
+
+def test_parse_splits_negative_native_power_uses_stryd_fallback():
+    data = {
+        "lapDTOs": [{
+            "distance": 1000.0,
+            "duration": 300.0,
+            "averagePower": -25,
+            "connectIQMeasurement": [{
+                "appID": STRYD_POWER_ZONE_APP_ID,
+                "developerFieldNumber": 10,
+                "value": "270.0",
+            }],
+        }],
+    }
+
+    rows = parse_splits("a1", data)
+
     assert rows[0]["avg_power"] == "270"
     assert rows[0]["power_source"] == "stryd"
 

--- a/tests/test_write_samples.py
+++ b/tests/test_write_samples.py
@@ -89,6 +89,59 @@ def test_write_samples_idempotent(db_with_user):
     assert len(rows) == 5
 
 
+def test_write_samples_backfills_missing_power_and_provenance(db_with_user):
+    """A re-sync fills newly parsed Stryd watts on an existing Garmin sample."""
+    from analysis.data_loader import load_activity_samples
+    from db import sync_writer
+    from db.models import ActivitySample
+
+    db, user_id = db_with_user
+    first = _make_sample(
+        "act-power-backfill",
+        2500,
+        source="garmin",
+        power_watts=None,
+    )
+    incoming = _make_sample(
+        "act-power-backfill",
+        2500,
+        source="stryd",
+        power_watts=275.0,
+    )
+
+    assert sync_writer.write_samples(user_id, [first], db) == 1
+    db.commit()
+    assert sync_writer.write_samples(user_id, [incoming], db) == 1
+    db.commit()
+
+    row = db.query(ActivitySample).filter_by(
+        user_id=user_id,
+        activity_id="act-power-backfill",
+    ).one()
+    assert row.power_watts == 275.0
+    assert row.source == "stryd"
+
+    downstream = load_activity_samples(
+        user_id,
+        db,
+        activity_ids=["act-power-backfill"],
+    )
+    assert downstream.loc[0, "power_watts"] == 275.0
+    assert downstream.loc[0, "source"] == "stryd"
+
+    later_native = _make_sample(
+        "act-power-backfill",
+        2500,
+        source="garmin",
+        power_watts=250.0,
+    )
+    assert sync_writer.write_samples(user_id, [later_native], db) == 0
+    db.commit()
+    db.refresh(row)
+    assert row.power_watts == 275.0
+    assert row.source == "stryd"
+
+
 def test_write_samples_pace_derived_from_speed(db_with_user):
     """pace_sec_km is computed from speed_ms when not explicitly provided."""
     from db import sync_writer


### PR DESCRIPTION
## Summary

- Import Garmin native running power from activity `avgPower` (with detailed-summary `averagePower` compatibility) and lap `averagePower`, while rejecting invalid native values and preserving valid native lap precedence.
- Recognize only the evidenced Stryd ConnectIQ app/field identities in Garmin detail streams and lap summaries, derive otherwise-missing lap watts from recognized samples, and reject unknown, spoofed, malformed, or negative fields.
- Persist newly available watts and provenance through fill-only sync-writer updates so re-syncs repair missing data without replacing existing power; isolate malformed split payloads to their individual activity.
- Leave the separate Stryd connector and its access restriction unchanged.

## Validation

- `python3 -m pytest tests/test_garmin_activity_stream.py tests/test_garmin_sync.py tests/test_write_samples.py -q` — 112 passed.
- Independent Quality focused verification on the exact head — 134 passed.
- `python3 scripts/agent_preflight.py --base origin/main` — passed in a clean exact-head worktree: 3032 passed, 53 skipped.
- Preflight head: d51fe05476adf56ca80c8c00d10d09f13caacbeb
